### PR TITLE
chore: Make core crates a workspace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -354,15 +354,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -445,6 +445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff-series"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b143524c9d0b6c3e8e80542a0a17e1e472ccfd5a3d3696bd6ad2b18248d3350"
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base2histogram"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74d05707c315a6c0601b1089186476cf11ee5fe8d6e035ea43c44ae1a0215cd"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,9 +497,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "base64urlsafedata"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f7f6be94fa637132933fd0a68b9140bcb60e3d46164cb68e82a2bb8d102b3a"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
 dependencies = [
  "base64 0.21.7",
  "pastey 0.1.1",
@@ -496,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "bcrypt"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523ab528ce3a7ada6597f8ccf5bd8d85ebe26d5edf311cad4d1d3cfb2d357ac6"
+checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
 dependencies = [
  "base64 0.22.1",
  "blowfish",
@@ -518,6 +530,15 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
  "serde",
 ]
 
@@ -568,12 +589,12 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -622,10 +643,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
@@ -700,26 +730,20 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -759,6 +783,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+ "serde",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,15 +838,25 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -819,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -915,9 +972,9 @@ checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -929,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -944,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.22"
+version = "0.15.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1002,11 +1059,12 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -1093,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1247,6 +1305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1393,7 +1460,7 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1496,7 +1563,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -1522,10 +1589,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "display-more"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "bf8aaad655bf39f0691f6f4025a8b58f1ff46fb12cb70f6d69e4f0dd2eb717a8"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1614,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1791,13 +1868,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1871,6 +1947,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -2021,9 +2103,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -2131,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2182,7 +2264,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2190,12 +2272,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2204,6 +2289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2277,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2365,10 +2459,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.9.0"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2572,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2604,7 +2707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2651,6 +2754,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "interval-heap"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,16 +2785,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-docker"
@@ -2744,27 +2846,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2798,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2810,14 +2917,14 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
 dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2855,7 +2962,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2873,11 +2980,26 @@ checksum = "209cc18fddbe7caf18c1cacf692ecc60b7cb8b17423644abd5e9ca0283a27ecc"
 dependencies = [
  "async-trait",
  "percent-encoding",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_with",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
@@ -2891,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -2916,9 +3038,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2928,14 +3050,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.8.0",
 ]
 
 [[package]]
@@ -2969,9 +3091,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a59a0cb1c7f84471ad5cd38d768c2a29390d17f1ff2827cdf49bc53e8ac70b"
+checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
 dependencies = [
  "libc",
  "neli",
@@ -2989,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -3023,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -3074,9 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -3224,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3301,16 +3423,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -3363,7 +3485,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3397,7 +3519,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -3420,9 +3542,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3446,7 +3568,7 @@ dependencies = [
  "oauth2",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde-value",
@@ -3462,23 +3584,28 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.17"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b9d8db10f834d517e4c2c45ab5c645bc5cafee9d07f7b150b8029a0b1ebdca"
+checksum = "42a7b7775774f72c1ec9c4a7a74ec5274515c66c0af40b0f8119ebd36ec3fde4"
 dependencies = [
  "anyerror",
+ "backoff-series",
+ "base2histogram",
  "byte-unit",
  "chrono",
  "clap",
  "derive_more",
+ "display-more",
  "futures-util",
+ "itertools 0.14.0",
  "maplit",
  "openraft-macros",
  "openraft-rt",
  "openraft-rt-tokio",
  "peel-off",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
  "validit",
@@ -3486,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.17"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22b0bd215948ed47997a1d0447ea592e49220096360a833b118f329a08aa286"
+checksum = "880853cd85c2dd7883122134abcc5483005dd175d6027e9e00c1eede8fd2a956"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -3499,25 +3626,26 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.17"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b651e6e2f25d022e34549e605eb8875c78ebc26862b16b06143a551e53ec00"
+checksum = "0ba87cea8e45601807f2537fd9e657e02c9ee2fdaa9be4ece013b296b03b2c97"
 dependencies = [
  "futures-channel",
  "futures-util",
  "openraft-macros",
- "rand 0.9.4",
+ "pin-project-lite",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.17"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478d5625fdeb13293e68549ba1d42b7a25085f3be04204412147637ad22e2827"
+checksum = "2a539ef5ef89d4da720c56300aeb702d6ddf2a9fa653b029b79d30e5f8cf68fa"
 dependencies = [
  "futures-util",
  "openraft-rt",
- "rand 0.9.4",
+ "rand 0.10.1",
  "tokio",
 ]
 
@@ -3602,7 +3730,7 @@ dependencies = [
  "openstack-keystone-token-restriction-sql",
  "openstack-keystone-trust-sql",
  "openstack-keystone-webauthn",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rstest",
  "rustls",
  "sea-orm",
@@ -3762,7 +3890,7 @@ dependencies = [
  "openstack-keystone-core-types",
  "openstack-keystone-distributed-storage",
  "rand 0.10.1",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rstest",
  "sea-orm",
  "secrecy",
@@ -3986,7 +4114,7 @@ dependencies = [
  "criterion",
  "fernet",
  "itertools 0.14.0",
- "nix 0.31.2",
+ "nix 0.31.3",
  "openstack-keystone-config",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
@@ -4049,7 +4177,7 @@ dependencies = [
  "openstack-keystone-distributed-storage",
  "openstack-keystone-token-fernet",
  "rcgen",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "reserve-port",
  "sea-orm",
  "serde",
@@ -4073,10 +4201,380 @@ dependencies = [
 ]
 
 [[package]]
-name = "openstack_sdk_core"
+name = "openstack-sdk-auth-applicationcredential"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7ca32d3f2ec1ede065778b45ca22bc71f1df8d1e4f6787d463653fbe23feaf"
+checksum = "081e1f18aedc862cc9c67e42bdbe418f43ab7c50a0a135f97158588cf495c8d6"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "inventory",
+ "openstack-sdk-auth-core",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "openstack-sdk-auth-core"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c11dc19be9f2b4283f6033370d60725ec03b6854b7b7daa68c205ee1eec5a0a"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "derive_builder",
+ "dyn-clone",
+ "http",
+ "inventory",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "openstack-sdk-auth-oidcaccesstoken"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0d49ca0c993e10774a5e53a64d54fc4d9bfe64e8460116b23d37b7447061d3"
+dependencies = [
+ "async-trait",
+ "inventory",
+ "openstack-sdk-auth-core",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "openstack-sdk-auth-password"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae918aa6a9f1bb1d24af9e21f95f325193747029582255146a6b68a928364b1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "inventory",
+ "openstack-sdk-auth-core",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "openstack-sdk-auth-receipt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687128fd471c9f42541502d360a49f12f3fac6d977ff95bfd717cb508385d763"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "inventory",
+ "openstack-sdk-auth-core",
+ "openstack-sdk-auth-password",
+ "openstack-sdk-auth-token",
+ "openstack-sdk-auth-totp",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "openstack-sdk-auth-token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e34415a01d1c58015a38d2cc30818ce723d014a39f543d9a44beb078ae0a951"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "inventory",
+ "openstack-sdk-auth-core",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "openstack-sdk-auth-totp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae14bf7280098e72eec9d89b8429db7968fc3f0f9fc3f3b3bb1e968693ed2b2f"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "inventory",
+ "openstack-sdk-auth-core",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "openstack-sdk-auth-websso"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5400652ca7cf861c868374b9a85e62120be2c0c51c2e6b243c0c380393f36241"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "dialoguer",
+ "form_urlencoded",
+ "futures",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "inventory",
+ "open",
+ "openstack-sdk-auth-core",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "openstack-sdk-block-storage"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2356c0131029635dc743d10348328f856da3826162d61aec0a12d8e308f3aca1"
+dependencies = [
+ "derive_builder",
+ "http",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-compute"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf299b4fe6939a444434c963a2e015aa249eaa797d83c1f92a62d7befecbae7e"
+dependencies = [
+ "derive_builder",
+ "http",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-container-infrastructure-management"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaf7f166e156c18a1c4a890902b4c1192a2f2fc3777221176c51673dc736282"
+dependencies = [
+ "derive_builder",
+ "http",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-dns"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69daca6c41f24927a5f6b8f456f6a31d3d0cab558be52f990981ae9c5a48754a"
+dependencies = [
+ "derive_builder",
+ "http",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-identity"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d63af0815b396ac56210183bd6f3c851288a5467408c035ffa23e66b4e312a"
+dependencies = [
+ "derive_builder",
+ "http",
+ "openstack_sdk_core",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-image"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3bcab9295e440f84927528f0609b9f28a20b77724aa2932b5268b89a7a4307b"
+dependencies = [
+ "derive_builder",
+ "http",
+ "json-patch",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-load-balancer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96572fab87264806c2a1633a225834def085b50cb8766e5e0088e9ac0086cdac"
+dependencies = [
+ "derive_builder",
+ "http",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-network"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1952c3cd49a7dc312e9e088e8f09cd6adce2423980dd75111ab0cd85f5258bd0"
+dependencies = [
+ "derive_builder",
+ "http",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-object-store"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e9130712cab4e4519bd3415def2698bec6ee3888b0ed1b0956817a197262076"
+dependencies = [
+ "async-trait",
+ "derive_builder",
+ "futures",
+ "http",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack-sdk-placement"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb3556d896344c6b399576e162f561a00aa03c936932c5cf90a30e66cdd88d1"
+dependencies = [
+ "derive_builder",
+ "http",
+ "openstack_sdk_core",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "openstack_sdk"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad55d76aa6c594ef8dcf1429a53f90270f43d8daa0a3a397c54f4f2d099839e5"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "derive_builder",
+ "futures",
+ "futures-util",
+ "http",
+ "inventory",
+ "openstack-sdk-auth-applicationcredential",
+ "openstack-sdk-auth-core",
+ "openstack-sdk-auth-oidcaccesstoken",
+ "openstack-sdk-auth-password",
+ "openstack-sdk-auth-receipt",
+ "openstack-sdk-auth-token",
+ "openstack-sdk-auth-totp",
+ "openstack-sdk-auth-websso",
+ "openstack-sdk-block-storage",
+ "openstack-sdk-compute",
+ "openstack-sdk-container-infrastructure-management",
+ "openstack-sdk-dns",
+ "openstack-sdk-identity",
+ "openstack-sdk-image",
+ "openstack-sdk-load-balancer",
+ "openstack-sdk-network",
+ "openstack-sdk-object-store",
+ "openstack-sdk-placement",
+ "openstack_sdk_core",
+ "reqwest 0.13.4",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "openstack_sdk_core"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702b9cae36f51efe784adde932ab1ac8fa35c34fec61dc4a60153fe3781af609"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4086,19 +4584,16 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "dirs",
- "form_urlencoded",
+ "dyn-clone",
  "futures",
  "futures-util",
  "http",
- "http-body-util",
- "hyper",
- "hyper-util",
+ "inventory",
  "itertools 0.14.0",
- "json-patch",
- "open",
+ "openstack-sdk-auth-core",
  "postcard",
  "regex",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "secrecy",
  "serde",
  "serde_json",
@@ -4238,6 +4733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4251,9 +4755,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path-tree"
@@ -4357,27 +4861,65 @@ dependencies = [
 
 [[package]]
 name = "pgvector"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.11"
+name = "phf"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4660,9 +5202,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -4680,9 +5222,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -4773,9 +5315,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4869,9 +5411,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
@@ -4892,9 +5434,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -5014,9 +5556,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5248,15 +5790,15 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -5308,9 +5850,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5336,9 +5878,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5346,9 +5888,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -5747,9 +6289,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -5836,11 +6378,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5855,9 +6398,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5952,6 +6495,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5974,6 +6527,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -6002,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "spiffe"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54719680539609c66ad62ed7050e3b27f359a0040aee580582ce59c2b27d24a8"
+checksum = "6d3f9e45e9e53f03cb452fe0f050101a9280ff4f4214e326037bc8275284d906"
 dependencies = [
  "arc-swap",
  "base64ct",
@@ -6030,9 +6589,9 @@ dependencies = [
 
 [[package]]
 name = "spiffe-rustls"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc06b7e78bff3c414373f2a6265f63bfe49fbe712c6e92fee28487543ad994d1"
+checksum = "e922ff2c7255c4a5e7ae303cc16371c622ca08f06311bc82f1684740e38c36a4"
 dependencies = [
  "oid-registry 0.8.1",
  "rustls",
@@ -6107,7 +6666,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.14.0",
  "log",
  "memchr",
@@ -6197,7 +6756,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
@@ -6241,7 +6800,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -6340,6 +6899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6419,9 +6984,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -6467,8 +7032,8 @@ dependencies = [
  "eyre",
  "http",
  "openstack-keystone-api-types",
- "openstack_sdk_core",
- "reqwest 0.13.2",
+ "openstack_sdk",
+ "reqwest 0.13.4",
  "secrecy",
  "serde",
  "serde_json",
@@ -6493,7 +7058,7 @@ dependencies = [
  "keycloak",
  "local-ip-address",
  "openstack-keystone-api-types",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6554,8 +7119,8 @@ dependencies = [
  "futures-util",
  "http",
  "indexmap 2.14.0",
- "pastey 0.2.2",
- "reqwest 0.13.2",
+ "pastey 0.2.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6706,9 +7271,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6791,9 +7356,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -6812,9 +7377,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -6842,9 +7407,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6854,9 +7419,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -6865,9 +7430,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6900,9 +7465,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",
@@ -6912,7 +7477,6 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -6920,6 +7484,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -6949,11 +7514,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -7066,9 +7632,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -7243,9 +7809,9 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7344,11 +7910,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -7357,7 +7923,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -7368,9 +7934,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7382,9 +7948,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7392,9 +7958,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7402,9 +7968,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7415,9 +7981,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -7471,9 +8037,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7491,9 +8057,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-attestation-ca"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafcf13f7dc1fb292ed4aea22cdd3757c285d7559e9748950ee390249da4da6b"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
 dependencies = [
  "base64urlsafedata",
  "openssl",
@@ -7505,9 +8071,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-authenticator-rs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b41ed08aba475a969094226ae0691a286686210ae497bb2c5d0ed722d8d526"
+checksum = "779e9c80ff248c7e12ea967f909249101f6e86f70fccd742d4b66c490c1710b4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7538,9 +8104,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b24d082d3360258fefb6ffe56123beef7d6868c765c779f97b7a2fcf06727f8"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
 dependencies = [
  "base64urlsafedata",
  "serde",
@@ -7552,9 +8118,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-core"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15784340a24c170ce60567282fb956a0938742dbfbf9eff5df793a686a009b8b"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
@@ -7579,9 +8145,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-proto"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1fb2580ce73baa42d3011a24de2ceab0d428de1879ece06e02e8c416e497c"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
@@ -7592,18 +8158,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7721,15 +8287,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -7762,21 +8319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7829,12 +8371,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7853,12 +8389,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7874,12 +8404,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7913,12 +8437,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7934,12 +8452,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7961,12 +8473,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7982,12 +8488,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8009,9 +8509,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -8024,6 +8524,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -8142,7 +8648,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs 0.7.2",
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
@@ -8172,13 +8678,13 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.11.0",
 ]
 
 [[package]]
@@ -8189,10 +8695,11 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec",
  "time",
 ]
 
@@ -8221,18 +8728,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8241,9 +8748,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ futures = { version = "0.3" }
 futures-util = { version = "0.3" }
 http-body-util = "0.1"
 http = { version = "1.4" }
-hyper = { version = "1.9" }
+hyper = { version = "1.10" }
 hyper-util = { version = "0.1" }
 inventory = { version = "0.3" }
 itertools = { version = "0.14" }
@@ -76,15 +76,20 @@ mockall = { version = "0.14" }
 mockall_double = { version = "0.3" }
 nix = { version = "0.31", default-features = false }
 openidconnect = { version = "4.0" }
-openraft = { version = "0.10.0-alpha.17" }
+openraft = { version = "=0.10.0-alpha.20" }
+openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "crates/api-types" }
 openstack-keystone-config = { version = "0.1.0", path = "crates/config"}
+openstack-keystone-core = { version = "0.1.0", path = "crates/core" }
+openstack-keystone-core-types = { version = "0.1.0", path = "crates/core-types" }
+openstack-keystone-distributed-storage = { version = "0.1.0", path = "crates/storage"}
+openstack-keystone-token-fernet = { version = "0.1.0", path = "crates/token-fernet" }
 prost = { version = "0.14" }
 rand = { version = "0.10" }
 regex = { version = "1.12" }
 reqwest = { version = "0.13" }
-rcgen = "0.14.7"
+rcgen = { version = "0.14" }
 rmp = { version = "0.8" }
-rstest = "0.26"
+rstest = { version = "0.26" }
 rustls = { version = "0.23" }
 schemars = { version = "1.2" }
 scopeguard = "1.2.0"
@@ -95,10 +100,10 @@ serde = { version = "1.0" }
 serde_bytes = { version = "0.11" }
 serde_json = { version = "1.0" }
 serde_urlencoded = { version = "0.7" }
-spiffe = { version = "0.15.0" }
+spiffe = { version = "0.15" }
 tempfile = { version = "3.27" }
 thiserror = { version = "2.0" }
-tokio = { version = "1.51", default-features = false }
+tokio = { version = "1.52", default-features = false }
 tokio-rustls = "0.26.4"
 tokio-util = { version = "0.7" }
 tonic = { version = "0.14" }
@@ -141,6 +146,3 @@ expect_used = "deny"
 print_stdout = "deny"
 unwrap_used = "deny"
 doc_paragraphs_missing_punctuation = "warn"
-
-#[patch.crates-io]
-#openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.13" }

--- a/crates/appcred-sql/Cargo.toml
+++ b/crates/appcred-sql/Cargo.toml
@@ -14,9 +14,9 @@ exclude.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 inventory.workspace = true
-openstack-keystone-config = { version = "0.1", path = "../config" }
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-config.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 secrecy.workspace = true
 sea-orm.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/assignment-sql/Cargo.toml
+++ b/crates/assignment-sql/Cargo.toml
@@ -13,9 +13,9 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-keystone-config = { version = "0.1", path = "../config" }
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-config.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/catalog-sql/Cargo.toml
+++ b/crates/catalog-sql/Cargo.toml
@@ -13,8 +13,8 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/federation-sql/Cargo.toml
+++ b/crates/federation-sql/Cargo.toml
@@ -14,8 +14,8 @@ exclude.workspace = true
 async-trait.workspace = true
 chrono = { workspace = true, features = ["now"] }
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/identity-sql/Cargo.toml
+++ b/crates/identity-sql/Cargo.toml
@@ -14,9 +14,9 @@ exclude.workspace = true
 async-trait.workspace = true
 chrono = { workspace = true, features = ["now"] }
 inventory.workspace = true
-openstack-keystone-config = { version = "0.1", path = "../config" }
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-config.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/idmapping-sql/Cargo.toml
+++ b/crates/idmapping-sql/Cargo.toml
@@ -13,14 +13,14 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 chrono = { workspace = true, features = ["now"] }
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }
+openstack-keystone-core = { workspace = true, features = ["mock"] }
 sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite" ]}
 tokio = { workspace = true, features = ["macros"] }
 

--- a/crates/k8s-auth-raft/Cargo.toml
+++ b/crates/k8s-auth-raft/Cargo.toml
@@ -13,9 +13,9 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types/" }
-openstack-keystone-distributed-storage = { version = "0.1", path = "../storage/"}
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
+openstack-keystone-distributed-storage.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 

--- a/crates/k8s-auth-sql/Cargo.toml
+++ b/crates/k8s-auth-sql/Cargo.toml
@@ -13,14 +13,14 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }
+openstack-keystone-core = { workspace = true, features = ["mock"] }
 sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite" ]}
 tokio = { workspace = true, features = ["macros"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -31,14 +31,14 @@ eyre.workspace = true
 futures-util.workspace = true
 hyper-util.workspace = true
 hyper.workspace = true
-openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "../api-types/"}
+openstack-keystone-api-types = { workspace = true, features = ["openapi", "validate", "conv"]}
 openstack-keystone-appcred-sql = { version = "0.1", path = "../appcred-sql/" }
 openstack-keystone-assignment-sql = { version = "0.1", path = "../assignment-sql/" }
 openstack-keystone-catalog-sql = { version = "0.1", path = "../catalog-sql/" }
-openstack-keystone-config = { version = "0.1", path = "../config" }
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["api"] }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
-openstack-keystone-distributed-storage = { version = "0.1", path = "../storage/"}
+openstack-keystone-config.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
+openstack-keystone-distributed-storage.workspace = true
 openstack-keystone-federation-sql = { version = "0.1", path = "../federation-sql" }
 openstack-keystone-k8s-auth-sql = { version = "0.1", path = "../k8s-auth-sql/" }
 openstack-keystone-k8s-auth-raft = { version = "0.1", path = "../k8s-auth-raft/" }
@@ -48,7 +48,7 @@ openstack-keystone-resource-sql = { version = "0.1", path = "../resource-sql/" }
 openstack-keystone-revoke-sql = { version = "0.1", path = "../revoke-sql/" }
 openstack-keystone-role-sql = { version = "0.1", path = "../role-sql/" }
 openstack-keystone-spiffe-raft = { version = "0.1", path = "../spiffe-raft/" }
-openstack-keystone-token-fernet = { version = "0.1", path = "../token-fernet/" }
+openstack-keystone-token-fernet.workspace = true
 openstack-keystone-token-restriction-sql = { version = "0.1", path = "../token-restriction-sql/" }
 openstack-keystone-trust-sql = { version = "0.1", path = "../trust-sql/" }
 openstack-keystone-webauthn = { version = "0.1", path = "../webauthn/"}
@@ -62,7 +62,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
 spiffe = { workspace = true, features = ["x509-source"] }
-spiffe-rustls = "0.6.0"
+spiffe-rustls = "0.6.1"
 spiffe-rustls-tokio = "0.3"
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "signal", "rt-multi-thread"] }

--- a/crates/resource-sql/Cargo.toml
+++ b/crates/resource-sql/Cargo.toml
@@ -13,15 +13,15 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }
+openstack-keystone-core = { workspace = true, features = ["mock"] }
 sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite" ]}
 tokio = { workspace = true, features = ["macros"] }
 

--- a/crates/revoke-sql/Cargo.toml
+++ b/crates/revoke-sql/Cargo.toml
@@ -14,15 +14,15 @@ exclude.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }
+openstack-keystone-core = { workspace = true, features = ["mock"] }
 sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite" ]}
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/role-sql/Cargo.toml
+++ b/crates/role-sql/Cargo.toml
@@ -13,15 +13,15 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }
+openstack-keystone-core = { workspace = true, features = ["mock"] }
 sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite" ]}
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/spiffe-raft/Cargo.toml
+++ b/crates/spiffe-raft/Cargo.toml
@@ -15,7 +15,7 @@ async-trait.workspace = true
 inventory.workspace = true
 openstack-keystone-core = { version = "0.1", path = "../core" }
 openstack-keystone-core-types = { version = "0.1", path = "../core-types/" }
-openstack-keystone-distributed-storage = { version = "0.1", path = "../storage/"}
+openstack-keystone-distributed-storage.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -35,7 +35,7 @@ futures.workspace = true
 http.workspace = true
 mockall.workspace = true
 openraft = { workspace = true, features = ["serde", "type-alias"] }
-openstack-keystone-config = { version = "0.1", path = "../config/" }
+openstack-keystone-config.workspace = true
 prost.workspace = true
 rand.workspace = true
 rmp.workspace = true

--- a/crates/storage/src/network.rs
+++ b/crates/storage/src/network.rs
@@ -286,8 +286,8 @@ impl NetSnapshot<TypeConfig> for NetworkConnection {
 }
 
 impl NetBackoff<TypeConfig> for NetworkConnection {
-    fn backoff(&self) -> Backoff {
-        Backoff::new(std::iter::repeat(Duration::from_millis(200)))
+    fn backoff(&self) -> Option<Backoff> {
+        Some(Backoff::new(std::iter::repeat(Duration::from_millis(200))))
     }
 }
 

--- a/crates/token-fernet/Cargo.toml
+++ b/crates/token-fernet/Cargo.toml
@@ -19,9 +19,9 @@ bytes.workspace = true
 chrono.workspace = true
 fernet = { workspace = true, features = ["rustcrypto"] }
 itertools.workspace = true
-openstack-keystone-config = { version = "0.1", path = "../config" }
-openstack-keystone-core = { version = "0.1", path = "../core/"}
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-config.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 nix = { workspace = true, features = ["fs", "user"] }
 rmp.workspace = true
 scopeguard.workspace = true

--- a/crates/token-restriction-sql/Cargo.toml
+++ b/crates/token-restriction-sql/Cargo.toml
@@ -13,14 +13,14 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true
 
 [dev-dependencies]
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }
+openstack-keystone-core = { workspace = true, features = ["mock"] }
 sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite" ]}
 tokio = { workspace = true, features = ["macros"] }
 

--- a/crates/trust-sql/Cargo.toml
+++ b/crates/trust-sql/Cargo.toml
@@ -14,8 +14,8 @@ exclude.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 inventory.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core" }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types" }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros"] }
@@ -23,7 +23,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }
+openstack-keystone-core = { workspace = true, features = ["mock"] }
 sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite" ]}
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/webauthn/Cargo.toml
+++ b/crates/webauthn/Cargo.toml
@@ -16,10 +16,10 @@ chrono.workspace = true
 derive_builder.workspace = true
 eyre.workspace = true
 inventory.workspace = true
-openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "../api-types/" }
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["api"] }
-openstack-keystone-core-types = { version = "0.1", path = "../core-types/" }
-openstack-keystone-distributed-storage = { version = "0.1", path = "../storage/"}
+openstack-keystone-api-types = { workspace = true, features = ["openapi", "validate", "conv"] }
+openstack-keystone-core = { workspace = true, features = ["api"] }
+openstack-keystone-core-types.workspace = true
+openstack-keystone-distributed-storage.workspace = true
 sea-orm = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
@@ -37,9 +37,9 @@ webauthn-rs = { workspace = true, features = ["danger-allow-state-serialisation"
 axum = { workspace = true, features = ["http2", "tokio"] }
 base64urlsafedata.workspace = true
 mockall.workspace = true
-openstack-keystone-config = { version = "0.1", path = "../config" }
-openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }
-openstack-keystone-token-fernet = { version = "0.1", path = "../token-fernet/" }
+openstack-keystone-config.workspace = true
+openstack-keystone-core = { workspace = true, features = ["mock"] }
+openstack-keystone-token-fernet.workspace = true
 rcgen.workspace = true
 reqwest.workspace = true
 reserve-port = "2.4"

--- a/tests/api/Cargo.toml
+++ b/tests/api/Cargo.toml
@@ -15,8 +15,8 @@ bytes.workspace = true
 eyre.workspace = true
 derive_builder.workspace = true
 http.workspace = true
-openstack-keystone-api-types = { version = "0.1", features = ["builder"], path = "../../crates/api-types" }
-openstack_sdk_core = { version = "0.22" }
+openstack-keystone-api-types = { workspace = true, features = ["builder"] }
+openstack_sdk = { version = "0.22" }
 reqwest = { workspace = true, features = ["json", "http2", "multipart", "gzip", "deflate"] }
 secrecy = { workspace = true, features = ["serde"] }
 serde.workspace = true

--- a/tests/api/src/assignment/grant/project/user/role.rs
+++ b/tests/api/src/assignment/grant/project/user/role.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use derive_builder::Builder;
 use eyre::Result;
 
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
-use openstack_sdk_core::{AsyncOpenStack, api::QueryAsync};
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
 mod check;
 mod grant;
@@ -93,7 +93,7 @@ pub async fn check_grant<
     user_id: U,
     role_id: R,
 ) -> Result<bool> {
-    Ok(openstack_sdk_core::api::ignore(
+    Ok(openstack_sdk::api::ignore(
         ProjectUserRoleGrantCheckBuilder::default()
             .project_id(project_id.as_ref())
             .user_id(user_id.as_ref())
@@ -115,7 +115,7 @@ pub async fn add_project_grant<
     user_id: U,
     role_id: R,
 ) -> Result<()> {
-    openstack_sdk_core::api::ignore(
+    openstack_sdk::api::ignore(
         ProjectUserRoleGrantSetBuilder::default()
             .project_id(project_id.as_ref())
             .user_id(user_id.as_ref())

--- a/tests/api/src/assignment/grant/project/user/role/check.rs
+++ b/tests/api/src/assignment/grant/project/user/role/check.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_sdk_core::{AsyncOpenStack, config::CloudConfig};
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use super::*;
 use crate::role::list_roles;

--- a/tests/api/src/assignment/grant/project/user/role/grant.rs
+++ b/tests/api/src/assignment/grant/project/user/role/grant.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 use openstack_keystone_api_types::v3::project::ProjectCreateBuilder;
 use openstack_keystone_api_types::v3::user::UserCreateBuilder;
-use openstack_sdk_core::{AsyncOpenStack, config::CloudConfig};
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use super::*;
 use crate::guard::*;

--- a/tests/api/src/auth/project.rs
+++ b/tests/api/src/auth/project.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use eyre::Result;
 
 use openstack_keystone_api_types::v3::project::ProjectShort;
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
-use openstack_sdk_core::{AsyncOpenStack, api::QueryAsync, config::CloudConfig};
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync, config::CloudConfig};
 
 #[derive(Clone, Debug)]
 struct AuthProjectsRequest {}

--- a/tests/api/src/auth/token/revoke.rs
+++ b/tests/api/src/auth/token/revoke.rs
@@ -17,8 +17,6 @@ use reqwest::StatusCode;
 use secrecy::ExposeSecret;
 use tracing_test::traced_test;
 
-use openstack_keystone_api_types::scope::*;
-
 use crate::auth::token::*;
 use crate::common::*;
 

--- a/tests/api/src/auth/token/token.rs
+++ b/tests/api/src/auth/token/token.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use eyre::Result;
 
 //use openstack_keystone_api_types::scope::*;
-use openstack_sdk_core::{AsyncOpenStack, config::CloudConfig};
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use crate::auth::project::list_auth_projects;
 
@@ -31,15 +31,13 @@ async fn test_rescope_project_scope() -> Result<()> {
         // auth with project_id
         test_client
             .authorize(
-                Some(
-                    openstack_sdk_core::auth::authtoken::AuthTokenScope::Project(
-                        openstack_sdk_core::types::identity::v3::Project {
-                            id: Some(project.id.clone()),
-                            name: None,
-                            domain: None,
-                        },
-                    ),
-                ),
+                Some(openstack_sdk::auth::authtoken::AuthTokenScope::Project(
+                    openstack_sdk::types::identity::v3::Project {
+                        id: Some(project.id.clone()),
+                        name: None,
+                        domain: None,
+                    },
+                )),
                 false,
                 false,
             )
@@ -47,18 +45,16 @@ async fn test_rescope_project_scope() -> Result<()> {
         // auth with project name and domain_id
         test_client
             .authorize(
-                Some(
-                    openstack_sdk_core::auth::authtoken::AuthTokenScope::Project(
-                        openstack_sdk_core::types::identity::v3::Project {
-                            id: None,
-                            name: Some(project.name.clone()),
-                            domain: Some(openstack_sdk_core::types::identity::v3::Domain {
-                                id: Some(project.domain_id.clone()),
-                                name: None,
-                            }),
-                        },
-                    ),
-                ),
+                Some(openstack_sdk::auth::authtoken::AuthTokenScope::Project(
+                    openstack_sdk::types::identity::v3::Project {
+                        id: None,
+                        name: Some(project.name.clone()),
+                        domain: Some(openstack_sdk::types::identity::v3::Domain {
+                            id: Some(project.domain_id.clone()),
+                            name: None,
+                        }),
+                    },
+                )),
                 false,
                 false,
             )

--- a/tests/api/src/guard.rs
+++ b/tests/api/src/guard.rs
@@ -16,7 +16,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use eyre::Result;
-use openstack_sdk_core::AsyncOpenStack;
+use openstack_sdk::AsyncOpenStack;
 
 #[async_trait::async_trait]
 pub trait DeletableResource: Send + Sync {

--- a/tests/api/src/identity/user.rs
+++ b/tests/api/src/identity/user.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use eyre::Result;
 
 use openstack_keystone_api_types::v3::user::*;
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
-use openstack_sdk_core::{AsyncOpenStack, api::QueryAsync};
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
 use crate::guard::*;
 
@@ -121,7 +121,7 @@ impl RestEndpoint for UserDeleteRequest {
 #[async_trait::async_trait]
 impl DeletableResource for User {
     async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(openstack_sdk_core::api::ignore(UserDeleteRequest {
+        Ok(openstack_sdk::api::ignore(UserDeleteRequest {
             id: self.id.clone(),
         })
         .query_async(state.as_ref())

--- a/tests/api/src/k8s_auth.rs
+++ b/tests/api/src/k8s_auth.rs
@@ -21,8 +21,8 @@ use secrecy::SecretString;
 use tokio::fs;
 use uuid::Uuid;
 
-use openstack_sdk_core::config::CloudConfig;
-use openstack_sdk_core::{AsyncOpenStack, api::RawQueryAsync};
+use openstack_sdk::config::CloudConfig;
+use openstack_sdk::{AsyncOpenStack, api::RawQueryAsync};
 
 use openstack_keystone_api_types::k8s_auth::role::*;
 use openstack_keystone_api_types::k8s_auth::{K8sAuthRequest, instance::*};

--- a/tests/api/src/k8s_auth/auth.rs
+++ b/tests/api/src/k8s_auth/auth.rs
@@ -18,7 +18,7 @@ use derive_builder::Builder;
 use eyre::Result;
 
 use openstack_keystone_api_types::k8s_auth::auth::*;
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
+use openstack_sdk::api::rest_endpoint_prelude::*;
 
 #[derive(Builder)]
 //#[builder(build_fn(error = "BuilderError"))]

--- a/tests/api/src/k8s_auth/instance.rs
+++ b/tests/api/src/k8s_auth/instance.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 use eyre::Result;
 
 use openstack_keystone_api_types::k8s_auth::instance::*;
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
-use openstack_sdk_core::{AsyncOpenStack, api::QueryAsync};
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
 use crate::guard::*;
 
@@ -125,12 +125,10 @@ impl RestEndpoint for K8sAuthInstanceDeleteRequest<'_> {
 #[async_trait::async_trait]
 impl DeletableResource for K8sAuthInstance {
     async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(
-            openstack_sdk_core::api::ignore(K8sAuthInstanceDeleteRequest {
-                id: self.id.clone().into(),
-            })
-            .query_async(state.as_ref())
-            .await?,
-        )
+        Ok(openstack_sdk::api::ignore(K8sAuthInstanceDeleteRequest {
+            id: self.id.clone().into(),
+        })
+        .query_async(state.as_ref())
+        .await?)
     }
 }

--- a/tests/api/src/k8s_auth/role.rs
+++ b/tests/api/src/k8s_auth/role.rs
@@ -19,8 +19,8 @@ use derive_builder::Builder;
 use eyre::Result;
 
 use openstack_keystone_api_types::k8s_auth::role::*;
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
-use openstack_sdk_core::{AsyncOpenStack, api::QueryAsync};
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
 use crate::guard::*;
 
@@ -140,7 +140,7 @@ impl RestEndpoint for K8sAuthRoleDeleteRequest<'_> {
 #[async_trait::async_trait]
 impl DeletableResource for K8sAuthRole {
     async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(openstack_sdk_core::api::ignore(K8sAuthRoleDeleteRequest {
+        Ok(openstack_sdk::api::ignore(K8sAuthRoleDeleteRequest {
             id: self.id.clone().into(),
         })
         .query_async(state.as_ref())

--- a/tests/api/src/resource/project.rs
+++ b/tests/api/src/resource/project.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 use eyre::Result;
 
 use openstack_keystone_api_types::v3::project::*;
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
-use openstack_sdk_core::{AsyncOpenStack, api::QueryAsync};
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
 use crate::guard::*;
 
@@ -94,7 +94,7 @@ impl RestEndpoint for ProjectDeleteRequest {
 #[async_trait::async_trait]
 impl DeletableResource for Project {
     async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(openstack_sdk_core::api::ignore(ProjectDeleteRequest {
+        Ok(openstack_sdk::api::ignore(ProjectDeleteRequest {
             id: self.id.clone(),
         })
         .query_async(state.as_ref())

--- a/tests/api/src/role.rs
+++ b/tests/api/src/role.rs
@@ -18,10 +18,9 @@ use derive_builder::Builder;
 use eyre::Result;
 
 use openstack_keystone_api_types::v3::role::*;
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
-use openstack_sdk_core::{AsyncOpenStack, api::QueryAsync};
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
-use crate::common::*;
 use crate::guard::*;
 
 mod create;
@@ -125,7 +124,7 @@ impl RestEndpoint for RoleDeleteRequest {
 #[async_trait::async_trait]
 impl DeletableResource for Role {
     async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(openstack_sdk_core::api::ignore(RoleDeleteRequest {
+        Ok(openstack_sdk::api::ignore(RoleDeleteRequest {
             id: self.id.clone(),
         })
         .query_async(state.as_ref())

--- a/tests/api/src/role/create.rs
+++ b/tests/api/src/role/create.rs
@@ -16,9 +16,8 @@ use eyre::Result;
 use tracing_test::traced_test;
 
 use openstack_keystone_api_types::v3::role::*;
-use openstack_sdk_core::{AsyncOpenStack, config::CloudConfig};
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
-use crate::common::*;
 use crate::role::*;
 
 #[tokio::test]

--- a/tests/api/src/role/list.rs
+++ b/tests/api/src/role/list.rs
@@ -18,7 +18,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 
 use openstack_keystone_api_types::v3::role::Role;
-use openstack_sdk_core::{AsyncOpenStack, config::CloudConfig};
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use crate::role::*;
 

--- a/tests/api/src/token_restriction.rs
+++ b/tests/api/src/token_restriction.rs
@@ -19,8 +19,8 @@ use derive_builder::Builder;
 use eyre::Result;
 
 use openstack_keystone_api_types::v4::token_restriction::*;
-use openstack_sdk_core::api::rest_endpoint_prelude::*;
-use openstack_sdk_core::{AsyncOpenStack, api::QueryAsync};
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
 use crate::guard::*;
 
@@ -96,12 +96,10 @@ impl RestEndpoint for TokenRestrictionDeleteRequest {
 #[async_trait::async_trait]
 impl DeletableResource for TokenRestriction {
     async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(
-            openstack_sdk_core::api::ignore(TokenRestrictionDeleteRequest {
-                id: self.id.clone(),
-            })
-            .query_async(state.as_ref())
-            .await?,
-        )
+        Ok(openstack_sdk::api::ignore(TokenRestrictionDeleteRequest {
+            id: self.id.clone(),
+        })
+        .query_async(state.as_ref())
+        .await?)
     }
 }

--- a/tests/api/src/webauthn.rs
+++ b/tests/api/src/webauthn.rs
@@ -23,11 +23,11 @@ use url::Url;
 
 use openstack_keystone_api_types::webauthn::register::*;
 use openstack_keystone_api_types::webauthn::{PublicKeyCredentialCreationOptions, auth::*};
-use openstack_sdk_core::{
+use openstack_sdk::{
     AsyncOpenStack,
     api::{QueryAsync, RawQueryAsync},
 };
-use openstack_sdk_core::{api::rest_endpoint_prelude::*, types::identity::v3::AuthResponse};
+use openstack_sdk::{api::rest_endpoint_prelude::*, types::identity::v3::AuthResponse};
 use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
 
 mod register;

--- a/tests/api/src/webauthn/register.rs
+++ b/tests/api/src/webauthn/register.rs
@@ -22,7 +22,7 @@ use webauthn_authenticator_rs::WebauthnAuthenticator;
 use webauthn_authenticator_rs::softtoken::SoftToken;
 
 use openstack_keystone_api_types::v3::user::UserCreateBuilder;
-use openstack_sdk_core::{AsyncOpenStack, config::CloudConfig};
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use super::*;
 use crate::guard::*;

--- a/tests/api/src/webauthn/roundtrip.rs
+++ b/tests/api/src/webauthn/roundtrip.rs
@@ -22,8 +22,8 @@ use webauthn_authenticator_rs::WebauthnAuthenticator;
 use webauthn_authenticator_rs::softtoken::SoftToken;
 
 use openstack_keystone_api_types::v3::user::UserCreateBuilder;
-use openstack_sdk_core::AsyncOpenStack;
-use openstack_sdk_core::config::CloudConfig;
+use openstack_sdk::AsyncOpenStack;
+use openstack_sdk::config::CloudConfig;
 
 use super::*;
 use crate::guard::*;

--- a/tests/federation/Cargo.toml
+++ b/tests/federation/Cargo.toml
@@ -17,7 +17,7 @@ hyper-util = { workspace = true, features = ["tokio", "http1"] }
 eyre.workspace = true
 keycloak = { version = "26.6" }
 local-ip-address = { version = "0.6" }
-openstack-keystone-api-types = { version = "0.1", path = "../../crates/api-types", features = ["builder" ] }
+openstack-keystone-api-types = { workspace = true, features = ["builder" ] }
 reqwest = { workspace = true, features = ["json", "http2", "multipart", "gzip", "deflate"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -14,14 +14,14 @@ chrono.workspace = true
 eyre.workspace = true
 inventory.workspace = true
 itertools.workspace = true
-openstack-keystone-config = { version = "0.1", path = "../../crates/config" }
-openstack-keystone-api-types = { version = "0.1", path = "../../crates/api-types", features = ["builder", "conv"] }
-openstack-keystone-core = { version = "0.1", path = "../../crates/core", features = ["mock"] }
-openstack-keystone-core-types = { version = "0.1", path = "../../crates/core-types", features = ["mock"] }
+openstack-keystone-config.workspace = true
+openstack-keystone-api-types = { workspace = true, features = ["builder", "conv"] }
+openstack-keystone-core = { workspace = true, features = ["mock"] }
+openstack-keystone-core-types = { workspace = true, features = ["mock"] }
 openstack-keystone-identity-sql = { version = "0.1", path = "../../crates/identity-sql/" }
 openstack-keystone-token-fernet = { version = "0.1", path = "../../crates/token-fernet/" }
 openstack-keystone-trust-sql = { version = "0.1", path = "../../crates/trust-sql/" }
-openstack-keystone-distributed-storage = { version = "0.1", path = "../../crates/storage/" }
+openstack-keystone-distributed-storage.workspace = true
 openstack-keystone = { version = "0.1", path = "../../crates/keystone/" }
 rcgen.workspace = true
 sea-orm = { workspace = true, features = ["sqlx-sqlite"] }

--- a/tests/interop/Cargo.toml
+++ b/tests/interop/Cargo.toml
@@ -11,4 +11,4 @@ repository.workspace = true
 dist = false
 
 [dependencies]
-openstack_keystone_api_types = { version = "0.1", path = "../../crates/keystone" }
+openstack_keystone_api_types.workspace = true


### PR DESCRIPTION
In the OSC we learned, that in the case of a multicrate project it is
important to properly declare the dependencies so that everything work
even after publishing to crates.io.

Update dependencies as well.
