### PR TITLE
feat: Add spiffe provider

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,8 @@
 experimental = ["setup-scripts"]
 
 [profile.default]
+# exclude raft-only tests
+default-filter = 'not test(/spiffe/)'
 # Global default settings
 #
 [scripts.setup.setup-pg]
@@ -17,6 +19,7 @@ command = { command-line = [ "tools/raft-env.sh" ] }
 
 # --- POSTGRES PROFILE ---
 [profile.postgres]
+
 [[profile.postgres.scripts]]
 filter = "binary(api)"
 setup = "setup-pg"
@@ -29,6 +32,7 @@ setup = "setup-pg"
 
 # --- MYSQL PROFILE ---
 [profile.mysql]
+
 [[profile.mysql.scripts]]
 filter = "binary(api)"
 setup = "setup-mysql"
@@ -40,6 +44,8 @@ filter = "binary(provider)"
 setup = "setup-mysql"
 
 [profile.raft]
+default-filter = "all()"
+
 [[profile.raft.scripts]]
 filter = "binary(integration)"
 setup = "raft-env"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,6 +3597,7 @@ dependencies = [
  "openstack-keystone-resource-sql",
  "openstack-keystone-revoke-sql",
  "openstack-keystone-role-sql",
+ "openstack-keystone-spiffe-raft",
  "openstack-keystone-token-fernet",
  "openstack-keystone-token-restriction-sql",
  "openstack-keystone-trust-sql",
@@ -3953,6 +3954,19 @@ dependencies = [
  "sea-orm",
  "serde_json",
  "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "openstack-keystone-spiffe-raft"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "inventory",
+ "openstack-keystone-core",
+ "openstack-keystone-core-types",
+ "openstack-keystone-distributed-storage",
  "tracing",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
   "crates/cli-manage",
   "tests/api",
   "tests/integration",
-  "tests/federation", "crates/k8s-auth-raft",
+  "tests/federation", "crates/k8s-auth-raft", "crates/spiffe-raft",
 ]
 exclude = [
   "tests/loadtest"
@@ -114,7 +114,7 @@ url-macro = { version = "0.2" }
 utoipa = { version = "5.5" }
 utoipa-axum = { version = "0.2" }
 utoipa-swagger-ui = { version = "9.0", default-features = false }
-uuid = { version = "1.23" }
+uuid = { version = "1.23", features = ["v4"] }
 validator = { version = "0.20" }
 webauthn-authenticator-rs = { version = "0.5" }
 webauthn-rs = { version = "0.5" }

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -31,6 +31,7 @@ use openstack_keystone_core_types::identity::IdentityProviderError;
 use openstack_keystone_core_types::resource::ResourceProviderError;
 use openstack_keystone_core_types::revoke::RevokeProviderError;
 use openstack_keystone_core_types::role::RoleProviderError;
+use openstack_keystone_core_types::spiffe::SpiffeProviderError;
 use openstack_keystone_core_types::token::TokenProviderError;
 
 use crate::error::KeystoneApiError;
@@ -224,6 +225,15 @@ impl From<RevokeProviderError> for KeystoneApiError {
     fn from(value: RevokeProviderError) -> Self {
         match value {
             ref err @ RevokeProviderError::Conflict(..) => Self::BadRequest(err.to_string()),
+            other => Self::InternalError(other.to_string()),
+        }
+    }
+}
+
+impl From<SpiffeProviderError> for KeystoneApiError {
+    fn from(value: SpiffeProviderError) -> Self {
+        match value {
+            ref err @ SpiffeProviderError::Conflict(..) => Self::BadRequest(err.to_string()),
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/config/src/common.rs
+++ b/crates/config/src/common.rs
@@ -74,6 +74,10 @@ pub fn default_sql_driver() -> String {
     "sql".into()
 }
 
+pub fn default_raft_driver() -> String {
+    "raft".into()
+}
+
 pub fn default_true() -> bool {
     true
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -75,6 +75,7 @@ mod resource;
 mod revoke;
 mod role;
 mod security_compliance;
+mod spiffe;
 mod token;
 mod token_restriction;
 mod trust;
@@ -100,6 +101,7 @@ pub use resource::*;
 pub use revoke::*;
 pub use role::*;
 pub use security_compliance::*;
+pub use spiffe::*;
 pub use token::*;
 pub use token_restriction::*;
 pub use trust::*;
@@ -182,6 +184,10 @@ pub struct Config {
     /// Security compliance configuration.
     #[serde(default)]
     pub security_compliance: SecurityComplianceProvider,
+
+    /// Spiffe provider configuration.
+    #[serde(default)]
+    pub spiffe: SpiffeProvider,
 
     /// Token provider configuration.
     #[serde(default)]

--- a/crates/config/src/spiffe.rs
+++ b/crates/config/src/spiffe.rs
@@ -11,30 +11,22 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+use serde::Deserialize;
 
-//! # OpenStack Keystone core provider types
+use crate::common::default_raft_driver;
 
-#![allow(clippy::module_inception)]
-#![deny(clippy::unwrap_used)]
+/// Spiffe provider.
+#[derive(Debug, Deserialize, Clone)]
+pub struct SpiffeProvider {
+    /// Spiffe backend.
+    #[serde(default = "default_raft_driver")]
+    pub driver: String,
+}
 
-pub mod application_credential;
-pub mod assignment;
-pub mod auth;
-pub mod catalog;
-pub mod error;
-pub mod federation;
-pub mod identity;
-pub mod identity_mapping;
-pub mod k8s_auth;
-pub mod resource;
-pub mod revoke;
-pub mod role;
-pub mod scope;
-pub mod spiffe;
-pub mod token;
-pub mod trust;
-
-/// Return `true` to be used as a positive default for the serde macros.
-pub fn default_true() -> bool {
-    true
+impl Default for SpiffeProvider {
+    fn default() -> Self {
+        Self {
+            driver: default_raft_driver(),
+        }
+    }
 }

--- a/crates/core-types/src/assignment/assignment.rs
+++ b/crates/core-types/src/assignment/assignment.rs
@@ -183,6 +183,22 @@ impl AssignmentCreate {
             inherited,
         )
     }
+
+    /// Instantiate UserSystem assignment.
+    pub fn user_system<A, T, R>(actor_id: A, target_id: T, role_id: R, inherited: bool) -> Self
+    where
+        A: Into<String>,
+        T: Into<String>,
+        R: Into<String>,
+    {
+        Self::new(
+            actor_id,
+            target_id,
+            role_id,
+            AssignmentType::UserSystem,
+            inherited,
+        )
+    }
 }
 
 /// Role assignment type.

--- a/crates/core-types/src/auth.rs
+++ b/crates/core-types/src/auth.rs
@@ -36,6 +36,7 @@ use crate::error::BuilderError;
 use crate::identity::{Group, UserResponse};
 use crate::resource::{Domain, Project};
 use crate::role::RoleRef;
+use crate::spiffe::SpiffeBinding;
 use crate::token::{FernetToken, TokenRestriction};
 use crate::trust::Trust;
 
@@ -590,6 +591,7 @@ impl SecurityContext {
                     AuthenticationContext::Oidc { .. } => Ok(()),
                     AuthenticationContext::K8s(_) => Err(AuthenticationError::ScopeNotAllowed),
                     AuthenticationContext::Password => Ok(()),
+                    AuthenticationContext::Spiffe(_) => Ok(()),
                     AuthenticationContext::Token(_) => Ok(()),
                     AuthenticationContext::Trust { .. } => {
                         Err(AuthenticationError::ScopeNotAllowed)
@@ -618,6 +620,7 @@ impl SecurityContext {
                     AuthenticationContext::Oidc { .. } => Ok(()),
                     AuthenticationContext::K8s(_) => Ok(()),
                     AuthenticationContext::Password => Ok(()),
+                    AuthenticationContext::Spiffe(_) => Ok(()),
                     AuthenticationContext::Token(_) => Ok(()),
                     AuthenticationContext::Trust { .. } => {
                         // Trust authentication must use TrustProject scope. Rescoping to a plain
@@ -638,6 +641,7 @@ impl SecurityContext {
                     AuthenticationContext::Oidc { .. } => Err(AuthenticationError::ScopeNotAllowed),
                     AuthenticationContext::K8s(_) => Err(AuthenticationError::ScopeNotAllowed),
                     AuthenticationContext::Password => Ok(()),
+                    AuthenticationContext::Spiffe(_) => Err(AuthenticationError::ScopeNotAllowed),
                     AuthenticationContext::Token(_) => Ok(()),
                     AuthenticationContext::Trust { .. } => Err(AuthenticationError::Forbidden),
                     AuthenticationContext::WebauthN => Err(AuthenticationError::ScopeNotAllowed),
@@ -648,13 +652,13 @@ impl SecurityContext {
                     return Err(AuthenticationError::ScopeNotAllowed);
                 };
                 match &self.authentication_context {
-                    // TODO: SPIFFE auth should be included here
                     AuthenticationContext::ApplicationCredential { .. } => {
                         Err(AuthenticationError::ScopeNotAllowed)
                     }
                     AuthenticationContext::Oidc { .. } => Err(AuthenticationError::ScopeNotAllowed),
                     AuthenticationContext::K8s(_) => Err(AuthenticationError::ScopeNotAllowed),
                     AuthenticationContext::Password => Ok(()),
+                    AuthenticationContext::Spiffe(_) => Ok(()),
                     AuthenticationContext::Token(_) => Ok(()),
                     AuthenticationContext::Trust { .. } => {
                         Err(AuthenticationError::ScopeNotAllowed)
@@ -673,6 +677,7 @@ impl SecurityContext {
                     AuthenticationContext::Oidc { .. } => Ok(()),
                     AuthenticationContext::K8s(_) => Err(AuthenticationError::ScopeNotAllowed),
                     AuthenticationContext::Password => Ok(()),
+                    AuthenticationContext::Spiffe(_) => Ok(()),
                     AuthenticationContext::Token(_) => Ok(()),
                     AuthenticationContext::Trust { .. } => {
                         Err(AuthenticationError::ScopeNotAllowed)
@@ -864,10 +869,10 @@ impl PrincipalInfo {
             IdentityInfo::User(user) => {
                 if let Some(domain) = &user.user_domain {
                     Some(domain.id.clone())
-                } else if let Some(user_resp) = &user.user {
-                    Some(user_resp.domain_id.clone())
                 } else {
-                    None
+                    user.user
+                        .as_ref()
+                        .map(|user_resp| user_resp.domain_id.clone())
                 }
             }
             IdentityInfo::Principal(principal) => {
@@ -942,16 +947,10 @@ impl IdentityInfo {
             Self::User(user) => user.validate(),
             Self::Principal(principal) => {
                 principal.validate()?;
-                if let Some(domain) = &principal.domain {
-                    if !domain.enabled {
-                        return Err(AuthenticationError::DomainDisabled(domain.id.clone()));
-                    }
-                } else {
-                    warn!(
-                        "Principal domain data must be resolved before validating: {:?}",
-                        principal
-                    );
-                    return Err(AuthenticationError::Unauthorized);
+                if let Some(domain) = &principal.domain
+                    && !domain.enabled
+                {
+                    return Err(AuthenticationError::DomainDisabled(domain.id.clone()));
                 }
                 Ok(())
             }
@@ -1110,6 +1109,8 @@ pub enum AuthenticationContext {
     K8s(K8sContext),
     /// Login with password.
     Password,
+    /// SPIRE authentication.
+    Spiffe(SpiffeBinding),
     /// Login using regular fernet/jwt token.
     Token(FernetToken),
     /// Login consuming the trust.
@@ -1152,6 +1153,7 @@ impl AuthenticationContext {
             Self::Oidc { .. } => once("openid".to_string()).collect(),
             Self::Password => once("password".to_string()).collect(),
             Self::K8s(_) => once("mapped".to_string()).collect(),
+            Self::Spiffe(_) => once("x509".to_string()).collect(),
             Self::Token(token) => token
                 .methods()
                 .iter()
@@ -1493,7 +1495,6 @@ mod tests {
             is_domain: false,
             parent_id: None,
             extra: HashMap::new(),
-            ..Default::default()
         }
     }
 
@@ -2177,12 +2178,10 @@ mod tests {
             AuthenticationContext::Password
         ));
         assert!(matches!(ctx.principal().identity, IdentityInfo::User(_)));
-        let authz_scope_match = if let Some(AuthzInfo { scope, .. }) = ctx.authorization() {
-            if let ScopeInfo::Project { project, .. } = scope {
-                project.id == "pid"
-            } else {
-                false
-            }
+        let authz_scope_match = if let Some(AuthzInfo { scope, .. }) = ctx.authorization()
+            && let ScopeInfo::Project { project, .. } = scope
+        {
+            project.id == "pid"
         } else {
             false
         };
@@ -2249,10 +2248,7 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        assert!(matches!(
-            principal.validate(),
-            Err(AuthenticationError::Unauthorized)
-        ));
+        assert!(principal.validate().is_ok());
     }
 
     #[test]

--- a/crates/core-types/src/error.rs
+++ b/crates/core-types/src/error.rs
@@ -27,6 +27,7 @@ use crate::k8s_auth::K8sAuthProviderError;
 use crate::resource::ResourceProviderError;
 use crate::revoke::RevokeProviderError;
 use crate::role::RoleProviderError;
+use crate::spiffe::SpiffeProviderError;
 use crate::token::TokenProviderError;
 use crate::trust::TrustProviderError;
 
@@ -170,6 +171,14 @@ pub enum KeystoneError {
         /// The source of the error.
         #[from]
         source: RoleProviderError,
+    },
+
+    /// Spiffe provider.
+    #[error(transparent)]
+    SpiffeProvider {
+        /// The source of the error.
+        #[from]
+        source: SpiffeProviderError,
     },
 
     /// Token provider.

--- a/crates/core-types/src/k8s_auth/error.rs
+++ b/crates/core-types/src/k8s_auth/error.rs
@@ -105,7 +105,7 @@ pub enum K8sAuthProviderError {
     #[error("raft storage is not available in the k8s_auth provider")]
     RaftNotAvailable,
 
-    /// Raft storage is not available.
+    /// Raft storage error.
     #[error("raft storage error in the k8s_auth provider")]
     RaftStoreError {
         /// The source of the error.

--- a/crates/core-types/src/resource/domain.rs
+++ b/crates/core-types/src/resource/domain.rs
@@ -15,14 +15,14 @@
 use std::collections::{HashMap, HashSet};
 
 use derive_builder::Builder;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use validator::Validate;
 
 use crate::error::BuilderError;
 
 /// Domain data.
-#[derive(Builder, Clone, Debug, Default, PartialEq, Serialize, Validate)]
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Domain {

--- a/crates/core-types/src/resource/project.rs
+++ b/crates/core-types/src/resource/project.rs
@@ -14,14 +14,14 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 use validator::Validate;
 
 use crate::error::BuilderError;
 
-#[derive(Builder, Clone, Debug, Default, PartialEq, Serialize, Validate)]
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Project {

--- a/crates/core-types/src/role/role.rs
+++ b/crates/core-types/src/role/role.rs
@@ -14,7 +14,7 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use validator::Validate;
 
@@ -50,7 +50,7 @@ pub struct Role {
 }
 
 /// Short role representation (reference).
-#[derive(Builder, Clone, Debug, PartialEq, Serialize, Validate)]
+#[derive(Builder, Clone, Debug, Deserialize, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct RoleRef {

--- a/crates/core-types/src/spiffe.rs
+++ b/crates/core-types/src/spiffe.rs
@@ -11,30 +11,10 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+//! # SPIFFE managed identity
 
-//! # OpenStack Keystone core provider types
+mod binding;
+mod error;
 
-#![allow(clippy::module_inception)]
-#![deny(clippy::unwrap_used)]
-
-pub mod application_credential;
-pub mod assignment;
-pub mod auth;
-pub mod catalog;
-pub mod error;
-pub mod federation;
-pub mod identity;
-pub mod identity_mapping;
-pub mod k8s_auth;
-pub mod resource;
-pub mod revoke;
-pub mod role;
-pub mod scope;
-pub mod spiffe;
-pub mod token;
-pub mod trust;
-
-/// Return `true` to be used as a positive default for the serde macros.
-pub fn default_true() -> bool {
-    true
-}
+pub use binding::*;
+pub use error::*;

--- a/crates/core-types/src/spiffe/binding.rs
+++ b/crates/core-types/src/spiffe/binding.rs
@@ -1,0 +1,195 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # SPIFFE binding
+//!
+//! A binding represents a fixed bind between the SPIFFE identity and the
+//! OpenStack user and scope.
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use crate::error::BuilderError;
+use crate::role::RoleRef;
+
+/// Authorization information.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub enum SpiffeAuthorization {
+    /// Domain scope.
+    Domain {
+        /// Domain ID.
+        domain_id: String,
+        /// Roles to limit the authorization to.
+        role_ids: Option<Vec<String>>,
+    },
+    /// Project scope.
+    // TODO: to increase fine-granularity individual policy rules can be listed instead of the
+    // roles, but that require a new approach of how to enable protection so that not admin
+    // does not get access to the admin-only rule.
+    Project {
+        /// Project ID.
+        project_id: String,
+        /// Roles to limit the authorization to.
+        role_ids: Option<Vec<String>>,
+    },
+    /// System authorization
+    System {
+        /// System ID.
+        system_id: String,
+        /// Roles to limit the authorization to.
+        role_ids: Option<Vec<String>>,
+    },
+}
+
+impl SpiffeAuthorization {
+    /// Return role ids bound by the authorization as a vector or [`RoleRef`].
+    pub fn role_refs(&self) -> Option<Vec<RoleRef>> {
+        match &self {
+            Self::Domain { role_ids, .. } => role_ids.as_ref().map(|rids| {
+                rids.iter()
+                    .map(|rid| RoleRef {
+                        id: rid.clone(),
+                        name: None,
+                        domain_id: None,
+                    })
+                    .collect()
+            }),
+            Self::Project { role_ids, .. } => role_ids.as_ref().map(|rids| {
+                rids.iter()
+                    .map(|rid| RoleRef {
+                        id: rid.clone(),
+                        name: None,
+                        domain_id: None,
+                    })
+                    .collect()
+            }),
+            Self::System { role_ids, .. } => role_ids.as_ref().map(|rids| {
+                rids.iter()
+                    .map(|rid| RoleRef {
+                        id: rid.clone(),
+                        name: None,
+                        domain_id: None,
+                    })
+                    .collect()
+            }),
+        }
+    }
+}
+
+/// Spiffe identity binding.
+#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct SpiffeBinding {
+    /// Bound authorizations.
+    pub authorizations: Option<Vec<SpiffeAuthorization>>,
+
+    /// Domain ID the identity belongs to.
+    pub domain_id: String,
+
+    /// SPIFFE SVID.
+    pub svid: String,
+
+    /// Flag indicating the system wide identity (system scope). This property
+    /// cannot be changed after creation.
+    pub is_system: bool,
+
+    /// The ID of the User the identity is mapped to. When not specified a
+    /// virtual user_id is being derived from the SVID.
+    pub user_id: Option<String>,
+}
+
+/// New binding.
+#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct SpiffeBindingCreate {
+    /// Bound authorizations.
+    pub authorizations: Option<Vec<SpiffeAuthorization>>,
+
+    /// Domain ID the identity belongs to.
+    pub domain_id: String,
+
+    /// SPIFFE SVID.
+    pub svid: String,
+
+    /// Flag indicating the system wide identity (system scope). This property
+    /// cannot be changed after creation. System bindings are also protected
+    /// from deletion.
+    pub is_system: bool,
+
+    /// The ID of the User the identity is mapped to. When not specified a
+    /// virtual user_id is being derived from the SVID.
+    pub user_id: Option<String>,
+}
+
+/// Update Spiffe binding.
+#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct SpiffeBindingUpdate {
+    /// Bound authorizations.
+    pub authorizations: Option<Vec<SpiffeAuthorization>>,
+}
+
+/// K8s Auth role list parameters.
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
+pub struct SpiffeBindingListParameters {
+    /// Domain ID the filter identity bindings.
+    pub domain_id: Option<String>,
+
+    /// The ID of the User the identity is mapped to.
+    pub user_id: Option<String>,
+}
+
+pub enum SpiffeBindingFilter {
+    Domain(String),
+}
+
+impl SpiffeBindingFilter {
+    pub fn matches(&self, obj: &SpiffeBinding) -> bool {
+        match self {
+            SpiffeBindingFilter::Domain(val) => obj.domain_id == *val,
+        }
+    }
+}
+
+impl From<SpiffeBindingCreate> for SpiffeBinding {
+    fn from(value: SpiffeBindingCreate) -> Self {
+        Self {
+            authorizations: value.authorizations,
+            domain_id: value.domain_id,
+            svid: value.svid,
+            is_system: value.is_system,
+            user_id: value.user_id,
+        }
+    }
+}
+
+impl SpiffeBinding {
+    /// Apply the [`SpiffeBindingUpdate`] to the [`SpiffeBinding`] structure
+    /// returning the new object.
+    ///
+    /// Construct a new version of the [`SpiffeBinding`] for persisting in the
+    /// storage.
+    pub fn with_update(self, update: SpiffeBindingUpdate) -> Self {
+        Self {
+            authorizations: update.authorizations,
+            domain_id: self.domain_id,
+            svid: self.svid,
+            is_system: self.is_system,
+            user_id: self.user_id,
+        }
+    }
+}

--- a/crates/core-types/src/spiffe/error.rs
+++ b/crates/core-types/src/spiffe/error.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # K8s Auth error
+
+use thiserror::Error;
+
+use crate::error::BuilderError;
+
+/// Spiffe provider error.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum SpiffeProviderError {
+    /// Binding not found.
+    #[error("SVID binding is not found")]
+    BindingNotFound(String),
+
+    /// Conflict.
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Driver error.
+    #[error("backend driver error: {source}")]
+    Driver {
+        /// The source of the error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// Raft storage is not available.
+    #[error("raft storage is not available in the spiffe identity provider")]
+    RaftNotAvailable,
+
+    /// Raft storage error.
+    #[error("raft storage error in the spiffe provider")]
+    RaftStoreError {
+        /// The source of the error.
+        #[from]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Structures builder error.
+    #[error(transparent)]
+    StructBuilder {
+        /// The source of the error.
+        #[from]
+        source: Box<BuilderError>,
+    },
+
+    /// Unsupported driver.
+    #[error("unsupported driver `{0}` for the spiffe provider")]
+    UnsupportedDriver(String),
+}
+
+impl SpiffeProviderError {
+    /// Raft storage error.
+    pub fn raft<E>(source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::RaftStoreError {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<BuilderError> for SpiffeProviderError {
+    fn from(value: BuilderError) -> Self {
+        Self::StructBuilder {
+            source: Box::new(value),
+        }
+    }
+}

--- a/crates/core-types/src/token.rs
+++ b/crates/core-types/src/token.rs
@@ -92,6 +92,9 @@ impl FernetToken {
                 AuthenticationContext::Password => Ok(Self::DomainScope(
                     DomainScopePayload::from_security_context(ctx, domain, expires_at)?,
                 )),
+                AuthenticationContext::Spiffe(_) => {
+                    todo!()
+                }
                 AuthenticationContext::Token(..) => Ok(Self::DomainScope(
                     DomainScopePayload::from_security_context(ctx, domain, expires_at)?,
                 )),
@@ -118,6 +121,9 @@ impl FernetToken {
                         ctx, project, oidc, expires_at,
                     )?,
                 )),
+                AuthenticationContext::Spiffe(_) => {
+                    todo!()
+                }
                 _ => Ok(Self::ProjectScope(
                     ProjectScopePayload::from_security_context(ctx, project, expires_at)?,
                 )),
@@ -135,6 +141,9 @@ impl FernetToken {
                 AuthenticationContext::Oidc { oidc, .. } => Ok(Self::FederationUnscoped(
                     FederationUnscopedPayload::from_security_context(ctx, oidc, expires_at)?,
                 )),
+                AuthenticationContext::Spiffe(_) => {
+                    todo!()
+                }
 
                 _ => Ok(Self::Unscoped(UnscopedPayload::from_security_context(
                     ctx, expires_at,

--- a/crates/core-types/src/trust/trust.rs
+++ b/crates/core-types/src/trust/trust.rs
@@ -15,7 +15,7 @@
 //! # Trust types
 use chrono::{DateTime, Utc};
 use derive_builder::Builder;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use validator::Validate;
 
@@ -23,7 +23,7 @@ use crate::error::BuilderError;
 use crate::role::RoleRef;
 
 /// A trust object.
-#[derive(Builder, Clone, Debug, Default, Serialize, PartialEq, Validate)]
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Trust {

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -23,10 +23,12 @@ use spiffe::SpiffeId;
 use tracing::{debug, error};
 
 use openstack_keystone_config::Interface;
+use openstack_keystone_core_types::auth::*;
 
 use crate::api::KeystoneApiError;
 use crate::auth::ValidatedSecurityContext;
 use crate::keystone::ServiceState;
+use crate::spiffe::SpiffeApi;
 use crate::token::TokenApi;
 
 #[derive(Debug, Clone)]
@@ -47,6 +49,21 @@ where
     type Rejection = KeystoneApiError;
 
     #[tracing::instrument(skip(state), err)]
+    /// Try to authenticate the request
+    ///
+    /// Authenticate the request creating the `ValidatedSecurityContext` using
+    /// the following information:
+    ///
+    /// * `mTLS` - SPIFFE issued x509 certificate that is passed as an extension
+    ///   by the mtls
+    /// connection handler. For the SVID a corresponding binding is looked up.
+    /// When present the `ValidatedSecurityContext` is attempted to be
+    /// instantiated as `ScopeInfo::Unscoped` scope.
+    /// * `X-Auth-Token` - HTTP header is used as encoded `FernetToken` which is
+    ///   decoded and used
+    /// to instantiate the `ValidatedSecurityContext`. The `FernetToken` always
+    /// contains the scope information (whether it is scoped or explicitly
+    /// Unscoped).
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         #[cfg(any(test, feature = "mock"))]
         {
@@ -56,41 +73,76 @@ where
             }
         }
 
-        if let Some(svid) = parts.extensions.get::<SpiffeId>() {
-            tracing::debug!("spiffe svid present: {}", svid);
-        }
         // Extract the interface on which the connection is being served
-        let interface = parts
+        // TODO: Insert interface info into the Context
+        let _interface = parts
             .extensions
             .get::<Interface>()
             .cloned()
             .unwrap_or(Interface::Public);
-        tracing::info!("the interface is {:?}", interface);
-
-        let auth_header = parts
-            .headers
-            .get("X-Auth-Token")
-            .and_then(|header| header.to_str().ok());
-
-        let auth_header = if let Some(auth_header) = auth_header {
-            auth_header
-        } else {
-            debug!("No supported information has been provided.");
-            return Err(KeystoneApiError::UnauthorizedNoContext);
-        };
 
         let state = Arc::from_ref(state);
 
-        let vsc = state
-            .provider
-            .get_token_provider()
-            .authorize_by_token(&state, auth_header, Some(false), None)
-            .await
-            .inspect_err(|e| error!("{:#?}", e))
-            .map_err(|_| KeystoneApiError::UnauthorizedNoContext)?;
+        // Check the SPIFFE svid first as the primary identity source
+        if let Some(svid) = parts.extensions.get::<SpiffeId>() {
+            tracing::debug!("authenticating the spiffe svid {}", svid);
 
-        vsc.fully_resolved()?;
+            if let Some(binding) = state
+                .provider
+                .get_spiffe_provider()
+                .get_binding(&state, &svid.to_string())
+                .await?
+            {
+                let auth_result: AuthenticationResult = AuthenticationResultBuilder::default()
+                    .context(AuthenticationContext::Spiffe(binding.clone()))
+                    .principal(
+                        PrincipalInfoBuilder::default()
+                            .identity(IdentityInfo::Principal(
+                                PrincipalIdentityInfoBuilder::default()
+                                    .id(binding.svid.clone())
+                                    .issuer(svid.trust_domain_name())
+                                    .build()?,
+                            ))
+                            .build()?,
+                    )
+                    .build()?;
+                let ctx = SecurityContext::try_from(auth_result)?;
+                let vsc = ValidatedSecurityContext::new_for_scope(
+                    ctx,
+                    if binding.is_system {
+                        // For the "system" binding explicitly scope as system
+                        ScopeInfo::System("all".into())
+                    } else {
+                        ScopeInfo::Unscoped
+                    },
+                    &state,
+                )
+                .await?;
+                return Ok(Auth(vsc));
+            } else {
+                tracing::debug!("no binding for the svid present: {}", svid);
+            }
+        }
+        // Now headers can be checked
+        if let Some(auth_header) = parts
+            .headers
+            .get("X-Auth-Token")
+            .and_then(|header| header.to_str().ok())
+        {
+            tracing::debug!("authenticating request with the x-auth-token");
+            let vsc = state
+                .provider
+                .get_token_provider()
+                .authorize_by_token(&state, auth_header, Some(false), None)
+                .await
+                .inspect_err(|e| error!("{:#?}", e))
+                .map_err(|_| KeystoneApiError::UnauthorizedNoContext)?;
 
-        Ok(Auth(vsc))
+            vsc.fully_resolved()?;
+            return Ok(Auth(vsc));
+        }
+
+        debug!("No supported information has been provided.");
+        Err(KeystoneApiError::UnauthorizedNoContext)
     }
 }

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -23,6 +23,7 @@ use openstack_keystone_core_types::assignment::{
 use openstack_keystone_core_types::identity::IdentityProviderError;
 use openstack_keystone_core_types::resource::ResourceProviderError;
 use openstack_keystone_core_types::role::*;
+use openstack_keystone_core_types::spiffe::*;
 use openstack_keystone_core_types::token::FernetToken;
 
 use crate::assignment::AssignmentApi;
@@ -79,6 +80,7 @@ impl ValidatedSecurityContext {
     /// context, [`SecurityContext::validate_scope_boundaries`] is enforced to
     /// guard the override. Scope-setting, validation, and role resolution
     /// happen as a single atomic step.
+    #[tracing::instrument(skip(state), err(Debug))]
     pub async fn new_for_scope(
         mut ctx: SecurityContext,
         scope: ScopeInfo,
@@ -103,7 +105,7 @@ impl ValidatedSecurityContext {
             let user_domain = state
                 .provider
                 .get_resource_provider()
-                .get_domain(state, &domain_id)
+                .get_domain(state, domain_id)
                 .await
                 .auth_context("fetching user domain")?
                 .ok_or(ResourceProviderError::DomainNotFound(domain_id.clone()))
@@ -136,6 +138,7 @@ impl ValidatedSecurityContext {
             AuthenticationContext::Oidc { .. } => {}
             AuthenticationContext::K8s(..) => {}
             AuthenticationContext::Password => {}
+            AuthenticationContext::Spiffe(..) => {}
             AuthenticationContext::Trust { trust, .. } => {
                 // Validate the trust chain
                 state
@@ -251,178 +254,14 @@ async fn calculate_effective_roles(
     scope: &ScopeInfo,
 ) -> Result<Vec<RoleRef>, AuthenticationError> {
     scope.validate()?;
-    let user_id = ctx.principal().get_user_id();
-    let roles = match &scope {
-        ScopeInfo::Domain(domain) => state
-            .provider
-            .get_assignment_provider()
-            .list_role_assignments(
-                state,
-                &RoleAssignmentListParametersBuilder::default()
-                    .user_id(&user_id)
-                    .domain_id(&domain.id)
-                    .include_names(true)
-                    .effective(true)
-                    .build()
-                    .map_err(AssignmentProviderError::from)?,
-            )
-            .await
-            .auth_context("resolving role assignments")?
-            .into_iter()
-            .map(|a| {
-                a.try_into()
-                    .map_err(|_| AuthenticationError::RoleConversionFailed)
-            })
-            .collect::<Result<Vec<_>, _>>()?,
+
+    let roles = match scope {
+        ScopeInfo::Domain(domain) => resolve_domain_roles(state, ctx, &domain.id).await?,
         ScopeInfo::Project { project, .. } => {
-            if let Some(token_restriction) = &ctx.token_restriction()
-                && !token_restriction.role_ids.is_empty()
-            {
-                // When the context has a token restriction bound use the roles tied to the
-                // token restriction otherwise use the normal role resolution
-                if let Some(roles) = &token_restriction.roles {
-                    roles.clone()
-                } else {
-                    let roles: std::collections::HashMap<String, Role> = state
-                        .provider
-                        .get_role_provider()
-                        .list_roles(&state, &RoleListParameters::default())
-                        .await
-                        .auth_context("reading roles to expand token restrictions")?
-                        .into_iter()
-                        .map(|role| (role.id.clone(), role))
-                        .collect();
-                    let mut filtered_roles: Vec<RoleRef> = token_restriction
-                        .role_ids
-                        .iter()
-                        .filter_map(|rid| roles.get(rid).map(|role| role.into()))
-                        .collect();
-                    state
-                        .provider
-                        .get_role_provider()
-                        .expand_implied_roles(&state, &mut filtered_roles)
-                        .await
-                        .auth_context("expanding token restriction roles")?;
-                    filtered_roles
-                }
-            } else {
-                let user_assignments = state
-                    .provider
-                    .get_assignment_provider()
-                    .list_role_assignments(
-                        state,
-                        &RoleAssignmentListParametersBuilder::default()
-                            .user_id(&user_id)
-                            .project_id(&project.id)
-                            .include_names(false)
-                            .effective(true)
-                            .build()
-                            .map_err(AssignmentProviderError::from)?,
-                    )
-                    .await
-                    .auth_context("resolving role assignments")?;
-                match &ctx.authentication_context() {
-                    AuthenticationContext::ApplicationCredential {
-                        application_credential,
-                        ..
-                    } => {
-                        let user_role_ids: HashSet<String> = user_assignments
-                            .into_iter()
-                            .map(|x| x.role_id.clone())
-                            .collect();
-                        application_credential
-                            .roles
-                            .iter()
-                            .filter(|role| user_role_ids.contains(&role.id))
-                            .cloned()
-                            .collect()
-                    }
-                    _ => user_assignments
-                        .into_iter()
-                        .map(|a| {
-                            a.try_into()
-                                .map_err(|_| AuthenticationError::RoleConversionFailed)
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                }
-            }
+            resolve_project_roles(state, ctx, &project.id).await?
         }
-        ScopeInfo::System(system_id) => state
-            .provider
-            .get_assignment_provider()
-            .list_role_assignments(
-                state,
-                &RoleAssignmentListParametersBuilder::default()
-                    .user_id(&user_id)
-                    .system_id(system_id)
-                    .include_names(true)
-                    .effective(true)
-                    .build()
-                    .map_err(AssignmentProviderError::from)?,
-            )
-            .await
-            .auth_context("resolving role assignments")?
-            .into_iter()
-            .map(|a| {
-                a.try_into()
-                    .map_err(|_| AuthenticationError::RoleConversionFailed)
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-        ScopeInfo::TrustProject(tpi) => {
-            // Get all trustor roles
-            let trustor_assignments = state
-                .provider
-                .get_assignment_provider()
-                .list_role_assignments(
-                    state,
-                    &RoleAssignmentListParameters {
-                        user_id: Some(tpi.trust.trustor_user_id.clone()),
-                        project_id: Some(tpi.project.id.clone()),
-                        effective: Some(true),
-                        ..Default::default()
-                    },
-                )
-                .await
-                .auth_context("resolving trust role assignments")?;
-            if let Some(trust_roles) = &tpi.trust.roles {
-                // Capture unique role_id of the trustor on the project
-                let trustor_role_ids: HashSet<String> = trustor_assignments
-                    .into_iter()
-                    .map(|x| x.role_id.clone())
-                    .collect();
-                let mut trust_roles = trust_roles.clone();
-                // expand implied roles of the trust
-                state
-                    .provider
-                    .get_role_provider()
-                    .expand_implied_roles(state, &mut trust_roles)
-                    .await
-                    .auth_context("expanding implied roles for trust")?;
-                // Filter out roles frozen in the trust that the trustor does not possess
-                // anymore.
-                if !trust_roles
-                    .iter()
-                    .all(|role| trustor_role_ids.contains(&role.id))
-                {
-                    debug!(
-                        "Trust roles {:?} are missing for the trustor {:?}",
-                        trust_roles, trustor_role_ids
-                    );
-                    return Err(AuthenticationError::ActorHasNoRolesOnTarget);
-                }
-                trust_roles.retain_mut(|role| role.domain_id.is_none());
-                trust_roles
-            } else {
-                // No roles were tied to the trust. Return all trustor roles.
-                trustor_assignments
-                    .into_iter()
-                    .map(|a| {
-                        a.try_into()
-                            .map_err(|_| AuthenticationError::RoleConversionFailed)
-                    })
-                    .collect::<Result<Vec<_>, _>>()?
-            }
-        }
+        ScopeInfo::System(system_id) => resolve_system_roles(state, ctx, system_id).await?,
+        ScopeInfo::TrustProject(tpi) => resolve_trust_roles(state, tpi).await?,
         ScopeInfo::Unscoped => Vec::new(),
     };
 
@@ -432,25 +271,274 @@ async fn calculate_effective_roles(
 
     Ok(roles)
 }
+
+// Resolve effective roles for a domain scope.
+async fn resolve_domain_roles(
+    state: &ServiceState,
+    ctx: &SecurityContext,
+    domain_id: &str,
+) -> Result<Vec<RoleRef>, AuthenticationError> {
+    let user_id = ctx.principal().get_user_id();
+    let assignments = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(
+            state,
+            &RoleAssignmentListParametersBuilder::default()
+                .user_id(&user_id)
+                .domain_id(domain_id)
+                .include_names(true)
+                .effective(true)
+                .build()
+                .map_err(AssignmentProviderError::from)?,
+        )
+        .await
+        .auth_context("resolving role assignments")?;
+    assignments_to_roles(assignments)
+}
+
+// Resolve effective roles for a project scope.
+async fn resolve_project_roles(
+    state: &ServiceState,
+    ctx: &SecurityContext,
+    project_id: &str,
+) -> Result<Vec<RoleRef>, AuthenticationError> {
+    if let Some(restriction) = ctx.token_restriction()
+        && !restriction.role_ids.is_empty()
+    {
+        return resolve_project_token_restriction_roles(state, restriction).await;
+    }
+
+    if let Some(mut roles) = resolve_project_spiffe_roles(ctx, project_id) {
+        state
+            .provider
+            .get_role_provider()
+            .expand_implied_roles(state, &mut roles)
+            .await
+            .auth_context("expanding scope roles")?;
+        return Ok(roles);
+    }
+
+    resolve_project_default_roles(state, ctx, project_id).await
+}
+
+// Resolve roles from a token restriction on a project scope.
+async fn resolve_project_token_restriction_roles(
+    state: &ServiceState,
+    restriction: &openstack_keystone_core_types::token::TokenRestriction,
+) -> Result<Vec<RoleRef>, AuthenticationError> {
+    if let Some(roles) = &restriction.roles {
+        return Ok(roles.clone());
+    }
+
+    let mut roles = restriction
+        .role_ids
+        .iter()
+        .map(|rid| RoleRef {
+            id: rid.clone(),
+            name: None,
+            domain_id: None,
+        })
+        .collect();
+    state
+        .provider
+        .get_role_provider()
+        .expand_implied_roles(state, &mut roles)
+        .await
+        .auth_context("expanding token restriction roles")?;
+    Ok(roles)
+}
+
+// Resolve roles from a SPIFFE binding for a given project scope.
+//
+// Returns `Some(Vec<RoleRef>)` if the binding contains a matching project
+// authorization with role IDs, `None` otherwise.  When `Some` is returned the
+// caller is responsible for expanding implied roles.
+fn resolve_project_spiffe_roles(ctx: &SecurityContext, project_id: &str) -> Option<Vec<RoleRef>> {
+    let binding = match ctx.authentication_context() {
+        AuthenticationContext::Spiffe(binding) => binding,
+        _ => return None,
+    };
+
+    let authz = binding.authorizations.as_ref()?.iter().find(|scope| {
+        matches!(scope, SpiffeAuthorization::Project { project_id: pid, .. } if *pid == project_id)
+    })?;
+
+    authz.role_refs()
+}
+
+// Resolve project-scoped roles using the default assignment-based logic.
+async fn resolve_project_default_roles(
+    state: &ServiceState,
+    ctx: &SecurityContext,
+    project_id: &str,
+) -> Result<Vec<RoleRef>, AuthenticationError> {
+    let user_id = ctx.principal().get_user_id();
+    let assignments = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(
+            state,
+            &RoleAssignmentListParametersBuilder::default()
+                .user_id(&user_id)
+                .project_id(project_id)
+                .include_names(false)
+                .effective(true)
+                .build()
+                .map_err(AssignmentProviderError::from)?,
+        )
+        .await
+        .auth_context("resolving role assignments")?;
+
+    match ctx.authentication_context() {
+        AuthenticationContext::ApplicationCredential {
+            application_credential,
+            ..
+        } => {
+            let user_role_ids: HashSet<String> =
+                assignments.iter().map(|a| a.role_id.clone()).collect();
+            let restricted = application_credential
+                .roles
+                .iter()
+                .filter(|role| user_role_ids.contains(&role.id))
+                .cloned()
+                .collect();
+            Ok(restricted)
+        }
+        _ => assignments_to_roles(assignments),
+    }
+}
+
+// Resolve effective roles for a system scope.
+async fn resolve_system_roles(
+    state: &ServiceState,
+    ctx: &SecurityContext,
+    system_id: &str,
+) -> Result<Vec<RoleRef>, AuthenticationError> {
+    if let AuthenticationContext::Spiffe(binding) = ctx.authentication_context() {
+        if binding.is_system {
+            let roles = state
+                .provider
+                .get_role_provider()
+                .list_roles(
+                    state,
+                    &RoleListParameters {
+                        name: Some("reader".into()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .auth_context("searching reader role")?
+                .into_iter()
+                .map(|role| role.into())
+                .collect();
+            return Ok(roles);
+        } else {
+            return Ok(Vec::new());
+        }
+    }
+
+    let user_id = ctx.principal().get_user_id();
+    let assignments = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(
+            state,
+            &RoleAssignmentListParametersBuilder::default()
+                .user_id(&user_id)
+                .system_id(system_id)
+                .include_names(true)
+                .effective(true)
+                .build()
+                .map_err(AssignmentProviderError::from)?,
+        )
+        .await
+        .auth_context("resolving role assignments")?;
+    assignments_to_roles(assignments)
+}
+
+// Resolve effective roles for a trust scope.
+async fn resolve_trust_roles(
+    state: &ServiceState,
+    tpi: &TrustProjectInfo,
+) -> Result<Vec<RoleRef>, AuthenticationError> {
+    let trustor_assignments = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(
+            state,
+            &RoleAssignmentListParameters {
+                user_id: Some(tpi.trust.trustor_user_id.clone()),
+                project_id: Some(tpi.project.id.clone()),
+                effective: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .auth_context("resolving trust role assignments")?;
+
+    if let Some(trust_roles) = &tpi.trust.roles {
+        let trustor_role_ids: HashSet<String> = trustor_assignments
+            .iter()
+            .map(|a| a.role_id.clone())
+            .collect();
+        let mut trust_roles = trust_roles.clone();
+        state
+            .provider
+            .get_role_provider()
+            .expand_implied_roles(state, &mut trust_roles)
+            .await
+            .auth_context("expanding implied roles for trust")?;
+
+        if !trust_roles
+            .iter()
+            .all(|role| trustor_role_ids.contains(&role.id))
+        {
+            debug!(
+                "Trust roles {:?} are missing for the trustor {:?}",
+                trust_roles, trustor_role_ids
+            );
+            return Err(AuthenticationError::ActorHasNoRolesOnTarget);
+        }
+        trust_roles.retain_mut(|role| role.domain_id.is_none());
+        Ok(trust_roles)
+    } else {
+        assignments_to_roles(trustor_assignments)
+    }
+}
+
+// Convert a list of role assignments into [`RoleRef`] values.
+fn assignments_to_roles(
+    assignments: Vec<openstack_keystone_core_types::assignment::Assignment>,
+) -> Result<Vec<RoleRef>, AuthenticationError> {
+    assignments
+        .into_iter()
+        .map(|a| {
+            a.try_into()
+                .map_err(|_| AuthenticationError::RoleConversionFailed)
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
 #[cfg(test)]
 mod tests {
     use openstack_keystone_core_types::assignment::{
-        Assignment, AssignmentType, RoleAssignmentListParameters,
+        Assignment, AssignmentProviderError, AssignmentType, RoleAssignmentListParameters,
     };
     use openstack_keystone_core_types::auth::{
-        AuthenticationContext, IdentityInfo, PrincipalInfo, ScopeInfo,
+        AuthenticationContext, IdentityInfo, PrincipalIdentityInfo, PrincipalInfo, ScopeInfo,
         SecurityContextTestingBuilder, TrustProjectInfo, UserIdentityInfo,
     };
     use openstack_keystone_core_types::identity::{UserOptions, UserResponse};
     use openstack_keystone_core_types::resource::Project;
-    use openstack_keystone_core_types::role::{RoleRef, RoleRefBuilder};
+    use openstack_keystone_core_types::role::{Role, RoleRef, RoleRefBuilder};
     use openstack_keystone_core_types::token::TokenRestriction;
     use openstack_keystone_core_types::trust::Trust;
     use std::collections::HashMap;
 
     use crate::assignment::MockAssignmentProvider;
     use crate::provider::Provider;
-    use crate::role::MockRoleProvider;
+    use crate::role::{MockRoleProvider, RoleProviderError};
     use crate::tests::get_mocked_state;
 
     use super::*;
@@ -555,8 +643,12 @@ mod tests {
     }
 
     fn assignment_with_role(rid: impl Into<String>) -> Assignment {
+        assignment_with_role_actor(rid, "uid")
+    }
+
+    fn assignment_with_role_actor(rid: impl Into<String>, actor: impl Into<String>) -> Assignment {
         Assignment {
-            actor_id: "uid".to_string(),
+            actor_id: actor.into(),
             role_id: rid.into(),
             role_name: Some("admin".to_string()),
             target_id: "target".to_string(),
@@ -568,6 +660,193 @@ mod tests {
 
     fn role_ref(id: impl Into<String>, name: impl Into<String>) -> RoleRef {
         RoleRefBuilder::default().id(id).name(name).build().unwrap()
+    }
+
+    fn role_ref_with_domain(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        domain_id: Option<String>,
+    ) -> RoleRef {
+        let mut r = RoleRefBuilder::default().id(id).name(name).build().unwrap();
+        r.domain_id = domain_id;
+        r
+    }
+
+    fn make_spiffe_binding(
+        svid: impl Into<String>,
+        is_system: bool,
+        authorizations: Option<Vec<SpiffeAuthorization>>,
+    ) -> SpiffeBinding {
+        SpiffeBinding {
+            authorizations,
+            domain_id: "d1".to_string(),
+            svid: svid.into(),
+            is_system,
+            user_id: None,
+        }
+    }
+
+    fn make_spiffe_principal(svid: impl Into<String>, issuer: impl Into<String>) -> PrincipalInfo {
+        PrincipalInfo {
+            identity: IdentityInfo::Principal(PrincipalIdentityInfo {
+                id: svid.into(),
+                issuer: issuer.into(),
+                attributes: HashMap::new(),
+                domain: Some(openstack_keystone_core_types::resource::Domain {
+                    id: "d1".to_string(),
+                    description: None,
+                    enabled: true,
+                    name: "default".to_string(),
+                    extra: HashMap::new(),
+                }),
+            }),
+        }
+    }
+
+    fn make_role(id: impl Into<String>, name: impl Into<String>) -> Role {
+        Role {
+            id: id.into(),
+            name: name.into(),
+            description: None,
+            domain_id: None,
+            extra: HashMap::new(),
+        }
+    }
+
+    fn disabled_domain_scope(did: impl Into<String>) -> ScopeInfo {
+        ScopeInfo::Domain(openstack_keystone_core_types::resource::Domain {
+            id: did.into(),
+            description: None,
+            enabled: false,
+            name: "disabled".to_string(),
+            extra: HashMap::new(),
+        })
+    }
+
+    fn disabled_project_scope(pid: impl Into<String>) -> ScopeInfo {
+        ScopeInfo::Project {
+            project: Project {
+                id: pid.into(),
+                domain_id: "d1".to_string(),
+                enabled: false,
+                name: "p".to_string(),
+                description: None,
+                is_domain: false,
+                parent_id: None,
+                extra: HashMap::new(),
+            },
+            project_domain: openstack_keystone_core_types::resource::Domain {
+                id: "d1".to_string(),
+                description: None,
+                enabled: true,
+                name: "default".to_string(),
+                extra: HashMap::new(),
+            },
+        }
+    }
+
+    fn disabled_project_domain_scope(pid: impl Into<String>) -> ScopeInfo {
+        ScopeInfo::Project {
+            project: Project {
+                id: pid.into(),
+                domain_id: "d1".to_string(),
+                enabled: true,
+                name: "p".to_string(),
+                description: None,
+                is_domain: false,
+                parent_id: None,
+                extra: HashMap::new(),
+            },
+            project_domain: openstack_keystone_core_types::resource::Domain {
+                id: "d1".to_string(),
+                description: None,
+                enabled: false,
+                name: "disabled".to_string(),
+                extra: HashMap::new(),
+            },
+        }
+    }
+
+    fn disabled_trust_scope(
+        trustor: impl Into<String>,
+        trustee: impl Into<String>,
+        project: &str,
+        roles: Option<Vec<RoleRef>>,
+    ) -> ScopeInfo {
+        ScopeInfo::TrustProject(Box::new(TrustProjectInfo {
+            trust: Trust {
+                id: "t1".to_string(),
+                trustor_user_id: trustor.into(),
+                trustee_user_id: trustee.into(),
+                impersonation: false,
+                project_id: None,
+                expires_at: None,
+                deleted_at: None,
+                extra: None,
+                remaining_uses: None,
+                redelegated_trust_id: None,
+                redelegation_count: None,
+                roles,
+            },
+            project: Project {
+                id: project.to_string(),
+                domain_id: "d1".to_string(),
+                enabled: false,
+                name: "p".to_string(),
+                description: None,
+                is_domain: false,
+                parent_id: None,
+                extra: HashMap::new(),
+            },
+            project_domain: openstack_keystone_core_types::resource::Domain {
+                id: "d1".to_string(),
+                description: None,
+                enabled: true,
+                name: "default".to_string(),
+                extra: HashMap::new(),
+            },
+        }))
+    }
+
+    fn disabled_trust_project_domain_scope(
+        trustor: impl Into<String>,
+        trustee: impl Into<String>,
+        project: &str,
+        roles: Option<Vec<RoleRef>>,
+    ) -> ScopeInfo {
+        ScopeInfo::TrustProject(Box::new(TrustProjectInfo {
+            trust: Trust {
+                id: "t1".to_string(),
+                trustor_user_id: trustor.into(),
+                trustee_user_id: trustee.into(),
+                impersonation: false,
+                project_id: None,
+                expires_at: None,
+                deleted_at: None,
+                extra: None,
+                remaining_uses: None,
+                redelegated_trust_id: None,
+                redelegation_count: None,
+                roles,
+            },
+            project: Project {
+                id: project.to_string(),
+                domain_id: "d1".to_string(),
+                enabled: true,
+                name: "p".to_string(),
+                description: None,
+                is_domain: false,
+                parent_id: None,
+                extra: HashMap::new(),
+            },
+            project_domain: openstack_keystone_core_types::resource::Domain {
+                id: "d1".to_string(),
+                description: None,
+                enabled: false,
+                name: "disabled".to_string(),
+                extra: HashMap::new(),
+            },
+        }))
     }
 
     #[tokio::test]
@@ -829,5 +1108,1172 @@ mod tests {
             .unwrap();
         assert_eq!(roles.len(), 1);
         assert_eq!(roles[0].id, admin_rid);
+    }
+
+    #[tokio::test]
+    async fn test_project_scope_spiffe_matching_authz() {
+        let pid = "pid";
+        let rid1 = "spiffe_role";
+        let binding = make_spiffe_binding(
+            "spiffe://domain/ns/workload",
+            false,
+            Some(vec![SpiffeAuthorization::Project {
+                project_id: pid.to_string(),
+                role_ids: Some(vec![rid1.to_string()]),
+            }]),
+        );
+        let principal = make_spiffe_principal("spiffe://domain/ns/workload", "spire-agent");
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(|_state, _roles| Ok(()));
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = make_project_scope(pid);
+        let roles = calculate_effective_roles(&state, &ctx, &scope)
+            .await
+            .unwrap();
+        assert_eq!(roles.len(), 1);
+        assert_eq!(roles[0].id, rid1);
+    }
+
+    #[tokio::test]
+    async fn test_project_scope_token_restriction_expand_role_ids() {
+        let rid1 = "rid1";
+        let rid2 = "rid2";
+        let tr = TokenRestriction {
+            id: "tr1".to_string(),
+            domain_id: "d1".to_string(),
+            allow_rescope: true,
+            allow_renew: false,
+            role_ids: vec![rid1.to_string(), rid2.to_string()],
+            roles: None,
+            project_id: Some("pid".to_string()),
+            user_id: Some("uid".to_string()),
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("uid"))
+            .token_restriction(tr)
+            .build();
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .withf(move |_state, roles| roles.len() == 2 && roles.iter().any(|r| r.id == rid1))
+            .returning(move |_state, roles| {
+                for role in roles.iter_mut() {
+                    if role.id == rid1 {
+                        role.name = Some("admin".to_string());
+                    }
+                }
+                Ok(())
+            });
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
+        let scope = make_project_scope("pid");
+        let roles = calculate_effective_roles(&state, &ctx, &scope)
+            .await
+            .unwrap();
+        assert_eq!(roles.len(), 2);
+        assert!(roles.iter().any(|r| r.id == rid1));
+        assert!(roles.iter().any(|r| r.id == rid2));
+    }
+
+    #[tokio::test]
+    async fn test_trust_scope_missing_role_error() {
+        let trustor = "trustor";
+        let pid = "pid";
+        let trust_rid = "trust_role";
+        let trustor_rid = "other_role";
+        let trust_roles = vec![role_ref(trust_rid, "trustadmin")];
+        // Trustor has a different role, not the one on the trust
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(trustor)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| Ok(vec![assignment_with_role(trustor_rid)]));
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(|_state, _roles| Ok(()));
+        let state = get_mocked_state(
+            None,
+            Some(
+                Provider::mocked_builder()
+                    .mock_assignment(assignment_mock)
+                    .mock_role(role_mock),
+            ),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(trustor))
+            .build();
+        let scope = make_trust_scope(trustor, "trustee", pid, Some(trust_roles));
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_trust_scope_filters_domain_roles() {
+        let trustor = "trustor";
+        let pid = "pid";
+        let rid1 = "rid1";
+        let rid2 = "rid2";
+        let trust_roles = vec![
+            role_ref_with_domain(rid1, "admin", None),
+            role_ref_with_domain(rid2, "domain_admin", Some("d1".to_string())),
+        ];
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(trustor)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| {
+                Ok(vec![assignment_with_role(rid1), assignment_with_role(rid2)])
+            });
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(|_state, _roles| Ok(()));
+        let state = get_mocked_state(
+            None,
+            Some(
+                Provider::mocked_builder()
+                    .mock_assignment(assignment_mock)
+                    .mock_role(role_mock),
+            ),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(trustor))
+            .build();
+        let scope = make_trust_scope(trustor, "trustee", pid, Some(trust_roles));
+        let roles = calculate_effective_roles(&state, &ctx, &scope)
+            .await
+            .unwrap();
+        assert_eq!(roles.len(), 1);
+        assert_eq!(roles[0].id, rid1);
+    }
+
+    #[tokio::test]
+    async fn test_domain_scope_empty_assignments_error() {
+        let uid = "uid";
+        let did = "did";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.domain_id.as_deref() == Some(did)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(uid))
+            .build();
+        let scope = make_domain_scope(did);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_domain_scope_disabled_error() {
+        let did = "did";
+        let state = get_mocked_state(None, None).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("uid"))
+            .build();
+        let scope = disabled_domain_scope(did);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        match result.unwrap_err() {
+            //result,
+            //Err(AuthenticationError::DomainDisabled(id))
+            AuthenticationError::DomainDisabled(id) if id == did => {}
+            e => panic!("unexpected error: {:?}", e),
+        };
+    }
+
+    #[tokio::test]
+    async fn test_project_scope_disabled_error() {
+        let pid = "pid";
+        let state = get_mocked_state(None, None).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("uid"))
+            .build();
+        let scope = disabled_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        match result.unwrap_err() {
+            //result,
+            //Err(AuthenticationError::ProjectDisabled(id))
+            AuthenticationError::ProjectDisabled(id) if id == pid => {}
+            e => panic!("unexpected error: {:?}", e),
+        };
+    }
+
+    #[tokio::test]
+    async fn test_project_scope_disabled_domain_error() {
+        let pid = "pid";
+        let state = get_mocked_state(None, None).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("uid"))
+            .build();
+        let scope = disabled_project_domain_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        match result.unwrap_err() {
+            //result,
+            //Err(AuthenticationError::DomainDisabled(id))
+            AuthenticationError::DomainDisabled(id) if id == "d1" => {}
+            e => panic!("unexpected error: {:?}", e),
+        };
+    }
+
+    #[tokio::test]
+    async fn test_trust_scope_disabled_project_error() {
+        let state = get_mocked_state(None, None).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("trustor"))
+            .build();
+        let scope = disabled_trust_scope("trustor", "trustee", "pid", None);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        match result.unwrap_err() {
+            //result,
+            //Err(AuthenticationError::ProjectDisabled(id))
+            AuthenticationError::ProjectDisabled(id) if id == "pid" => {}
+            e => panic!("unexpected error: {:?}", e),
+        };
+    }
+
+    #[tokio::test]
+    async fn test_trust_scope_disabled_domain_error() {
+        let state = get_mocked_state(None, None).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("trustor"))
+            .build();
+        let scope = disabled_trust_project_domain_scope("trustor", "trustee", "pid", None);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        match result.unwrap_err() {
+            // result,
+            //Err(AuthenticationError::DomainDisabled(id))
+            AuthenticationError::DomainDisabled(id) if id == "d1" => {}
+            e => panic!("unexpected error: {:?}", e),
+        };
+    }
+
+    // --- Project scope empty assignments error ---
+    #[tokio::test]
+    async fn test_project_scope_empty_assignments_error() {
+        let uid = "uid";
+        let pid = "pid";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(uid))
+            .build();
+        let scope = make_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- System scope empty assignments error ---
+    #[tokio::test]
+    async fn test_system_scope_empty_assignments_error() {
+        let uid = "uid";
+        let system = "all";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.system_id.as_deref() == Some(system)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(true)
+            })
+            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(uid))
+            .build();
+        let scope = ScopeInfo::System(system.to_string());
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- SPIFFE system: is_system = true, returns reader role ---
+    #[tokio::test]
+    async fn test_system_scope_spiffe_system_true() {
+        let reader_rid = "reader";
+        let binding = make_spiffe_binding(
+            "spiffe://domain/ns/system-workload",
+            true,
+            Some(vec![SpiffeAuthorization::System {
+                system_id: "all".to_string(),
+                role_ids: None,
+            }]),
+        );
+        let principal = make_spiffe_principal("spiffe://domain/ns/system-workload", "spire-agent");
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_list_roles()
+            .returning(move |_state, _params| Ok(vec![make_role(reader_rid, "reader")]));
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = ScopeInfo::System("all".to_string());
+        let roles = calculate_effective_roles(&state, &ctx, &scope)
+            .await
+            .unwrap();
+        assert_eq!(roles.len(), 1);
+        assert_eq!(roles[0].id, reader_rid);
+    }
+
+    // --- SPIFFE system: is_system = false, returns empty → error ---
+    #[tokio::test]
+    async fn test_system_scope_spiffe_system_false() {
+        let binding = make_spiffe_binding(
+            "spiffe://domain/ns/workload",
+            false,
+            Some(vec![SpiffeAuthorization::System {
+                system_id: "all".to_string(),
+                role_ids: None,
+            }]),
+        );
+        let principal = make_spiffe_principal("spiffe://domain/ns/workload", "spire-agent");
+        let state = get_mocked_state(None, None).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = ScopeInfo::System("all".to_string());
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- SPIFFE project: authorizations_none, falls through to default
+    //     (which with no assignments returns empty → error) ---
+    #[tokio::test]
+    async fn test_project_scope_spiffe_authorizations_none() {
+        let pid = "pid";
+        let binding = make_spiffe_binding("spiffe://domain/ns/workload", false, None);
+        let principal = make_spiffe_principal("spiffe://domain/ns/workload", "spire-agent");
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = make_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- SPIFFE project: no matching project_id, falls through to default ---
+    #[tokio::test]
+    async fn test_project_scope_spiffe_no_matching_project() {
+        let target_pid = "pid";
+        let other_pid = "other_pid";
+        let binding = make_spiffe_binding(
+            "spiffe://domain/ns/workload",
+            false,
+            Some(vec![SpiffeAuthorization::Project {
+                project_id: other_pid.to_string(),
+                role_ids: Some(vec!["spiffe_role".to_string()]),
+            }]),
+        );
+        let principal = make_spiffe_principal("spiffe://domain/ns/workload", "spire-agent");
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.project_id.as_deref() == Some(target_pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = make_project_scope(target_pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- SPIFFE project: role_ids_none, falls through to default ---
+    #[tokio::test]
+    async fn test_project_scope_spiffe_role_ids_none() {
+        let pid = "pid";
+        let binding = make_spiffe_binding(
+            "spiffe://domain/ns/workload",
+            false,
+            Some(vec![SpiffeAuthorization::Project {
+                project_id: pid.to_string(),
+                role_ids: None,
+            }]),
+        );
+        let principal = make_spiffe_principal("spiffe://domain/ns/workload", "spire-agent");
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = make_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- AppCred: all roles pass filter ---
+    #[tokio::test]
+    async fn test_project_scope_appcred_all_roles_pass() {
+        let uid = "uid";
+        let pid = "pid";
+        let admin_rid = "admin";
+        let viewer_rid = "viewer";
+        let appcred_roles = vec![role_ref(admin_rid, "admin"), role_ref(viewer_rid, "viewer")];
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| {
+                Ok(vec![
+                    assignment_with_role(admin_rid),
+                    assignment_with_role(viewer_rid),
+                ])
+            });
+        let ac = openstack_keystone_core_types::application_credential::ApplicationCredential {
+            id: "ac1".to_string(),
+            user_id: uid.to_string(),
+            project_id: pid.to_string(),
+            name: "cred".to_string(),
+            description: None,
+            roles: appcred_roles,
+            unrestricted: false,
+            expires_at: None,
+            access_rules: None,
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::ApplicationCredential {
+                application_credential: ac,
+                token: None,
+            })
+            .principal(make_user_identity(uid))
+            .build();
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let scope = make_project_scope(pid);
+        let roles = calculate_effective_roles(&state, &ctx, &scope)
+            .await
+            .unwrap();
+        assert_eq!(roles.len(), 2);
+        assert!(roles.iter().any(|r| r.id == admin_rid));
+        assert!(roles.iter().any(|r| r.id == viewer_rid));
+    }
+
+    // --- Token restriction: roles: Some(empty) returns empty ---
+    #[tokio::test]
+    async fn test_project_scope_token_restriction_empty_roles() {
+        let tr = TokenRestriction {
+            id: "tr1".to_string(),
+            domain_id: "d1".to_string(),
+            allow_rescope: true,
+            allow_renew: false,
+            role_ids: vec!["rid1".to_string()],
+            roles: Some(Vec::new()),
+            project_id: Some("pid".to_string()),
+            user_id: Some("uid".to_string()),
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("uid"))
+            .token_restriction(tr)
+            .build();
+        let state = get_mocked_state(None, None).await;
+        let scope = make_project_scope("pid");
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- Trust scope: expand_implied_roles adds an implied role, trustor has it
+    // ---
+    #[tokio::test]
+    async fn test_trust_scope_implied_role_expansion() {
+        let trustor = "trustor";
+        let pid = "pid";
+        let base_rid = "base_role";
+        let implied_rid = "implied_role";
+        let trust_roles = vec![role_ref(base_rid, "base")];
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(trustor)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| {
+                Ok(vec![
+                    assignment_with_role_actor(base_rid, trustor),
+                    assignment_with_role_actor(implied_rid, trustor),
+                ])
+            });
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(move |_state, roles| {
+                roles.push(role_ref(implied_rid, "implied"));
+                Ok(())
+            });
+        let state = get_mocked_state(
+            None,
+            Some(
+                Provider::mocked_builder()
+                    .mock_assignment(assignment_mock)
+                    .mock_role(role_mock),
+            ),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(trustor))
+            .build();
+        let scope = make_trust_scope(trustor, "trustee", pid, Some(trust_roles));
+        let roles = calculate_effective_roles(&state, &ctx, &scope)
+            .await
+            .unwrap();
+        assert_eq!(roles.len(), 2);
+        assert!(roles.iter().any(|r| r.id == base_rid));
+        assert!(roles.iter().any(|r| r.id == implied_rid));
+    }
+
+    // --- Project scope: expand_implied_roles adds an implied role for SPIFFE ---
+    #[tokio::test]
+    async fn test_project_scope_spiffe_implied_role_expansion() {
+        let pid = "pid";
+        let base_rid = "spiffe_role";
+        let implied_rid = "implied_role";
+        let binding = make_spiffe_binding(
+            "spiffe://domain/ns/workload",
+            false,
+            Some(vec![SpiffeAuthorization::Project {
+                project_id: pid.to_string(),
+                role_ids: Some(vec![base_rid.to_string()]),
+            }]),
+        );
+        let principal = make_spiffe_principal("spiffe://domain/ns/workload", "spire-agent");
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(move |_state, roles| {
+                roles.push(role_ref(implied_rid, "implied"));
+                Ok(())
+            });
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = make_project_scope(pid);
+        let roles = calculate_effective_roles(&state, &ctx, &scope)
+            .await
+            .unwrap();
+        assert_eq!(roles.len(), 2);
+        assert!(roles.iter().any(|r| r.id == base_rid));
+        assert!(roles.iter().any(|r| r.id == implied_rid));
+    }
+
+    // --- assignments_to_roles: role conversion failure ---
+    #[test]
+    fn test_assignments_to_roles_conversion_failure() {
+        let mut bad_assignment = assignment_with_role("rid1");
+        bad_assignment.role_name = None;
+        let result = assignments_to_roles(vec![bad_assignment]);
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::RoleConversionFailed)
+        ));
+    }
+
+    // --- SPIFFE non-system with principal identity on system scope, no assignments
+    // ---
+    #[tokio::test]
+    async fn test_system_scope_spiffe_non_system_no_assignments() {
+        let binding = make_spiffe_binding("spiffe://domain/ns/workload", false, None);
+        let principal = make_spiffe_principal("spiffe://domain/ns/workload", "spire-agent");
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let state = get_mocked_state(None, None).await;
+        let scope = ScopeInfo::System("all".to_string());
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- Provider error: domain scope list_role_assignments ---
+    #[tokio::test]
+    async fn test_domain_scope_provider_error() {
+        let uid = "uid";
+        let did = "did";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.domain_id.as_deref() == Some(did)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| Err(AssignmentProviderError::Driver("db down".into())));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(uid))
+            .build();
+        let scope = make_domain_scope(did);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(result, Err(AuthenticationError::Provider { .. })));
+    }
+
+    // --- Provider error: project scope list_role_assignments ---
+    #[tokio::test]
+    async fn test_project_scope_provider_error() {
+        let uid = "uid";
+        let pid = "pid";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| Err(AssignmentProviderError::Driver("db down".into())));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(uid))
+            .build();
+        let scope = make_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(result, Err(AuthenticationError::Provider { .. })));
+    }
+
+    // --- Provider error: system scope list_role_assignments ---
+    #[tokio::test]
+    async fn test_system_scope_provider_error() {
+        let uid = "uid";
+        let system = "all";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.system_id.as_deref() == Some(system)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(true)
+            })
+            .returning(move |_state, _q| Err(AssignmentProviderError::Driver("db down".into())));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(uid))
+            .build();
+        let scope = ScopeInfo::System(system.to_string());
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(result, Err(AuthenticationError::Provider { .. })));
+    }
+
+    // --- Provider error: trust scope list_role_assignments ---
+    #[tokio::test]
+    async fn test_trust_scope_provider_error() {
+        let trustor = "trustor";
+        let pid = "pid";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(trustor)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| Err(AssignmentProviderError::Driver("db down".into())));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(trustor))
+            .build();
+        let scope = make_trust_scope(trustor, "trustee", pid, None);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(result, Err(AuthenticationError::Provider { .. })));
+    }
+
+    // --- Provider error: SPIFFE expand_implied_roles ---
+    #[tokio::test]
+    async fn test_project_scope_spiffe_expand_implied_error() {
+        let pid = "pid";
+        let binding = make_spiffe_binding(
+            "spiffe://domain/ns/workload",
+            false,
+            Some(vec![SpiffeAuthorization::Project {
+                project_id: pid.to_string(),
+                role_ids: Some(vec!["spiffe_role".to_string()]),
+            }]),
+        );
+        let principal = make_spiffe_principal("spiffe://domain/ns/workload", "spire-agent");
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(move |_state, _roles| Err(RoleProviderError::Driver("db down".into())));
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = make_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(result, Err(AuthenticationError::Provider { .. })));
+    }
+
+    // --- Provider error: trust expand_implied_roles ---
+    #[tokio::test]
+    async fn test_trust_scope_expand_implied_error() {
+        let trustor = "trustor";
+        let pid = "pid";
+        let trust_rid = "trust_role";
+        let trust_roles = vec![role_ref(trust_rid, "trustadmin")];
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(trustor)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| Ok(vec![assignment_with_role(trust_rid)]));
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(move |_state, _roles| Err(RoleProviderError::Driver("db down".into())));
+        let state = get_mocked_state(
+            None,
+            Some(
+                Provider::mocked_builder()
+                    .mock_assignment(assignment_mock)
+                    .mock_role(role_mock),
+            ),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(trustor))
+            .build();
+        let scope = make_trust_scope(trustor, "trustee", pid, Some(trust_roles));
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(result, Err(AuthenticationError::Provider { .. })));
+    }
+
+    // --- Provider error: token restriction expand_implied_roles ---
+    #[tokio::test]
+    async fn test_project_scope_token_restriction_expand_error() {
+        let rid1 = "rid1";
+        let tr = TokenRestriction {
+            id: "tr1".to_string(),
+            domain_id: "d1".to_string(),
+            allow_rescope: true,
+            allow_renew: false,
+            role_ids: vec![rid1.to_string()],
+            roles: None,
+            project_id: Some("pid".to_string()),
+            user_id: Some("uid".to_string()),
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("uid"))
+            .token_restriction(tr)
+            .build();
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(move |_state, _roles| Err(RoleProviderError::Driver("db".into())));
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
+        let scope = make_project_scope("pid");
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(result, Err(AuthenticationError::Provider { .. })));
+    }
+
+    // --- Provider error: SPIFFE system list_roles ---
+    #[tokio::test]
+    async fn test_system_scope_spiffe_list_roles_error() {
+        let binding = make_spiffe_binding(
+            "spiffe://domain/ns/system-workload",
+            true,
+            Some(vec![SpiffeAuthorization::System {
+                system_id: "all".to_string(),
+                role_ids: None,
+            }]),
+        );
+        let principal = make_spiffe_principal("spiffe://domain/ns/system-workload", "spire-agent");
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_list_roles()
+            .returning(move |_state, _params| Err(RoleProviderError::Driver("db".into())));
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Spiffe(binding))
+            .principal(principal)
+            .build();
+        let scope = ScopeInfo::System("all".to_string());
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(result, Err(AuthenticationError::Provider { .. })));
+    }
+
+    // --- AppCred: empty roles list returns empty after filter ---
+    #[tokio::test]
+    async fn test_project_scope_appcred_empty_roles() {
+        let uid = "uid";
+        let pid = "pid";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| Ok(vec![assignment_with_role("admin")]));
+        let ac = openstack_keystone_core_types::application_credential::ApplicationCredential {
+            id: "ac1".to_string(),
+            user_id: uid.to_string(),
+            project_id: pid.to_string(),
+            name: "cred".to_string(),
+            description: None,
+            roles: Vec::new(),
+            unrestricted: false,
+            expires_at: None,
+            access_rules: None,
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::ApplicationCredential {
+                application_credential: ac,
+                token: None,
+            })
+            .principal(make_user_identity(uid))
+            .build();
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let scope = make_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- AppCred: all credential roles missing after filter ---
+    #[tokio::test]
+    async fn test_project_scope_appcred_all_roles_missing() {
+        let uid = "uid";
+        let pid = "pid";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| Ok(vec![assignment_with_role("admin")]));
+        let ac = openstack_keystone_core_types::application_credential::ApplicationCredential {
+            id: "ac1".to_string(),
+            user_id: uid.to_string(),
+            project_id: pid.to_string(),
+            name: "cred".to_string(),
+            description: None,
+            roles: vec![role_ref("other", "other")],
+            unrestricted: false,
+            expires_at: None,
+            access_rules: None,
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::ApplicationCredential {
+                application_credential: ac,
+                token: None,
+            })
+            .principal(make_user_identity(uid))
+            .build();
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let scope = make_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- Trust: expand adds role trustor does not have, .all() fails ---
+    #[tokio::test]
+    async fn test_trust_scope_expand_adds_missing_role() {
+        let trustor = "trustor";
+        let pid = "pid";
+        let base_rid = "base_role";
+        let extra_rid = "extra_role";
+        let trust_roles = vec![role_ref(base_rid, "base")];
+        // Trustor only has base_role, not extra_role
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(trustor)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| Ok(vec![assignment_with_role_actor(base_rid, trustor)]));
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(move |_state, roles| {
+                roles.push(role_ref(extra_rid, "extra"));
+                Ok(())
+            });
+        let state = get_mocked_state(
+            None,
+            Some(
+                Provider::mocked_builder()
+                    .mock_assignment(assignment_mock)
+                    .mock_role(role_mock),
+            ),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(trustor))
+            .build();
+        let scope = make_trust_scope(trustor, "trustee", pid, Some(trust_roles));
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        // After expand, trust_roles includes extra_role, but trustor does not have it
+        // .all() check fails -> ActorHasNoRolesOnTarget
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- Trust: no roles, trustor has no assignments ---
+    #[tokio::test]
+    async fn test_trust_scope_no_roles_no_assignments() {
+        let trustor = "trustor";
+        let pid = "pid";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(trustor)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+            })
+            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(trustor))
+            .build();
+        let scope = make_trust_scope(trustor, "trustee", pid, None);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
+    }
+
+    // --- Token restriction: role_ids empty, roles Some(roles) falls through ---
+    #[tokio::test]
+    async fn test_project_scope_token_restriction_no_role_ids_fallthrough() {
+        let uid = "uid";
+        let pid = "pid";
+        let restriction_roles = vec![role_ref("restricted", "restricted")];
+        let tr = TokenRestriction {
+            id: "tr1".to_string(),
+            domain_id: "d1".to_string(),
+            allow_rescope: true,
+            allow_renew: false,
+            role_ids: Vec::new(),
+            roles: Some(restriction_roles.clone()),
+            project_id: Some(pid.to_string()),
+            user_id: Some(uid.to_string()),
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(uid))
+            .token_restriction(tr)
+            .build();
+        // role_ids is empty so !restriction.role_ids.is_empty() is false
+        // Falls through to assignment lookup which returns empty
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some(uid)
+                    && q.project_id.as_deref() == Some(pid)
+                    && q.effective == Some(true)
+                    && q.include_names == Some(false)
+            })
+            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+        let scope = make_project_scope(pid);
+        let result = calculate_effective_roles(&state, &ctx, &scope).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::ActorHasNoRolesOnTarget)
+        ));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -96,6 +96,7 @@ pub mod provider;
 pub mod resource;
 pub mod revoke;
 pub mod role;
+pub mod spiffe;
 pub mod token;
 pub mod trust;
 

--- a/crates/core/src/plugin_manager.rs
+++ b/crates/core/src/plugin_manager.rs
@@ -43,6 +43,8 @@ use crate::revoke::RevokeProviderError;
 use crate::revoke::backend::RevokeBackend;
 use crate::role::RoleProviderError;
 use crate::role::backend::RoleBackend;
+use crate::spiffe::SpiffeProviderError;
+use crate::spiffe::backend::SpiffeBackend;
 use crate::token::TokenProviderError;
 use crate::token::backend::TokenBackend;
 use crate::token::backend::TokenRestrictionBackend;
@@ -181,6 +183,19 @@ pub trait PluginManagerApi {
         name: S,
     ) -> Result<&Arc<dyn RoleBackend>, RoleProviderError>;
 
+    /// Get registered spiffe backend.
+    ///
+    /// # Parameters
+    /// - `name`: The name of the backend to retrieve.
+    ///
+    /// # Returns
+    /// - `Ok(&Arc<dyn SpiffeBackend>)` if found, otherwise
+    ///   `Err(SpiffeProviderError)`.
+    fn get_spiffe_backend<S: AsRef<str>>(
+        &self,
+        name: S,
+    ) -> Result<&Arc<dyn SpiffeBackend>, SpiffeProviderError>;
+
     /// Get registered token backend.
     ///
     /// # Parameters
@@ -317,6 +332,13 @@ pub trait PluginManagerApi {
     /// - `name`: The name to register the backend under.
     /// - `plugin`: The backend implementation.
     fn register_role_backend<S: AsRef<str>>(&mut self, name: S, plugin: Arc<dyn RoleBackend>);
+
+    /// Register spiffe backend.
+    ///
+    /// # Parameters
+    /// - `name`: The name to register the backend under.
+    /// - `plugin`: The backend implementation.
+    fn register_spiffe_backend<S: AsRef<str>>(&mut self, name: S, plugin: Arc<dyn SpiffeBackend>);
 
     /// Register token backend.
     ///

--- a/crates/core/src/policy.rs
+++ b/crates/core/src/policy.rs
@@ -129,6 +129,28 @@ pub trait PolicyEnforcer: Send + Sync {
     }
 }
 
+//#[async_trait]
+//pub trait PolicyEnforcerExt: Send + Sync {
+//    /// Enforces a policy for a given action and credentials.
+//    ///
+//    /// # Parameters
+//    /// - `policy_name`: The name of the policy to enforce.
+//    /// - `credentials`: The credentials of the user requesting the action.
+//    /// - `target`: The target resource of the action.
+//    /// - `update`: Optional update data for the resource.
+//    ///
+//    /// # Returns
+//    /// - `Ok(PolicyEvaluationResult)` if the policy was evaluated
+// successfully.    /// - `Err(PolicyError)` if an error occurred during
+// enforcement.    async fn enforce<C: Into<Credentials>>(
+//        &self,
+//        policy_name: &'static str,
+//        credentials: &C,
+//        target: Value,
+//        update: Option<Value>,
+//    ) -> Result<PolicyEvaluationResult, PolicyError>;
+//}
+
 #[cfg(any(test, feature = "mock"))]
 mock! {
     pub Policy {}
@@ -175,6 +197,7 @@ pub struct Credentials {
     #[serde(default)]
     pub domain_id: Option<String>,
 
+    /// System scope information.
     #[builder(default)]
     #[serde(default)]
     pub system: Option<String>,
@@ -227,7 +250,6 @@ impl TryFrom<&ValidatedSecurityContext> for Credentials {
             }
         }
         let cred = builder.build()?;
-        tracing::info!("Converted {:?} into {:?}", sc, cred);
         Ok(cred)
     }
 }

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -54,6 +54,9 @@ use crate::revoke::RevokeProvider;
 use crate::role::MockRoleProvider;
 use crate::role::RoleProvider;
 #[cfg(any(test, feature = "mock"))]
+use crate::spiffe::MockSpiffeProvider;
+use crate::spiffe::SpiffeProvider;
+#[cfg(any(test, feature = "mock"))]
 use crate::token::MockTokenProvider;
 use crate::token::TokenProvider;
 #[cfg(any(test, feature = "mock"))]
@@ -80,6 +83,8 @@ pub struct Provider {
     identity_mapping: IdentityMappingProvider,
     /// K8s auth provider.
     k8s_auth: K8sAuthProvider,
+    /// Spiffe provider.
+    spiffe: SpiffeProvider,
     /// Resource provider.
     resource: ResourceProvider,
     /// Revoke provider.
@@ -133,6 +138,11 @@ impl ProviderBuilder {
         new.k8s_auth = Some(K8sAuthProvider::Mock(value));
         new
     }
+    pub fn mock_spiffe(self, value: MockSpiffeProvider) -> Self {
+        let mut new = self;
+        new.spiffe = Some(SpiffeProvider::Mock(value));
+        new
+    }
     pub fn mock_resource(self, value: MockResourceProvider) -> Self {
         let mut new = self;
         new.resource = Some(ResourceProvider::Mock(value));
@@ -174,6 +184,7 @@ impl Provider {
         let identity_provider = IdentityProvider::new(cfg, plugin_manager)?;
         let identity_mapping_provider = IdentityMappingProvider::new(cfg, plugin_manager)?;
         let k8s_auth_provider = K8sAuthProvider::new(cfg, plugin_manager)?;
+        let spiffe_provider = SpiffeProvider::new(cfg, plugin_manager)?;
         let resource_provider = ResourceProvider::new(cfg, plugin_manager)?;
         let revoke_provider = RevokeProvider::new(cfg, plugin_manager)?;
         let role_provider = RoleProvider::new(cfg, plugin_manager)?;
@@ -188,6 +199,7 @@ impl Provider {
             identity: identity_provider,
             identity_mapping: identity_mapping_provider,
             k8s_auth: k8s_auth_provider,
+            spiffe: spiffe_provider,
             resource: resource_provider,
             revoke: revoke_provider,
             role: role_provider,
@@ -207,6 +219,7 @@ impl Provider {
         let identity_mapping_mock = crate::identity_mapping::MockIdentityMappingProvider::default();
         let federation_mock = crate::federation::MockFederationProvider::default();
         let k8s_auth_mock = crate::k8s_auth::MockK8sAuthProvider::default();
+        let spiffe_mock = crate::spiffe::MockSpiffeProvider::default();
         let resource_mock = crate::resource::MockResourceProvider::default();
         let revoke_mock = crate::revoke::MockRevokeProvider::default();
         let role_mock = crate::role::MockRoleProvider::default();
@@ -221,6 +234,7 @@ impl Provider {
             .mock_identity_mapping(identity_mapping_mock)
             .mock_federation(federation_mock)
             .mock_k8s_auth(k8s_auth_mock)
+            .mock_spiffe(spiffe_mock)
             .mock_resource(resource_mock)
             .mock_revoke(revoke_mock)
             .mock_role(role_mock)
@@ -261,6 +275,11 @@ impl Provider {
     /// Get the K8s auth provider.
     pub fn get_k8s_auth_provider(&self) -> &K8sAuthProvider {
         &self.k8s_auth
+    }
+
+    /// Get the spiffe provider.
+    pub fn get_spiffe_provider(&self) -> &SpiffeProvider {
+        &self.spiffe
     }
 
     /// Get the resource provider.

--- a/crates/core/src/spiffe.rs
+++ b/crates/core/src/spiffe.rs
@@ -1,0 +1,170 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # SPIFFE identity management
+
+use async_trait::async_trait;
+
+pub mod backend;
+pub mod error;
+#[cfg(any(test, feature = "mock"))]
+mod mock;
+mod provider_api;
+pub mod service;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core_types::spiffe::*;
+
+use crate::keystone::ServiceState;
+use crate::plugin_manager::PluginManagerApi;
+
+pub use crate::spiffe::service::SpiffeService;
+pub use error::SpiffeProviderError;
+#[cfg(any(test, feature = "mock"))]
+pub use mock::MockSpiffeProvider;
+pub use provider_api::SpiffeApi;
+
+/// Spiffe provider.
+pub enum SpiffeProvider {
+    Service(SpiffeService),
+    #[cfg(any(test, feature = "mock"))]
+    Mock(MockSpiffeProvider),
+}
+
+impl SpiffeProvider {
+    /// Create a new `K8sAuthProvider`.
+    ///
+    /// # Arguments
+    /// * `config` - Reference to the [`Config`].
+    /// * `plugin_manager` - Reference to the [`PluginManagerApi`].
+    ///
+    /// # Returns
+    /// * Success with a new `K8sAuthProvider` instance.
+    /// * `K8sAuthProviderError` if the service could not be initialized.
+    pub fn new<P: PluginManagerApi>(
+        config: &Config,
+        plugin_manager: &P,
+    ) -> Result<Self, SpiffeProviderError> {
+        Ok(Self::Service(SpiffeService::new(config, plugin_manager)?))
+    }
+}
+
+#[async_trait]
+impl SpiffeApi for SpiffeProvider {
+    /// Register new binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `binding` - [`SpiffeBindingCreate`] data for the new binding.
+    ///
+    /// # Returns
+    /// * Success with the created [`SpiffeBinding`].
+    /// * Error if the instance could not be created.
+    async fn create_binding(
+        &self,
+        state: &ServiceState,
+        binding: SpiffeBindingCreate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError> {
+        match self {
+            Self::Service(provider) => provider.create_binding(state, binding).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.create_binding(state, binding).await,
+        }
+    }
+
+    /// Delete SPIFFE binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID of a binding to delete.
+    ///
+    /// # Returns
+    /// * Success if the binding was deleted.
+    /// * Error if the deletion failed.
+    async fn delete_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<(), SpiffeProviderError> {
+        match self {
+            Self::Service(provider) => provider.delete_binding(state, svid).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.delete_binding(state, svid).await,
+        }
+    }
+
+    /// Fetch binding for the SVID.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID identifier to fetch.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the [`SpiffeBinding`] if found,
+    /// or an `Error`.
+    async fn get_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<Option<SpiffeBinding>, SpiffeProviderError> {
+        match self {
+            Self::Service(provider) => provider.get_binding(state, svid).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.get_binding(state, svid).await,
+        }
+    }
+
+    /// List SpiffeBindings.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `params` - [`SpiffeBindingListParameters`] for filtering the list.
+    ///
+    /// # Returns
+    /// * Success with a list of [`SpiffeBinding`].
+    /// * Error if the listing failed.
+    async fn list_bindings(
+        &self,
+        state: &ServiceState,
+        params: &SpiffeBindingListParameters,
+    ) -> Result<Vec<SpiffeBinding>, SpiffeProviderError> {
+        match self {
+            Self::Service(provider) => provider.list_bindings(state, params).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.list_bindings(state, params).await,
+        }
+    }
+
+    /// Update binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `id` - The SVID for the binding to update.
+    /// * `data` - [`SpiffeBindingUpdate`] data to apply.
+    ///
+    /// # Returns
+    /// * Success with the updated [`SpiffeBinding`].
+    /// * Error if the update failed.
+    async fn update_binding<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        data: SpiffeBindingUpdate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError> {
+        match self {
+            Self::Service(provider) => provider.update_binding(state, id, data).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.update_binding(state, id, data).await,
+        }
+    }
+}

--- a/crates/core/src/spiffe/backend.rs
+++ b/crates/core/src/spiffe/backend.rs
@@ -1,0 +1,104 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # K8s auth: Backends.
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::spiffe::*;
+
+use crate::keystone::ServiceState;
+use crate::spiffe::SpiffeProviderError;
+
+/// K8s auth Backend trait.
+///
+/// Backend driver interface expected by the revocation auth_instance.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait SpiffeBackend: Send + Sync {
+    /// * Success with the created [`SpiffeBinding`].
+    /// Register new binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `binding` - [`SpiffeBindingCreate`] data for the new binding.
+    ///
+    /// # Returns
+    /// * Error if the instance could not be created.
+    async fn create_binding(
+        &self,
+        state: &ServiceState,
+        binding: SpiffeBindingCreate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError>;
+
+    /// Delete SPIFFE binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID of a binding to delete.
+    ///
+    /// # Returns
+    /// * Success if the binding was deleted.
+    /// * Error if the deletion failed.
+    async fn delete_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<(), SpiffeProviderError>;
+
+    /// Fetch binding for the SVID.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID identifier to fetch.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the [`SpiffeBinding`] if found,
+    /// or an `Error`.
+    async fn get_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<Option<SpiffeBinding>, SpiffeProviderError>;
+
+    /// List SpiffeBindings.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `params` - [`SpiffeBindingListParameters`] for filtering the list.
+    ///
+    /// # Returns
+    /// * Success with a list of [`SpiffeBinding`].
+    /// * Error if the listing failed.
+    async fn list_bindings(
+        &self,
+        state: &ServiceState,
+        params: &SpiffeBindingListParameters,
+    ) -> Result<Vec<SpiffeBinding>, SpiffeProviderError>;
+
+    /// Update binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID for the binding to update.
+    /// * `data` - [`SpiffeBindingUpdate`] data to apply.
+    ///
+    /// # Returns
+    /// * Success with the updated [`SpiffeBinding`].
+    /// * Error if the update failed.
+    async fn update_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+        data: SpiffeBindingUpdate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError>;
+}

--- a/crates/core/src/spiffe/error.rs
+++ b/crates/core/src/spiffe/error.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # K8s Auth error
+pub use openstack_keystone_core_types::spiffe::SpiffeProviderError;
+
+impl From<crate::error::DatabaseError> for SpiffeProviderError {
+    /// Convert a database error into a Spiffe provider error.
+    ///
+    /// # Arguments
+    /// * `source` - The database error to convert.
+    ///
+    /// # Returns
+    /// * Success with the converted `K8sAuthProviderError`.
+    fn from(source: crate::error::DatabaseError) -> Self {
+        match source {
+            cfl @ crate::error::DatabaseError::Conflict { .. } => Self::Conflict(cfl.to_string()),
+            other => Self::Driver {
+                source: other.into(),
+            },
+        }
+    }
+}

--- a/crates/core/src/spiffe/mock.rs
+++ b/crates/core/src/spiffe/mock.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # K8s auth - internal mocking tools.
+use async_trait::async_trait;
+use mockall::mock;
+
+use openstack_keystone_core_types::spiffe::*;
+
+use crate::keystone::ServiceState;
+use crate::spiffe::{SpiffeApi, SpiffeProviderError};
+
+mock! {
+    pub SpiffeProvider {}
+
+    #[async_trait]
+    impl SpiffeApi for SpiffeProvider {
+
+        async fn create_binding(
+            &self,
+            state: &ServiceState,
+            binding: SpiffeBindingCreate,
+        ) -> Result<SpiffeBinding, SpiffeProviderError>;
+
+        async fn delete_binding<'a>(
+            &self,
+            state: &ServiceState,
+            svid: &'a str,
+        ) -> Result<(), SpiffeProviderError>;
+
+        async fn get_binding<'a>(
+            &self,
+            state: &ServiceState,
+            id: &'a str,
+        ) -> Result<Option<SpiffeBinding>, SpiffeProviderError>;
+
+        async fn list_bindings(
+            &self,
+            state: &ServiceState,
+            params: &SpiffeBindingListParameters,
+        ) -> Result<Vec<SpiffeBinding>, SpiffeProviderError>;
+
+        async fn update_binding<'a>(
+            &self,
+            state: &ServiceState,
+            id: &'a str,
+            data: SpiffeBindingUpdate,
+        ) -> Result<SpiffeBinding, SpiffeProviderError>;
+    }
+}

--- a/crates/core/src/spiffe/provider_api.rs
+++ b/crates/core/src/spiffe/provider_api.rs
@@ -1,0 +1,102 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # SPIFFE workload identity mapping provider API.
+
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::spiffe::*;
+
+use crate::keystone::ServiceState;
+use crate::spiffe::SpiffeProviderError;
+
+/// The trait for managing the SPIFFE functionality.
+#[async_trait]
+pub trait SpiffeApi: Send + Sync {
+    /// Register new binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `binding` - [`SpiffeBindingCreate`] data for the new binding.
+    ///
+    /// # Returns
+    /// * Success with the created [`SpiffeBinding`].
+    /// * Error if the instance could not be created.
+    async fn create_binding(
+        &self,
+        state: &ServiceState,
+        binding: SpiffeBindingCreate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError>;
+
+    /// Delete SPIFFE binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID of a binding to delete.
+    ///
+    /// # Returns
+    /// * Success if the binding was deleted.
+    /// * Error if the deletion failed.
+    async fn delete_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<(), SpiffeProviderError>;
+
+    /// Fetch binding for the SVID.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID identifier to fetch.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the [`SpiffeBinding`] if found,
+    /// or an `Error`.
+    async fn get_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<Option<SpiffeBinding>, SpiffeProviderError>;
+
+    /// List SpiffeBindings.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `params` - [`SpiffeBindingListParameters`] for filtering the list.
+    ///
+    /// # Returns
+    /// * Success with a list of [`SpiffeBinding`].
+    /// * Error if the listing failed.
+    async fn list_bindings(
+        &self,
+        state: &ServiceState,
+        params: &SpiffeBindingListParameters,
+    ) -> Result<Vec<SpiffeBinding>, SpiffeProviderError>;
+
+    /// Update binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID for the binding to update.
+    /// * `data` - [`SpiffeBindingUpdate`] data to apply.
+    ///
+    /// # Returns
+    /// * Success with the updated [`SpiffeBinding`].
+    /// * Error if the update failed.
+    async fn update_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+        data: SpiffeBindingUpdate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError>;
+}

--- a/crates/core/src/spiffe/service.rs
+++ b/crates/core/src/spiffe/service.rs
@@ -1,0 +1,215 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Kubernetes authentication.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core_types::spiffe::*;
+
+use crate::keystone::ServiceState;
+use crate::plugin_manager::PluginManagerApi;
+use crate::spiffe::{SpiffeApi, SpiffeProviderError, backend::SpiffeBackend};
+
+/// Spiffeprovider.
+pub struct SpiffeService {
+    /// Backend driver.
+    pub(super) backend_driver: Arc<dyn SpiffeBackend>,
+}
+
+impl SpiffeService {
+    /// Create a new `SpiffeService`.
+    ///
+    /// # Arguments
+    /// * `config` - Reference to the [`Config`].
+    /// * `plugin_manager` - Reference to the [`PluginManagerApi`].
+    ///
+    /// # Returns
+    /// * Success with a new `SpiffeService` instance.
+    /// * `SpiffeProviderError` if the backend driver cannot be loaded.
+    pub fn new<P: PluginManagerApi>(
+        config: &Config,
+        plugin_manager: &P,
+    ) -> Result<Self, SpiffeProviderError> {
+        let backend_driver = plugin_manager
+            .get_spiffe_backend(config.spiffe.driver.clone())?
+            .clone();
+        Ok(Self { backend_driver })
+    }
+}
+
+#[async_trait]
+impl SpiffeApi for SpiffeService {
+    /// Register new binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `binding` - [`SpiffeBindingCreate`] data for the new binding.
+    ///
+    /// # Returns
+    /// * Success with the created [`SpiffeBinding`].
+    /// * Error if the instance could not be created.
+    async fn create_binding(
+        &self,
+        state: &ServiceState,
+        binding: SpiffeBindingCreate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError> {
+        self.backend_driver.create_binding(state, binding).await
+    }
+
+    /// Delete SPIFFE binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID of a binding to delete.
+    ///
+    /// # Returns
+    /// * Success if the binding was deleted.
+    /// * Error if the deletion failed.
+    async fn delete_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<(), SpiffeProviderError> {
+        self.backend_driver.delete_binding(state, svid).await
+    }
+
+    /// Fetch binding for the SVID.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID identifier to fetch.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the [`SpiffeBinding`] if found,
+    /// or an `Error`.
+    async fn get_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<Option<SpiffeBinding>, SpiffeProviderError> {
+        self.backend_driver.get_binding(state, svid).await
+    }
+
+    /// List SpiffeBindings.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `params` - [`SpiffeBindingListParameters`] for filtering the list.
+    ///
+    /// # Returns
+    /// * Success with a list of [`SpiffeBinding`].
+    /// * Error if the listing failed.
+    async fn list_bindings(
+        &self,
+        state: &ServiceState,
+        params: &SpiffeBindingListParameters,
+    ) -> Result<Vec<SpiffeBinding>, SpiffeProviderError> {
+        self.backend_driver.list_bindings(state, params).await
+    }
+
+    /// Update binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID for the binding to update.
+    /// * `data` - [`SpiffeBindingUpdate`] data to apply.
+    ///
+    /// # Returns
+    /// * Success with the updated [`SpiffeBinding`].
+    /// * Error if the update failed.
+    async fn update_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+        data: SpiffeBindingUpdate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError> {
+        self.backend_driver.update_binding(state, svid, data).await
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    // use std::sync::Arc;
+
+    // use super::*;
+    // use crate::k8s_auth::backend::MockK8sAuthBackend;
+    // use crate::tests::get_mocked_state;
+
+    //#[tokio::test]
+    //async fn test_create_auth_instance() {
+    //    let state = get_mocked_state(None, None).await;
+    //    let mut backend = MockK8sAuthBackend::default();
+    //    backend
+    //        .expect_create_auth_instance()
+    //        .returning(|_, _| Ok(K8sAuthInstance::default()));
+    //    let provider = K8sAuthService {
+    //        backend_driver: Arc::new(backend),
+    //        http_client_pool: Box::new(HttpClientPool::default()),
+    //    };
+
+    //    assert!(
+    //        provider
+    //            .create_auth_instance(
+    //                &state,
+    //                K8sAuthInstanceCreate {
+    //                    ca_cert: Some("ca".into()),
+    //                    disable_local_ca_jwt: Some(true),
+    //                    domain_id: "did".into(),
+    //                    enabled: true,
+    //                    host: "host".into(),
+    //                    id: Some("id".into()),
+    //                    name: Some("name".into()),
+    //                }
+    //            )
+    //            .await
+    //            .is_ok()
+    //    );
+    //}
+
+    //#[tokio::test]
+    //async fn test_create_auth_role() {
+    //    let state = get_mocked_state(None, None).await;
+    //    let mut backend = MockK8sAuthBackend::default();
+    //    backend
+    //        .expect_create_auth_role()
+    //        .returning(|_, _| Ok(K8sAuthRole::default()));
+    //    let provider = K8sAuthService {
+    //        backend_driver: Arc::new(backend),
+    //        http_client_pool: Box::new(HttpClientPool::default()),
+    //    };
+
+    //    assert!(
+    //        provider
+    //            .create_auth_role(
+    //                &state,
+    //                K8sAuthRoleCreate {
+    //                    auth_instance_id: "cid".into(),
+    //                    bound_audience: Some("aud".into()),
+    //                    bound_service_account_names: vec!["a".into(),
+    // "b".into()],                    bound_service_account_namespaces:
+    // vec!["na".into(), "nb".into()],                    domain_id:
+    // "did".into(),                    enabled: true,
+    //                    id: Some("id".into()),
+    //                    name: "name".into(),
+    //                    token_restriction_id: "trid".into(),
+    //                }
+    //            )
+    //            .await
+    //            .is_ok()
+    //    );
+    //}
+}

--- a/crates/core/src/token/service.rs
+++ b/crates/core/src/token/service.rs
@@ -517,7 +517,7 @@ impl TokenApi for TokenService {
             let roles: HashMap<String, Role> = state
                 .provider
                 .get_role_provider()
-                .list_roles(&state, &RoleListParameters::default())
+                .list_roles(state, &RoleListParameters::default())
                 .await?
                 .into_iter()
                 .map(|role| (role.id.clone(), role))
@@ -531,7 +531,7 @@ impl TokenApi for TokenService {
             state
                 .provider
                 .get_role_provider()
-                .expand_implied_roles(&state, &mut filtered_roles)
+                .expand_implied_roles(state, &mut filtered_roles)
                 .await?;
             tr.roles.get_or_insert_default().extend(filtered_roles);
         }

--- a/crates/k8s-auth-raft/src/lib.rs
+++ b/crates/k8s-auth-raft/src/lib.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # OpenStack Keystone SQL driver for the K8s auth provider
+//! # OpenStack Keystone Raft driver for the K8s auth provider
 use std::collections::BTreeSet;
 
 use async_trait::async_trait;
@@ -24,7 +24,7 @@ use openstack_keystone_distributed_storage::{
     Metadata, StorageApi, StoreDataEnvelope, store_command::Mutation,
 };
 
-/// Raft  Database K8s auth backend.
+/// Raft Database K8s auth backend.
 #[derive(Default)]
 pub struct RaftBackend {}
 
@@ -268,10 +268,10 @@ impl K8sAuthBackend for RaftBackend {
             .map(|x| x.data);
         if let Some(obj) = curr {
             let mutations = vec![
-                Mutation::remove(self.get_auth_instance_id_key_name(&obj.id), None::<&str>)
+                Mutation::remove(self.get_auth_instance_id_key_name(&id), None::<&str>)
                     .map_err(K8sAuthProviderError::raft)?,
                 Mutation::remove_index(
-                    self.get_auth_instance_domain_id_idx_key_name(&obj.id, &obj.domain_id),
+                    self.get_auth_instance_domain_id_idx_key_name(&id, &obj.domain_id),
                 )
                 .map_err(K8sAuthProviderError::raft)?,
             ];

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -47,6 +47,7 @@ openstack-keystone-idmapping-sql = { version = "0.1", path = "../idmapping-sql" 
 openstack-keystone-resource-sql = { version = "0.1", path = "../resource-sql/" }
 openstack-keystone-revoke-sql = { version = "0.1", path = "../revoke-sql/" }
 openstack-keystone-role-sql = { version = "0.1", path = "../role-sql/" }
+openstack-keystone-spiffe-raft = { version = "0.1", path = "../spiffe-raft/" }
 openstack-keystone-token-fernet = { version = "0.1", path = "../token-fernet/" }
 openstack-keystone-token-restriction-sql = { version = "0.1", path = "../token-restriction-sql/" }
 openstack-keystone-trust-sql = { version = "0.1", path = "../trust-sql/" }

--- a/crates/keystone/src/plugin_manager.rs
+++ b/crates/keystone/src/plugin_manager.rs
@@ -45,6 +45,8 @@ use openstack_keystone_core::revoke::RevokeProviderError;
 use openstack_keystone_core::revoke::backend::RevokeBackend;
 use openstack_keystone_core::role::RoleProviderError;
 use openstack_keystone_core::role::backend::RoleBackend;
+use openstack_keystone_core::spiffe::SpiffeProviderError;
+use openstack_keystone_core::spiffe::backend::SpiffeBackend;
 use openstack_keystone_core::token::TokenProviderError;
 use openstack_keystone_core::token::backend::{TokenBackend, TokenRestrictionBackend};
 use openstack_keystone_core::trust::TrustProviderError;
@@ -76,6 +78,8 @@ pub struct PluginManager {
     revoke_backends: HashMap<String, Arc<dyn RevokeBackend>>,
     /// Role backend plugins.
     role_backends: HashMap<String, Arc<dyn RoleBackend>>,
+    /// Spiffe backend plugins.
+    spiffe_backends: HashMap<String, Arc<dyn SpiffeBackend>>,
     /// Token backend plugins.
     token_backends: HashMap<String, Arc<dyn TokenBackend>>,
     /// Token restriction backend plugins.
@@ -279,6 +283,26 @@ impl PluginManagerApi for PluginManager {
             ))
     }
 
+    /// Get registered spiffe backend.
+    ///
+    /// # Parameters
+    /// * `name` - The name of the backend to retrieve.
+    ///
+    /// # Returns
+    /// A `Result` containing a reference to the `SpiffeBackend` if found, or a
+    /// `SpiffeProviderError`.
+    #[allow(clippy::borrowed_box)]
+    fn get_spiffe_backend<S: AsRef<str>>(
+        &self,
+        name: S,
+    ) -> Result<&Arc<dyn SpiffeBackend>, SpiffeProviderError> {
+        self.spiffe_backends
+            .get(name.as_ref())
+            .ok_or(SpiffeProviderError::UnsupportedDriver(
+                name.as_ref().to_string(),
+            ))
+    }
+
     /// Get registered token backend.
     ///
     /// # Parameters
@@ -468,6 +492,16 @@ impl PluginManagerApi for PluginManager {
         self.role_backends.insert(name.as_ref().to_string(), plugin);
     }
 
+    /// Register spiffe backend.
+    ///
+    /// # Parameters
+    /// * `name` - The name of the backend to register.
+    /// * `plugin` - The backend implementation to register.
+    fn register_spiffe_backend<S: AsRef<str>>(&mut self, name: S, plugin: Arc<dyn SpiffeBackend>) {
+        self.spiffe_backends
+            .insert(name.as_ref().to_string(), plugin);
+    }
+
     /// Register token backend.
     ///
     /// # Parameters
@@ -575,6 +609,7 @@ impl PluginManager {
             resource_backends: HashMap::new(),
             revoke_backends: HashMap::new(),
             role_backends: HashMap::new(),
+            spiffe_backends: HashMap::new(),
             token_backends: HashMap::new(),
             token_restriction_backends: HashMap::new(),
             trust_backends: HashMap::new(),
@@ -589,6 +624,10 @@ impl PluginManager {
         slf.register_k8s_auth_backend(
             "raft",
             Arc::new(openstack_keystone_k8s_auth_raft::RaftBackend::default()),
+        );
+        slf.register_spiffe_backend(
+            "raft",
+            Arc::new(openstack_keystone_spiffe_raft::RaftBackend::default()),
         );
         slf
     }

--- a/crates/keystone/src/policy.rs
+++ b/crates/keystone/src/policy.rs
@@ -16,9 +16,11 @@ use std::time::SystemTime;
 
 use reqwest::{Client, Url};
 use serde_json::{Value, json};
-use tracing::{debug, trace};
+use tracing::{Level, debug, trace};
 
 use openstack_keystone_core::auth::ValidatedSecurityContext;
+
+pub use openstack_keystone_core::api::auth::Auth;
 pub use openstack_keystone_core::policy::*;
 
 /// Policy factory.
@@ -74,18 +76,18 @@ impl HttpPolicyEnforcer {
 
 #[async_trait::async_trait]
 impl PolicyEnforcer for HttpPolicyEnforcer {
-    //#[tracing::instrument(
-    //    name = "policy.enforce",
-    //    skip_all,
-    //    fields(
-    //        entrypoint = policy_name.as_ref(),
-    //        input,
-    //        result,
-    //        duration_ms
-    //    ),
-    //    err,
-    //    level = Level::DEBUG
-    //)]
+    #[tracing::instrument(
+        name = "policy.enforce",
+        skip_all,
+        fields(
+            entrypoint = policy_name,
+            input,
+            result,
+            duration_ms
+        ),
+        err(Debug),
+        level = Level::DEBUG
+    )]
     /// Enforces a policy decision using OPA.
     ///
     /// # Parameters
@@ -113,7 +115,7 @@ impl PolicyEnforcer for HttpPolicyEnforcer {
         });
         let span = tracing::Span::current();
 
-        trace!("checking policy decision with OPA using http");
+        debug!("checking policy decision with OPA using http");
         let url = self.base_url.join(policy_name.as_ref())?;
         let res: PolicyEvaluationResult = self
             .http_client

--- a/crates/spiffe-raft/Cargo.toml
+++ b/crates/spiffe-raft/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "openstack-keystone-spiffe-raft"
+description = "OpenStack Keystone Raft driver for the mTLS identities powered by SPIFFE"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+exclude.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+inventory.workspace = true
+openstack-keystone-core = { version = "0.1", path = "../core" }
+openstack-keystone-core-types = { version = "0.1", path = "../core-types/" }
+openstack-keystone-distributed-storage = { version = "0.1", path = "../storage/"}
+tracing.workspace = true
+uuid.workspace = true
+
+[lints]
+workspace = true

--- a/crates/spiffe-raft/src/lib.rs
+++ b/crates/spiffe-raft/src/lib.rs
@@ -1,0 +1,297 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OpenStack Keystone Raft driver for the SPIFFE workload identity mapping
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+
+use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::spiffe::backend::SpiffeBackend;
+use openstack_keystone_core::spiffe::error::SpiffeProviderError;
+use openstack_keystone_core_types::spiffe::*;
+use openstack_keystone_distributed_storage::{
+    Metadata, StorageApi, StoreDataEnvelope, store_command::Mutation,
+};
+
+/// Raft Database SPIFFE identity backend.
+#[derive(Default)]
+pub struct RaftBackend {}
+
+impl RaftBackend {
+    /// Get the storage key for binding - direct entry.
+    ///
+    /// # Parameters
+    /// - `svid`: The auth instance ID.
+    ///
+    /// # Returns
+    /// The storage key.
+    fn get_binding_id_key_name<I: AsRef<str>>(&self, svid: I) -> String {
+        format!("spiffe:binding:svid:{}", svid.as_ref())
+    }
+
+    /// Get the storage key for binding - domain based index.
+    ///
+    /// # Parameters
+    /// - `svid`: The identity binding.
+    /// - `domain_id`: The domain ID.
+    ///
+    /// # Returns
+    /// The storage key.
+    fn get_binding_domain_id_idx_key_name<I: AsRef<str>, D: AsRef<str>>(
+        &self,
+        svid: I,
+        domain_id: D,
+    ) -> String {
+        format!(
+            "spiffe:binding:domain:{}:{}",
+            domain_id.as_ref(),
+            svid.as_ref()
+        )
+    }
+
+    /// Get the prefix key for listing all bindings.
+    ///
+    /// # Returns
+    /// The prefix key.
+    fn get_binding_prefix(&self) -> String {
+        format!("spiffe:binding:svid:")
+    }
+
+    /// Get the prefix for listing bindings by the domain_id.
+    ///
+    /// # Parameters
+    /// - `domain_id`: The domain ID.
+    ///
+    /// # Returns
+    /// The prefix key.
+    fn get_binding_by_domain_id_prefix<D: AsRef<str>>(&self, domain_id: D) -> String {
+        format!("spiffe:binding:domain:{}:", domain_id.as_ref(),)
+    }
+}
+
+#[async_trait]
+impl SpiffeBackend for RaftBackend {
+    /// Register new binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `binding` - [`SpiffeBindingCreate`] data for the new binding.
+    ///
+    /// # Returns
+    /// * Error if the instance could not be created.
+    async fn create_binding(
+        &self,
+        state: &ServiceState,
+        binding: SpiffeBindingCreate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError> {
+        let raft = state
+            .storage
+            .as_ref()
+            .ok_or(SpiffeProviderError::RaftNotAvailable)?;
+        let obj = SpiffeBinding::from(binding);
+        let mutations = vec![
+            Mutation::set(
+                self.get_binding_id_key_name(&obj.svid),
+                obj.clone(),
+                Metadata::new(),
+                None::<&str>,
+                None,
+            )
+            .map_err(SpiffeProviderError::raft)?,
+            Mutation::set_index(self.get_binding_domain_id_idx_key_name(&obj.svid, &obj.domain_id))
+                .map_err(SpiffeProviderError::raft)?,
+        ];
+        raft.transaction(mutations)
+            .await
+            .map_err(SpiffeProviderError::raft)?;
+        Ok(obj)
+    }
+
+    /// Delete SPIFFE binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID of a binding to delete.
+    ///
+    /// # Returns
+    /// * Success if the binding was deleted.
+    /// * Error if the deletion failed.
+    async fn delete_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<(), SpiffeProviderError> {
+        let raft = state
+            .storage
+            .as_ref()
+            .ok_or(SpiffeProviderError::RaftNotAvailable)?;
+        // Find the current object to be able to cleanup indexes as well
+        let curr: Option<SpiffeBinding> = raft
+            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
+            .await
+            .map_err(SpiffeProviderError::raft)?
+            .map(|x| x.data);
+        if let Some(obj) = curr {
+            let mutations = vec![
+                Mutation::remove(self.get_binding_id_key_name(&svid), None::<&str>)
+                    .map_err(SpiffeProviderError::raft)?,
+                Mutation::remove_index(
+                    self.get_binding_domain_id_idx_key_name(&svid, &obj.domain_id),
+                )
+                .map_err(SpiffeProviderError::raft)?,
+            ];
+            raft.transaction(mutations)
+                .await
+                .map_err(SpiffeProviderError::raft)?;
+        }
+        Ok(())
+    }
+
+    /// Fetch binding for the SVID.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID identifier to fetch.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the [`SpiffeBinding`] if found,
+    /// or an `Error`.
+    async fn get_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+    ) -> Result<Option<SpiffeBinding>, SpiffeProviderError> {
+        let raft = state
+            .storage
+            .as_ref()
+            .ok_or(SpiffeProviderError::RaftNotAvailable)?;
+        Ok(raft
+            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
+            .await
+            .map_err(SpiffeProviderError::raft)?
+            .map(|x| x.data))
+    }
+
+    /// List SpiffeBindings.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `params` - [`SpiffeBindingListParameters`] for filtering the list.
+    ///
+    /// # Returns
+    /// * Success with a list of [`SpiffeBinding`].
+    /// * Error if the listing failed.
+    async fn list_bindings(
+        &self,
+        state: &ServiceState,
+        params: &SpiffeBindingListParameters,
+    ) -> Result<Vec<SpiffeBinding>, SpiffeProviderError> {
+        let raft = state
+            .storage
+            .as_ref()
+            .ok_or(SpiffeProviderError::RaftNotAvailable)?;
+        let mut res: Vec<SpiffeBinding> = Vec::new();
+        let mut post_filters: Vec<SpiffeBindingFilter> = Vec::new();
+        let mut pre_filter_ids: BTreeSet<String> = BTreeSet::new();
+        if let Some(did) = &params.domain_id {
+            post_filters.push(SpiffeBindingFilter::Domain(did.clone()));
+            // pre-calculate the ID candidates by the DOMAIN_ID filter
+            let prefix = self.get_binding_by_domain_id_prefix(did);
+            let id_offset = if prefix.ends_with(':') {
+                prefix.len()
+            } else {
+                prefix.len() + 1
+            };
+            pre_filter_ids.extend(
+                raft.prefix_index(self.get_binding_by_domain_id_prefix(did))
+                    .await
+                    .map_err(SpiffeProviderError::raft)?
+                    .into_iter()
+                    .map(|entry| entry[id_offset..].into()),
+            );
+        }
+
+        if !pre_filter_ids.is_empty() {
+            for id in pre_filter_ids {
+                if let Some(candidate) = raft
+                    .get_by_key::<SpiffeBinding, String, &str>(
+                        self.get_binding_id_key_name(id),
+                        None::<&str>,
+                    )
+                    .await
+                    .map_err(SpiffeProviderError::raft)?
+                    .map(|x| x.data)
+                {
+                    if post_filters.iter().all(|f| f.matches(&candidate)) {
+                        res.push(candidate);
+                    }
+                }
+            }
+        } else {
+            for candidate in raft
+                .prefix::<SpiffeBinding, String, &str>(self.get_binding_prefix(), None::<&str>)
+                .await
+                .map_err(SpiffeProviderError::raft)?
+                .into_iter()
+                .map(|(_, v)| v.data)
+            {
+                if post_filters.iter().all(|f| f.matches(&candidate)) {
+                    res.push(candidate);
+                }
+            }
+        }
+        Ok(res)
+    }
+
+    /// Update binding.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `svid` - The SVID for the binding to update.
+    /// * `data` - [`SpiffeBindingUpdate`] data to apply.
+    ///
+    /// # Returns
+    /// * Success with the updated [`SpiffeBinding`].
+    /// * Error if the update failed.
+    async fn update_binding<'a>(
+        &self,
+        state: &ServiceState,
+        svid: &'a str,
+        data: SpiffeBindingUpdate,
+    ) -> Result<SpiffeBinding, SpiffeProviderError> {
+        let raft = state
+            .storage
+            .as_ref()
+            .ok_or(SpiffeProviderError::RaftNotAvailable)?;
+        let curr: StoreDataEnvelope<SpiffeBinding> = raft
+            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
+            .await
+            .map_err(SpiffeProviderError::raft)?
+            .ok_or(SpiffeProviderError::BindingNotFound(svid.to_string()))?;
+        let new = curr.data.with_update(data);
+        let new_meta = curr.metadata.new_revision();
+        raft.set_value(
+            self.get_binding_id_key_name(svid),
+            StoreDataEnvelope {
+                data: new.clone(),
+                metadata: new_meta,
+            },
+            None::<&str>,
+            Some(curr.metadata.revision),
+        )
+        .await
+        .map_err(SpiffeProviderError::raft)?;
+        Ok(new)
+    }
+}

--- a/policy/identity/user/list.rego
+++ b/policy/identity/user/list.rego
@@ -12,8 +12,25 @@ allow if {
 
 allow if {
 	"reader" in input.credentials.roles
+	input.credentials.system == "all"
+}
+
+allow if {
+	"reader" in input.credentials.roles
 	identity.domain_matches_domain_scope
 }
+
+#allow if {
+#  response := http.send({
+#    "method": "HEAD",
+#    "url": sprintf("https://localhost:8215/v3/projects/%s/users/%s/roles/reader", [input.credentials.project_id, input.credentials.user_id]),
+#    "tls_client_cert_file": "/tmp/certs/svid.0.pem",
+#    "tls_client_key_file": "/tmp/certs/svid.0.key",
+#    "tls_ca_cert_file": "/tmp/certs/bundle.0.pem",
+#    "tls_insecure_skip_verify": true
+#  })
+#  response.status_code == 200
+#}
 
 violation contains {"field": "domain_id", "msg": "listing users in domain different to the domain scope requires `admin` role."} if {
 	not "admin" in input.credentials.roles

--- a/policy/identity/user/list_test.rego
+++ b/policy/identity/user/list_test.rego
@@ -4,6 +4,7 @@ import data.identity.user.list
 
 test_allowed if {
 	list.allow with input as {"credentials": {"roles": ["admin"]}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 	list.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "target": {"domain_id": "foo"}}
 }
 

--- a/tests/integration/src/integration.rs
+++ b/tests/integration/src/integration.rs
@@ -23,6 +23,7 @@ mod k8s_auth;
 mod resource;
 mod revoke;
 mod role;
+mod spiffe;
 mod token;
 
 #[macro_use]

--- a/tests/integration/src/spiffe.rs
+++ b/tests/integration/src/spiffe.rs
@@ -12,29 +12,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! # OpenStack Keystone core provider types
-
-#![allow(clippy::module_inception)]
-#![deny(clippy::unwrap_used)]
-
-pub mod application_credential;
-pub mod assignment;
-pub mod auth;
-pub mod catalog;
-pub mod error;
-pub mod federation;
-pub mod identity;
-pub mod identity_mapping;
-pub mod k8s_auth;
-pub mod resource;
-pub mod revoke;
-pub mod role;
-pub mod scope;
-pub mod spiffe;
-pub mod token;
-pub mod trust;
-
-/// Return `true` to be used as a positive default for the serde macros.
-pub fn default_true() -> bool {
-    true
-}
+mod binding;

--- a/tests/integration/src/spiffe/binding.rs
+++ b/tests/integration/src/spiffe/binding.rs
@@ -1,0 +1,56 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone::keystone::Service;
+use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::spiffe::SpiffeApi;
+use openstack_keystone_core_types::spiffe::*;
+
+mod create;
+mod delete;
+mod get;
+mod list;
+mod update;
+
+use crate::common::*;
+
+impl ResourceDeleter<SpiffeBinding> for Arc<Service> {
+    fn delete(&self, resource: SpiffeBinding) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            let _ = self
+                .provider
+                .get_spiffe_provider()
+                .delete_binding(self, &resource.svid)
+                .await;
+        })
+    }
+}
+
+pub async fn create_binding(
+    state: &ServiceState,
+    data: SpiffeBindingCreate,
+) -> Result<AsyncResourceGuard<SpiffeBinding, ServiceState>> {
+    let res = state
+        .provider
+        .get_spiffe_provider()
+        .create_binding(state, data)
+        .await
+        .unwrap();
+    Ok(AsyncResourceGuard::new(res, state.clone()))
+}

--- a/tests/integration/src/spiffe/binding/create.rs
+++ b/tests/integration/src/spiffe/binding/create.rs
@@ -1,0 +1,54 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test k8s auth config.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::spiffe::SpiffeApi;
+use openstack_keystone_core_types::spiffe::*;
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_create() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let sot = SpiffeBindingCreate {
+        authorizations: None,
+        domain_id: domain.id.clone(),
+        svid: "spiffe://example.com/foo".into(),
+        is_system: false,
+        user_id: Some("uid".into()),
+    };
+    let res = state
+        .provider
+        .get_spiffe_provider()
+        .create_binding(&state, sot.clone())
+        .await?;
+    assert_eq!(sot.svid, res.svid);
+    assert_eq!(sot.authorizations, res.authorizations);
+    assert_eq!(sot.domain_id, res.domain_id);
+    assert_eq!(sot.is_system, res.is_system);
+    assert_eq!(sot.user_id, res.user_id);
+
+    state
+        .provider
+        .get_spiffe_provider()
+        .delete_binding(&state, &res.svid)
+        .await?;
+    Ok(())
+}

--- a/tests/integration/src/spiffe/binding/delete.rs
+++ b/tests/integration/src/spiffe/binding/delete.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test k8s auth config.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::spiffe::SpiffeApi;
+use openstack_keystone_core_types::spiffe::*;
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_delete() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let sot = SpiffeBindingCreate {
+        authorizations: None,
+        domain_id: domain.id.clone(),
+        svid: "spiffe://example.com/foo".into(),
+        is_system: false,
+        user_id: Some("uid".into()),
+    };
+    let res = state
+        .provider
+        .get_spiffe_provider()
+        .create_binding(&state, sot.clone())
+        .await?;
+
+    state
+        .provider
+        .get_spiffe_provider()
+        .delete_binding(&state, &res.svid)
+        .await?;
+    Ok(())
+}

--- a/tests/integration/src/spiffe/binding/get.rs
+++ b/tests/integration/src/spiffe/binding/get.rs
@@ -1,0 +1,72 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test k8s auth config.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::spiffe::SpiffeApi;
+use openstack_keystone_core_types::spiffe::*;
+
+use super::create_binding;
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_binding() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let sot = create_binding(
+        &state,
+        SpiffeBindingCreate {
+            authorizations: None,
+            domain_id: domain.id.clone(),
+            svid: "spiffe://example.com/foo".into(),
+            is_system: false,
+            user_id: Some("uid".into()),
+        },
+    )
+    .await?;
+
+    let res = state
+        .provider
+        .get_spiffe_provider()
+        .get_binding(&state, &sot.svid)
+        .await?
+        .expect("binding should be there");
+    assert_eq!(sot.svid, res.svid);
+    assert_eq!(sot.authorizations, res.authorizations);
+    assert_eq!(sot.domain_id, res.domain_id);
+    assert_eq!(sot.is_system, res.is_system);
+    assert_eq!(sot.user_id, res.user_id);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_binding_missing() -> Result<()> {
+    let (state, _) = get_state().await?;
+
+    assert!(
+        state
+            .provider
+            .get_spiffe_provider()
+            .get_binding(&state, &uuid::Uuid::new_v4().to_string())
+            .await?
+            .is_none()
+    );
+    Ok(())
+}

--- a/tests/integration/src/spiffe/binding/list.rs
+++ b/tests/integration/src/spiffe/binding/list.rs
@@ -1,0 +1,149 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test SPIFFE bindings.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::spiffe::SpiffeApi;
+use openstack_keystone_core_types::spiffe::*;
+
+use super::create_binding;
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_list() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let domain2 = create_domain!(state)?;
+
+    let binding1 = create_binding(
+        &state,
+        SpiffeBindingCreate {
+            authorizations: None,
+            domain_id: domain.id.clone(),
+            svid: "spiffe://example.com/foo".into(),
+            is_system: false,
+            user_id: None,
+        },
+    )
+    .await?;
+    let binding2 = create_binding(
+        &state,
+        SpiffeBindingCreate {
+            authorizations: None,
+            domain_id: domain.id.clone(),
+            svid: "spiffe://example.com/bar".into(),
+            is_system: false,
+            user_id: None,
+        },
+    )
+    .await?;
+    let binding3 = create_binding(
+        &state,
+        SpiffeBindingCreate {
+            authorizations: None,
+            domain_id: domain2.id.clone(),
+            svid: "spiffe://example.com/baz".into(),
+            is_system: false,
+            user_id: None,
+        },
+    )
+    .await?;
+
+    let res = state
+        .provider
+        .get_spiffe_provider()
+        .list_bindings(&state, &SpiffeBindingListParameters::default())
+        .await?;
+    assert!(res.contains(&binding1));
+    assert!(res.contains(&binding2));
+    assert!(res.contains(&binding3));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_list_domain() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let domain2 = create_domain!(state)?;
+
+    let binding1 = create_binding(
+        &state,
+        SpiffeBindingCreate {
+            authorizations: None,
+            domain_id: domain.id.clone(),
+            svid: "spiffe://example.com/foo".into(),
+            is_system: false,
+            user_id: None,
+        },
+    )
+    .await?;
+    let binding2 = create_binding(
+        &state,
+        SpiffeBindingCreate {
+            authorizations: None,
+            domain_id: domain.id.clone(),
+            svid: "spiffe://example.com/bar".into(),
+            is_system: false,
+            user_id: None,
+        },
+    )
+    .await?;
+    let binding3 = create_binding(
+        &state,
+        SpiffeBindingCreate {
+            authorizations: None,
+            domain_id: domain2.id.clone(),
+            svid: "spiffe://example.com/baz".into(),
+            is_system: false,
+            user_id: None,
+        },
+    )
+    .await?;
+
+    let res = state
+        .provider
+        .get_spiffe_provider()
+        .list_bindings(
+            &state,
+            &SpiffeBindingListParameters {
+                domain_id: Some(domain.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(res.contains(&binding1));
+    assert!(res.contains(&binding2));
+    assert!(!res.contains(&binding3));
+    let res = state
+        .provider
+        .get_spiffe_provider()
+        .list_bindings(
+            &state,
+            &SpiffeBindingListParameters {
+                domain_id: Some("missing".into()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(!res.contains(&binding1));
+    assert!(!res.contains(&binding2));
+    assert!(!res.contains(&binding3));
+    Ok(())
+}

--- a/tests/integration/src/spiffe/binding/update.rs
+++ b/tests/integration/src/spiffe/binding/update.rs
@@ -1,0 +1,64 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test k8s auth config.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::spiffe::SpiffeApi;
+use openstack_keystone_core_types::spiffe::*;
+
+use super::create_binding;
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_update() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let authz = vec![SpiffeAuthorization::Project {
+        project_id: "pid".into(),
+        role_ids: Some(vec!["r1".into()]),
+    }];
+    let sot = SpiffeBindingCreate {
+        authorizations: Some(authz),
+        domain_id: domain.id.clone(),
+        svid: "spiffe://example.com/foo".into(),
+        is_system: false,
+        user_id: Some("uid".into()),
+    };
+    let binding = create_binding(&state, sot.clone()).await?;
+
+    let authz2 = vec![SpiffeAuthorization::Project {
+        project_id: "pid2".into(),
+        role_ids: Some(vec!["r2".into()]),
+    }];
+    let req = SpiffeBindingUpdate {
+        authorizations: Some(authz2.clone()),
+    };
+    let res = state
+        .provider
+        .get_spiffe_provider()
+        .update_binding(&state, &binding.svid, req)
+        .await?;
+    assert_eq!(sot.svid, res.svid);
+    assert_eq!(authz2, res.authorizations.unwrap());
+    assert_eq!(sot.domain_id, res.domain_id);
+    assert_eq!(sot.is_system, res.is_system);
+    assert_eq!(sot.user_id, res.user_id);
+
+    Ok(())
+}

--- a/tools/k8s/keystone/base/conf/helper.conf
+++ b/tools/k8s/keystone/base/conf/helper.conf
@@ -1,0 +1,6 @@
+agent_address = "/run/spire/sockets/spire-agent.sock"
+cmd = ""
+cert_dir = "/etc/certs"
+svid_file_name = "tls.crt"
+svid_key_file_name = "tls.key"
+svid_bundle_file_name = "ca.crt"

--- a/tools/k8s/keystone/base/kustomization.yaml
+++ b/tools/k8s/keystone/base/kustomization.yaml
@@ -2,6 +2,9 @@ configMapGenerator:
   - name: keystone
     files:
       - conf/keystone.conf
+  - name: spiffe-helper-cfg
+    files:
+      - conf/helper.conf
 images:
   - name: py-keystone
     newName: ghcr.io/openstack-experimental/keystone/py-keystone

--- a/tools/k8s/keystone/base/statefulset-rs.yaml
+++ b/tools/k8s/keystone/base/statefulset-rs.yaml
@@ -124,7 +124,7 @@ spec:
             - mountPath: "/var/opa"
               name: "opa-socket"
 
-        - command: ["opa", "run", "--server", "/policy", "--addr", "unix:///var/opa/opa.sock", "--log-level", "debug"]
+        - command: ["opa", "run", "--server", "/policy", "--addr", "unix:///var/opa/opa.sock", "--log-level", "debug", "--watch", "/etc/certs"]
           image: opa
           name: opa
           ports:
@@ -133,6 +133,24 @@ spec:
           volumeMounts:
             - mountPath: /var/opa
               name: opa-socket
+            - name: "certs"
+              mountPath: "/etc/certs"
+              readOnly: true
+
+        # --- SPIFFE-Helper Container ---
+        - name: spiffe-helper
+          image: ghcr.io/spiffe/spiffe-helper:0.11.0
+          args: ["-config", "/etc/spiffe-helper/helper.conf"]
+          securityContext:
+            runAsUser: 1000
+          volumeMounts:
+            - name: certs
+              mountPath: /etc/certs
+            - mountPath: /run/spire/sockets
+              name: spiffe-workload-api
+              readOnly: true
+            - name: helper-config
+              mountPath: /etc/spiffe-helper
 
       volumes:
         - name: config
@@ -166,3 +184,8 @@ spec:
           csi:
             driver: "csi.spiffe.io"
             readOnly: true
+        - name: "certs"
+          emptyDir: {}
+        - name: "helper-config"
+          configMap:
+            name: spiffe-helper-cfg


### PR DESCRIPTION
- add spiffe provider
- add support for bindings to map svid to the AuthenticationResult and a
  VSC
- rework auth extractor to apply svid binding
