### PR TITLE
test: Auth projects returns empty for user without roles

### DIFF
--- a/tests/api/src/auth/project.rs
+++ b/tests/api/src/auth/project.rs
@@ -20,6 +20,10 @@ use openstack_keystone_api_types::v3::project::ProjectShort;
 use openstack_sdk::api::rest_endpoint_prelude::*;
 use openstack_sdk::{AsyncOpenStack, api::QueryAsync, config::CloudConfig};
 
+use crate::common::get_session_by_user_password;
+use crate::guard::ResourceGuard;
+use tracing_test::traced_test;
+
 #[derive(Clone, Debug)]
 struct AuthProjectsRequest {}
 
@@ -55,5 +59,38 @@ async fn test_list_user_projects() -> Result<()> {
     let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
     let projects = list_auth_projects(&test_client).await?;
     assert!(!projects.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_auth_projects_empty_for_user_without_roles() -> Result<()> {
+    use crate::identity::user::create_user;
+    use openstack_keystone_api_types::v3::user::UserCreateBuilder;
+    use uuid::Uuid;
+
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("usr_{}", Uuid::new_v4().simple());
+    let password = "TestPassword123!";
+
+    // Create a user with no role assignments
+    let guard = create_user(
+        &tc,
+        UserCreateBuilder::default()
+            .name(&name)
+            .domain_id("default")
+            .enabled(true)
+            .password(password)
+            .build()?,
+    )
+    .await?;
+
+    let user_client =
+        get_session_by_user_password(&guard.name, &guard.domain_id, &password).await?;
+
+    let projects = list_auth_projects(&user_client).await?;
+    assert!(projects.is_empty());
+
+    guard.delete().await?;
     Ok(())
 }

--- a/tests/api/src/common.rs
+++ b/tests/api/src/common.rs
@@ -22,6 +22,9 @@ use secrecy::{ExposeSecret, SecretString};
 use std::env;
 use url::Url;
 
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+use std::sync::Arc;
+
 use openstack_keystone_api_types::scope::{
     DomainBuilder, Scope, ScopeProjectBuilder, System as ScopeSystem,
 };
@@ -265,4 +268,23 @@ pub async fn auth_user_by_password<U: AsRef<str>, D: AsRef<str>, P: AsRef<str>>(
         return Err(eyre!("Authentication failed with {}", rsp.status()));
     }
     Ok(())
+}
+
+/// Get AsyncOpenStack session for user by name, domain and password.
+pub async fn get_session_by_user_password<U: AsRef<str>, D: AsRef<str>, P: AsRef<str>>(
+    username: U,
+    domain_id: D,
+    password: P,
+) -> Result<Arc<AsyncOpenStack>> {
+    let config = CloudConfig {
+        auth: Some(openstack_sdk::config::Auth {
+            auth_url: Some(env::var("OS_AUTH_URL")?),
+            username: Some(username.as_ref().to_string()),
+            user_domain_id: Some(domain_id.as_ref().to_string()),
+            password: Some(password.as_ref().into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    Ok(Arc::new(AsyncOpenStack::new(&config).await?))
 }


### PR DESCRIPTION
Closes #515

Added API test to verify that when a user has no role assignments,
the /auth/projects endpoint returns an empty list instead of all
projects in the system.

Test: test_auth_projects_empty_for_user_without_roles
- Creates a user with no role assignments
- Authenticates as that user
- Calls /auth/projects
- Verifies the returned list is empty