### PR TITLE
feat: Talk to OPA over unix socket

### DIFF
--- a/crates/core/src/policy.rs
+++ b/crates/core/src/policy.rs
@@ -58,6 +58,10 @@ pub enum PolicyError {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
 
+    /// Unsupported access scheme.
+    #[error("unsupported scheme {0}")]
+    UnsupportedScheme(String),
+
     /// Url parsing error.
     #[error(transparent)]
     UrlParse(#[from] url::ParseError),

--- a/crates/keystone/src/policy.rs
+++ b/crates/keystone/src/policy.rs
@@ -38,22 +38,37 @@ impl HttpPolicyEnforcer {
     /// Creates a new `HttpPolicyEnforcer`.
     ///
     /// # Parameters
-    /// * `url` - The base URL of the OPA server.
+    /// * `url` - The base URL of the OPA server. Can be http/https or the unix socket
     ///
     /// # Returns
     /// A `Result` containing the `HttpPolicyEnforcer` instance, or a
     /// `PolicyError`.
     pub async fn new(url: Url) -> Result<Self, PolicyError> {
-        let client = Client::builder()
-            .tcp_keepalive(std::time::Duration::from_secs(60))
-            .gzip(true)
-            .deflate(true)
-            .build()?;
-        Ok(Self {
-            http_client: Arc::new(client),
-            base_url: url.join("/v1/data/")?,
-            health_url: url.join("/health")?,
-        })
+        match url.scheme() {
+            "http" | "https" => {
+                // Communication with OPA over the network IF
+                let client = Client::builder()
+                    .tcp_keepalive(std::time::Duration::from_secs(60))
+                    .gzip(true)
+                    .deflate(true)
+                    .build()?;
+                Ok(Self {
+                    http_client: Arc::new(client),
+                    base_url: url.join("/v1/data/")?,
+                    health_url: url.join("/health")?,
+                })
+            }
+            "unix" => {
+                // Communication with OPA over the unix socket
+                let client = Client::builder().unix_socket(url.path()).build()?;
+                Ok(Self {
+                    http_client: Arc::new(client),
+                    base_url: "http://localhost/v1/data/".parse()?,
+                    health_url: "http://localhost/health".parse()?,
+                })
+            }
+            other => return Err(PolicyError::UnsupportedScheme(other.to_string())),
+        }
     }
 }
 
@@ -130,5 +145,32 @@ impl PolicyEnforcer for HttpPolicyEnforcer {
             .await?
             .error_for_status()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_constructor() {
+        let enforcer = HttpPolicyEnforcer::new("http://foo.bar".parse().unwrap())
+            .await
+            .unwrap();
+        assert_eq!("http://foo.bar/v1/data/", enforcer.base_url.as_str());
+        assert_eq!("http://foo.bar/health", enforcer.health_url.as_str());
+        let enforcer = HttpPolicyEnforcer::new("unix:///var/test.sock".parse().unwrap())
+            .await
+            .unwrap();
+        assert_eq!("http://localhost/v1/data/", enforcer.base_url.as_str());
+        assert_eq!("http://localhost/health", enforcer.health_url.as_str());
+        match HttpPolicyEnforcer::new("moz:///var/test.sock".parse().unwrap()).await {
+            Err(PolicyError::UnsupportedScheme(s)) => {
+                assert_eq!("moz", s);
+            }
+            _ => {
+                panic!("should be unsupported scheme");
+            }
+        }
     }
 }

--- a/tools/k8s/keystone/base/conf/keystone.conf
+++ b/tools/k8s/keystone/base/conf/keystone.conf
@@ -6,7 +6,7 @@ use_stderr = true
 methods = password,token,openid,application_credential,x509,mapped
 
 [api_policy]
-opa_base_url = http://localhost:8181
+opa_base_url = unix:///var/opa/opa.sock
 
 [webauthn]
 enabled = true

--- a/tools/k8s/keystone/base/statefulset-rs.yaml
+++ b/tools/k8s/keystone/base/statefulset-rs.yaml
@@ -121,13 +121,18 @@ spec:
             - mountPath: /run/spire/sockets
               name: spiffe-workload-api
               readOnly: true
+            - mountPath: "/var/opa"
+              name: "opa-socket"
 
-        - command: ["opa", "run", "--server", "/policy", "--addr", ":8181", "--log-level", "debug"]
+        - command: ["opa", "run", "--server", "/policy", "--addr", "unix:///var/opa/opa.sock", "--log-level", "debug"]
           image: opa
           name: opa
           ports:
             - containerPort: 8181
               name: http
+          volumeMounts:
+            - mountPath: /var/opa
+              name: opa-socket
 
       volumes:
         - name: config
@@ -154,6 +159,8 @@ spec:
         - name: raft-storage
           emptyDir: {}
         - name: raft-config-shared
+          emptyDir: {}
+        - name: opa-socket
           emptyDir: {}
         - name: "spiffe-workload-api"
           csi:


### PR DESCRIPTION
It is possible to communicate with OPA (when it is running as a
side-care) over the unix socket what helps to improve the latency.
Extend the policy enforcer with the specific logic of establishing the
Reqwest client over the socket and switch to that by default in the
skaffold setup.

Fixes: #698
