### PR TITLE
fix: Enforce minimum range boundaries for security compliance (fixes #746)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,6 +3873,7 @@ dependencies = [
  "tracing",
  "url",
  "url-macro",
+ "validator",
 ]
 
 [[package]]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["fs", "rt", "sync", "time"] }
 tracing.workspace = true
 url = { workspace = true, features = ["serde"] }
 url-macro.workspace = true
+validator = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -54,6 +54,7 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Deserialize;
 use tokio::sync::RwLock;
 use tracing::error;
+use validator::Validate;
 
 mod application_credentials;
 mod assignment;
@@ -108,7 +109,7 @@ pub use trust::*;
 pub use webauthn::*;
 
 /// Keystone configuration.
-#[derive(Debug, Default, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Clone, Validate)]
 pub struct Config {
     /// Application credentials provider configuration.
     #[serde(default)]
@@ -187,6 +188,7 @@ pub struct Config {
 
     /// Security compliance configuration.
     #[serde(default)]
+    #[validate(nested)]
     pub security_compliance: SecurityComplianceProvider,
 
     /// Spiffe provider configuration.
@@ -253,6 +255,8 @@ impl Config {
             tls.read_certs()
                 .wrap_err("reading distributed storage TLS configuration")?;
         }
+        // Validate the config after loading all the referred files.
+        cfg.validate().wrap_err("Configuration validation failed")?;
         Ok(cfg)
     }
 
@@ -647,5 +651,74 @@ mod tests {
             }
         }
         assert!(success, "Config did not update after file change");
+    }
+    #[tokio::test]
+    async fn test_invalid_security_compliance_validation() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let config_file = NamedTempFile::with_suffix(".conf").unwrap();
+        let mut f = std::fs::File::create(config_file.path()).unwrap();
+        f.write_all(
+            r#"
+    [auth]
+    methods = []
+    
+    [database]
+    connection = "foo"
+    
+    [distributed_storage]
+    node_cluster_addr = "https://localhost:8310"
+    node_id = 1
+    path = "/keystone/storage"
+
+    [security_compliance]
+    password_expires_days = 0
+    disable_user_account_days_inactive = 0
+    lockout_failure_attempts = 0
+    invalid_password_hash_max_chars = 0
+            "#
+            .as_bytes(),
+        )
+        .unwrap();
+        f.sync_all().unwrap();
+
+        // 1. Attempt to load the configuration
+        let result = Config::load_all(config_file.path().to_path_buf());
+
+        // 2. Assert that it completely fails and catches our error
+        assert!(
+            result.is_err(),
+            "Expected configuration to be REJECTED because of 0 values, but it loaded successfully!"
+        );
+
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("Configuration validation failed"),
+            "Expected a validation error, got: {}",
+            err_msg
+        );
+
+        // 3. FULL COVERAGE: Explicitly ensure the error message blames every single invalid field
+        assert!(
+            err_msg.contains("security_compliance.password_expires_days"),
+            "Error message should explicitly blame password_expires_days, but got: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("security_compliance.disable_user_account_days_inactive"),
+            "Error message should explicitly blame disable_user_account_days_inactive, but got: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("security_compliance.lockout_failure_attempts"),
+            "Error message should explicitly blame lockout_failure_attempts, but got: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("security_compliance.invalid_password_hash_max_chars"),
+            "Error message should explicitly blame invalid_password_hash_max_chars, but got: {}",
+            err_msg
+        );
     }
 }

--- a/crates/config/src/security_compliance.rs
+++ b/crates/config/src/security_compliance.rs
@@ -11,13 +11,13 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+use crate::common::*;
 use chrono::{DateTime, NaiveDate, TimeDelta, Utc};
 use serde::Deserialize;
-
-use crate::common::*;
+use validator::Validate;
 
 /// Security compliance configuration.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Validate)]
 pub struct SecurityComplianceProvider {
     /// The maximum number of days a user can go without authenticating before
     /// being considered "inactive" and automatically disabled (locked).
@@ -27,6 +27,7 @@ pub struct SecurityComplianceProvider {
     /// user's enabled attribute in the HTTP API may not match the value of
     /// the user's enabled column in the user table.
     #[serde(default)]
+    #[validate(range(min = 1))]
     pub disable_user_account_days_inactive: Option<u16>,
     /// Enabling this option requires users to change their password when the
     /// user is created, or upon administrative reset. Before accessing any
@@ -62,6 +63,7 @@ pub struct SecurityComplianceProvider {
     /// characters. It's recommended to use the least reasonable value however -
     /// it's the most effective measure to protect the hashes.
     #[serde(default)]
+    #[validate(range(min = 1))]
     pub invalid_password_hash_max_chars: Option<u8>,
 
     /// The maximum number of times that a user can fail to authenticate before
@@ -72,6 +74,7 @@ pub struct SecurityComplianceProvider {
     /// until the user is explicitly enabled via the API. This feature depends
     /// on the sql backend for the `[identity] driver`.
     #[serde(default)]
+    #[validate(range(min = 1))]
     pub lockout_failure_attempts: Option<u16>,
     /// The number of seconds a user account will be locked when the maximum
     /// number of failed authentication attempts (as specified by
@@ -101,6 +104,7 @@ pub struct SecurityComplianceProvider {
     /// however existing passwords would not be impacted. This feature depends
     /// on the sql backend for the `[identity] driver`.
     #[serde(default)]
+    #[validate(range(min = 1))]
     pub password_expires_days: Option<u64>,
     /// The regular expression used to validate password strength requirements.
     /// By default, the regular expression will match any password. The


### PR DESCRIPTION

This patch introduces runtime configuration validation rules ensuring that specific security compliance settings (like 'password_expires_days', 'disable_user_account_days_inactive', etc.)  mirroring openstack/keystone python implementation.

The config crate has been updated to use the validator crate, and the ConfigManager now invokes validation on startup and file reloads.

Closes #746 