### PR TITLE
feat: Add timing attack protection and failed auth tracking

### DIFF
--- a/crates/core/src/common/password_hashing.rs
+++ b/crates/core/src/common/password_hashing.rs
@@ -64,6 +64,42 @@ fn verify_length_and_trunc_password(password: &[u8], max_length: usize) -> &[u8]
     password
 }
 
+/// Generate a dummy password hash matching the configured algorithm.
+///
+/// Used for timing attack prevention: when a user is not found, a dummy hash
+/// is generated and verified against the provided password, so the response
+/// time is approximately the same as when the user exists but the password is
+/// wrong.
+///
+/// # Parameters
+/// - `conf`: The service configuration.
+///
+/// # Returns
+/// - `Ok(String)` - A dummy hash string matching the configured algorithm.
+/// - `Err(PasswordHashError)` - If hash generation failed.
+pub async fn generate_dummy_hash(conf: &Config) -> Result<String, PasswordHashError> {
+    match conf.identity.password_hashing_algorithm {
+        PasswordHashingAlgo::Bcrypt => {
+            let rounds = conf.identity.password_hash_rounds.unwrap_or(12);
+            // bcrypt dummy hash: "$2b$XX$" + 53 random base64 chars
+            // Generate a dummy hash with a random salt by hashing a random string
+            // with matching rounds, so verify_password takes the same time
+            let dummy_password = rand::random::<[u8; 16]>();
+            let hash =
+                task::spawn_blocking(move || bcrypt::hash(dummy_password, rounds as u32)).await??;
+            Ok(hash)
+        }
+        PasswordHashingAlgo::None => {
+            let dummy: [u8; 32] = rand::random();
+            Ok(dummy
+                .map(|b| b % 95 + 32 as u8)
+                .into_iter()
+                .map(|b| b as char)
+                .collect())
+        }
+    }
+}
+
 /// Calculate password hash with the configuration defaults.
 ///
 /// # Parameters
@@ -237,5 +273,52 @@ mod tests {
         assert!(!verify_password(&conf, &pass, "foobar").await.unwrap());
         assert!(!logs_contain("foobar"));
         assert!(!logs_contain(&pass));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_generate_and_verify_dummy_hash_bcrypt() {
+        let builder = config::Config::builder()
+            .set_override("auth.methods", "")
+            .unwrap()
+            .set_override("database.connection", "dummy")
+            .unwrap();
+        let conf: Config = Config::try_from(builder).expect("can build a valid config");
+        let dummy_hash = generate_dummy_hash(&conf).await.unwrap();
+        // Dummy hash should be a valid bcrypt hash (starts with $2b$)
+        assert!(
+            dummy_hash.starts_with("$2b$"),
+            "Dummy hash should be a valid bcrypt hash"
+        );
+        // Verify should return false for any random password
+        let pass = Alphanumeric.sample_string(&mut rand::rng(), 32);
+        let result = verify_password(&conf, &pass, &dummy_hash).await.unwrap();
+        // Result should be false (password doesn't match dummy hash)
+        assert!(!result, "Dummy hash should not match random password");
+        assert!(!logs_contain(&pass));
+        assert!(!logs_contain(&dummy_hash));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_generate_dummy_hash_none() {
+        let builder = config::Config::builder()
+            .set_override("auth.methods", "")
+            .unwrap()
+            .set_override("database.connection", "dummy")
+            .unwrap()
+            .set_override("identity.password_hashing_algorithm", "None")
+            .unwrap();
+        let conf: Config = Config::try_from(builder).expect("can build a valid config");
+        let dummy_hash = generate_dummy_hash(&conf).await.unwrap();
+        // Dummy hash should be a non-empty string
+        assert!(!dummy_hash.is_empty(), "Dummy hash should not be empty");
+        // Verify should return false for any random password
+        let pass = Alphanumeric.sample_string(&mut rand::rng(), 32);
+        let result = verify_password(&conf, &pass, &dummy_hash).await.unwrap();
+        // Result should almost certainly be false (random password unlikely to match)
+        assert!(!result, "Dummy hash should not match random password");
+        assert!(!logs_contain(&pass));
+        assert!(!logs_contain(&dummy_hash));
     }
 }

--- a/crates/identity-driver-sql/src/authenticate.rs
+++ b/crates/identity-driver-sql/src/authenticate.rs
@@ -66,36 +66,55 @@ pub async fn authenticate_by_password(
     )
     .await?;
 
-    let (local_user, password) =
+    let user_found = user_with_passwords.is_some();
+    // Prevent timing attacks: if user is not found, generate a dummy hash and
+    // verify against it to consume comparable time to the "user exists" path.
+    // The `log_failed_auth` function is intentionally not called here because the
+    // user does not exist and cannot be locked out. The dummy hash prevents an
+    // attacker from distinguishing between "user not found" and "wrong
+    // password" via timing analysis.
+    if !user_found {
+        let dummy_hash = password_hashing::generate_dummy_hash(config)
+            .await
+            .map_err(IdentityProviderError::password_hash)?;
+        let _ = password_hashing::verify_password(config, &auth.password, &dummy_hash)
+            .await
+            .map_err(IdentityProviderError::password_hash)?;
+        return Err(AuthenticationError::UserNameOrPasswordWrong.into());
+    }
+
+    let (local_user_entry, password) =
         user_with_passwords.ok_or(AuthenticationError::UserNameOrPasswordWrong)?;
     // User has been found.
     // Get user options
-    let user_opts = user_option::list_by_user_id(db, local_user.user_id.clone()).await?;
+    let user_opts = user_option::list_by_user_id(db, local_user_entry.user_id.clone()).await?;
 
     // Check for the temporary lock
     if !user_opts
         .ignore_lockout_failure_attempts
         .is_some_and(|val| val)
-        && should_lock(config, db, &local_user).await?
+        && should_lock(config, db, &local_user_entry).await?
     {
-        return Err(AuthenticationError::UserLocked(local_user.user_id.clone()).into());
+        return Err(AuthenticationError::UserLocked(local_user_entry.user_id.clone()).into());
     }
 
     // Verify user exists
-    let user_entry = user::get_main_entry(db, &local_user.user_id).await?.ok_or(
-        IdentityProviderError::NoMainUserEntry(local_user.user_id.clone()),
-    )?;
+    let user_entry = user::get_main_entry(db, &local_user_entry.user_id)
+        .await?
+        .ok_or(IdentityProviderError::NoMainUserEntry(
+            local_user_entry.user_id.clone(),
+        ))?;
 
     // Check if the user is disabled
     if !user_entry.enabled.unwrap_or(false) {
-        return Err(AuthenticationError::UserDisabled(local_user.user_id.clone()).into());
+        return Err(AuthenticationError::UserDisabled(local_user_entry.user_id.clone()).into());
     }
 
     let passwords: Vec<db_password::Model> = password.into_iter().collect();
     let latest_password = passwords
         .first()
         .ok_or(IdentityProviderError::NoPasswordsForUser(
-            local_user.user_id.clone(),
+            local_user_entry.user_id.clone(),
         ))?;
     let expected_hash =
         latest_password
@@ -106,10 +125,12 @@ pub async fn authenticate_by_password(
             ))?;
 
     // Verify the password
+    let now = Utc::now();
     if !password_hashing::verify_password(config, &auth.password, expected_hash)
         .await
         .map_err(IdentityProviderError::password_hash)?
     {
+        local_user::log_failed_auth(db, &local_user_entry, now).await?;
         return Err(AuthenticationError::UserNameOrPasswordWrong.into());
     }
     // Check if expired password exempt is on
@@ -117,13 +138,13 @@ pub async fn authenticate_by_password(
         // otherwise check for expired password
         if password::is_password_expired(latest_password)? {
             return Err(
-                AuthenticationError::UserPasswordExpired(local_user.user_id.clone()).into(),
+                AuthenticationError::UserPasswordExpired(local_user_entry.user_id.clone()).into(),
             );
         }
     }
 
     // Reset the last_active_at for the user that successfully authenticated.
-    user::reset_last_active(db, &user_entry).await?;
+    user::reset_last_active(db, &user_entry, now).await?;
 
     let user_entry = UserResponseBuilder::default()
         .merge_user_data(
@@ -134,7 +155,7 @@ pub async fn authenticate_by_password(
                 .get_user_last_activity_cutof_date()
                 .as_ref(),
         )
-        .merge_local_user_data(&local_user)
+        .merge_local_user_data(&local_user_entry)
         .merge_passwords_data(passwords)
         .build()?;
 
@@ -149,13 +170,6 @@ pub async fn authenticate_by_password(
             ),
         })
         .build()?)
-
-    //Ok(AuthenticatedInfo::builder()
-    //    .user_id(user_entry.id.clone())
-    //    .user(user_entry)
-    //    .methods(vec!["password".into()])
-    //    .build()
-    //    .map_err(AuthenticationError::from)?)
 }
 
 /// Verify whether the account is temporarily locked according to the security
@@ -467,30 +481,44 @@ mod tests {
         );
 
         // Checking transaction log
+        let log = db.into_transaction_log();
+        assert_eq!(log.len(), 4);
         assert_eq!(
-            db.into_transaction_log(),
-            [
-                Transaction::from_sql_and_values(
-                    DatabaseBackend::Postgres,
-                    r#"SELECT "local_user"."id" AS "A_id", "local_user"."user_id" AS "A_user_id", "local_user"."domain_id" AS "A_domain_id", "local_user"."name" AS "A_name", "local_user"."failed_auth_count" AS "A_failed_auth_count", "local_user"."failed_auth_at" AS "A_failed_auth_at", "password"."id" AS "B_id", "password"."local_user_id" AS "B_local_user_id", "password"."self_service" AS "B_self_service", "password"."created_at" AS "B_created_at", "password"."expires_at" AS "B_expires_at", "password"."password_hash" AS "B_password_hash", "password"."created_at_int" AS "B_created_at_int", "password"."expires_at_int" AS "B_expires_at_int" FROM "local_user" LEFT JOIN "password" ON "local_user"."id" = "password"."local_user_id" WHERE "local_user"."user_id" = $1 ORDER BY "local_user"."id" ASC, "password"."created_at_int" DESC"#,
-                    ["user_id".into()]
-                ),
-                Transaction::from_sql_and_values(
-                    DatabaseBackend::Postgres,
-                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE "user_option"."user_id" = $1"#,
-                    ["user_id".into()]
-                ),
-                Transaction::from_sql_and_values(
-                    DatabaseBackend::Postgres,
-                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user" WHERE "user"."id" = $1 LIMIT $2"#,
-                    ["user_id".into(), 1u64.into()]
-                ),
-                Transaction::from_sql_and_values(
-                    DatabaseBackend::Postgres,
-                    r#"UPDATE "user" SET "last_active_at" = $1 WHERE "user"."id" = $2 RETURNING "created_at", "default_project_id", "domain_id", "enabled", "extra", "id", "last_active_at""#,
-                    [Utc::now().date_naive().into(), "user_id".into()]
-                ),
-            ]
+            log[0],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "local_user"."id" AS "A_id", "local_user"."user_id" AS "A_user_id", "local_user"."domain_id" AS "A_domain_id", "local_user"."name" AS "A_name", "local_user"."failed_auth_count" AS "A_failed_auth_count", "local_user"."failed_auth_at" AS "A_failed_auth_at", "password"."id" AS "B_id", "password"."local_user_id" AS "B_local_user_id", "password"."self_service" AS "B_self_service", "password"."created_at" AS "B_created_at", "password"."expires_at" AS "B_expires_at", "password"."password_hash" AS "B_password_hash", "password"."created_at_int" AS "B_created_at_int", "password"."expires_at_int" AS "B_expires_at_int" FROM "local_user" LEFT JOIN "password" ON "local_user"."id" = "password"."local_user_id" WHERE "local_user"."user_id" = $1 ORDER BY "local_user"."id" ASC, "password"."created_at_int" DESC"#,
+                ["user_id".into()]
+            )
+        );
+        assert_eq!(
+            log[1],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE "user_option"."user_id" = $1"#,
+                ["user_id".into()]
+            )
+        );
+        assert_eq!(
+            log[2],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user" WHERE "user"."id" = $1 LIMIT $2"#,
+                ["user_id".into(), 1u64.into()]
+            )
+        );
+
+        // Verify the UPDATE statement for successful authentication
+        let update_debug = format!("{:?}", log[3]);
+        assert!(
+            update_debug.contains("UPDATE \\\"user\\\" SET \\\"last_active_at\\\"")
+                && update_debug.contains("user_id"),
+            "UPDATE user with last_active_at not found, got: {}",
+            update_debug
+        );
+        assert!(
+            update_debug.contains("ChronoDate(Some("),
+            "last_active_at should be set"
         );
     }
 
@@ -535,7 +563,7 @@ mod tests {
                 assert_eq!(user_id, "user_id");
             }
             other => {
-                panic!("Locked user should be refused even before checking password: {other:?}",);
+                panic!("Locked user should be refused even before checking password: {other:?}");
             }
         }
     }
@@ -617,6 +645,7 @@ mod tests {
             )])
             // user::get_main_entry()
             .append_query_results([vec![get_user_mock("user_id")]])
+            .append_query_results([vec![get_local_user_mock("user_id")]])
             .into_connection();
         match authenticate_by_password(
             &config,
@@ -637,6 +666,184 @@ mod tests {
             }
         }
         assert!(!logs_contain("foo_pass"));
+
+        // Verify that the failure was logged
+        let log = db.into_transaction_log();
+        assert_eq!(log.len(), 4);
+
+        // Verify first 3 transactions exactly
+        assert_eq!(
+            log[0],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "local_user"."id" AS "A_id", "local_user"."user_id" AS "A_user_id", "local_user"."domain_id" AS "A_domain_id", "local_user"."name" AS "A_name", "local_user"."failed_auth_count" AS "A_failed_auth_count", "local_user"."failed_auth_at" AS "A_failed_auth_at", "password"."id" AS "B_id", "password"."local_user_id" AS "B_local_user_id", "password"."self_service" AS "B_self_service", "password"."created_at" AS "B_created_at", "password"."expires_at" AS "B_expires_at", "password"."password_hash" AS "B_password_hash", "password"."created_at_int" AS "B_created_at_int", "password"."expires_at_int" AS "B_expires_at_int" FROM "local_user" LEFT JOIN "password" ON "local_user"."id" = "password"."local_user_id" WHERE "local_user"."user_id" = $1 ORDER BY "local_user"."id" ASC, "password"."created_at_int" DESC"#,
+                ["user_id".into()]
+            )
+        );
+        assert_eq!(
+            log[1],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE "user_option"."user_id" = $1"#,
+                ["user_id".into()]
+            )
+        );
+        assert_eq!(
+            log[2],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user" WHERE "user"."id" = $1 LIMIT $2"#,
+                ["user_id".into(), 1u64.into()]
+            )
+        );
+
+        // Verify the UPDATE statement for failed auth logging
+        // timestamp (ChronoDateTime) is dynamic so we check via debug string
+        let update_debug = format!("{:?}", log[3]);
+        assert!(
+            update_debug.contains("UPDATE \\\"local_user\\\" SET \\\"failed_auth_count\\\"")
+                && update_debug.contains("\\\"failed_auth_at\\\""),
+            "UPDATE local_user with failed_auth fields not found, got: {}",
+            update_debug
+        );
+        assert!(
+            update_debug.contains("Int(Some(1))"),
+            "failed_auth_count should be 1"
+        );
+        assert!(
+            update_debug.contains("Int(Some(1))"),
+            "local_user id should be 1"
+        );
+        assert!(
+            update_debug.contains("ChronoDateTime(Some("),
+            "failed_auth_at should be set"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_user_not_found() {
+        let config = Config::default();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<(db_local_user::Model, db_password::Model)>::new()])
+            .into_connection();
+        match authenticate_by_password(
+            &config,
+            &db,
+            &UserPasswordAuthRequest {
+                id: Some("nonexistent_user".into()),
+                password: "secret".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        {
+            Err(IdentityProviderError::Authentication {
+                source: AuthenticationError::UserNameOrPasswordWrong,
+            }) => {}
+            other => {
+                panic!("User not found should return UserNameOrPasswordWrong, got: {other:?}");
+            }
+        }
+
+        // Verify that only the initial SELECT was executed (no UPDATE, no extra
+        // lookups)
+        let log = db.into_transaction_log();
+        assert_eq!(log.len(), 1);
+        assert_eq!(
+            log[0],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "local_user"."id" AS "A_id", "local_user"."user_id" AS "A_user_id", "local_user"."domain_id" AS "A_domain_id", "local_user"."name" AS "A_name", "local_user"."failed_auth_count" AS "A_failed_auth_count", "local_user"."failed_auth_at" AS "A_failed_auth_at", "password"."id" AS "B_id", "password"."local_user_id" AS "B_local_user_id", "password"."self_service" AS "B_self_service", "password"."created_at" AS "B_created_at", "password"."expires_at" AS "B_expires_at", "password"."password_hash" AS "B_password_hash", "password"."created_at_int" AS "B_created_at_int", "password"."expires_at_int" AS "B_expires_at_int" FROM "local_user" LEFT JOIN "password" ON "local_user"."id" = "password"."local_user_id" WHERE "local_user"."user_id" = $1 ORDER BY "local_user"."id" ASC, "password"."created_at_int" DESC"#,
+                ["nonexistent_user".into()]
+            )
+        );
+    }
+
+    /// Timing consistency test: verify that "user not found" and "wrong
+    /// password" take comparable time, preventing username enumeration via
+    /// timing attacks.
+    ///
+    /// This test is #[ignore] by default because timing tests are inherently
+    /// unreliable in CI environments. Run with `--ignored` flag to execute.
+    #[tokio::test]
+    #[ignore]
+    async fn test_authenticate_timing_consistency() {
+        let config = Config::default();
+        let iterations = 10;
+
+        // Measure "user not found" timing
+        let mut not_found_total = std::time::Duration::ZERO;
+        for _ in 0..iterations {
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<(db_local_user::Model, db_password::Model)>::new()])
+                .into_connection();
+            let start = std::time::Instant::now();
+            let _ = authenticate_by_password(
+                &config,
+                &db,
+                &UserPasswordAuthRequest {
+                    id: Some("nonexistent_user".into()),
+                    password: "secret".into(),
+                    ..Default::default()
+                },
+            )
+            .await;
+            not_found_total += start.elapsed();
+        }
+
+        // Measure "wrong password" timing
+        let mut wrong_password_total = std::time::Duration::ZERO;
+        for _ in 0..iterations {
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![(
+                    get_local_user_mock("user_id"),
+                    db_password::ModelBuilder::default()
+                        .password_hash("wrong_hash")
+                        .build()
+                        .unwrap(),
+                )]])
+                .append_query_results([user_option::tests::get_user_options_mock(
+                    "user_id",
+                    &UserOptions::default(),
+                )])
+                .append_query_results([vec![get_user_mock("user_id")]])
+                .append_query_results([vec![get_local_user_mock("user_id")]])
+                .into_connection();
+            let start = std::time::Instant::now();
+            let _ = authenticate_by_password(
+                &config,
+                &db,
+                &UserPasswordAuthRequest {
+                    id: Some("user_id".into()),
+                    password: "secret".into(),
+                    ..Default::default()
+                },
+            )
+            .await;
+            wrong_password_total += start.elapsed();
+        }
+
+        let not_found_avg = not_found_total.as_secs_f64() / iterations as f64;
+        let wrong_password_avg = wrong_password_total.as_secs_f64() / iterations as f64;
+
+        // The "user not found" path should take at least 70% of the time of the "wrong
+        // password" path. If it's significantly faster, an attacker could
+        // distinguish between the two paths.
+        let ratio = if wrong_password_avg > 0.0 {
+            not_found_avg / wrong_password_avg
+        } else {
+            0.0
+        };
+
+        // Allow some variance (up to 150%) to account for system noise,
+        // but if the ratio is much less than 1, it indicates a leak.
+        assert!(
+            ratio >= 0.5,
+            "Timing leak detected: user_not_found avg {:.3}s, wrong_password avg {:.3}s (ratio {:.2}).",
+            not_found_avg,
+            wrong_password_avg,
+            ratio
+        );
     }
 
     #[tokio::test]

--- a/crates/identity-driver-sql/src/local_user.rs
+++ b/crates/identity-driver-sql/src/local_user.rs
@@ -32,7 +32,7 @@ mod set;
 pub use create::create;
 pub use load::load_local_user_with_passwords;
 pub use load::load_local_users_passwords;
-pub use set::reset_failed_auth;
+pub use set::*;
 
 /// Set a new password for the local user.
 ///

--- a/crates/identity-driver-sql/src/local_user/set.rs
+++ b/crates/identity-driver-sql/src/local_user/set.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use chrono::{DateTime, Utc};
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
@@ -41,4 +42,149 @@ pub async fn reset_failed_auth(
         .update(db)
         .await
         .context("resetting local user failed auth counters")?)
+}
+
+/// Increase the failed authentication attempt for a local user.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `user`: The local user model.
+/// - `attempt_at`: The timestamp of the failed authentication attempt.
+///
+/// # Returns
+/// A `Result` containing the updated `db_local_user::Model` if successful, or
+/// an `Error`.
+#[tracing::instrument(skip_all)]
+pub async fn log_failed_auth(
+    db: &DatabaseConnection,
+    user: &db_local_user::Model,
+    attempt_at: DateTime<Utc>,
+) -> Result<db_local_user::Model, IdentityProviderError> {
+    let mut update: db_local_user::ActiveModel = user.clone().into();
+    update.failed_auth_count = Set(Some(user.failed_auth_count.unwrap_or_default() + 1));
+    update.failed_auth_at = Set(Some(attempt_at.naive_utc()));
+    Ok(update
+        .update(db)
+        .await
+        .context("incrementing local user failed auth count")?)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+
+    use super::*;
+    use crate::local_user::tests::get_local_user_mock;
+
+    #[tokio::test]
+    async fn test_log_failed_auth_from_zero() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_local_user_mock("user_id")]])
+            .into_connection();
+        let now = Utc::now();
+        let user = get_local_user_mock("user_id");
+        assert!(log_failed_auth(&db, &user, now).await.is_ok());
+
+        // Checking transaction log
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"UPDATE "local_user" SET "failed_auth_count" = $1, "failed_auth_at" = $2 WHERE "local_user"."id" = $3 RETURNING "id", "user_id", "domain_id", "name", "failed_auth_count", "failed_auth_at""#,
+                [Some(1i32).into(), Some(now.naive_utc()).into(), 1i32.into()]
+            ),]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_log_failed_auth_count_incremented() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![db_local_user::Model {
+                id: 1,
+                user_id: "user_id".into(),
+                domain_id: "foo_domain".into(),
+                name: "foo_domain".into(),
+                failed_auth_count: Some(3),
+                failed_auth_at: Some(Utc::now().naive_utc()),
+            }]])
+            .into_connection();
+        let now = Utc::now();
+        let user = db_local_user::Model {
+            id: 1,
+            user_id: "user_id".into(),
+            domain_id: "foo_domain".into(),
+            name: "foo_domain".into(),
+            failed_auth_count: Some(3),
+            failed_auth_at: Some(Utc::now().naive_utc()),
+        };
+        assert!(log_failed_auth(&db, &user, now).await.is_ok());
+
+        // Checking transaction log
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"UPDATE "local_user" SET "failed_auth_count" = $1, "failed_auth_at" = $2 WHERE "local_user"."id" = $3 RETURNING "id", "user_id", "domain_id", "name", "failed_auth_count", "failed_auth_at""#,
+                [Some(4i32).into(), Some(now.naive_utc()).into(), 1i32.into()]
+            ),]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_log_failed_auth_count_from_none() {
+        let user = db_local_user::Model {
+            id: 1,
+            user_id: "user_id".into(),
+            domain_id: "foo_domain".into(),
+            name: "foo_domain".into(),
+            failed_auth_count: None,
+            failed_auth_at: None,
+        };
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![user.clone()]])
+            .into_connection();
+        let now = Utc::now();
+        assert!(log_failed_auth(&db, &user, now).await.is_ok());
+
+        // Checking transaction log - None + 1 should default to 0 + 1 = 1
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"UPDATE "local_user" SET "failed_auth_count" = $1, "failed_auth_at" = $2 WHERE "local_user"."id" = $3 RETURNING "id", "user_id", "domain_id", "name", "failed_auth_count", "failed_auth_at""#,
+                [Some(1i32).into(), Some(now.naive_utc()).into(), 1i32.into()]
+            ),]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_failed_auth() {
+        let user = db_local_user::Model {
+            id: 1,
+            user_id: "user_id".into(),
+            domain_id: "foo_domain".into(),
+            name: "foo_domain".into(),
+            failed_auth_count: Some(5),
+            failed_auth_at: Some(Utc::now().naive_utc()),
+        };
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![user.clone()]])
+            .into_connection();
+        assert!(reset_failed_auth(&db, &user).await.is_ok());
+
+        // Checking transaction log - both fields should be reset to None
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"UPDATE "local_user" SET "failed_auth_count" = $1, "failed_auth_at" = $2 WHERE "local_user"."id" = $3 RETURNING "id", "user_id", "domain_id", "name", "failed_auth_count", "failed_auth_at""#,
+                [
+                    None::<i32>.into(),
+                    None::<chrono::NaiveDateTime>.into(),
+                    1i32.into()
+                ]
+            ),]
+        );
+    }
 }

--- a/crates/identity-driver-sql/src/user/set.rs
+++ b/crates/identity-driver-sql/src/user/set.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Set user properties.
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 
@@ -22,11 +22,12 @@ use openstack_keystone_core::identity::IdentityProviderError;
 
 use crate::entity::user as db_user;
 
-/// Reset the `user.last_active_at` to the current date.
+/// Reset the `user.last_active_at` to the specified date.
 ///
 /// # Parameters
 /// - `db`: The database connection.
-/// - `user`: The user model.
+/// - `user`: The user model to update.
+/// - `last_active_at`: The date to set as the user's last active date.
 ///
 /// # Returns
 /// A `Result` containing the updated `db_user::Model` if successful, or an
@@ -35,9 +36,11 @@ use crate::entity::user as db_user;
 pub async fn reset_last_active(
     db: &DatabaseConnection,
     user: &db_user::Model,
+    last_active_at: DateTime<Utc>,
 ) -> Result<db_user::Model, IdentityProviderError> {
     let mut update: db_user::ActiveModel = user.clone().into();
-    update.last_active_at = Set(Some(Utc::now().date_naive()));
+    update.last_active_at = Set(Some(last_active_at.date_naive()));
+
     Ok(update
         .update(db)
         .await
@@ -57,8 +60,9 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_user_mock("user_id")]])
             .into_connection();
+        let now = Utc::now();
         assert!(
-            reset_last_active(&db, &get_user_mock("user_id"))
+            reset_last_active(&db, &get_user_mock("user_id"), now)
                 .await
                 .is_ok()
         );
@@ -69,7 +73,7 @@ mod tests {
             [Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"UPDATE "user" SET "last_active_at" = $1 WHERE "user"."id" = $2 RETURNING "created_at", "default_project_id", "domain_id", "enabled", "extra", "id", "last_active_at""#,
-                [Utc::now().date_naive().into(), "user_id".into()]
+                [now.date_naive().into(), "user_id".into()]
             ),]
         );
     }


### PR DESCRIPTION
Prevent username enumeration via timing attacks by generating a dummy
password hash when a user is not found, ensuring the response time is
comparable to the "user exists, wrong password" path.

- password_hashing: add generate_dummy_hash() matching configured
  algorithm
- authenticate_by_password: verify against dummy hash when user not
  found
- log_failed_auth: accept DateTime<Utc> parameter instead of generating
  it
- reset_last_active: accept DateTime<Utc> parameter for single timestamp
- refactor: rename local_user -> local_user_entry for clarity
- tests: add unit tests for log_failed_auth, reset_failed_auth, timing
  consistency
