### PR TITLE
refactor: Replace Regex with str::find for db connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,7 +3864,6 @@ dependencies = [
  "http",
  "http-serde",
  "notify",
- "regex",
  "secrecy",
  "serde",
  "serde_json",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -18,7 +18,6 @@ eyre.workspace = true
 http.workspace = true
 http-serde = "2.1"
 notify = "8.2"
-regex.workspace = true
 secrecy = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["fs", "rt", "sync", "time"] }

--- a/crates/config/src/database.rs
+++ b/crates/config/src/database.rs
@@ -11,7 +11,6 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use regex::Regex;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
@@ -25,10 +24,12 @@ pub struct DatabaseSection {
 impl DatabaseSection {
     pub fn get_connection(&self) -> SecretString {
         let val = self.connection.expose_secret();
-        if val.contains("+") {
-            return Regex::new(r"(?<type>\w+)\+(\w+)://")
-                .map(|re| SecretString::from(re.replace(val, "${type}://").to_string()))
-                .unwrap_or(self.connection.clone());
+        if let Some(slash_pos) = val.find("://") {
+            let scheme = &val[..slash_pos];
+            if let Some(plus_pos) = scheme.find('+') {
+                let base = &scheme[..plus_pos];
+                return SecretString::from(format!("{}://{}", base, &val[slash_pos + 3..]));
+            }
         }
         self.connection.clone()
     }
@@ -41,13 +42,157 @@ mod tests {
 
     #[test]
     fn test_db_connection() {
+        // No driver suffix – no change
         let sot = DatabaseSection {
             connection: "mysql://u:p@h".into(),
         };
         assert_eq!("mysql://u:p@h", sot.get_connection().expose_secret());
+
+        // Driver suffix stripped
         let sot = DatabaseSection {
             connection: "mysql+driver://u:p@h".into(),
         };
         assert_eq!("mysql://u:p@h", sot.get_connection().expose_secret());
+    }
+
+    #[test]
+    fn test_db_connection_multiple_scheme_delimiters() {
+        // :// in password, driver stripped
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u:p://x@h".into(),
+        };
+        assert_eq!("mysql://u:p://x@h", sot.get_connection().expose_secret());
+
+        // Multiple :// in password, driver stripped
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u://x:p://y@h".into(),
+        };
+        assert_eq!(
+            "mysql://u://x:p://y@h",
+            sot.get_connection().expose_secret()
+        );
+    }
+
+    #[test]
+    fn test_db_connection_plus_in_password() {
+        // Single + in password, no driver – unchanged
+        let sot = DatabaseSection {
+            connection: "mysql://u:p+q@h".into(),
+        };
+        assert_eq!("mysql://u:p+q@h", sot.get_connection().expose_secret());
+
+        // Multiple + in password, no driver – unchanged
+        let sot = DatabaseSection {
+            connection: "mysql://u:a+b+c@h".into(),
+        };
+        assert_eq!("mysql://u:a+b+c@h", sot.get_connection().expose_secret());
+
+        // Only + as password, no driver – unchanged
+        let sot = DatabaseSection {
+            connection: "mysql://u:+@h".into(),
+        };
+        assert_eq!("mysql://u:+@h", sot.get_connection().expose_secret());
+
+        // + at end of password, no driver – unchanged
+        let sot = DatabaseSection {
+            connection: "mysql://u:pass+@h".into(),
+        };
+        assert_eq!("mysql://u:pass+@h", sot.get_connection().expose_secret());
+
+        // Driver suffix + single + in password
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u:p+q@h".into(),
+        };
+        assert_eq!("mysql://u:p+q@h", sot.get_connection().expose_secret());
+
+        // Driver suffix + multiple + in password
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u:a+b+c@h".into(),
+        };
+        assert_eq!("mysql://u:a+b+c@h", sot.get_connection().expose_secret());
+
+        // Driver suffix + only + as password
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u:+@h".into(),
+        };
+        assert_eq!("mysql://u:+@h", sot.get_connection().expose_secret());
+
+        // Driver suffix + :// and + in password
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u:p+q://r@h".into(),
+        };
+        assert_eq!("mysql://u:p+q://r@h", sot.get_connection().expose_secret());
+
+        // + in username and password, no driver
+        let sot = DatabaseSection {
+            connection: "mysql://u+v:p+w@h".into(),
+        };
+        assert_eq!("mysql://u+v:p+w@h", sot.get_connection().expose_secret());
+
+        // Driver suffix + + in username and password
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u+v:p+w@h".into(),
+        };
+        assert_eq!("mysql://u+v:p+w@h", sot.get_connection().expose_secret());
+
+        // Empty password, no driver
+        let sot = DatabaseSection {
+            connection: "mysql://u:@h".into(),
+        };
+        assert_eq!("mysql://u:@h", sot.get_connection().expose_secret());
+
+        // Empty password, driver stripped
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u:@h".into(),
+        };
+        assert_eq!("mysql://u:@h", sot.get_connection().expose_secret());
+
+        // No password, no driver
+        let sot = DatabaseSection {
+            connection: "mysql://u@h".into(),
+        };
+        assert_eq!("mysql://u@h", sot.get_connection().expose_secret());
+
+        // No password, driver stripped
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u@h".into(),
+        };
+        assert_eq!("mysql://u@h", sot.get_connection().expose_secret());
+
+        // Special chars in password: @, /, ?, #
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u:p@ss/w?_r#k@h".into(),
+        };
+        assert_eq!(
+            "mysql://u:p@ss/w?_r#k@h",
+            sot.get_connection().expose_secret()
+        );
+
+        // % encoded + in password (literal %2B)
+        let sot = DatabaseSection {
+            connection: "mysql+driver://u:%2B@h".into(),
+        };
+        assert_eq!("mysql://u:%2B@h", sot.get_connection().expose_secret());
+    }
+
+    #[test]
+    fn test_db_connection_edge_cases() {
+        // Multiple consecutive +
+        let sot = DatabaseSection {
+            connection: "mysql+driver+extra://u:p@h".into(),
+        };
+        assert_eq!("mysql://u:p@h", sot.get_connection().expose_secret());
+
+        // No scheme separator – passthrough
+        let sot = DatabaseSection {
+            connection: "mysql+driver/u:p@h".into(),
+        };
+        assert_eq!("mysql+driver/u:p@h", sot.get_connection().expose_secret());
+
+        // Empty connection
+        let sot = DatabaseSection {
+            connection: "".into(),
+        };
+        assert_eq!("", sot.get_connection().expose_secret());
     }
 }


### PR DESCRIPTION
Remove the regex dependency from openstack-keystone-config by replacing the
Runtime regex-based stripping of SQLAlchemy-style driver suffix (e.g.,
mysql+driver:// -> mysql://) with two simple str::find() calls on the scheme
portion of the URL before the first '://' delimiter.

This is more correct than the previous approach which only checked for '+'
anywhere in the string, as it now correctly handles '+' appearing in usernames,
passwords, or paths by only looking for it within the scheme portion.

Add extensive unit tests covering:
  - '+' in password and username with and without driver suffix
  - Multiple '://' in password/URI
  - Multiple '+' in scheme (mysql+driver+extra://)
  - Empty password, missing password, empty connection string
  - Special characters (@, /, ?, #, %2B) in password
  - Missing '://' separator passthrough
