### PR TITLE
feat: Add region CRUD to catalog SQL driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,6 +3828,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/catalog-driver-sql/Cargo.toml
+++ b/crates/catalog-driver-sql/Cargo.toml
@@ -18,6 +18,7 @@ openstack-keystone-core-types.workspace = true
 sea-orm.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 openstack-keystone-core = { version = "0.1", path = "../core", features = ["mock"] }

--- a/crates/catalog-driver-sql/src/lib.rs
+++ b/crates/catalog-driver-sql/src/lib.rs
@@ -35,6 +35,7 @@ use crate::entity::{
 
 mod endpoint;
 pub mod entity;
+mod region;
 mod service;
 
 #[derive(Default)]
@@ -54,22 +55,92 @@ inventory::submit! {
 
 #[async_trait]
 impl CatalogBackend for SqlBackend {
-    /// List services.
+    /// Create a new region.
     ///
     /// # Parameters
     /// - `state`: The service state containing the database connection.
-    /// - `params`: The parameters for listing services.
+    /// - `region_data`: The region creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing a vector of `Service`s, or a
-    /// `CatalogProviderError`.
+    /// A `Result` containing the created `Region`, or a `CatalogProviderError`.
     #[tracing::instrument(level = "debug", skip(self, state))]
-    async fn list_services(
+    async fn create_region(
         &self,
         state: &ServiceState,
-        params: &ServiceListParameters,
-    ) -> Result<Vec<Service>, CatalogProviderError> {
-        Ok(service::list(&state.db, params).await?)
+        region_data: RegionCreate,
+    ) -> Result<Region, CatalogProviderError> {
+        Ok(region::create(&state.db, region_data).await?)
+    }
+
+    /// Delete a region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `id`: The ID of the region to delete.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn delete_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError> {
+        Ok(region::delete(&state.db, id).await?)
+    }
+
+    /// Get the catalog (services with endpoints).
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `enabled`: Whether to return only enabled entries.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of tuples of `Service` and its associated
+    /// `Endpoint`s, or a `CatalogProviderError`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn get_catalog(
+        &self,
+        state: &ServiceState,
+        enabled: bool,
+    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError> {
+        Ok(get_catalog(&state.db, enabled).await?)
+    }
+
+    /// Get a single endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `id`: The ID of the endpoint to retrieve.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `Endpoint` if found, or an
+    /// `Error`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn get_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Endpoint>, CatalogProviderError> {
+        Ok(endpoint::get(&state.db, id).await?)
+    }
+
+    /// Get a single region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `id`: The ID of the region to retrieve.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `Region` if found, or an
+    /// `Error`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn get_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Region>, CatalogProviderError> {
+        Ok(region::get(&state.db, id).await?)
     }
 
     /// Get a single service by ID.
@@ -108,49 +179,58 @@ impl CatalogBackend for SqlBackend {
         Ok(endpoint::list(&state.db, params).await?)
     }
 
-    /// Get a single endpoint by ID.
+    /// List regions.
     ///
     /// # Parameters
     /// - `state`: The service state containing the database connection.
-    /// - `id`: The ID of the endpoint to retrieve.
+    /// - `params`: The parameters for listing regions.
     ///
     /// # Returns
-    /// A `Result` containing an `Option` with the `Endpoint` if found, or an
-    /// `Error`.
+    /// A `Result` containing a vector of `Region`s, or a `CatalogProviderError`.
     #[tracing::instrument(level = "debug", skip(self, state))]
-    async fn get_endpoint<'a>(
+    async fn list_regions(
+        &self,
+        state: &ServiceState,
+        params: &RegionListParameters,
+    ) -> Result<Vec<Region>, CatalogProviderError> {
+        Ok(region::list(&state.db, params).await?)
+    }
+
+    /// List services.
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `params`: The parameters for listing services.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of `Service`s, or a
+    /// `CatalogProviderError`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn list_services(
+        &self,
+        state: &ServiceState,
+        params: &ServiceListParameters,
+    ) -> Result<Vec<Service>, CatalogProviderError> {
+        Ok(service::list(&state.db, params).await?)
+    }
+
+    /// Update an existing region.
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `id`: The ID of the region to update.
+    /// - `region_data`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Region`, or a `CatalogProviderError`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn update_region<'a>(
         &self,
         state: &ServiceState,
         id: &'a str,
-    ) -> Result<Option<Endpoint>, CatalogProviderError> {
-        Ok(endpoint::get(&state.db, id).await?)
-    }
-
-    /// Get the catalog (services with endpoints).
-    ///
-    /// # Parameters
-    /// - `state`: The service state containing the database connection.
-    /// - `enabled`: Whether to return only enabled entries.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of tuples of `Service` and its associated
-    /// `Endpoint`s, or a `CatalogProviderError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
-    /// Get the catalog.
-    ///
-    /// # Parameters
-    /// - `db`: The database connection.
-    /// - `enabled`: Whether to return only enabled entries.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of tuples of `Service` and its associated
-    /// `Endpoint`s, or a `CatalogProviderError`.
-    async fn get_catalog(
-        &self,
-        state: &ServiceState,
-        enabled: bool,
-    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError> {
-        Ok(get_catalog(&state.db, enabled).await?)
+        region_data: RegionUpdate,
+    ) -> Result<Region, CatalogProviderError> {
+        Ok(region::update(&state.db, id, region_data).await?)
     }
 }
 

--- a/crates/catalog-driver-sql/src/region.rs
+++ b/crates/catalog-driver-sql/src/region.rs
@@ -1,0 +1,108 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::entity::*;
+use serde_json::Value;
+use tracing::error;
+use uuid::Uuid;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core_types::catalog::*;
+
+use crate::entity::region as db_region;
+
+mod create;
+mod delete;
+mod get;
+mod list;
+mod update;
+
+pub use create::create;
+pub use delete::delete;
+pub use get::get;
+pub use list::list;
+pub use update::update;
+
+impl TryFrom<db_region::Model> for Region {
+    type Error = CatalogProviderError;
+
+    /// Tries to convert a database region model into a domain region.
+    ///
+    /// # Parameters
+    /// - `value`: The database region model.
+    ///
+    /// # Returns
+    /// A `Result` containing the `Region`, or a `CatalogProviderError`.
+    fn try_from(value: db_region::Model) -> Result<Self, Self::Error> {
+        let mut builder = RegionBuilder::default();
+        builder.id(value.id.clone());
+        if !value.description.is_empty() {
+            builder.description(value.description.clone());
+        }
+        if let Some(parent_region_id) = &value.parent_region_id {
+            builder.parent_region_id(parent_region_id.clone());
+        }
+
+        if let Some(extra) = &value.extra
+            && extra != "{}"
+        {
+            match serde_json::from_str::<Value>(extra) {
+                Ok(val) => {
+                    builder.extra(val);
+                }
+                Err(e) => {
+                    error!("failed to deserialize region extra: {e}");
+                }
+            }
+        }
+
+        Ok(builder.build()?)
+    }
+}
+
+impl TryFrom<RegionCreate> for db_region::ActiveModel {
+    type Error = CatalogProviderError;
+
+    /// Tries to convert region creation parameters into a database active model.
+    ///
+    /// # Parameters
+    /// - `value`: The region creation parameters.
+    ///
+    /// # Returns
+    /// A `Result` containing the `ActiveModel`, or a `CatalogProviderError`.
+    fn try_from(value: RegionCreate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: Set(value
+                .id
+                .unwrap_or_else(|| Uuid::new_v4().simple().to_string())),
+            description: Set(value.description.unwrap_or_default()),
+            parent_region_id: Set(value.parent_region_id),
+            extra: Set(Some(serde_json::to_string(&value.extra)?)),
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::entity::region;
+
+    pub fn get_region_mock<I: Into<String>>(id: I) -> region::Model {
+        region::Model {
+            id: id.into(),
+            description: "region description".into(),
+            parent_region_id: None,
+            extra: Some(r#"{"key": "value"}"#.to_string()),
+        }
+    }
+}

--- a/crates/catalog-driver-sql/src/region/create.rs
+++ b/crates/catalog-driver-sql/src/region/create.rs
@@ -1,0 +1,102 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::catalog::{Region, RegionCreate};
+
+use crate::entity::region as db_region;
+
+/// Creates a new region.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `region`: The region creation parameters.
+///
+/// # Returns
+/// A `Result` containing the created `Region`, or an `Error`.
+pub async fn create(
+    db: &DatabaseConnection,
+    region: RegionCreate,
+) -> Result<Region, CatalogProviderError> {
+    TryInto::<db_region::ActiveModel>::try_into(region)?
+        .insert(db)
+        .await
+        .context("creating region")?
+        .try_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use serde_json::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![db_region::Model {
+                id: "region-1".into(),
+                description: "Region One".into(),
+                parent_region_id: None,
+                extra: Some(r#"{"key":"value"}"#.into()),
+            }]])
+            .into_connection();
+
+        let region_create = RegionCreate {
+            id: Some("region-1".to_string()),
+            description: Some("Region One".to_string()),
+            parent_region_id: None,
+            extra: HashMap::from([("key".into(), json!("value"))]),
+        };
+
+        let created = create(&db, region_create).await.unwrap();
+
+        assert_eq!(created.id, "region-1");
+        assert_eq!(created.description.as_deref(), Some("Region One"));
+        assert_eq!(created.extra, Some(json!({"key": "value"})));
+    }
+
+    #[tokio::test]
+    async fn test_create_with_parent() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![db_region::Model {
+                id: "child".into(),
+                description: String::new(),
+                parent_region_id: Some("parent".into()),
+                extra: None,
+            }]])
+            .into_connection();
+
+        let region_create = RegionCreate {
+            id: Some("child".to_string()),
+            description: None,
+            parent_region_id: Some("parent".to_string()),
+            extra: HashMap::new(),
+        };
+
+        let created = create(&db, region_create).await.unwrap();
+
+        assert_eq!(created.id, "child");
+        // Empty DB description is normalized to None on the domain type.
+        assert_eq!(created.description, None);
+        assert_eq!(created.parent_region_id.as_deref(), Some("parent"));
+    }
+}

--- a/crates/catalog-driver-sql/src/region/delete.rs
+++ b/crates/catalog-driver-sql/src/region/delete.rs
@@ -1,0 +1,70 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Delete Region
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core::error::DbContextExt;
+
+use crate::entity::prelude::Region as DbRegion;
+
+/// Deletes an existing region.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `id`: The region ID.
+///
+/// # Returns
+/// A `Result` indicating success or an `Error`.
+pub async fn delete<S: AsRef<str>>(
+    db: &DatabaseConnection,
+    id: S,
+) -> Result<(), CatalogProviderError> {
+    DbRegion::delete_by_id(id.as_ref())
+        .exec(db)
+        .await
+        .context("deleting region")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Transaction};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_delete() {
+        // Create MockDatabase with mock exec results
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
+            .into_connection();
+
+        delete(&db, "id").await.unwrap();
+        // Checking transaction log
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"DELETE FROM "region" WHERE "region"."id" = $1"#,
+                ["id".into()]
+            ),]
+        );
+    }
+}

--- a/crates/catalog-driver-sql/src/region/get.rs
+++ b/crates/catalog-driver-sql/src/region/get.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::catalog::Region;
+
+use crate::entity::prelude::Region as DbRegion;
+
+/// Gets a region by ID.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `id`: The ID of the region to retrieve.
+///
+/// # Returns
+/// A `Result` containing an `Option` with the `Region` if found, or an `Error`.
+pub async fn get<I: AsRef<str>>(
+    db: &DatabaseConnection,
+    id: I,
+) -> Result<Option<Region>, CatalogProviderError> {
+    DbRegion::find_by_id(id.as_ref())
+        .one(db)
+        .await
+        .context("fetching region by ID")?
+        .map(TryInto::try_into)
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use serde_json::json;
+
+    use super::super::tests::get_region_mock;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get() {
+        // Create MockDatabase with mock query results
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_region_mock("1")]])
+            .into_connection();
+        assert_eq!(
+            get(&db, "1").await.unwrap().unwrap(),
+            Region {
+                id: "1".into(),
+                description: Some("region description".into()),
+                parent_region_id: None,
+                extra: Some(json!({"key": "value"})),
+            }
+        );
+
+        // Checking transaction log
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region" WHERE "region"."id" = $1 LIMIT $2"#,
+                ["1".into(), 1u64.into()]
+            ),]
+        );
+    }
+}

--- a/crates/catalog-driver-sql/src/region/list.rs
+++ b/crates/catalog-driver-sql/src/region/list.rs
@@ -1,0 +1,102 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::catalog::*;
+
+use crate::entity::{prelude::Region as DbRegion, region as db_region};
+
+/// Lists regions.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `params`: The parameters for listing regions.
+///
+/// # Returns
+/// A `Result` containing a vector of `Region`s, or a `CatalogProviderError`.
+pub async fn list(
+    db: &DatabaseConnection,
+    params: &RegionListParameters,
+) -> Result<Vec<Region>, CatalogProviderError> {
+    let mut select = DbRegion::find();
+
+    if let Some(parent_region_id) = &params.parent_region_id {
+        select = select.filter(db_region::Column::ParentRegionId.eq(parent_region_id));
+    }
+
+    select
+        .all(db)
+        .await
+        .context("fetching regions")?
+        .into_iter()
+        .map(TryInto::<Region>::try_into)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use serde_json::json;
+
+    use super::super::tests::get_region_mock;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_list() {
+        // Create MockDatabase with mock query results
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_region_mock("1")]])
+            .append_query_results([vec![get_region_mock("1")]])
+            .into_connection();
+        assert!(list(&db, &RegionListParameters::default()).await.is_ok());
+        assert_eq!(
+            list(
+                &db,
+                &RegionListParameters {
+                    parent_region_id: Some("parent".into()),
+                }
+            )
+            .await
+            .unwrap(),
+            vec![Region {
+                id: "1".into(),
+                description: Some("region description".into()),
+                parent_region_id: None,
+                extra: Some(json!({"key": "value"})),
+            }]
+        );
+
+        // Checking transaction log
+        assert_eq!(
+            db.into_transaction_log(),
+            [
+                Transaction::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region""#,
+                    []
+                ),
+                Transaction::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region" WHERE "region"."parent_region_id" = $1"#,
+                    ["parent".into()]
+                ),
+            ]
+        );
+    }
+}

--- a/crates/catalog-driver-sql/src/region/update.rs
+++ b/crates/catalog-driver-sql/src/region/update.rs
@@ -1,0 +1,107 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Update Region
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::catalog::{Region, RegionUpdate};
+
+use crate::entity::{prelude::Region as DbRegion, region as db_region};
+
+/// Updates an existing region.
+///
+/// Only the fields set in `region` are changed; the rest are left as-is.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `id`: The ID of the region to update.
+/// - `region`: The fields to change.
+///
+/// # Returns
+/// A `Result` containing the updated `Region`, or an `Error` (including
+/// `RegionNotFound` if no region with that ID exists).
+pub async fn update<I: AsRef<str>>(
+    db: &DatabaseConnection,
+    id: I,
+    region: RegionUpdate,
+) -> Result<Region, CatalogProviderError> {
+    // Fetch the existing region; error if it does not exist.
+    let existing = DbRegion::find_by_id(id.as_ref())
+        .one(db)
+        .await
+        .context("fetching region for update")?
+        .ok_or_else(|| CatalogProviderError::RegionNotFound(id.as_ref().to_string()))?;
+
+    // Start from the existing row, then overwrite only the provided fields.
+    let mut update_model: db_region::ActiveModel = existing.into();
+
+    if let Some(description) = region.description {
+        update_model.description = Set(description);
+    }
+    if let Some(parent_region_id) = region.parent_region_id {
+        update_model.parent_region_id = Set(Some(parent_region_id));
+    }
+    if let Some(extra) = region.extra {
+        update_model.extra = Set(Some(serde_json::to_string(&extra)?));
+    }
+
+    update_model
+        .update(db)
+        .await
+        .context("updating region")?
+        .try_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    use super::super::tests::get_region_mock;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // 1. fetch the existing region
+            .append_query_results([vec![get_region_mock("1")]])
+            // 2. the UPDATE returns the updated row
+            .append_query_results([vec![get_region_mock("1")]])
+            .into_connection();
+
+        let req = RegionUpdate {
+            description: Some("new description".to_string()),
+            ..Default::default()
+        };
+
+        let result = update(&db, "1", req).await;
+        assert!(result.is_ok(), "update failed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        // No region rows returned → update should report RegionNotFound.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<db_region::Model>::new()])
+            .into_connection();
+
+        let result = update(&db, "missing", RegionUpdate::default()).await;
+        assert!(matches!(
+            result,
+            Err(CatalogProviderError::RegionNotFound(_))
+        ));
+    }
+}

--- a/crates/core-types/src/catalog/error.rs
+++ b/crates/core-types/src/catalog/error.rs
@@ -35,6 +35,10 @@ pub enum CatalogProviderError {
     #[error("service {0} not found")]
     ServiceNotFound(String),
 
+    /// The region has not been found.
+    #[error("region {0} not found")]
+    RegionNotFound(String),
+
     /// Structures builder error.
     #[error(transparent)]
     StructBuilder {
@@ -46,4 +50,12 @@ pub enum CatalogProviderError {
     /// Unsupported driver.
     #[error("unsupported driver `{0}` for the catalog provider.")]
     UnsupportedDriver(String),
+
+    /// Validation error.
+    #[error("request validation error: {}", source)]
+    Validation {
+        /// The source of the error.
+        #[from]
+        source: validator::ValidationErrors,
+    },
 }

--- a/crates/core-types/src/catalog/region.rs
+++ b/crates/core-types/src/catalog/region.rs
@@ -1,0 +1,90 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use serde_json::Value;
+use validator::Validate;
+
+use crate::error::BuilderError;
+
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct Region {
+    /// The region description.
+    #[builder(default)]
+    #[validate(length(max = 255))]
+    pub description: Option<String>,
+
+    /// Additional region properties.
+    #[builder(default)]
+    pub extra: Option<Value>,
+
+    /// The ID of the region.
+    #[validate(length(min = 1, max = 255))]
+    pub id: String,
+
+    /// The ID of the parent region, when this region is nested under another.
+    #[builder(default)]
+    #[validate(length(max = 255))]
+    pub parent_region_id: Option<String>,
+}
+
+/// Parameters for creating a new region.
+#[derive(Clone, Debug, Default, PartialEq, Validate)]
+pub struct RegionCreate {
+    /// The region description.
+    #[validate(length(max = 255))]
+    pub description: Option<String>,
+
+    /// Additional region properties.
+    pub extra: HashMap<String, Value>,
+
+    /// The ID of the region. A UUID is generated when omitted.
+    #[validate(length(min = 1, max = 255))]
+    pub id: Option<String>,
+
+    /// The ID of the parent region.
+    #[validate(length(max = 255))]
+    pub parent_region_id: Option<String>,
+}
+
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct RegionListParameters {
+    /// Filters the response by a parent region ID.
+    #[validate(length(max = 255))]
+    pub parent_region_id: Option<String>,
+}
+
+/// Fields that can be changed when updating a region.
+///
+/// Each field is `None` when the caller did not provide it (leave unchanged) and
+/// `Some(..)` to set a new value.
+#[derive(Clone, Debug, Default, PartialEq, Validate)]
+pub struct RegionUpdate {
+    /// New region description.
+    #[validate(length(max = 255))]
+    pub description: Option<String>,
+
+    /// New additional region properties (replaces the existing `extra`).
+    pub extra: Option<HashMap<String, Value>>,
+
+    /// New parent region ID.
+    #[validate(length(max = 255))]
+    pub parent_region_id: Option<String>,
+}

--- a/crates/core/src/catalog/backend.rs
+++ b/crates/core/src/catalog/backend.rs
@@ -22,20 +22,78 @@ use crate::keystone::ServiceState;
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait CatalogBackend: Send + Sync {
-    /// List services.
+    /// Create a new region.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `params`: Parameters for filtering the service list.
+    /// - `region`: The region creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing a vector of `Service` objects or a
-    /// `CatalogProviderError`.
-    async fn list_services(
+    /// A `Result` containing the created `Region`, or a `CatalogProviderError`.
+    async fn create_region(
         &self,
         state: &ServiceState,
-        params: &ServiceListParameters,
-    ) -> Result<Vec<Service>, CatalogProviderError>;
+        region: RegionCreate,
+    ) -> Result<Region, CatalogProviderError>;
+
+    /// Delete a region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    async fn delete_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError>;
+
+    /// Get Catalog (Services with Endpoints).
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `enabled`: Whether to return only enabled services.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of tuples of `Service` and its associated
+    /// `Endpoint`s, or a `CatalogProviderError`.
+    async fn get_catalog(
+        &self,
+        state: &ServiceState,
+        enabled: bool,
+    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError>;
+
+    /// Get single endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `Endpoint` if found, or a
+    /// `CatalogProviderError`.
+    async fn get_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Endpoint>, CatalogProviderError>;
+
+    /// Get single region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `Region` if found, or a
+    /// `CatalogProviderError`.
+    async fn get_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Region>, CatalogProviderError>;
 
     /// Get single service by ID.
     ///
@@ -67,33 +125,49 @@ pub trait CatalogBackend: Send + Sync {
         params: &EndpointListParameters,
     ) -> Result<Vec<Endpoint>, CatalogProviderError>;
 
-    /// Get single endpoint by ID.
+    /// List regions.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `id`: The unique identifier of the endpoint.
+    /// - `params`: Parameters for filtering the region list.
     ///
     /// # Returns
-    /// A `Result` containing an `Option` with the `Endpoint` if found, or a
+    /// A `Result` containing a vector of `Region` objects or a
     /// `CatalogProviderError`.
-    async fn get_endpoint<'a>(
+    async fn list_regions(
+        &self,
+        state: &ServiceState,
+        params: &RegionListParameters,
+    ) -> Result<Vec<Region>, CatalogProviderError>;
+
+    /// List services.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `params`: Parameters for filtering the service list.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of `Service` objects or a
+    /// `CatalogProviderError`.
+    async fn list_services(
+        &self,
+        state: &ServiceState,
+        params: &ServiceListParameters,
+    ) -> Result<Vec<Service>, CatalogProviderError>;
+
+    /// Update an existing region.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    /// - `region`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Region`, or a `CatalogProviderError`.
+    async fn update_region<'a>(
         &self,
         state: &ServiceState,
         id: &'a str,
-    ) -> Result<Option<Endpoint>, CatalogProviderError>;
-
-    /// Get Catalog (Services with Endpoints).
-    ///
-    /// # Parameters
-    /// - `state`: The current service state.
-    /// - `enabled`: Whether to return only enabled services.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of tuples of `Service` and its associated
-    /// `Endpoint`s, or a `CatalogProviderError`.
-    async fn get_catalog(
-        &self,
-        state: &ServiceState,
-        enabled: bool,
-    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError>;
+        region: RegionUpdate,
+    ) -> Result<Region, CatalogProviderError>;
 }

--- a/crates/core/src/catalog/mock.rs
+++ b/crates/core/src/catalog/mock.rs
@@ -26,11 +26,35 @@ mock! {
 
     #[async_trait]
     impl CatalogApi for CatalogProvider {
-        async fn list_services(
+        async fn create_region(
             &self,
             state: &ServiceState,
-            params: &ServiceListParameters
-        ) -> Result<Vec<Service>, CatalogProviderError>;
+            region: RegionCreate,
+        ) -> Result<Region, CatalogProviderError>;
+
+        async fn delete_region<'a>(
+            &self,
+            state: &ServiceState,
+            id: &'a str,
+        ) -> Result<(), CatalogProviderError>;
+
+        async fn get_catalog(
+            &self,
+            state: &ServiceState,
+            enabled: bool,
+        ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError>;
+
+        async fn get_endpoint<'a>(
+            &self,
+            state: &ServiceState,
+            id: &'a str,
+        ) -> Result<Option<Endpoint>, CatalogProviderError>;
+
+        async fn get_region<'a>(
+            &self,
+            state: &ServiceState,
+            id: &'a str,
+        ) -> Result<Option<Region>, CatalogProviderError>;
 
         async fn get_service<'a>(
             &self,
@@ -44,17 +68,23 @@ mock! {
             params: &EndpointListParameters,
         ) -> Result<Vec<Endpoint>, CatalogProviderError>;
 
-        async fn get_endpoint<'a>(
+        async fn list_regions(
+            &self,
+            state: &ServiceState,
+            params: &RegionListParameters,
+        ) -> Result<Vec<Region>, CatalogProviderError>;
+
+        async fn list_services(
+            &self,
+            state: &ServiceState,
+            params: &ServiceListParameters
+        ) -> Result<Vec<Service>, CatalogProviderError>;
+
+        async fn update_region<'a>(
             &self,
             state: &ServiceState,
             id: &'a str,
-        ) -> Result<Option<Endpoint>, CatalogProviderError>;
-
-        async fn get_catalog(
-            &self,
-            state: &ServiceState,
-            enabled: bool,
-        ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError>;
-
+            region: RegionUpdate,
+        ) -> Result<Region, CatalogProviderError>;
     }
 }

--- a/crates/core/src/catalog/mod.rs
+++ b/crates/core/src/catalog/mod.rs
@@ -77,25 +77,111 @@ impl CatalogProvider {
 
 #[async_trait]
 impl CatalogApi for CatalogProvider {
-    /// List services.
+    /// Create a new region.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `params`: Parameters for filtering the service list.
+    /// - `region`: The region creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing a vector of `Service` objects or a
-    /// `CatalogProviderError`.
+    /// A `Result` containing the created `Region`, or a `CatalogProviderError`.
     #[tracing::instrument(level = "info", skip(self, state))]
-    async fn list_services(
+    async fn create_region(
         &self,
         state: &ServiceState,
-        params: &ServiceListParameters,
-    ) -> Result<Vec<Service>, CatalogProviderError> {
+        region: RegionCreate,
+    ) -> Result<Region, CatalogProviderError> {
         match self {
-            Self::Service(provider) => provider.list_services(state, params).await,
+            Self::Service(provider) => provider.create_region(state, region).await,
             #[cfg(any(test, feature = "mock"))]
-            Self::Mock(provider) => provider.list_services(state, params).await,
+            Self::Mock(provider) => provider.create_region(state, region).await,
+        }
+    }
+
+    /// Delete a region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn delete_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError> {
+        match self {
+            Self::Service(provider) => provider.delete_region(state, id).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.delete_region(state, id).await,
+        }
+    }
+
+    /// Get catalog.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `enabled`: Whether to return only enabled services.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of tuples of `Service` and its associated
+    /// `Endpoint`s, or a `CatalogProviderError`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn get_catalog(
+        &self,
+        state: &ServiceState,
+        enabled: bool,
+    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError> {
+        match self {
+            Self::Service(provider) => provider.get_catalog(state, enabled).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.get_catalog(state, enabled).await,
+        }
+    }
+
+    /// Get single endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the endpoint if found, or an
+    /// `Error`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn get_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Endpoint>, CatalogProviderError> {
+        match self {
+            Self::Service(provider) => provider.get_endpoint(state, id).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.get_endpoint(state, id).await,
+        }
+    }
+
+    /// Get single region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the region if found, or an
+    /// `Error`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn get_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Region>, CatalogProviderError> {
+        match self {
+            Self::Service(provider) => provider.get_region(state, id).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.get_region(state, id).await,
         }
     }
 
@@ -143,47 +229,70 @@ impl CatalogApi for CatalogProvider {
         }
     }
 
-    /// Get single endpoint by ID.
+    /// List regions.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `id`: The unique identifier of the endpoint.
+    /// - `params`: Parameters for filtering the region list.
     ///
     /// # Returns
-    /// A `Result` containing an `Option` with the endpoint if found, or an
-    /// `Error`.
+    /// A `Result` containing a vector of `Region` objects or a
+    /// `CatalogProviderError`.
     #[tracing::instrument(level = "info", skip(self, state))]
-    async fn get_endpoint<'a>(
+    async fn list_regions(
         &self,
         state: &ServiceState,
-        id: &'a str,
-    ) -> Result<Option<Endpoint>, CatalogProviderError> {
+        params: &RegionListParameters,
+    ) -> Result<Vec<Region>, CatalogProviderError> {
         match self {
-            Self::Service(provider) => provider.get_endpoint(state, id).await,
+            Self::Service(provider) => provider.list_regions(state, params).await,
             #[cfg(any(test, feature = "mock"))]
-            Self::Mock(provider) => provider.get_endpoint(state, id).await,
+            Self::Mock(provider) => provider.list_regions(state, params).await,
         }
     }
 
-    /// Get catalog.
+    /// List services.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `enabled`: Whether to return only enabled services.
+    /// - `params`: Parameters for filtering the service list.
     ///
     /// # Returns
-    /// A `Result` containing a vector of tuples of `Service` and its associated
-    /// `Endpoint`s, or a `CatalogProviderError`.
+    /// A `Result` containing a vector of `Service` objects or a
+    /// `CatalogProviderError`.
     #[tracing::instrument(level = "info", skip(self, state))]
-    async fn get_catalog(
+    async fn list_services(
         &self,
         state: &ServiceState,
-        enabled: bool,
-    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError> {
+        params: &ServiceListParameters,
+    ) -> Result<Vec<Service>, CatalogProviderError> {
         match self {
-            Self::Service(provider) => provider.get_catalog(state, enabled).await,
+            Self::Service(provider) => provider.list_services(state, params).await,
             #[cfg(any(test, feature = "mock"))]
-            Self::Mock(provider) => provider.get_catalog(state, enabled).await,
+            Self::Mock(provider) => provider.list_services(state, params).await,
+        }
+    }
+
+    /// Update an existing region.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    /// - `region`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Region`, or a `CatalogProviderError`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn update_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        region: RegionUpdate,
+    ) -> Result<Region, CatalogProviderError> {
+        match self {
+            Self::Service(provider) => provider.update_region(state, id, region).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.update_region(state, id, region).await,
         }
     }
 }

--- a/crates/core/src/catalog/provider_api.rs
+++ b/crates/core/src/catalog/provider_api.rs
@@ -21,20 +21,78 @@ use crate::keystone::ServiceState;
 
 #[async_trait]
 pub trait CatalogApi: Send + Sync {
-    /// List services.
+    /// Create a new region.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `params`: Parameters for filtering the service list.
+    /// - `region`: The region creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing a vector of `Service` objects or a
-    /// `CatalogProviderError`.
-    async fn list_services(
+    /// A `Result` containing the created `Region`, or a `CatalogProviderError`.
+    async fn create_region(
         &self,
         state: &ServiceState,
-        params: &ServiceListParameters,
-    ) -> Result<Vec<Service>, CatalogProviderError>;
+        region: RegionCreate,
+    ) -> Result<Region, CatalogProviderError>;
+
+    /// Delete a region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    async fn delete_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError>;
+
+    /// Get catalog.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `enabled`: Whether to return only enabled services.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of tuples of `Service` and its associated
+    /// `Endpoint`s, or a `CatalogProviderError`.
+    async fn get_catalog(
+        &self,
+        state: &ServiceState,
+        enabled: bool,
+    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError>;
+
+    /// Get single endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `Endpoint` if found, or a
+    /// `CatalogProviderError`.
+    async fn get_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Endpoint>, CatalogProviderError>;
+
+    /// Get single region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `Region` if found, or a
+    /// `CatalogProviderError`.
+    async fn get_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Region>, CatalogProviderError>;
 
     /// Get single service by ID.
     ///
@@ -66,33 +124,49 @@ pub trait CatalogApi: Send + Sync {
         params: &EndpointListParameters,
     ) -> Result<Vec<Endpoint>, CatalogProviderError>;
 
-    /// Get single endpoint by ID.
+    /// List regions.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `id`: The unique identifier of the endpoint.
+    /// - `params`: Parameters for filtering the region list.
     ///
     /// # Returns
-    /// A `Result` containing an `Option` with the `Endpoint` if found, or a
+    /// A `Result` containing a vector of `Region` objects or a
     /// `CatalogProviderError`.
-    async fn get_endpoint<'a>(
+    async fn list_regions(
+        &self,
+        state: &ServiceState,
+        params: &RegionListParameters,
+    ) -> Result<Vec<Region>, CatalogProviderError>;
+
+    /// List services.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `params`: Parameters for filtering the service list.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of `Service` objects or a
+    /// `CatalogProviderError`.
+    async fn list_services(
+        &self,
+        state: &ServiceState,
+        params: &ServiceListParameters,
+    ) -> Result<Vec<Service>, CatalogProviderError>;
+
+    /// Update an existing region.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    /// - `region`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Region`, or a `CatalogProviderError`.
+    async fn update_region<'a>(
         &self,
         state: &ServiceState,
         id: &'a str,
-    ) -> Result<Option<Endpoint>, CatalogProviderError>;
-
-    /// Get catalog.
-    ///
-    /// # Parameters
-    /// - `state`: The current service state.
-    /// - `enabled`: Whether to return only enabled services.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of tuples of `Service` and its associated
-    /// `Endpoint`s, or a `CatalogProviderError`.
-    async fn get_catalog(
-        &self,
-        state: &ServiceState,
-        enabled: bool,
-    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError>;
+        region: RegionUpdate,
+    ) -> Result<Region, CatalogProviderError>;
 }

--- a/crates/core/src/catalog/service.rs
+++ b/crates/core/src/catalog/service.rs
@@ -14,6 +14,7 @@
 //! # Catalog provider
 use async_trait::async_trait;
 use std::sync::Arc;
+use validator::Validate;
 
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::catalog::*;
@@ -49,21 +50,88 @@ impl CatalogService {
 
 #[async_trait]
 impl CatalogApi for CatalogService {
-    /// List services.
+    /// Create a new region.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `params`: Parameters for filtering the service list.
+    /// - `region`: The region creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing a vector of `Service` objects or a
-    /// `CatalogProviderError`.
-    async fn list_services(
+    /// A `Result` containing the created `Region`, or a `CatalogProviderError`.
+    async fn create_region(
         &self,
         state: &ServiceState,
-        params: &ServiceListParameters,
-    ) -> Result<Vec<Service>, CatalogProviderError> {
-        self.backend_driver.list_services(state, params).await
+        region: RegionCreate,
+    ) -> Result<Region, CatalogProviderError> {
+        region.validate()?;
+        self.backend_driver.create_region(state, region).await
+    }
+
+    /// Delete a region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    async fn delete_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError> {
+        self.backend_driver.delete_region(state, id).await
+    }
+
+    /// Get catalog.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `enabled`: Whether to return only enabled services.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of tuples of `Service` and its associated
+    /// `Endpoint`s, or a `CatalogProviderError`.
+    async fn get_catalog(
+        &self,
+        state: &ServiceState,
+        enabled: bool,
+    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError> {
+        self.backend_driver.get_catalog(state, enabled).await
+    }
+
+    /// Get single endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the endpoint if found, or an
+    /// `Error`.
+    async fn get_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Endpoint>, CatalogProviderError> {
+        self.backend_driver.get_endpoint(state, id).await
+    }
+
+    /// Get single region by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the region if found, or an
+    /// `Error`.
+    async fn get_region<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Region>, CatalogProviderError> {
+        self.backend_driver.get_region(state, id).await
     }
 
     /// Get single service by ID.
@@ -100,37 +168,57 @@ impl CatalogApi for CatalogService {
         self.backend_driver.list_endpoints(state, params).await
     }
 
-    /// Get single endpoint by ID.
+    /// List regions.
     ///
     /// # Parameters
     /// - `state`: The current service state.
-    /// - `id`: The unique identifier of the endpoint.
+    /// - `params`: Parameters for filtering the region list.
     ///
     /// # Returns
-    /// A `Result` containing an `Option` with the endpoint if found, or an
-    /// `Error`.
-    async fn get_endpoint<'a>(
+    /// A `Result` containing a vector of `Region` objects or a
+    /// `CatalogProviderError`.
+    async fn list_regions(
+        &self,
+        state: &ServiceState,
+        params: &RegionListParameters,
+    ) -> Result<Vec<Region>, CatalogProviderError> {
+        params.validate()?;
+        self.backend_driver.list_regions(state, params).await
+    }
+
+    /// List services.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `params`: Parameters for filtering the service list.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of `Service` objects or a
+    /// `CatalogProviderError`.
+    async fn list_services(
+        &self,
+        state: &ServiceState,
+        params: &ServiceListParameters,
+    ) -> Result<Vec<Service>, CatalogProviderError> {
+        self.backend_driver.list_services(state, params).await
+    }
+
+    /// Update an existing region.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the region.
+    /// - `region`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Region`, or a `CatalogProviderError`.
+    async fn update_region<'a>(
         &self,
         state: &ServiceState,
         id: &'a str,
-    ) -> Result<Option<Endpoint>, CatalogProviderError> {
-        self.backend_driver.get_endpoint(state, id).await
-    }
-
-    /// Get catalog.
-    ///
-    /// # Parameters
-    /// - `state`: The current service state.
-    /// - `enabled`: Whether to return only enabled services.
-    ///
-    /// # Returns
-    /// A `Result` containing a vector of tuples of `Service` and its associated
-    /// `Endpoint`s, or a `CatalogProviderError`.
-    async fn get_catalog(
-        &self,
-        state: &ServiceState,
-        enabled: bool,
-    ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError> {
-        self.backend_driver.get_catalog(state, enabled).await
+        region: RegionUpdate,
+    ) -> Result<Region, CatalogProviderError> {
+        region.validate()?;
+        self.backend_driver.update_region(state, id, region).await
     }
 }

--- a/tests/integration/src/catalog.rs
+++ b/tests/integration/src/catalog.rs
@@ -1,0 +1,45 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod region;
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone::keystone::Service;
+use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::*;
+
+use crate::common::*;
+use crate::impl_deleter;
+
+impl_deleter!(Service, Region, get_catalog_provider, delete_region);
+
+/// Create a region through the catalog provider, returning a guard that deletes
+/// it again when dropped.
+pub async fn create_region(
+    state: &ServiceState,
+    data: RegionCreate,
+) -> Result<AsyncResourceGuard<Region, ServiceState>> {
+    let res = state
+        .provider
+        .get_catalog_provider()
+        .create_region(state, data)
+        .await
+        .unwrap();
+    Ok(AsyncResourceGuard::new(res, state.clone()))
+}

--- a/tests/integration/src/catalog/region.rs
+++ b/tests/integration/src/catalog/region.rs
@@ -11,13 +11,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # Catalog provider
-mod endpoint;
-mod error;
-mod region;
-mod service;
 
-pub use endpoint::*;
-pub use error::*;
-pub use region::*;
-pub use service::*;
+mod create;
+mod delete;
+mod get;
+mod list;
+mod update;

--- a/tests/integration/src/catalog/region/create.rs
+++ b/tests/integration/src/catalog/region/create.rs
@@ -1,0 +1,103 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test region creation.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::RegionCreate;
+
+use crate::catalog::create_region;
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_create() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let region = create_region(
+        &state,
+        RegionCreate {
+            id: None,
+            description: Some("Region One".to_string()),
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+
+    // An ID is generated when none is provided.
+    assert!(!region.id.is_empty());
+    assert_eq!(region.description.as_deref(), Some("Region One"));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_with_parent() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let parent = create_region(
+        &state,
+        RegionCreate {
+            id: Some("parent-region".to_string()),
+            description: None,
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+    let child = create_region(
+        &state,
+        RegionCreate {
+            id: None,
+            description: None,
+            parent_region_id: Some(parent.id.clone()),
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+
+    assert_eq!(child.parent_region_id.as_deref(), Some("parent-region"));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_description_too_long() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    // The Region description is limited to 255 characters by the validator, and
+    // the provider must reject it before touching the database.
+    let too_long = "x".repeat(256);
+    let result = state
+        .provider
+        .get_catalog_provider()
+        .create_region(
+            &state,
+            RegionCreate {
+                id: None,
+                description: Some(too_long),
+                parent_region_id: None,
+                extra: HashMap::new(),
+            },
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected a validation error for a description longer than 255 characters"
+    );
+    Ok(())
+}

--- a/tests/integration/src/catalog/region/delete.rs
+++ b/tests/integration/src/catalog/region/delete.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test deleting a region.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::RegionCreate;
+
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_delete() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let provider = state.provider.get_catalog_provider();
+
+    let region = provider
+        .create_region(
+            &state,
+            RegionCreate {
+                id: Some("del".to_string()),
+                description: None,
+                parent_region_id: None,
+                extra: HashMap::new(),
+            },
+        )
+        .await?;
+
+    provider.delete_region(&state, &region.id).await?;
+
+    let fetched = provider.get_region(&state, &region.id).await?;
+    assert!(fetched.is_none(), "region should be gone after delete");
+    Ok(())
+}

--- a/tests/integration/src/catalog/region/get.rs
+++ b/tests/integration/src/catalog/region/get.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test fetching a single region.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::RegionCreate;
+
+use crate::catalog::create_region;
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_get() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let region = create_region(
+        &state,
+        RegionCreate {
+            id: Some("region-get".to_string()),
+            description: Some("a region".to_string()),
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+
+    let fetched = state
+        .provider
+        .get_catalog_provider()
+        .get_region(&state, &region.id)
+        .await?;
+
+    assert!(fetched.is_some());
+    let fetched = fetched.unwrap();
+    assert_eq!(fetched.id, "region-get");
+    assert_eq!(fetched.description.as_deref(), Some("a region"));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let fetched = state
+        .provider
+        .get_catalog_provider()
+        .get_region(&state, "does-not-exist")
+        .await?;
+    assert!(fetched.is_none());
+    Ok(())
+}

--- a/tests/integration/src/catalog/region/list.rs
+++ b/tests/integration/src/catalog/region/list.rs
@@ -1,0 +1,125 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test listing regions.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::{RegionCreate, RegionListParameters};
+
+use crate::catalog::create_region;
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_list() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let _r1 = create_region(
+        &state,
+        RegionCreate {
+            id: Some("list-r1".to_string()),
+            description: None,
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+    let _r2 = create_region(
+        &state,
+        RegionCreate {
+            id: Some("list-r2".to_string()),
+            description: None,
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+
+    let regions = state
+        .provider
+        .get_catalog_provider()
+        .list_regions(&state, &RegionListParameters::default())
+        .await?;
+
+    let ids: Vec<&str> = regions.iter().map(|r| r.id.as_str()).collect();
+    assert!(ids.contains(&"list-r1"));
+    assert!(ids.contains(&"list-r2"));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_list_filter_by_parent() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let _parent = create_region(
+        &state,
+        RegionCreate {
+            id: Some("parent".to_string()),
+            description: None,
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+    let _child1 = create_region(
+        &state,
+        RegionCreate {
+            id: Some("child1".to_string()),
+            description: None,
+            parent_region_id: Some("parent".to_string()),
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+    let _child2 = create_region(
+        &state,
+        RegionCreate {
+            id: Some("child2".to_string()),
+            description: None,
+            parent_region_id: Some("parent".to_string()),
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+    let _unrelated = create_region(
+        &state,
+        RegionCreate {
+            id: Some("unrelated".to_string()),
+            description: None,
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+
+    let regions = state
+        .provider
+        .get_catalog_provider()
+        .list_regions(
+            &state,
+            &RegionListParameters {
+                parent_region_id: Some("parent".to_string()),
+            },
+        )
+        .await?;
+
+    let ids: Vec<&str> = regions.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(regions.len(), 2, "expected only the two children");
+    assert!(ids.contains(&"child1"));
+    assert!(ids.contains(&"child2"));
+    Ok(())
+}

--- a/tests/integration/src/catalog/region/update.rs
+++ b/tests/integration/src/catalog/region/update.rs
@@ -1,0 +1,126 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test updating a region.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::{RegionCreate, RegionUpdate};
+
+use crate::catalog::create_region;
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_update() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let region = create_region(
+        &state,
+        RegionCreate {
+            id: Some("upd".to_string()),
+            description: Some("old".to_string()),
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+
+    let updated = state
+        .provider
+        .get_catalog_provider()
+        .update_region(
+            &state,
+            &region.id,
+            RegionUpdate {
+                description: Some("new".to_string()),
+                parent_region_id: None,
+                extra: None,
+            },
+        )
+        .await?;
+    assert_eq!(updated.description.as_deref(), Some("new"));
+
+    // Confirm the change was persisted.
+    let fetched = state
+        .provider
+        .get_catalog_provider()
+        .get_region(&state, &region.id)
+        .await?
+        .unwrap();
+    assert_eq!(fetched.description.as_deref(), Some("new"));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let result = state
+        .provider
+        .get_catalog_provider()
+        .update_region(
+            &state,
+            "missing",
+            RegionUpdate {
+                description: Some("x".to_string()),
+                parent_region_id: None,
+                extra: None,
+            },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected a not-found error when updating a region that does not exist"
+    );
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_description_too_long() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let region = create_region(
+        &state,
+        RegionCreate {
+            id: Some("upd-long".to_string()),
+            description: None,
+            parent_region_id: None,
+            extra: HashMap::new(),
+        },
+    )
+    .await?;
+
+    let too_long = "x".repeat(256);
+    let result = state
+        .provider
+        .get_catalog_provider()
+        .update_region(
+            &state,
+            &region.id,
+            RegionUpdate {
+                description: Some(too_long),
+                parent_region_id: None,
+                extra: None,
+            },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected a validation error for a too-long description"
+    );
+    Ok(())
+}

--- a/tests/integration/src/integration.rs
+++ b/tests/integration/src/integration.rs
@@ -17,6 +17,7 @@
 
 mod application_credential;
 mod assignment;
+mod catalog;
 mod common;
 mod identity;
 mod k8s_auth;


### PR DESCRIPTION
feat: add region CRUD to catalog-driver-sql (#723)

Extends the catalog-sql driver with region CRUD, following the existing SQL-driver patterns.

- Adds Region / RegionCreate / RegionUpdate / RegionListParameters types in core-types
- Adds a region module to catalog-driver-sql (list/get/create/update/delete) with entity/domain conversions
- Wires the operations into the CatalogBackend trait and SqlBackend impl
- Adds a RegionNotFound error variant
- Unit tests for each operation using MockDatabase

Reads mirror the existing service/endpoint modules. Create/update/delete follow the patterns used in other SQL drivers.

Closes #723

Note: this contribution was developed with AI assistance