### PR TITLE
feat: Add keystone container with opa and policies

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -13,6 +13,7 @@ on:
       - 'crates/**'
       - 'Dockerfile'
       - '.dockerignore'
+      - 'policy/**'
 
 
 permissions:
@@ -59,3 +60,38 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  build-opa-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-opa
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+
+      - name: Build OPA Docker image
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          target: runtime-opa
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           context: .
           push: true
+          target: runtime
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -75,3 +76,54 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  build-and-push-opa-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-opa
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+
+      - name: Build and push OPA Docker image
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          target: runtime-opa
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-opa
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,3 +52,18 @@ COPY --from=builder /app/target/release/keystone-db /usr/local/bin
 COPY --from=builder /app/target/release/keystone-manage /usr/local/bin
 
 CMD ["/usr/local/bin/keystone"]
+
+################
+##### Runtime with embedded OPA and policies
+FROM runtime AS runtime-opa
+
+ARG OPA_VERSION=1.16.2
+
+LABEL maintainer="Artem Goncharov"
+
+# Download OPA binary directly from GitHub releases
+ADD https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64_static /usr/local/bin/opa
+RUN chmod 755 /usr/local/bin/opa
+
+# Copy policy files
+COPY policy /policy

--- a/crates/config/src/policy.rs
+++ b/crates/config/src/policy.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use serde::Deserialize;
+use std::path::PathBuf;
 use url::Url;
 use url_macro::url;
 
@@ -27,6 +28,11 @@ pub struct PolicyProvider {
     /// OpenPolicyAgent instance url to use for evaluating the policy.
     #[serde(default = "default_opa_base_url")]
     pub opa_base_url: Url,
+
+    /// Path to the policies to trigger starting OPA as a subprocess. When set
+    /// OPA would be started as `opa run -s <OPA_POLICIES_PATH> --addr
+    /// OPA_BASE_URL`. The OPA binary must be in the PATH for this to work.
+    pub opa_policies_path: Option<PathBuf>,
 }
 
 impl Default for PolicyProvider {
@@ -34,6 +40,7 @@ impl Default for PolicyProvider {
         Self {
             enable: true,
             opa_base_url: default_opa_base_url(),
+            opa_policies_path: None,
         }
     }
 }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -317,6 +317,58 @@ async fn main() -> Result<(), Report> {
         raft_grpc::ensure_raft_initialized(shared_state.clone(), cfg.clone()).await?;
     }
 
+    // OPA Subprocess
+    if let Some(policies_path) = &cfg.api_policy.opa_policies_path {
+        let opa_url = &cfg.api_policy.opa_base_url;
+        let addr = match opa_url.scheme() {
+            "http" | "https" => format!(
+                "{}:{}",
+                opa_url.host_str().unwrap_or("0.0.0.0"),
+                opa_url.port().unwrap_or(8181)
+            ),
+            "unix" | "http+unix" => format!("unix://{}", opa_url.path()),
+            _ => format!(
+                "{}:{}",
+                opa_url.host_str().unwrap_or("0.0.0.0"),
+                opa_url.port().unwrap_or(8181)
+            ),
+        };
+
+        info!(
+            "Starting OPA subprocess with policies from {:?} listening on {}",
+            policies_path, addr
+        );
+        let mut opa_cmd = tokio::process::Command::new("opa");
+        opa_cmd
+            .arg("run")
+            .arg("-s")
+            .arg(policies_path)
+            .arg("--addr")
+            .arg(&addr)
+            .kill_on_drop(true);
+
+        match opa_cmd.spawn() {
+            Ok(mut child) => {
+                let opa_cancel_token = token.clone();
+                handles.spawn(async move {
+                    tokio::select! {
+                        status = child.wait() => {
+                            error!("OPA subprocess exited unexpectedly: {:?}", status);
+                        }
+                        () = opa_cancel_token.cancelled() => {
+                            info!("Killing OPA subprocess");
+                            child.kill().await.ok();
+                        }
+                    }
+                });
+            }
+            Err(e) => {
+                error!("Failed to start OPA subprocess: {}", e);
+                return Err(e).wrap_err("Failed to start OPA subprocess");
+            }
+        }
+    }
+
     // Start the public interface listener
     match cfg.interface_public.listener {
         ListenerConfig::Http => {


### PR DESCRIPTION
Add possibility for Keystone to start OPA as a subprocess to help out in
the maintenance. Also add OPA binary (and policies) into a dedicated
container.
There are few reasons why user may decide not do use it:
- need to use different version of OPA
- OPA logs

Fixes: #700
