### PR TITLE
refactor: Consolidate password update flows

### DIFF
--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -201,12 +201,11 @@ impl ValidatedSecurityContext {
             ctx.set_effective_roles(role_vec);
         }
 
-        if let Some(authz) = ctx.authorization() {
-            if !matches!(authz.scope, ScopeInfo::Unscoped)
-                && authz.effective_roles().is_none_or(|r| r.is_empty())
-            {
-                return Err(AuthenticationError::ActorHasNoRolesOnTarget);
-            }
+        if let Some(authz) = ctx.authorization()
+            && !matches!(authz.scope, ScopeInfo::Unscoped)
+            && authz.effective_roles().is_none_or(|r| r.is_empty())
+        {
+            return Err(AuthenticationError::ActorHasNoRolesOnTarget);
         }
         Ok(ValidatedSecurityContext(ctx))
     }

--- a/crates/core/src/identity/backend.rs
+++ b/crates/core/src/identity/backend.rs
@@ -14,6 +14,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use secrecy::SecretString;
 use std::collections::HashSet;
 
 use openstack_keystone_core_types::identity::*;
@@ -331,6 +332,21 @@ pub trait IdentityBackend: Send + Sync {
         user_id: &'a str,
         user: UserUpdate,
     ) -> Result<UserResponse, IdentityProviderError>;
+
+    /// Update user password.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `user_id`: The ID of the user to update.
+    /// - `original_password`: The current password for verification.
+    /// - `new_password`: The new password to set.
+    async fn update_user_password<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+        original_password: SecretString,
+        new_password: SecretString,
+    ) -> Result<(), IdentityProviderError>;
 
     /// Set expiring group memberships for the user.
     ///

--- a/crates/core/src/identity/mock.rs
+++ b/crates/core/src/identity/mock.rs
@@ -15,6 +15,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mockall::mock;
+use secrecy::SecretString;
 use std::collections::HashSet;
 
 use openstack_keystone_core_types::identity::*;
@@ -98,6 +99,14 @@ mock! {
             user_id: &'a str,
             user: UserUpdate,
         ) -> Result<UserResponse, IdentityProviderError>;
+
+        async fn update_user_password<'a>(
+            &self,
+            state: &ServiceState,
+            user_id: &'a str,
+            original_password: SecretString,
+            new_password: SecretString,
+        ) -> Result<(), IdentityProviderError>;
 
         async fn get_group<'a>(
             &self,

--- a/crates/core/src/identity/mod.rs
+++ b/crates/core/src/identity/mod.rs
@@ -35,6 +35,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use secrecy::SecretString;
 use std::collections::HashSet;
 
 use openstack_keystone_config::Config;
@@ -301,6 +302,36 @@ impl IdentityApi for IdentityProvider {
             Self::Service(provider) => provider.update_user(state, user_id, user).await,
             #[cfg(any(test, feature = "mock"))]
             Self::Mock(provider) => provider.update_user(state, user_id, user).await,
+        }
+    }
+
+    /// Update user password.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `user_id`: The ID of the user to update.
+    /// - `original_password`: The current password for verification.
+    /// - `new_password`: The new password to set.
+    #[tracing::instrument(skip(self, state, original_password, new_password))]
+    async fn update_user_password<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+        original_password: SecretString,
+        new_password: SecretString,
+    ) -> Result<(), IdentityProviderError> {
+        match self {
+            Self::Service(provider) => {
+                provider
+                    .update_user_password(state, user_id, original_password, new_password)
+                    .await
+            }
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => {
+                provider
+                    .update_user_password(state, user_id, original_password, new_password)
+                    .await
+            }
         }
     }
 

--- a/crates/core/src/identity/provider_api.rs
+++ b/crates/core/src/identity/provider_api.rs
@@ -14,6 +14,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use secrecy::SecretString;
 use std::collections::HashSet;
 
 use openstack_keystone_core_types::identity::*;
@@ -330,6 +331,24 @@ pub trait IdentityApi: Send + Sync {
         user_id: &'a str,
         user: UserUpdate,
     ) -> Result<UserResponse, IdentityProviderError>;
+
+    /// Update user password.
+    ///
+    /// Verifies the original password, checks password history for reuse,
+    /// then sets the new password.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `user_id`: The ID of the user to update.
+    /// - `original_password`: The current password for verification.
+    /// - `new_password`: The new password to set.
+    async fn update_user_password<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+        original_password: SecretString,
+        new_password: SecretString,
+    ) -> Result<(), IdentityProviderError>;
 
     /// Set expiring group memberships of the user.
     ///

--- a/crates/core/src/identity/service.rs
+++ b/crates/core/src/identity/service.rs
@@ -556,6 +556,27 @@ impl IdentityApi for IdentityService {
         self.backend_driver.update_user(state, user_id, user).await
     }
 
+    /// Update user password.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `user_id`: The ID of the user to update.
+    /// - `original_password`: The current password for verification.
+    /// - `new_password`: The new password to set.
+    async fn update_user_password<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+        original_password: SecretString,
+        new_password: SecretString,
+    ) -> Result<(), IdentityProviderError> {
+        let cfg = state.config_manager.config.read().await;
+        cfg.security_compliance.validate_password(&new_password)?;
+        self.backend_driver
+            .update_user_password(state, user_id, original_password, new_password)
+            .await
+    }
+
     /// Set expiring group memberships for the user.
     ///
     /// # Parameters

--- a/crates/identity-driver-sql/src/lib.rs
+++ b/crates/identity-driver-sql/src/lib.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sea_orm::{DatabaseConnection, Schema, sea_query::Index};
+use secrecy::SecretString;
 
 use openstack_keystone_core::auth::AuthenticationResult;
 use openstack_keystone_core::identity::IdentityProviderError;
@@ -553,6 +554,35 @@ impl IdentityBackend for SqlBackend {
     ) -> Result<UserResponse, IdentityProviderError> {
         let config = state.config_manager.config.read().await;
         Ok(user::update(&config, &state.db, user_id, user).await?)
+    }
+
+    /// Update user password.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `user_id`: The ID of the user to update.
+    /// - `original_password`: The current password for verification.
+    /// - `new_password`: The new password to set.
+    ///
+    /// # Returns
+    /// A `Result` containing `()` if successful, or an `Error`.
+    #[tracing::instrument(skip(self, state, original_password, new_password))]
+    async fn update_user_password<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+        original_password: SecretString,
+        new_password: SecretString,
+    ) -> Result<(), IdentityProviderError> {
+        let config = state.config_manager.config.read().await;
+        Ok(local_user::update_password(
+            &state.db,
+            &config,
+            user_id,
+            original_password,
+            new_password,
+        )
+        .await?)
     }
 }
 

--- a/crates/identity-driver-sql/src/local_user.rs
+++ b/crates/identity-driver-sql/src/local_user.rs
@@ -12,12 +12,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use chrono::Utc;
-use sea_orm::ConnectionTrait;
 use secrecy::ExposeSecret;
 use secrecy::SecretString;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core::auth::AuthenticationError;
 use openstack_keystone_core::common::password_hashing;
 use openstack_keystone_core_types::identity::*;
 
@@ -34,41 +33,62 @@ pub use load::load_local_user_with_passwords;
 pub use load::load_local_users_passwords;
 pub use set::*;
 
-/// Set a new password for the local user.
+/// Update user password with verification and history check.
 ///
-/// - expire all existing passwords.
-/// - truncate number of old passwords to `unique_count`.
-/// - add a new record with a new password
+/// Resolves user_id to local_user_id, verifies original password, checks
+/// password history for reuse, then sets the new password.
 ///
 /// # Parameters
 /// - `db`: The database connection.
-/// - `local_user_id`: The local user ID.
-/// - `unique_count`: Number of old passwords to keep for checking uniqueness.
-/// - `password`: The password to set.
+/// - `conf`: The service configuration.
+/// - `user_id`: The user ID.
+/// - `original_password`: The current password for verification.
+/// - `new_password`: The new password to set.
 ///
 /// # Returns
-/// A `Result` containing the created `password::Model` if successful, or an
-/// `Error`.
-pub async fn set_new_password<C: ConnectionTrait>(
-    db: &C,
+/// A `Result` containing `()` if successful, or an `Error`.
+pub async fn update_password(
+    db: &sea_orm::DatabaseConnection,
     conf: &Config,
-    local_user_id: i32,
-    password: SecretString,
-) -> Result<db_password::Model, IdentityProviderError> {
-    let now = Utc::now();
-    let unique_count = conf
-        .security_compliance
-        .unique_last_password_count
-        .unwrap_or(0);
-    // Hash the new password
-    let hashed_password = password_hashing::hash_password(conf, password.expose_secret())
-        .await
-        .map_err(IdentityProviderError::password_hash)?;
+    user_id: &str,
+    original_password: SecretString,
+    new_password: SecretString,
+) -> Result<(), IdentityProviderError> {
+    // Load local user with passwords
+    let (local_user, passwords) =
+        load_local_user_with_passwords(db, Some(user_id), None::<&str>, None::<&str>)
+            .await?
+            .ok_or(IdentityProviderError::UserNotFound(user_id.to_string()))?;
 
-    // Calculate password expiration time
-    let expires_at = conf.security_compliance.get_password_expires_at(now);
-    super::password::set_new_password(db, local_user_id, unique_count, hashed_password, expires_at)
+    // Get the latest password hash for verification
+    let passwords_vec: Vec<db_password::Model> = passwords.into_iter().collect();
+    let latest_password =
+        passwords_vec
+            .first()
+            .ok_or(IdentityProviderError::NoPasswordsForUser(
+                user_id.to_string(),
+            ))?;
+
+    let expected_hash =
+        latest_password
+            .password_hash
+            .as_ref()
+            .ok_or(IdentityProviderError::NoPasswordHash(
+                latest_password.id.to_string(),
+            ))?;
+
+    // Verify original password
+    if !password_hashing::verify_password(conf, original_password.expose_secret(), expected_hash)
         .await
+        .map_err(IdentityProviderError::password_hash)?
+    {
+        return Err(AuthenticationError::UserNameOrPasswordWrong.into());
+    }
+
+    // Set the new password (reuse pre-loaded passwords, history check is inside)
+    super::password::set_new_password(db, conf, local_user.id, new_password, passwords_vec).await?;
+
+    Ok(())
 }
 
 pub trait MergeLocalUserData {
@@ -85,8 +105,16 @@ impl MergeLocalUserData for UserResponseBuilder {
 #[cfg(test)]
 pub mod tests {
     use chrono::Utc;
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+    use secrecy::SecretString;
+
+    use openstack_keystone_config::{Config, PasswordHashingAlgo};
+    use openstack_keystone_core::auth::AuthenticationError;
+    use openstack_keystone_core::identity::IdentityProviderError;
 
     use crate::entity::{local_user as db_local_user, password as db_password};
+
+    use super::update_password;
 
     pub fn get_local_user_mock<UID: Into<String>>(user_id: UID) -> db_local_user::Model {
         db_local_user::Model {
@@ -129,5 +157,371 @@ pub mod tests {
             .map(|x| (lu.clone(), x.clone()))
             .collect()
     }
+    /// Create a mock local user with multiple passwords with specific IDs and created_at_int values.
+    pub fn get_local_user_with_passwords_mock(
+        user_id: &str,
+        passwords: &[db_password::Model],
+    ) -> Vec<(db_local_user::Model, db_password::Model)> {
+        let lu = db_local_user::Model {
+            id: 1,
+            user_id: user_id.into(),
+            domain_id: "foo_domain".into(),
+            name: "Apple Cake".to_owned(),
+            failed_auth_count: Some(0),
+            failed_auth_at: Some(Utc::now().naive_utc()),
+        };
+        passwords
+            .iter()
+            .map(|pw| (lu.clone(), pw.clone()))
+            .collect()
+    }
     // TODO: implement test for `UserCreate::to_local_user_active_model`
+
+    // -- test helpers for update_password tests --
+
+    fn get_local_user_with_password_hash_mock<H: Into<String>>(
+        user_id: &str,
+        password_hash: H,
+    ) -> Vec<(db_local_user::Model, db_password::Model)> {
+        let lu = db_local_user::Model {
+            id: 1,
+            user_id: user_id.into(),
+            domain_id: "foo_domain".into(),
+            name: "Apple Cake".to_owned(),
+            failed_auth_count: Some(0),
+            failed_auth_at: Some(Utc::now().naive_utc()),
+        };
+        let password = db_password::Model {
+            id: 1,
+            local_user_id: 1,
+            self_service: false,
+            expires_at: None,
+            password_hash: Some(password_hash.into()),
+            created_at: Utc::now().naive_utc(),
+            created_at_int: 12345,
+            expires_at_int: None,
+        };
+        vec![(lu, password)]
+    }
+
+    fn get_local_user_with_multiple_passwords_mock(
+        user_id: &str,
+        password_hashes: Vec<String>,
+    ) -> Vec<(db_local_user::Model, db_password::Model)> {
+        let lu = db_local_user::Model {
+            id: 1,
+            user_id: user_id.into(),
+            domain_id: "foo_domain".into(),
+            name: "Apple Cake".to_owned(),
+            failed_auth_count: Some(0),
+            failed_auth_at: Some(Utc::now().naive_utc()),
+        };
+        let mut results = Vec::new();
+        for (i, hash) in password_hashes.into_iter().enumerate() {
+            let password = db_password::Model {
+                id: (i + 1) as i32,
+                local_user_id: 1,
+                self_service: false,
+                expires_at: None,
+                password_hash: Some(hash),
+                created_at: Utc::now().naive_utc(),
+                created_at_int: (12345 - i as i64),
+                expires_at_int: None,
+            };
+            results.push((lu.clone(), password));
+        }
+        results
+    }
+
+    fn get_config_none_hashing() -> Config {
+        let mut config = Config::default();
+        config.identity.password_hashing_algorithm = PasswordHashingAlgo::None;
+        config
+    }
+
+    fn get_config_none_hashing_with_history(count: u16) -> Config {
+        let mut config = get_config_none_hashing();
+        config.security_compliance.unique_last_password_count = Some(count);
+        config
+    }
+
+    #[tokio::test]
+    async fn test_update_password_success_basic() {
+        let config = get_config_none_hashing();
+        let original_password = "old_password";
+        let new_password = "new_password";
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([get_local_user_with_password_hash_mock(
+                "user_id",
+                original_password,
+            )])
+            // unique=0: delete 1 existing password (id=1)
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
+            // Insert new password
+            .append_query_results([vec![
+                db_password::ModelBuilder::default()
+                    .password_hash(new_password)
+                    .build()
+                    .unwrap(),
+            ]])
+            .into_connection();
+
+        let result = update_password(
+            &db,
+            &config,
+            "user_id",
+            SecretString::from(original_password),
+            SecretString::from(new_password),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "update password should succeed: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_password_wrong_original_password() {
+        let config = get_config_none_hashing();
+        let stored_password = "correct_password";
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([get_local_user_with_password_hash_mock(
+                "user_id",
+                stored_password,
+            )])
+            .into_connection();
+
+        let result = update_password(
+            &db,
+            &config,
+            "user_id",
+            SecretString::from("wrong_password"),
+            SecretString::from("new_password"),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(IdentityProviderError::Authentication {
+                    source: AuthenticationError::UserNameOrPasswordWrong
+                })
+            ),
+            "wrong original password should be rejected, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_password_user_not_found() {
+        let config = get_config_none_hashing();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<(db_local_user::Model, db_password::Model)>::new()])
+            .into_connection();
+
+        let result = update_password(
+            &db,
+            &config,
+            "nonexistent_user",
+            SecretString::from("old_password"),
+            SecretString::from("new_password"),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(IdentityProviderError::UserNotFound(ref uid)) if uid == "nonexistent_user"),
+            "nonexistent user should return UserNotFound, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_password_no_password_hash() {
+        let config = get_config_none_hashing();
+
+        let lu = db_local_user::Model {
+            id: 1,
+            user_id: "user_id".into(),
+            domain_id: "foo_domain".into(),
+            name: "Apple Cake".to_owned(),
+            failed_auth_count: Some(0),
+            failed_auth_at: Some(Utc::now().naive_utc()),
+        };
+        let password_no_hash = db_password::Model {
+            id: 1,
+            local_user_id: 1,
+            self_service: false,
+            expires_at: None,
+            password_hash: None,
+            created_at: Utc::now().naive_utc(),
+            created_at_int: 12345,
+            expires_at_int: None,
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(lu, password_no_hash)]])
+            .into_connection();
+
+        let result = update_password(
+            &db,
+            &config,
+            "user_id",
+            SecretString::from("old_password"),
+            SecretString::from("new_password"),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(IdentityProviderError::NoPasswordHash(ref id)) if id == "1"),
+            "user with no password hash should return NoPasswordHash, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_password_history_reuse_rejected() {
+        let config = get_config_none_hashing_with_history(2);
+        let current_password = "current_password";
+        let old_password_1 = "old_password_1";
+        let old_password_2 = "old_password_2";
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([get_local_user_with_multiple_passwords_mock(
+                "user_id",
+                vec![
+                    current_password.to_string(),
+                    old_password_1.to_string(),
+                    old_password_2.to_string(),
+                ],
+            )])
+            .into_connection();
+
+        let result = update_password(
+            &db,
+            &config,
+            "user_id",
+            SecretString::from(current_password),
+            SecretString::from(old_password_1),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(IdentityProviderError::SecurityCompliance(ref _e))
+            ),
+            "reusing a password from history should be rejected, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_password_history_reuse_rejected_only_within_count() {
+        let config = get_config_none_hashing_with_history(1);
+        let current_password = "current_password";
+        let old_password_1 = "old_password_1";
+        let old_password_2 = "old_password_2";
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([get_local_user_with_multiple_passwords_mock(
+                "user_id",
+                vec![
+                    current_password.to_string(),
+                    old_password_1.to_string(),
+                    old_password_2.to_string(),
+                ],
+            )])
+            // Expire newest 1 (current_password, id=1)
+            .append_query_results([vec![
+                db_password::ModelBuilder::default().id(1).build().unwrap(),
+            ]])
+            // Delete 2 older (old_password_1 id=2, old_password_2 id=3)
+            .append_exec_results([
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+            ])
+            // Insert new password
+            .append_query_results([vec![
+                db_password::ModelBuilder::default()
+                    .password_hash(old_password_2)
+                    .build()
+                    .unwrap(),
+            ]])
+            .into_connection();
+
+        let result = update_password(
+            &db,
+            &config,
+            "user_id",
+            SecretString::from(current_password),
+            SecretString::from(old_password_2),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "old_password_2 is beyond history count (unique=1), should be allowed, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_password_history_disabled_allows_any_password() {
+        let config = get_config_none_hashing();
+        let current_password = "current_password";
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([get_local_user_with_multiple_passwords_mock(
+                "user_id",
+                vec![current_password.to_string(), current_password.to_string()],
+            )])
+            // unique=0: delete all 2 existing passwords
+            .append_exec_results([
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+            ])
+            // Insert new password
+            .append_query_results([vec![
+                db_password::ModelBuilder::default()
+                    .password_hash(current_password)
+                    .build()
+                    .unwrap(),
+            ]])
+            .into_connection();
+
+        let result = update_password(
+            &db,
+            &config,
+            "user_id",
+            SecretString::from(current_password),
+            SecretString::from(current_password),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "password history disabled (unique=0), reusing current password should be allowed, got: {:?}",
+            result
+        );
+    }
 }

--- a/crates/identity-driver-sql/src/local_user/load.rs
+++ b/crates/identity-driver-sql/src/local_user/load.rs
@@ -38,8 +38,13 @@ use crate::entity::{
 /// A `Result` containing an `Option` with the `(local_user::Model, impl
 /// IntoIterator<Item = password::Model>)` if found, or an `Error`.
 #[tracing::instrument(skip_all)]
-pub async fn load_local_user_with_passwords<S1: AsRef<str>, S2: AsRef<str>, S3: AsRef<str>>(
-    db: &DatabaseConnection,
+pub async fn load_local_user_with_passwords<
+    C: ConnectionTrait,
+    S1: AsRef<str>,
+    S2: AsRef<str>,
+    S3: AsRef<str>,
+>(
+    db: &C,
     user_id: Option<S1>,
     name: Option<S2>,
     domain_id: Option<S3>,
@@ -84,8 +89,11 @@ pub async fn load_local_user_with_passwords<S1: AsRef<str>, S2: AsRef<str>, S3: 
 /// # Returns
 /// A `Result` containing a list of optional password vectors, or an `Error`.
 #[tracing::instrument(skip_all)]
-pub async fn load_local_users_passwords<L: IntoIterator<Item = Option<i32>> + std::fmt::Debug>(
-    db: &DatabaseConnection,
+pub async fn load_local_users_passwords<
+    C: ConnectionTrait,
+    L: IntoIterator<Item = Option<i32>> + std::fmt::Debug,
+>(
+    db: &C,
     user_ids: L,
 ) -> Result<Vec<Option<Vec<password::Model>>>, IdentityProviderError> {
     let ids: Vec<Option<i32>> = user_ids.into_iter().collect();

--- a/crates/identity-driver-sql/src/password.rs
+++ b/crates/identity-driver-sql/src/password.rs
@@ -12,19 +12,72 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use chrono::{DateTime, Utc};
+use secrecy::ExposeSecret;
+use secrecy::SecretString;
 
+use openstack_keystone_config::Config;
+use openstack_keystone_core::common::password_hashing;
 use openstack_keystone_core::identity::IdentityProviderError;
 use openstack_keystone_core_types::identity::UserResponseBuilder;
 
 use crate::entity::password as db_password;
 
+mod check_history;
 mod create;
 mod list;
-mod set_new;
+mod set;
 
 pub use create::create;
 pub use list::list;
-pub use set_new::set_new_password;
+
+use sea_orm::ConnectionTrait;
+
+/// Set a new password for the local user using pre-loaded existing passwords.
+///
+/// - check password history for reuse (reject if match).
+/// - expire the newest `unique_count` passwords (kept as history).
+/// - delete older passwords beyond the history window.
+/// - hash and store the new password.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `conf`: The service configuration.
+/// - `local_user_id`: The local user ID.
+/// - `password`: The plaintext password to set.
+/// - `existing_passwords`: Pre-loaded existing passwords sorted DESC by creation.
+///
+/// # Returns
+/// A `Result` containing the created `db_password::Model` if successful, or an
+/// `Error`.
+pub async fn set_new_password<C: ConnectionTrait>(
+    db: &C,
+    conf: &Config,
+    local_user_id: i32,
+    password: SecretString,
+    existing_passwords: Vec<db_password::Model>,
+) -> Result<db_password::Model, IdentityProviderError> {
+    check_history::check_password_history(conf, &existing_passwords, &password).await?;
+
+    let now = Utc::now();
+    let unique_count = conf
+        .security_compliance
+        .unique_last_password_count
+        .unwrap_or(0);
+    let hashed_password = password_hashing::hash_password(conf, password.expose_secret())
+        .await
+        .map_err(IdentityProviderError::password_hash)?;
+
+    let expires_at = conf.security_compliance.get_password_expires_at(now);
+    set::set_new_password(
+        db,
+        local_user_id,
+        unique_count,
+        hashed_password,
+        expires_at,
+        existing_passwords,
+    )
+    .await
+}
 
 /// Verify whether the password has expired or not.
 ///

--- a/crates/identity-driver-sql/src/password/check_history.rs
+++ b/crates/identity-driver-sql/src/password/check_history.rs
@@ -1,0 +1,211 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use secrecy::ExposeSecret;
+use secrecy::SecretString;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core::identity::IdentityProviderError;
+
+use crate::entity::password as db_password;
+
+/// Check if a new password matches any password in the history.
+///
+/// Compares the new password against the most recent `unique_last_password_count`
+/// password hashes. Returns an error if the new password matches any hash in
+/// the history window.
+///
+/// # Parameters
+/// - `conf`: The service configuration.
+/// - `passwords`: Existing passwords sorted by creation date (descending).
+/// - `new_password`: The new password to check.
+///
+/// # Returns
+/// A `Result` containing `()` if the new password is not in the history, or an
+/// `Error` if it matches any password in the history window.
+pub async fn check_password_history<'a, I>(
+    conf: &Config,
+    passwords: I,
+    new_password: &SecretString,
+) -> Result<(), IdentityProviderError>
+where
+    I: IntoIterator<Item = &'a db_password::Model>,
+{
+    let unique_count = conf
+        .security_compliance
+        .unique_last_password_count
+        .unwrap_or(0);
+
+    if unique_count > 0 {
+        let check_count = unique_count as usize;
+        for (i, check_password) in passwords.into_iter().enumerate() {
+            if i >= check_count {
+                break;
+            }
+            if let Some(ref check_hash) = check_password.password_hash {
+                if openstack_keystone_core::common::password_hashing::verify_password(
+                    conf,
+                    new_password.expose_secret(),
+                    check_hash,
+                )
+                .await
+                .is_ok_and(|x| x)
+                {
+                    return Err(IdentityProviderError::SecurityCompliance(
+                        openstack_keystone_config::SecurityComplianceError::PasswordInvalid(
+                            "new password matches a previous password in history".to_string(),
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entity::password as db_password;
+    use chrono::Utc;
+
+    fn make_password_hash_mock(hash: &str) -> db_password::Model {
+        let now = Utc::now();
+        db_password::Model {
+            id: 1,
+            local_user_id: 1,
+            self_service: false,
+            expires_at: None,
+            password_hash: Some(hash.to_string()),
+            created_at: now.naive_utc(),
+            created_at_int: now.timestamp_micros(),
+            expires_at_int: None,
+        }
+    }
+
+    fn make_password_hash_mock_empty() -> db_password::Model {
+        let now = Utc::now();
+        db_password::Model {
+            id: 1,
+            local_user_id: 1,
+            self_service: false,
+            expires_at: None,
+            password_hash: None,
+            created_at: now.naive_utc(),
+            created_at_int: now.timestamp_micros(),
+            expires_at_int: None,
+        }
+    }
+
+    fn get_config_none_hashing() -> Config {
+        let mut config = Config::default();
+        config.identity.password_hashing_algorithm =
+            openstack_keystone_config::PasswordHashingAlgo::None;
+        config
+    }
+
+    fn get_config_none_hashing_with_history(count: u16) -> Config {
+        let mut config = get_config_none_hashing();
+        config.security_compliance.unique_last_password_count = Some(count);
+        config
+    }
+
+    #[tokio::test]
+    async fn test_check_password_history_disabled_allows_any() {
+        let config = get_config_none_hashing();
+        let passwords = vec![
+            make_password_hash_mock("same_password"),
+            make_password_hash_mock("other_password"),
+        ];
+
+        let result =
+            check_password_history(&config, &passwords, &SecretString::from("same_password")).await;
+        assert!(
+            result.is_ok(),
+            "history disabled (unique=0), should allow any"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_password_history_reuse_rejected() {
+        let config = get_config_none_hashing_with_history(2);
+        let passwords = vec![
+            make_password_hash_mock("current_password"),
+            make_password_hash_mock("old_password_1"),
+        ];
+
+        let result =
+            check_password_history(&config, &passwords, &SecretString::from("old_password_1"))
+                .await;
+        assert!(
+            matches!(result, Err(IdentityProviderError::SecurityCompliance(_))),
+            "reusing a password from history should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_password_history_rejected_only_within_count() {
+        let config = get_config_none_hashing_with_history(1);
+        let passwords = vec![
+            make_password_hash_mock("current_password"),
+            make_password_hash_mock("old_password_1"),
+            make_password_hash_mock("old_password_2"),
+        ];
+
+        // old_password_2 is beyond history count (unique=1), should be allowed
+        let result =
+            check_password_history(&config, &passwords, &SecretString::from("old_password_2"))
+                .await;
+        assert!(
+            result.is_ok(),
+            "old_password_2 is beyond history count (unique=1), should be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_password_history_empty_hash_allowed() {
+        let config = get_config_none_hashing_with_history(2);
+        let passwords = vec![
+            make_password_hash_mock("current_password"),
+            make_password_hash_mock_empty(),
+        ];
+
+        let result =
+            check_password_history(&config, &passwords, &SecretString::from("some_password")).await;
+        assert!(result.is_ok(), "empty hash should be skipped");
+    }
+
+    #[tokio::test]
+    async fn test_check_password_history_no_match_allowed() {
+        let config = get_config_none_hashing_with_history(3);
+        let passwords = vec![
+            make_password_hash_mock("old_password_1"),
+            make_password_hash_mock("old_password_2"),
+            make_password_hash_mock("old_password_3"),
+        ];
+
+        let result = check_password_history(
+            &config,
+            &passwords,
+            &SecretString::from("brand_new_password"),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "new password should be allowed, {:?}",
+            result
+        );
+    }
+}

--- a/crates/identity-driver-sql/src/password/set.rs
+++ b/crates/identity-driver-sql/src/password/set.rs
@@ -15,20 +15,18 @@
 use chrono::{DateTime, Utc};
 use sea_orm::ConnectionTrait;
 use sea_orm::entity::*;
-use sea_orm::query::*;
 
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::identity::IdentityProviderError;
 
-use crate::entity::prelude::Password;
-
 use crate::entity::password;
 
-/// Set a new password for the local user.
+/// Set a new password for the local user using pre-loaded existing passwords.
 ///
-/// - expire all existing passwords.
-/// - truncate number of old passwords to `unique_count`.
-/// - add a new record with a new password
+/// - expire the newest `unique_count` passwords (kept as history for uniqueness
+///   checks).
+/// - delete older passwords beyond the history window.
+/// - add a new record with the new password.
 ///
 /// # Parameters
 /// - `db`: The database connection.
@@ -36,6 +34,7 @@ use crate::entity::password;
 /// - `unique_count`: Number of old passwords to keep for checking uniqueness.
 /// - `password_hash`: The hashed password.
 /// - `expires_at`: The password expiration date.
+/// - `existing_passwords`: Pre-loaded existing passwords sorted DESC by creation.
 ///
 /// # Returns
 /// A `Result` containing the created `password::Model` if successful, or an
@@ -47,38 +46,23 @@ pub async fn set_new_password<C: ConnectionTrait, S: AsRef<str>>(
     unique_count: u16,
     password_hash: S,
     expires_at: Option<DateTime<Utc>>,
+    existing_passwords: Vec<password::Model>,
 ) -> Result<password::Model, IdentityProviderError> {
     let now = Utc::now();
-    // Fetch existing passwords
-    let existing_passwords = Password::find()
-        .filter(password::Column::LocalUserId.eq(local_user_id))
-        .order_by(password::Column::CreatedAtInt, Order::Desc)
-        .all(db)
-        .await
-        .context("fetching existing passwords for user")?;
 
     // Determine history size: unique_last_password_count + 1 (for the new password)
-    // If unique_last_password_count is 0 or None, just keep 1 (the new password)
-    let history_size = if unique_count == 0 {
-        1
-    } else {
-        unique_count as usize + 1
-    };
+    // If unique_count is 0, don't keep any old passwords.
+    let keep_count = unique_count as usize;
 
-    // Truncate extra passwords by keeping only the last `history_size - 1` entries
-    let truncated_passwords: Vec<password::Model> = if existing_passwords.len() > history_size - 1 {
-        existing_passwords
-            .into_iter()
-            .rev()
-            .take(history_size - 1)
-            .collect()
-    } else {
-        existing_passwords
-    };
+    // existing_passwords is sorted DESC (newest first). Expire the newest
+    // `keep_count` passwords (kept as history), delete the rest (older ones
+    // beyond the history window).
+    let (to_expire, to_delete) =
+        existing_passwords.split_at(keep_count.min(existing_passwords.len()));
 
-    // Expire all previous passwords (set expires_at to now)
+    // Expire the most recent passwords (kept as history)
     let expires_now = now.naive_utc();
-    for pw in &truncated_passwords {
+    for pw in to_expire {
         let mut pw_active: password::ActiveModel = pw.clone().into();
         pw_active.expires_at = Set(Some(expires_now));
         pw_active.expires_at_int = Set(Some(now.timestamp_micros()));
@@ -88,13 +72,21 @@ pub async fn set_new_password<C: ConnectionTrait, S: AsRef<str>>(
             .context("expiring previous password")?;
     }
 
+    // Delete older passwords beyond the history window
+    for pw in to_delete {
+        password::Entity::delete_by_id(pw.id)
+            .exec(db)
+            .await
+            .context("deleting old password beyond history window")?;
+    }
+
     super::create(db, local_user_id, password_hash, expires_at).await
 }
 
 #[cfg(test)]
 mod tests {
     use chrono::{TimeDelta, Utc};
-    use sea_orm::{DatabaseBackend, MockDatabase};
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
 
     use super::*;
 
@@ -125,25 +117,24 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------------
-    // unique_last_password_count = 0  →  history_size = 1, keep 0 old passwords
+    // unique_last_password_count = 0  ->  keep 0 old passwords, delete all
     // ---------------------------------------------------------------------------
 
     #[tokio::test]
     async fn unique_zero_no_existing() {
+        let existing = Vec::<password::Model>::new();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([Vec::<password::Model>::new()])
             // create → insert returns new record
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        let res = set_new_password(&db, 1, 0, "hash", None).await;
+        let res = set_new_password(&db, 1, 0, "hash", None, existing).await;
         assert!(res.is_ok(), "should succeed with no existing passwords");
     }
 
     #[tokio::test]
     async fn unique_zero_existing_passwords_truncated_away() {
-        // 3 existing passwords, unique=0 → history_size=1 → keep 0 → all truncated,
-        // none kept. Truncated list is empty, so no UPDATE calls, only INSERT.
+        // 3 existing passwords, unique=0 → keep 0 → all deleted.
         let existing = vec![
             make_pwd(1, 300, false),
             make_pwd(2, 200, false),
@@ -151,30 +142,47 @@ mod tests {
         ];
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([existing])
-            // No UPDATE because truncated list is empty
+            // Delete all 3
+            .append_exec_results([
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+            ])
             .append_query_results([vec![make_pwd(10, 500, false)]])
             .into_connection();
 
-        let res = set_new_password(&db, 1, 0, "hash", None).await;
+        let res = set_new_password(&db, 1, 0, "hash", None, existing).await;
         assert!(
             res.is_ok(),
-            "unique=0 should truncate everything and insert new"
+            "unique=0 should delete everything and insert new"
         );
     }
 
     // ---------------------------------------------------------------------------
-    // unique_last_password_count = 1  →  history_size = 2, keep 1 old password
+    // unique_last_password_count = 1  ->  expire 1 old password, delete the rest
     // ---------------------------------------------------------------------------
 
     #[tokio::test]
     async fn unique_one_no_existing() {
+        let existing = Vec::<password::Model>::new();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([Vec::<password::Model>::new()])
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        assert!(set_new_password(&db, 1, 1, "hash", None).await.is_ok());
+        assert!(
+            set_new_password(&db, 1, 1, "hash", None, existing)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -183,39 +191,47 @@ mod tests {
         let existing = vec![make_pwd(1, 100, false)];
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([existing])
             // Expire the 1 kept password
             .append_query_results([vec![make_pwd(1, 100, true)]])
             // Insert new
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        assert!(set_new_password(&db, 1, 1, "hash", None).await.is_ok());
+        assert!(
+            set_new_password(&db, 1, 1, "hash", None, existing)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
     async fn unique_one_two_existing_truncate_excess() {
-        // 2 existing (newest=200, older=100), unique=1 → keep 1 old.
-        // existing.len() (2) > history_size-1 (1) → truncate to 1.
-        // The truncation reverses the DESC list (200,100 → 100,200) then take(1) →
-        // [100]. Expire pw id=3 (created_at_int=100).
+        // 2 existing (newest=200, older=100), unique=1 → expire 1 (newest), delete 1 (older).
         let existing = vec![
             make_pwd(2, 200, false), // newest first
             make_pwd(3, 100, false), // older
         ];
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([existing])
-            // Expire truncated list: [pw3 (int=100)]
-            .append_query_results([vec![make_pwd(3, 100, true)]])
+            // Expire newest: [pw2 (int=200)]
+            .append_query_results([vec![make_pwd(2, 200, true)]])
+            // Delete older: [pw3 (int=100)]
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        assert!(set_new_password(&db, 1, 1, "hash", None).await.is_ok());
+        assert!(
+            set_new_password(&db, 1, 1, "hash", None, existing)
+                .await
+                .is_ok()
+        );
     }
 
     // ---------------------------------------------------------------------------
-    // unique_last_password_count = 2  →  history_size = 3, keep 2 old passwords
+    // unique_last_password_count = 2  ->  expire 2 old passwords, delete the rest
     // ---------------------------------------------------------------------------
 
     #[tokio::test]
@@ -223,21 +239,22 @@ mod tests {
         let existing = vec![make_pwd(2, 200, false), make_pwd(3, 100, false)];
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([existing])
             // Expire both
             .append_query_results([vec![make_pwd(2, 200, true)]])
             .append_query_results([vec![make_pwd(3, 100, true)]])
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        assert!(set_new_password(&db, 1, 2, "hash", None).await.is_ok());
+        assert!(
+            set_new_password(&db, 1, 2, "hash", None, existing)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
     async fn unique_two_five_existing_truncate_excess() {
-        // 5 existing, unique=2 → keep 2 old, truncate 3.
-        // Order DESC: 500,400,300,200,100 → rev: 100,200,300,400,500 → take(2) →
-        // [100,200]
+        // 5 existing, unique=2 → expire 2 new (id=1,2), delete 3 old (id=3,4,5).
         let existing = vec![
             make_pwd(1, 500, false),
             make_pwd(2, 400, false),
@@ -247,24 +264,42 @@ mod tests {
         ];
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([existing])
-            // Expire [pw5 (int=100), pw4 (int=200)]
-            .append_query_results([vec![make_pwd(5, 100, true)]])
-            .append_query_results([vec![make_pwd(4, 200, true)]])
+            // Expire newest 2: [pw1 (int=500), pw2 (int=400)]
+            .append_query_results([vec![make_pwd(1, 500, true)]])
+            .append_query_results([vec![make_pwd(2, 400, true)]])
+            // Delete older 3: [pw3, pw4, pw5]
+            .append_exec_results([
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+            ])
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        assert!(set_new_password(&db, 1, 2, "hash", None).await.is_ok());
+        assert!(
+            set_new_password(&db, 1, 2, "hash", None, existing)
+                .await
+                .is_ok()
+        );
     }
 
     // ---------------------------------------------------------------------------
-    // Mixed expired / active passwords — already expired still get expire call
+    // Mixed expired / active passwords — expire newest, delete older
     // ---------------------------------------------------------------------------
 
     #[tokio::test]
     async fn unique_two_mixed_expired_and_active() {
         // pw1 active, pw2 already expired, pw3 active
-        // DESC: 300,200,100 → rev: 100,200,300 → take(2) → [100,200] → expire pw3,pw2
+        // DESC: 300,200,100 -> expire pw1,pw2 (newest 2), delete pw3 (older)
         let existing = vec![
             make_pwd(1, 300, false),
             make_pwd(2, 200, true),
@@ -272,13 +307,22 @@ mod tests {
         ];
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([existing])
-            .append_query_results([vec![make_pwd(3, 100, true)]])
+            // Expire newest 2: [pw1 (int=300), pw2 (int=200)]
+            .append_query_results([vec![make_pwd(1, 300, true)]])
             .append_query_results([vec![make_pwd(2, 200, true)]])
+            // Delete older: [pw3 (int=100)]
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        assert!(set_new_password(&db, 1, 2, "hash", None).await.is_ok());
+        assert!(
+            set_new_password(&db, 1, 2, "hash", None, existing)
+                .await
+                .is_ok()
+        );
     }
 
     // ---------------------------------------------------------------------------
@@ -289,12 +333,12 @@ mod tests {
     async fn new_password_with_expiration() {
         let expires = Utc::now() + TimeDelta::days(90);
 
+        let existing = Vec::<password::Model>::new();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([Vec::<password::Model>::new()])
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        let res = set_new_password(&db, 1, 0, "hash", Some(expires)).await;
+        let res = set_new_password(&db, 1, 0, "hash", Some(expires), existing).await;
         assert!(res.is_ok());
         // The create() call uses the expires_at argument; mock doesn't validate,
         // but the fact that it succeeded means the flow is correct.
@@ -307,8 +351,7 @@ mod tests {
 
     #[tokio::test]
     async fn unique_five_exactly_six_existing_no_truncation() {
-        // unique=5 → history=6 → keep 5 old. 6 existing > 5 → truncate to 5.
-        // DESC: 600..100 → rev: 100..600 → take(5) → [100,200,300,400,500]
+        // unique=5, 6 existing -> expire 5 newest, delete 1 oldest.
         let existing = vec![
             make_pwd(1, 600, false),
             make_pwd(2, 500, false),
@@ -319,16 +362,24 @@ mod tests {
         ];
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([existing])
-            // Expire the 5 kept (oldest 5 in rev order)
-            .append_query_results([vec![make_pwd(6, 100, true)]])
-            .append_query_results([vec![make_pwd(5, 200, true)]])
-            .append_query_results([vec![make_pwd(4, 300, true)]])
-            .append_query_results([vec![make_pwd(3, 400, true)]])
+            // Expire the 5 newest
+            .append_query_results([vec![make_pwd(1, 600, true)]])
             .append_query_results([vec![make_pwd(2, 500, true)]])
+            .append_query_results([vec![make_pwd(3, 400, true)]])
+            .append_query_results([vec![make_pwd(4, 300, true)]])
+            .append_query_results([vec![make_pwd(5, 200, true)]])
+            // Delete the 1 oldest
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
             .append_query_results([vec![make_pwd(10, 999, false)]])
             .into_connection();
 
-        assert!(set_new_password(&db, 1, 5, "hash", None).await.is_ok());
+        assert!(
+            set_new_password(&db, 1, 5, "hash", None, existing)
+                .await
+                .is_ok()
+        );
     }
 }

--- a/crates/identity-driver-sql/src/user/create.rs
+++ b/crates/identity-driver-sql/src/user/create.rs
@@ -189,11 +189,12 @@ pub async fn create(
         response_builder.merge_local_user_data(&local_user);
 
         if let Some(password) = &user.password {
-            local_user::set_new_password(
+            password::set_new_password(
                 &txn,
                 conf,
                 local_user.id,
                 secrecy::SecretString::from(password.as_str()),
+                Vec::new(),
             )
             .await?;
             response_builder.merge_passwords_data(password::list(&txn, local_user.id).await?);
@@ -393,15 +394,26 @@ mod tests {
             ..Default::default()
         };
         let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Transaction queries:
+            // 1. Insert main user record
             .append_query_results([vec![get_user_mock("1")]])
+            // 2. Insert user option (ignore_password_expiry)
             .append_exec_results([MockExecResult {
                 rows_affected: 1,
                 ..Default::default()
             }])
+            // 3. Insert local_user record
             .append_query_results([vec![get_local_user_mock("1")]])
-            .append_query_results([Vec::<db_password::Model>::new()])
+            // 4. password::set_new_password with Vec::new() -> no expire, no delete
+            //    just insert new password record
             .append_query_results([vec![get_password_mock(1)]])
+            // 5. password::list after set_new_password
             .append_query_results([vec![get_password_mock(1)]])
+            // 6. Insert user option (ignore_password_expiry for user_options)
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
             .into_connection();
         let req = UserCreateBuilder::default()
             .default_project_id("dpid")

--- a/crates/identity-driver-sql/src/user/update.rs
+++ b/crates/identity-driver-sql/src/user/update.rs
@@ -16,16 +16,14 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::TransactionTrait;
 use sea_orm::entity::*;
-use sea_orm::query::*;
 
 use openstack_keystone_config::Config;
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::identity::IdentityProviderError;
 use openstack_keystone_core_types::identity::{UserResponse, UserUpdate};
 
-use crate::entity::prelude::LocalUser;
-use crate::entity::{local_user as db_local_user, user as db_user};
-use crate::local_user;
+use crate::entity::{local_user as db_local_user, password as db_password, user as db_user};
+use crate::local_user::load_local_user_with_passwords;
 
 /// Update an existing user.
 ///
@@ -88,51 +86,33 @@ pub async fn update(
     // Only load local user if we need to update name or password
     if user.name.is_some() || user.password.is_some() {
         // Load local user for name and password updates
-        let mut local_user_result = LocalUser::find()
-            .filter(db_local_user::Column::UserId.eq(user_id))
-            .one(&txn)
-            .await
-            .context("fetching local user for update")?;
+        let (local_user, passwords) =
+            load_local_user_with_passwords(&txn, Some(user_id), None::<&str>, None::<&str>)
+                .await?
+                .ok_or(IdentityProviderError::UserNotFound(user_id.to_string()))?;
 
-        // If local_user doesn't exist, create one (name will be updated if provided)
-        if local_user_result.is_none() {
-            local_user_result = Some(
-                db_local_user::ActiveModel {
-                    id: NotSet,
-                    user_id: Set(user_id.to_string()),
-                    domain_id: Set(existing_user.domain_id.clone()),
-                    // Will be overwritten by the name update below if provided
-                    name: Set(user.name.clone().unwrap_or_default()),
-                    failed_auth_count: NotSet,
-                    failed_auth_at: NotSet,
-                }
-                .insert(&txn)
+        // Update name if provided in the patch
+        if let Some(ref name) = user.name {
+            let mut lu_active: db_local_user::ActiveModel = local_user.clone().into();
+            lu_active.name = Set(name.clone());
+            lu_active
+                .update(&txn)
                 .await
-                .context("inserting new local user record")?,
-            );
+                .context("updating local user entry")?;
         }
 
-        if let Some(local_user_model) = &local_user_result {
-            // Update name if provided in the patch
-            if let Some(ref name) = user.name {
-                let mut lu_active: db_local_user::ActiveModel = local_user_model.clone().into();
-                lu_active.name = Set(name.clone());
-                lu_active
-                    .update(&txn)
-                    .await
-                    .context("updating local user entry")?;
-            }
-
-            // Update password if provided in the patch
-            if let Some(ref new_password) = user.password {
-                local_user::set_new_password(
-                    &txn,
-                    conf,
-                    local_user_model.id,
-                    secrecy::SecretString::from(new_password.as_str()),
-                )
-                .await?;
-            }
+        // Update password if provided in the patch
+        if let Some(ref new_password) = user.password {
+            // Load existing passwords for history check and set_new_password_with_existing
+            let passwords_vec: Vec<db_password::Model> = passwords.into_iter().collect();
+            crate::password::set_new_password(
+                &txn,
+                conf,
+                local_user.id,
+                secrecy::SecretString::from(new_password.as_str()),
+                passwords_vec,
+            )
+            .await?;
         }
     }
 
@@ -150,7 +130,7 @@ pub async fn update(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase};
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
 
     use crate::entity::password as db_password;
     use crate::entity::user_option as db_user_option;
@@ -158,7 +138,9 @@ mod tests {
     use openstack_keystone_core_types::identity::UserUpdate;
 
     use super::*;
-    use crate::local_user::tests::{get_local_user_mock, get_local_user_with_password_mock};
+    use crate::local_user::tests::{
+        get_local_user_mock, get_local_user_with_password_mock, get_local_user_with_passwords_mock,
+    };
 
     use crate::user::tests::get_user_mock;
 
@@ -218,10 +200,11 @@ mod tests {
             .append_query_results([vec![get_user_mock("1")]])
             // 2. Update user entry returns updated user
             .append_query_results([vec![get_user_mock("1")]])
-            // 3. Fetch local_user for name update
-            .append_query_results([vec![get_local_user_mock("1")]])
+            // 3. load_local_user_with_passwords (for name update)
+            .append_query_results([get_local_user_with_password_mock("1", 1)])
             // 4. Update local_user entry returns updated local user
             .append_query_results([vec![get_local_user_mock("1")]])
+            // Commit
             // Post-transaction queries (user::get()):
             // 5. Fetch user by ID
             .append_query_results([vec![get_user_mock("1")]])
@@ -252,10 +235,14 @@ mod tests {
             .append_query_results([vec![get_user_mock("1")]])
             // 2. Update user entry (no-op but still issues UPDATE)
             .append_query_results([vec![get_user_mock("1")]])
-            // 3. Fetch local_user
-            .append_query_results([vec![get_local_user_mock("1")]])
-            // 4. Fetch existing passwords (empty)
-            .append_query_results([Vec::<db_password::Model>::new()])
+            // 3. load_local_user_with_passwords (local_user has 1 existing password)
+            .append_query_results([get_local_user_with_password_mock("1", 1)])
+            // 4. set_new_password -> check_history passes -> unique_count=0 -> keep_count=0
+            //    split_at(0, 1) = ([], [pw]) -> expire: 0, delete: 1
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
             // 5. Insert new password
             .append_query_results([vec![make_pwd(10, 999, false)]])
             // Commit
@@ -279,10 +266,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_password_with_history_truncation() {
-        // Config: unique_last_password_count=1 means keep 1 old password
+        // Config: unique_last_password_count=1 means expire 1 newest, delete 2 older.
         let mut conf = Config::default();
-        // unique=1 → history=2 → keep 1 old. 3 existing → truncate oldest 2.
-        // Expire the 1 kept password, then insert new.
         conf.security_compliance.unique_last_password_count = Some(1);
 
         let existing = vec![
@@ -311,19 +296,28 @@ mod tests {
             .append_query_results([vec![get_user_mock("1")]])
             // 2. Update user entry
             .append_query_results([vec![get_user_mock("1")]])
-            // 3. Fetch local_user
-            .append_query_results([vec![get_local_user_mock("1")]])
-            // 4. Fetch existing passwords (3, DESC by created_at_int)
-            .append_query_results([existing])
-            // 5. Expire the 1 kept password (truncated list after rev+take(1))
+            // 3. load_local_user_with_passwords (LEFT JOIN returns pairs + existing passwords)
+            .append_query_results([get_local_user_with_passwords_mock("1", &existing)])
+            // 4. set_new_password -> check_history passes, expire 1 newest
             .append_query_results([vec![
                 db_password::ModelBuilder::default()
-                    .id(3)
-                    .created_at_int(100)
+                    .id(1)
+                    .created_at_int(300)
                     .local_user_id(1)
                     .build()
                     .unwrap(),
             ]])
+            // 5. Delete the 2 older passwords (id=2, id=3)
+            .append_exec_results([
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+            ])
             // 6. Insert new password
             .append_query_results([vec![make_pwd(10, 999, false)]])
             // Post-transaction:
@@ -356,10 +350,13 @@ mod tests {
             .append_query_results([vec![get_user_mock("1")]])
             // 2. Update user entry
             .append_query_results([vec![get_user_mock("1")]])
-            // 3. Fetch local_user
-            .append_query_results([vec![get_local_user_mock("1")]])
-            // 4. Fetch existing passwords (empty)
-            .append_query_results([Vec::<db_password::Model>::new()])
+            // 3. load_local_user_with_passwords (with 1 existing password)
+            .append_query_results([get_local_user_with_password_mock("1", 1)])
+            // 4. set_new_password -> check_history passes -> unique=0 -> split_at -> delete 1
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
             // 5. Insert new password (with expires_at set by config)
             .append_query_results([vec![
                 db_password::ModelBuilder::default()
@@ -397,12 +394,15 @@ mod tests {
             .append_query_results([vec![get_user_mock("1")]])
             // 2. Update user entry
             .append_query_results([vec![get_user_mock("1")]])
-            // 3. Fetch local_user
-            .append_query_results([vec![get_local_user_mock("1")]])
+            // 3. load_local_user_with_passwords (with 1 existing password)
+            .append_query_results([get_local_user_with_password_mock("1", 1)])
             // 4. Update local_user (name change)
             .append_query_results([vec![get_local_user_mock("1")]])
-            // 5. Fetch existing passwords (empty)
-            .append_query_results([Vec::<db_password::Model>::new()])
+            // 5. set_new_password -> check_history passes -> unique=0 -> delete 1 existing
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
             // 6. Insert new password
             .append_query_results([vec![make_pwd(10, 999, false)]])
             // Post-transaction:
@@ -422,5 +422,61 @@ mod tests {
 
         let result = update(&conf, &db, "1", req).await;
         assert!(result.is_ok(), "update failed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_update_password_history_reuse_rejected() {
+        // Config: unique_last_password_count=2, password history is checked
+        let mut conf = Config::default();
+        conf.security_compliance.unique_last_password_count = Some(2);
+        conf.identity.password_hashing_algorithm =
+            openstack_keystone_config::PasswordHashingAlgo::None;
+
+        let old_password = "old_password";
+        let new_password = "old_password"; // Same as an existing password in history
+
+        let existing = vec![
+            db_password::ModelBuilder::default()
+                .id(1)
+                .created_at_int(300)
+                .local_user_id(1)
+                .password_hash(old_password.to_string())
+                .build()
+                .unwrap(),
+            db_password::ModelBuilder::default()
+                .id(2)
+                .created_at_int(200)
+                .local_user_id(1)
+                .password_hash(old_password.to_string())
+                .build()
+                .unwrap(),
+        ];
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // 1. Fetch existing user
+            .append_query_results([vec![get_user_mock("1")]])
+            // 2. Update user entry
+            .append_query_results([vec![get_user_mock("1")]])
+            // 3. load_local_user_with_passwords (with 2 existing passwords)
+            .append_query_results([get_local_user_with_passwords_mock("1", &existing)])
+            // set_new_password -> check_history rejects immediately, no further operations
+            .into_connection();
+
+        let req = UserUpdate {
+            password: Some(new_password.to_string()),
+            ..Default::default()
+        };
+
+        let result = update(&conf, &db, "1", req).await;
+        assert!(
+            matches!(
+                result,
+                Err(IdentityProviderError::SecurityCompliance(
+                    openstack_keystone_config::SecurityComplianceError::PasswordInvalid(_)
+                ))
+            ),
+            "reusing a password from history should be rejected, got: {:?}",
+            result
+        );
     }
 }


### PR DESCRIPTION
- Add check_password_history module that verifies new password against
  previous hashes within unique_last_password_count window. The check is
  called automatically inside set_new_password so it cannot be missed.

- Eliminate double database fetch: password/set.rs now accepts
  pre-loaded existing_passwords vector instead of querying the database.
  Callers (user/update.rs, user/create.rs, local_user.rs) load once and
  pass.

- Fix backwards expire/delete logic: expire the newest unique_count
  passwords (kept as history), delete older ones beyond the window.

- Consolidate high-level password API into password.rs; rename
  password/set_new.rs to password/set.rs for low-level DB operations.

- Add update_user_password to core identity API layer (service, backend,
  provider_api, mock). Add update_password to local_user.rs with
  original password verification.
