### PR TITLE
feat: Add basic healthcheck endpoint

### DIFF
--- a/crates/core/src/policy.rs
+++ b/crates/core/src/policy.rs
@@ -79,6 +79,10 @@ pub trait PolicyEnforcer: Send + Sync {
         target: Value,
         update: Option<Value>,
     ) -> Result<PolicyEvaluationResult, PolicyError>;
+
+    async fn health_check(&self) -> Result<(), PolicyError> {
+        Ok(())
+    }
 }
 
 #[cfg(any(test, feature = "mock"))]
@@ -94,6 +98,8 @@ mock! {
             target: Value,
             current: Option<Value>
         ) -> Result<PolicyEvaluationResult, PolicyError>;
+
+        async fn health_check(&self) -> Result<(), PolicyError>;
     }
 }
 

--- a/crates/keystone/src/api/health.rs
+++ b/crates/keystone/src/api/health.rs
@@ -1,0 +1,362 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Keystone health check
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use serde::Serialize;
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::keystone::ServiceState;
+
+/// The health status.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+#[repr(usize)]
+enum HealthStatus {
+    /// The check has been skipped.
+    Skipped = 0,
+    /// Up and running.
+    Ok = 1,
+    /// Warn.
+    Warn = 2,
+    /// Error.
+    Error = 3,
+}
+
+/// Health status of the Raft storage.
+#[derive(Clone, Debug, PartialEq, Serialize, ToSchema)]
+struct RaftStatus {
+    /// The error message.
+    message: Option<String>,
+    /// Status of Raft cluster.
+    status: HealthStatus,
+}
+
+impl RaftStatus {
+    pub fn ok() -> Self {
+        Self {
+            message: None,
+            status: HealthStatus::Ok,
+        }
+    }
+
+    pub fn err<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self {
+            message: Some(error.to_string()),
+            status: HealthStatus::Error,
+        }
+    }
+
+    pub fn skipped() -> Self {
+        Self {
+            message: None,
+            status: HealthStatus::Skipped,
+        }
+    }
+
+    pub fn warn<M>(message: M) -> Self
+    where
+        M: Into<String>,
+    {
+        Self {
+            message: Some(message.into()),
+            status: HealthStatus::Warn,
+        }
+    }
+}
+
+/// Health status of the database.
+#[derive(Clone, Debug, PartialEq, Serialize, ToSchema)]
+struct DatabaseStatus {
+    /// The error message.
+    message: Option<String>,
+    /// Status of database.
+    status: HealthStatus,
+}
+
+impl DatabaseStatus {
+    pub fn ok() -> Self {
+        Self {
+            message: None,
+            status: HealthStatus::Ok,
+        }
+    }
+
+    pub fn err<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self {
+            message: Some(error.to_string()),
+            status: HealthStatus::Error,
+        }
+    }
+}
+
+/// Health status of the policy engine.
+#[derive(Clone, Debug, PartialEq, Serialize, ToSchema)]
+struct PolicyStatus {
+    /// The error message.
+    message: Option<String>,
+    /// Status of Raft cluster.
+    status: HealthStatus,
+}
+
+impl PolicyStatus {
+    pub fn ok() -> Self {
+        Self {
+            message: None,
+            status: HealthStatus::Ok,
+        }
+    }
+
+    pub fn warn<M>(message: M) -> Self
+    where
+        M: Into<String>,
+    {
+        Self {
+            message: Some(message.into()),
+            status: HealthStatus::Warn,
+        }
+    }
+}
+
+/// The health components of the system.
+#[derive(Clone, Debug, PartialEq, Serialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+struct HealthComponents {
+    /// Status of the raft storage.
+    raft: RaftStatus,
+    /// Status of the database.
+    database: DatabaseStatus,
+    /// Status of the policy enforcement engine.
+    policy: PolicyStatus,
+}
+
+impl HealthComponents {
+    /// Return the overall health status of the system taking the highest status among all
+    /// components.
+    pub fn overall_status(&self) -> HealthStatus {
+        self.raft
+            .status
+            .max(self.database.status)
+            .max(self.policy.status)
+    }
+}
+
+/// Health check response.
+#[derive(Clone, Debug, Serialize, ToSchema)]
+struct HealthResponse {
+    /// Overall health status of the system.
+    status: HealthStatus,
+    /// Individual health checks.
+    components: HealthComponents,
+}
+
+/// Health check router.
+pub fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new()
+        .routes(routes!(health))
+        .routes(routes!(ready))
+}
+
+/// Readiness health check endpoint.
+///
+/// Perform relevant checks only returning `OK` when all of them are ok. Any check in the
+/// degraded/warn state would result in `SERVICE_UNAVAILABLE` response.
+#[utoipa::path(
+    get,
+    path = "/ready",
+    responses(
+        (status = OK, description = "Service is healthy", body = HealthResponse),
+        (status = SERVICE_UNAVAILABLE, description = "Service is unhealthy", body = HealthResponse),
+    ),
+    tag = "health"
+)]
+async fn ready(State(state): State<ServiceState>) -> impl IntoResponse {
+    let components = HealthComponents {
+        database: check_database(&state).await,
+        policy: check_policy_engine(&state).await,
+        raft: check_storage(&state).await,
+    };
+
+    let status = components.overall_status();
+
+    let status_code = match status {
+        HealthStatus::Skipped => StatusCode::OK,
+        HealthStatus::Ok => StatusCode::OK,
+        _ => StatusCode::SERVICE_UNAVAILABLE,
+    };
+
+    (status_code, Json(HealthResponse { status, components })).into_response()
+}
+
+/// Health check endpoint.
+///
+/// Perform diverse checks to identify the overall status of the system. It can be `OK`,
+/// `SERVICE_UNAVAILABLE`. In difference to the `/ready` check this does not return
+/// `SERVICE_UNAVAILABLE` when components are in the degraded state to prevent from the restart. It
+/// is similar to the `/live` check.
+#[utoipa::path(
+    get,
+    path = "/health",
+    responses(
+        (status = OK, description = "Service is healthy", body = HealthResponse),
+        (status = SERVICE_UNAVAILABLE, description = "Service is unhealthy", body = HealthResponse),
+    ),
+    tag = "health"
+)]
+async fn health(State(state): State<ServiceState>) -> impl IntoResponse {
+    let components = HealthComponents {
+        database: check_database(&state).await,
+        policy: check_policy_engine(&state).await,
+        raft: check_storage(&state).await,
+    };
+
+    let status = components.overall_status();
+
+    let status_code = match status {
+        HealthStatus::Skipped => StatusCode::OK,
+        HealthStatus::Ok => StatusCode::OK,
+        HealthStatus::Warn => StatusCode::OK,
+        _ => StatusCode::SERVICE_UNAVAILABLE,
+    };
+
+    (status_code, Json(HealthResponse { status, components })).into_response()
+}
+
+/// Perform DB related checks.
+async fn check_database(state: &ServiceState) -> DatabaseStatus {
+    match state.db.ping().await {
+        Ok(()) => DatabaseStatus::ok(),
+        Err(err) => DatabaseStatus::err(err),
+    }
+}
+
+/// Perform Raft storage checks.
+async fn check_storage(state: &ServiceState) -> RaftStatus {
+    match &state.storage {
+        None => RaftStatus::skipped(),
+        Some(storage) => {
+            // TODO: many more raft checks should be processed here (e.g., log state,
+            // connection to the leader, storage readiness, etc).
+            match storage.raft.is_initialized().await {
+                Ok(true) => RaftStatus::ok(),
+                Ok(false) => RaftStatus::warn("storage is not initialized"),
+                Err(err) => RaftStatus::err(err),
+            }
+        }
+    }
+}
+
+/// Perform policy health checks.
+async fn check_policy_engine(state: &ServiceState) -> PolicyStatus {
+    match state.policy_enforcer.health_check().await {
+        Ok(()) => PolicyStatus::ok(),
+        Err(_) => PolicyStatus::warn("policy not enforced"),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::super::tests::get_mocked_state;
+    use super::*;
+    use crate::api::health::HealthComponents;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn health_returns_service_unavailable_for_disconnected_db() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None, None).await;
+        let (router, _api) = super::super::openapi_router().split_for_parts();
+        let app = router.with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn test_overall_status() {
+        let dummy_err = || std::io::Error::new(std::io::ErrorKind::Other, "dummy error");
+        assert_eq!(
+            HealthStatus::Ok,
+            HealthComponents {
+                raft: RaftStatus::ok(),
+                database: DatabaseStatus::ok(),
+                policy: PolicyStatus::ok()
+            }
+            .overall_status()
+        );
+        assert_eq!(
+            HealthStatus::Ok,
+            HealthComponents {
+                raft: RaftStatus::skipped(),
+                database: DatabaseStatus::ok(),
+                policy: PolicyStatus::ok()
+            }
+            .overall_status()
+        );
+        assert_eq!(
+            HealthStatus::Warn,
+            HealthComponents {
+                raft: RaftStatus::warn("warn"),
+                database: DatabaseStatus::ok(),
+                policy: PolicyStatus::ok()
+            }
+            .overall_status()
+        );
+        assert_eq!(
+            HealthStatus::Warn,
+            HealthComponents {
+                raft: RaftStatus::skipped(),
+                database: DatabaseStatus::ok(),
+                policy: PolicyStatus::warn("")
+            }
+            .overall_status()
+        );
+        assert_eq!(
+            HealthStatus::Error,
+            HealthComponents {
+                raft: RaftStatus::err(dummy_err()),
+                database: DatabaseStatus::ok(),
+                policy: PolicyStatus::warn("")
+            }
+            .overall_status()
+        );
+        assert_eq!(
+            HealthStatus::Error,
+            HealthComponents {
+                raft: RaftStatus::ok(),
+                database: DatabaseStatus::err(dummy_err()),
+                policy: PolicyStatus::ok()
+            }
+            .overall_status()
+        );
+    }
+}

--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -21,8 +21,9 @@ use axum::{
     http::{HeaderMap, StatusCode, header},
     response::IntoResponse,
 };
+use serde::Serialize;
 use utoipa::{
-    Modify, OpenApi,
+    Modify, OpenApi, ToSchema,
     openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
 };
 use utoipa_axum::{router::OpenApiRouter, routes};
@@ -64,12 +65,44 @@ impl Modify for SecurityAddon {
     }
 }
 
+#[derive(Clone, Copy, Debug, Serialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum HealthStatus {
+    Ok,
+    Error,
+    Skipped,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+struct HealthDependency {
+    name: String,
+    status: HealthStatus,
+    error: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+struct HealthResponse {
+    status: HealthStatus,
+    dependencies: Vec<HealthDependency>,
+}
+
+impl HealthDependency {
+    fn new(name: &str, status: HealthStatus, error: Option<String>) -> Self {
+        Self {
+            name: name.to_string(),
+            status,
+            error,
+        }
+    }
+}
+
 /// Main API router.
 pub fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new()
         .nest("/v3", v3::openapi_router())
         .nest("/v4", v4::openapi_router())
         .routes(routes!(version))
+        .routes(routes!(health))
 }
 
 /// Version discovery endpoint.
@@ -120,17 +153,96 @@ async fn version(
     Ok((StatusCode::OK, Json(res)).into_response())
 }
 
+/// Health check endpoint.
+#[utoipa::path(
+    get,
+    path = "/health",
+    description = "Health check for Keystone and its dependencies",
+    responses(
+        (status = OK, description = "Service is healthy", body = HealthResponse),
+        (status = SERVICE_UNAVAILABLE, description = "Service is unhealthy", body = HealthResponse),
+    ),
+    tag = "health"
+)]
+async fn health(State(state): State<ServiceState>) -> impl IntoResponse {
+    let mut dependencies = Vec::new();
+
+    let db_status = match check_database(&state).await {
+        Ok(()) => HealthDependency::new("database", HealthStatus::Ok, None),
+        Err(err) => HealthDependency::new("database", HealthStatus::Error, Some(err)),
+    };
+    dependencies.push(db_status);
+
+    let policy_status = if state.config.api_policy.enable {
+        match state.policy_enforcer.health_check().await {
+            Ok(()) => HealthDependency::new("policy", HealthStatus::Ok, None),
+            Err(err) => HealthDependency::new("policy", HealthStatus::Error, Some(err.to_string())),
+        }
+    } else {
+        HealthDependency::new("policy", HealthStatus::Skipped, None)
+    };
+    dependencies.push(policy_status);
+
+    let storage_status = match &state.storage {
+        None => HealthDependency::new("distributed_storage", HealthStatus::Skipped, None),
+        Some(storage) => match storage.raft.is_initialized().await {
+            Ok(true) => HealthDependency::new("distributed_storage", HealthStatus::Ok, None),
+            Ok(false) => HealthDependency::new(
+                "distributed_storage",
+                HealthStatus::Error,
+                Some("storage not initialized".to_string()),
+            ),
+            Err(err) => HealthDependency::new(
+                "distributed_storage",
+                HealthStatus::Error,
+                Some(err.to_string()),
+            ),
+        },
+    };
+    dependencies.push(storage_status);
+
+    let status = if dependencies
+        .iter()
+        .any(|dep| dep.status == HealthStatus::Error)
+    {
+        HealthStatus::Error
+    } else {
+        HealthStatus::Ok
+    };
+
+    let status_code = match status {
+        HealthStatus::Ok => StatusCode::OK,
+        _ => StatusCode::SERVICE_UNAVAILABLE,
+    };
+
+    (
+        status_code,
+        Json(HealthResponse {
+            status,
+            dependencies,
+        }),
+    )
+        .into_response()
+}
+
+async fn check_database(state: &ServiceState) -> Result<(), String> {
+    state.db.ping().await.map_err(|err| err.to_string())
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
     use sea_orm::DatabaseConnection;
     use std::sync::Arc;
+    use tower::ServiceExt;
 
     use openstack_keystone_config::Config;
     use openstack_keystone_core_types::identity::UserResponseBuilder;
 
     use crate::keystone::{Service, ServiceState};
     use crate::policy::{MockPolicy, PolicyError, PolicyEvaluationResult};
-    use crate::provider::ProviderBuilder;
+    use crate::provider::{Provider, ProviderBuilder};
     use crate::token::{MockTokenProvider, Token, UnscopedPayload};
 
     pub async fn get_mocked_state(
@@ -187,6 +299,10 @@ pub(crate) mod tests {
                 }
             });
 
+        policy_enforcer_mock
+            .expect_health_check()
+            .returning(|| Ok(()));
+
         Arc::new(
             Service::new(
                 Config::default(),
@@ -197,5 +313,24 @@ pub(crate) mod tests {
             .await
             .unwrap(),
         )
+    }
+
+    #[tokio::test]
+    async fn health_returns_service_unavailable_for_disconnected_db() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None, None).await;
+        let (router, _api) = super::openapi_router().split_for_parts();
+        let app = router.with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -21,9 +21,8 @@ use axum::{
     http::{HeaderMap, StatusCode, header},
     response::IntoResponse,
 };
-use serde::Serialize;
 use utoipa::{
-    Modify, OpenApi, ToSchema,
+    Modify, OpenApi,
     openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
 };
 use utoipa_axum::{router::OpenApiRouter, routes};
@@ -34,6 +33,7 @@ use crate::keystone::ServiceState;
 pub mod auth;
 pub(crate) mod common;
 pub mod error;
+pub mod health;
 pub mod types;
 pub mod v3;
 pub mod v4;
@@ -65,44 +65,13 @@ impl Modify for SecurityAddon {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, ToSchema, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-enum HealthStatus {
-    Ok,
-    Error,
-    Skipped,
-}
-
-#[derive(Clone, Debug, Serialize, ToSchema)]
-struct HealthDependency {
-    name: String,
-    status: HealthStatus,
-    error: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, ToSchema)]
-struct HealthResponse {
-    status: HealthStatus,
-    dependencies: Vec<HealthDependency>,
-}
-
-impl HealthDependency {
-    fn new(name: &str, status: HealthStatus, error: Option<String>) -> Self {
-        Self {
-            name: name.to_string(),
-            status,
-            error,
-        }
-    }
-}
-
 /// Main API router.
 pub fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new()
         .nest("/v3", v3::openapi_router())
         .nest("/v4", v4::openapi_router())
+        .merge(health::openapi_router())
         .routes(routes!(version))
-        .routes(routes!(health))
 }
 
 /// Version discovery endpoint.
@@ -151,82 +120,6 @@ async fn version(
         },
     };
     Ok((StatusCode::OK, Json(res)).into_response())
-}
-
-/// Health check endpoint.
-#[utoipa::path(
-    get,
-    path = "/health",
-    description = "Health check for Keystone and its dependencies",
-    responses(
-        (status = OK, description = "Service is healthy", body = HealthResponse),
-        (status = SERVICE_UNAVAILABLE, description = "Service is unhealthy", body = HealthResponse),
-    ),
-    tag = "health"
-)]
-async fn health(State(state): State<ServiceState>) -> impl IntoResponse {
-    let mut dependencies = Vec::new();
-
-    let db_status = match check_database(&state).await {
-        Ok(()) => HealthDependency::new("database", HealthStatus::Ok, None),
-        Err(err) => HealthDependency::new("database", HealthStatus::Error, Some(err)),
-    };
-    dependencies.push(db_status);
-
-    let policy_status = if state.config.api_policy.enable {
-        match state.policy_enforcer.health_check().await {
-            Ok(()) => HealthDependency::new("policy", HealthStatus::Ok, None),
-            Err(err) => HealthDependency::new("policy", HealthStatus::Error, Some(err.to_string())),
-        }
-    } else {
-        HealthDependency::new("policy", HealthStatus::Skipped, None)
-    };
-    dependencies.push(policy_status);
-
-    let storage_status = match &state.storage {
-        None => HealthDependency::new("distributed_storage", HealthStatus::Skipped, None),
-        Some(storage) => match storage.raft.is_initialized().await {
-            Ok(true) => HealthDependency::new("distributed_storage", HealthStatus::Ok, None),
-            Ok(false) => HealthDependency::new(
-                "distributed_storage",
-                HealthStatus::Error,
-                Some("storage not initialized".to_string()),
-            ),
-            Err(err) => HealthDependency::new(
-                "distributed_storage",
-                HealthStatus::Error,
-                Some(err.to_string()),
-            ),
-        },
-    };
-    dependencies.push(storage_status);
-
-    let status = if dependencies
-        .iter()
-        .any(|dep| dep.status == HealthStatus::Error)
-    {
-        HealthStatus::Error
-    } else {
-        HealthStatus::Ok
-    };
-
-    let status_code = match status {
-        HealthStatus::Ok => StatusCode::OK,
-        _ => StatusCode::SERVICE_UNAVAILABLE,
-    };
-
-    (
-        status_code,
-        Json(HealthResponse {
-            status,
-            dependencies,
-        }),
-    )
-        .into_response()
-}
-
-async fn check_database(state: &ServiceState) -> Result<(), String> {
-    state.db.ping().await.map_err(|err| err.to_string())
 }
 
 #[cfg(test)]
@@ -313,24 +206,5 @@ pub(crate) mod tests {
             .await
             .unwrap(),
         )
-    }
-
-    #[tokio::test]
-    async fn health_returns_service_unavailable_for_disconnected_db() {
-        let state = get_mocked_state(Provider::mocked_builder(), true, None, None).await;
-        let (router, _api) = super::openapi_router().split_for_parts();
-        let app = router.with_state(state);
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/health")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -49,14 +49,14 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 use uuid::Uuid;
 
-use openstack_keystone::api;
-use openstack_keystone::config::Config;
 use openstack_keystone::federation::FederationApi;
 use openstack_keystone::keystone::{Service, ServiceState};
 use openstack_keystone::plugin_manager::PluginManager;
 use openstack_keystone::policy::HttpPolicyEnforcer;
 use openstack_keystone::provider::Provider;
 use openstack_keystone::webauthn;
+use openstack_keystone::{api, common};
+use openstack_keystone::{common::KeystoneResponseClassifier, config::Config};
 use openstack_keystone_distributed_storage::app::get_app_server;
 
 // Default body limit 256kB
@@ -240,8 +240,7 @@ async fn main() -> Result<(), Report> {
         .sensitive_request_headers(sensitive_headers.clone())
         .layer(DefaultBodyLimit::max(DEFAULT_BODY_LIMIT))
         .layer(
-            TraceLayer::new_for_http()
-                //.make_span_with(DefaultMakeSpan::new().include_headers(true))
+            TraceLayer::new(common::KeystoneResponseClassifier)
                 .make_span_with(|request: &Request<_>| {
                     info_span!(
                         "request",

--- a/crates/keystone/src/common.rs
+++ b/crates/keystone/src/common.rs
@@ -12,4 +12,60 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # Common functionality
+use std::fmt;
+
+use axum::http::{Request, Response, StatusCode};
+use tower_http::classify::{
+    ClassifiedResponse, ClassifyResponse, MakeClassifier, NeverClassifyEos,
+};
+
 pub use openstack_keystone_core::common::*;
+
+/// Custom Response classifier to silent the 503 errors which are "normal" logic.
+#[derive(Clone)]
+pub struct KeystoneResponseClassifier;
+
+impl ClassifyResponse for KeystoneResponseClassifier {
+    type FailureClass = String;
+    type ClassifyEos = NeverClassifyEos<Self::FailureClass>;
+
+    fn classify_response<B>(
+        self,
+        res: &Response<B>,
+    ) -> ClassifiedResponse<Self::FailureClass, Self::ClassifyEos> {
+        let status = res.status();
+
+        // Logic: If it's a 503, we check if we should "ignore" it.
+        // For a global layer, you can simply decide that 503s are NEVER hard errors
+        // because in a Raft/Distributed system, 503 is an expected state (Catching up).
+        if status == StatusCode::SERVICE_UNAVAILABLE {
+            return ClassifiedResponse::Ready(Ok(()));
+        }
+
+        if status.is_server_error() {
+            ClassifiedResponse::Ready(Err(format!("Server Error: {}", status)))
+        } else if status.is_client_error() {
+            ClassifiedResponse::Ready(Err(format!("Client Error: {}", status)))
+        } else {
+            ClassifiedResponse::Ready(Ok(()))
+        }
+    }
+
+    fn classify_error<E>(self, error: &E) -> Self::FailureClass
+    where
+        E: fmt::Display,
+    {
+        error.to_string()
+    }
+}
+
+// Factory to provide the classifier to the middleware.
+impl MakeClassifier for KeystoneResponseClassifier {
+    type Classifier = Self;
+    type FailureClass = String;
+    type ClassifyEos = NeverClassifyEos<Self::FailureClass>;
+
+    fn make_classifier<B>(&self, _request: &Request<B>) -> Self::Classifier {
+        self.clone()
+    }
+}

--- a/crates/keystone/src/policy.rs
+++ b/crates/keystone/src/policy.rs
@@ -28,6 +28,8 @@ pub struct HttpPolicyEnforcer {
     http_client: Arc<Client>,
     /// OPA url address.
     base_url: Url,
+    /// OPA health url address.
+    health_url: Url,
 }
 
 impl HttpPolicyEnforcer {
@@ -42,6 +44,7 @@ impl HttpPolicyEnforcer {
         Ok(Self {
             http_client: Arc::new(client),
             base_url: url.join("/v1/data/")?,
+            health_url: url.join("/health")?,
         })
     }
 }
@@ -96,5 +99,14 @@ impl PolicyEnforcer for HttpPolicyEnforcer {
             return Err(PolicyError::Forbidden(res));
         }
         Ok(res)
+    }
+
+    async fn health_check(&self) -> Result<(), PolicyError> {
+        self.http_client
+            .get(self.health_url.as_str())
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
     }
 }

--- a/crates/storage/build.rs
+++ b/crates/storage/build.rs
@@ -5,6 +5,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/storage.proto",
     ];
 
+    // Use PROTOC_INCLUDE env var if set; otherwise auto-detect common system paths.
+    let sys_include = std::env::var("PROTOC_INCLUDE").ok().or_else(|| {
+        ["/usr/include", "/usr/local/include"]
+            .iter()
+            .find(|p| std::path::Path::new(p).exists())
+            .map(|p| p.to_string())
+    });
+    let mut includes = vec!["proto"];
+    if let Some(ref extra) = sys_include {
+        includes.push(extra.as_str());
+    }
+
     tonic_prost_build::configure()
         .btree_map(".")
         .type_attribute("keystone.raft.Entry", "#[derive(Deserialize, Serialize)]")
@@ -45,6 +57,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         //            "#[derive(serde::Deserialize, serde::Serialize)]",
         //        )
         //.type_attribute("keystone.api.Response", "#[derive(Deserialize, Serialize)]")
-        .compile_protos(&proto_files, &["proto"])?;
+        .compile_protos(&proto_files, &includes)?;
     Ok(())
 }

--- a/tools/k8s/keystone/base/statefulset-rs.yaml
+++ b/tools/k8s/keystone/base/statefulset-rs.yaml
@@ -75,7 +75,7 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /
+              path: /health
               port: keystone-rs
               scheme: HTTP
             periodSeconds: 10


### PR DESCRIPTION
Add a basic healthcheck endpoint that returns the health of important dependencies like the database, opa or raft.