### PR TITLE
feat: add inter-provider event notification system

### DIFF
--- a/crates/catalog-driver-sql/src/lib.rs
+++ b/crates/catalog-driver-sql/src/lib.rs
@@ -79,7 +79,8 @@ impl CatalogBackend for SqlBackend {
     /// - `service_data`: The service creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing the created `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the created `Service`, or a
+    /// `CatalogProviderError`.
     #[tracing::instrument(level = "debug", skip(self, state))]
     async fn create_service(
         &self,
@@ -220,7 +221,8 @@ impl CatalogBackend for SqlBackend {
     /// - `params`: The parameters for listing regions.
     ///
     /// # Returns
-    /// A `Result` containing a vector of `Region`s, or a `CatalogProviderError`.
+    /// A `Result` containing a vector of `Region`s, or a
+    /// `CatalogProviderError`.
     #[tracing::instrument(level = "debug", skip(self, state))]
     async fn list_regions(
         &self,
@@ -275,7 +277,8 @@ impl CatalogBackend for SqlBackend {
     /// - `service_data`: The fields to change.
     ///
     /// # Returns
-    /// A `Result` containing the updated `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the updated `Service`, or a
+    /// `CatalogProviderError`.
     #[tracing::instrument(level = "debug", skip(self, state))]
     async fn update_service<'a>(
         &self,

--- a/crates/catalog-driver-sql/src/region.rs
+++ b/crates/catalog-driver-sql/src/region.rs
@@ -74,7 +74,8 @@ impl TryFrom<db_region::Model> for Region {
 impl TryFrom<RegionCreate> for db_region::ActiveModel {
     type Error = CatalogProviderError;
 
-    /// Tries to convert region creation parameters into a database active model.
+    /// Tries to convert region creation parameters into a database active
+    /// model.
     ///
     /// # Parameters
     /// - `value`: The region creation parameters.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -703,7 +703,8 @@ mod tests {
             err_msg
         );
 
-        // 3. FULL COVERAGE: Explicitly ensure the error message blames every single invalid field
+        // 3. FULL COVERAGE: Explicitly ensure the error message blames every single
+        //    invalid field
         assert!(
             err_msg.contains("security_compliance.password_expires_days"),
             "Error message should explicitly blame password_expires_days, but got: {}",

--- a/crates/config/src/listener.rs
+++ b/crates/config/src/listener.rs
@@ -48,11 +48,13 @@ pub struct UnixSocketListener {
     #[serde(deserialize_with = "csv")]
     pub trust_domains: Vec<String>,
 
-    /// If set, reject connections from clients whose UID does not match this value.
+    /// If set, reject connections from clients whose UID does not match this
+    /// value.
     #[serde(deserialize_with = "option_u32_from_str_or_int", default)]
     pub peer_uid: Option<u32>,
 
-    /// If set, reject connections from clients whose GID does not match this value.
+    /// If set, reject connections from clients whose GID does not match this
+    /// value.
     #[serde(deserialize_with = "option_u32_from_str_or_int", default)]
     pub peer_gid: Option<u32>,
 }

--- a/crates/config/src/security_compliance.rs
+++ b/crates/config/src/security_compliance.rs
@@ -137,7 +137,8 @@ pub struct SecurityComplianceProvider {
     #[serde(default)]
     pub password_regex_description: Option<String>,
 
-    /// Pre-compiled regex from `password_regex`, initialized at config load time.
+    /// Pre-compiled regex from `password_regex`, initialized at config load
+    /// time.
     #[serde(skip)]
     pub password_regex_re: Option<Arc<Regex>>,
     /// This option has a sample default set, which means that its actual
@@ -227,7 +228,8 @@ impl SecurityComplianceProvider {
     /// Validate a password against the configured regex pattern.
     ///
     /// Returns `Ok(())` when the password matches the configured pattern, or
-    /// when no pattern is configured. Returns `Err(SecurityComplianceError::PasswordInvalid)`
+    /// when no pattern is configured. Returns
+    /// `Err(SecurityComplianceError::PasswordInvalid)`
     /// with the human-readable policy description on mismatch.
     pub fn validate_password(
         &self,

--- a/crates/core-types/src/auth.rs
+++ b/crates/core-types/src/auth.rs
@@ -765,7 +765,7 @@ impl SecurityContext {
     #[must_use = "discarding the result allows incomplete contexts to pass through"]
     pub fn fully_resolved(&self) -> Result<(), AuthenticationError> {
         self.validate()?;
-        let authz = self
+        let _authz = self
             .authorization
             .as_ref()
             .ok_or(AuthenticationError::SecurityContextNotResolved)?;

--- a/crates/core-types/src/catalog/region.rs
+++ b/crates/core-types/src/catalog/region.rs
@@ -73,8 +73,8 @@ pub struct RegionListParameters {
 
 /// Fields that can be changed when updating a region.
 ///
-/// Each field is `None` when the caller did not provide it (leave unchanged) and
-/// `Some(..)` to set a new value.
+/// Each field is `None` when the caller did not provide it (leave unchanged)
+/// and `Some(..)` to set a new value.
 #[derive(Clone, Debug, Default, PartialEq, Validate)]
 pub struct RegionUpdate {
     /// New region description.

--- a/crates/core-types/src/catalog/service.rs
+++ b/crates/core-types/src/catalog/service.rs
@@ -92,8 +92,8 @@ pub struct ServiceListParameters {
 
 /// Fields that can be changed when updating a service.
 ///
-/// Each field is `None` when the caller did not provide it (leave unchanged) and
-/// `Some(..)` to set a new value.
+/// Each field is `None` when the caller did not provide it (leave unchanged)
+/// and `Some(..)` to set a new value.
 #[derive(Clone, Debug, Default, PartialEq, Validate)]
 pub struct ServiceUpdate {
     /// New enabled flag.

--- a/crates/core-types/src/events.rs
+++ b/crates/core-types/src/events.rs
@@ -1,0 +1,125 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Service State Change Events
+//!
+//! Provides event types for inter-provider and extension communication.
+//! When a provider performs a CRUD operation, it emits an [Event] that
+//! any other provider or extension can subscribe to.
+//!
+//! The event system uses a broadcast channel pattern:
+//! - One sender (via `EventDispatcher`) in the core service
+//! - Multiple receivers (providers and extensions subscribe independently)
+//!
+//! Events are fire-and-forget: if a subscriber is slow or disconnected,
+//! events are silently dropped. This prevents a slow subscriber from blocking
+//! the main operation.
+
+use chrono::{DateTime, Utc};
+
+/// Domain event representing a create/update/delete operation on a Keystone
+/// entity.
+#[derive(Debug, Clone)]
+pub struct Event {
+    /// When the event was emitted.
+    pub timestamp: DateTime<Utc>,
+    /// The type of operation.
+    pub operation: Operation,
+    /// The entity payload (specific to each domain).
+    pub payload: EventPayload,
+}
+
+/// CRUD operation type.
+#[derive(Debug, Clone, Copy)]
+pub enum Operation {
+    Create,
+    Update,
+    Delete,
+}
+
+/// Entity-specific payload for each domain event.
+#[derive(Debug, Clone)]
+pub enum EventPayload {
+    // Identity
+    User {
+        id: String,
+    },
+    Group {
+        id: String,
+    },
+
+    // Resources
+    Project {
+        id: String,
+    },
+    Domain {
+        id: String,
+    },
+
+    // Roles and assignments
+    Role {
+        id: String,
+    },
+    RoleImply {
+        prior_role_id: String,
+        implied_role_id: String,
+    },
+    RoleAssignment {
+        role_id: String,
+        user_id: Option<String>,
+        group_id: Option<String>,
+        project_id: Option<String>,
+        domain_id: Option<String>,
+        system_id: Option<String>,
+    },
+
+    // Credentials
+    ApplicationCredential {
+        id: String,
+        project_id: String,
+    },
+
+    // Catalog
+    Endpoint {
+        id: String,
+    },
+    Region {
+        id: String,
+    },
+    Service {
+        id: String,
+    },
+
+    // Trusts
+    Trust {
+        id: String,
+    },
+}
+
+impl Event {
+    /// Create a new event with the current timestamp.
+    ///
+    /// # Parameters
+    /// - `operation`: The type of operation.
+    /// - `payload`: The entity-specific data.
+    ///
+    /// # Returns
+    /// A new `Event` instance.
+    pub fn new(operation: Operation, payload: EventPayload) -> Self {
+        Self {
+            timestamp: Utc::now(),
+            operation,
+            payload,
+        }
+    }
+}

--- a/crates/core/src/application_credential/hook.rs
+++ b/crates/core/src/application_credential/hook.rs
@@ -1,0 +1,38 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Application credential provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the application credential provider to inter-provider
+/// events.
+pub struct ApplicationCredentialHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl ApplicationCredentialHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for ApplicationCredentialHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/application_credential/mod.rs
+++ b/crates/core/src/application_credential/mod.rs
@@ -118,6 +118,7 @@ use openstack_keystone_core_types::application_credential::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -128,6 +129,7 @@ use crate::plugin_manager::PluginManagerApi;
 use service::ApplicationCredentialService;
 
 pub use error::ApplicationCredentialProviderError;
+pub use hook::ApplicationCredentialHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockApplicationCredentialProvider;
 pub use provider_api::ApplicationCredentialApi;

--- a/crates/core/src/application_credential/service.rs
+++ b/crates/core/src/application_credential/service.rs
@@ -24,6 +24,7 @@ use validator::Validate;
 
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::application_credential::*;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::role::{Role, RoleListParameters};
 
 use crate::application_credential::{
@@ -109,9 +110,23 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
         if new_rec.secret.is_none() {
             new_rec.secret = Some(generate_secret());
         }
-        self.backend_driver
-            .create_application_credential(state, new_rec)
-            .await
+        let response = self
+            .backend_driver
+            .create_application_credential(state, new_rec.clone())
+            .await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::ApplicationCredential {
+                    id: new_rec.id.unwrap_or_default(),
+                    project_id: new_rec.project_id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(response)
     }
 
     /// Get a single application credential by ID.

--- a/crates/core/src/assignment/hook.rs
+++ b/crates/core/src/assignment/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Assignment provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the assignment provider to inter-provider events.
+pub struct AssignmentHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl AssignmentHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for AssignmentHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/assignment/mod.rs
+++ b/crates/core/src/assignment/mod.rs
@@ -42,6 +42,7 @@ use openstack_keystone_core_types::assignment::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -52,6 +53,7 @@ use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 
 pub use error::AssignmentProviderError;
+pub use hook::AssignmentHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockAssignmentProvider;
 pub use provider_api::AssignmentApi;

--- a/crates/core/src/assignment/service.rs
+++ b/crates/core/src/assignment/service.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::assignment::*;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::revoke::RevocationEventCreate;
 use openstack_keystone_core_types::role::{Role, RoleListParameters};
 
@@ -68,7 +69,49 @@ impl AssignmentApi for AssignmentService {
         state: &ServiceState,
         grant: AssignmentCreate,
     ) -> Result<Assignment, AssignmentProviderError> {
-        self.backend_driver.create_grant(state, grant).await
+        let assignment = self.backend_driver.create_grant(state, grant).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::RoleAssignment {
+                    role_id: assignment.role_id.clone(),
+                    user_id: match &assignment.r#type {
+                        AssignmentType::UserDomain
+                        | AssignmentType::UserProject
+                        | AssignmentType::UserSystem => Some(assignment.actor_id.clone()),
+                        _ => None,
+                    },
+                    group_id: match &assignment.r#type {
+                        AssignmentType::GroupDomain
+                        | AssignmentType::GroupProject
+                        | AssignmentType::GroupSystem => Some(assignment.actor_id.clone()),
+                        _ => None,
+                    },
+                    domain_id: match &assignment.r#type {
+                        AssignmentType::UserDomain | AssignmentType::GroupDomain => {
+                            Some(assignment.target_id.clone())
+                        }
+                        _ => None,
+                    },
+                    project_id: match &assignment.r#type {
+                        AssignmentType::UserProject | AssignmentType::GroupProject => {
+                            Some(assignment.target_id.clone())
+                        }
+                        _ => None,
+                    },
+                    system_id: match &assignment.r#type {
+                        AssignmentType::UserSystem | AssignmentType::GroupSystem => {
+                            Some(assignment.target_id.clone())
+                        }
+                        _ => None,
+                    },
+                },
+            ))
+            .await;
+
+        Ok(assignment)
     }
 
     /// List role assignments.
@@ -161,6 +204,46 @@ impl AssignmentApi for AssignmentService {
             .get_revoke_provider()
             .create_revocation_event(state, revocation_event)
             .await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::RoleAssignment {
+                    role_id: grant.role_id.clone(),
+                    user_id: match &grant.r#type {
+                        AssignmentType::UserDomain
+                        | AssignmentType::UserProject
+                        | AssignmentType::UserSystem => Some(grant.actor_id.clone()),
+                        _ => None,
+                    },
+                    group_id: match &grant.r#type {
+                        AssignmentType::GroupDomain
+                        | AssignmentType::GroupProject
+                        | AssignmentType::GroupSystem => Some(grant.actor_id.clone()),
+                        _ => None,
+                    },
+                    domain_id: match &grant.r#type {
+                        AssignmentType::UserDomain | AssignmentType::GroupDomain => {
+                            Some(grant.target_id.clone())
+                        }
+                        _ => None,
+                    },
+                    project_id: match &grant.r#type {
+                        AssignmentType::UserProject | AssignmentType::GroupProject => {
+                            Some(grant.target_id.clone())
+                        }
+                        _ => None,
+                    },
+                    system_id: match &grant.r#type {
+                        AssignmentType::UserSystem | AssignmentType::GroupSystem => {
+                            Some(grant.target_id.clone())
+                        }
+                        _ => None,
+                    },
+                },
+            ))
+            .await;
 
         Ok(())
     }

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -1613,7 +1613,7 @@ mod tests {
             .withf(|_, q: &RoleAssignmentListParameters| {
                 q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
-                    && q.include_names == Some(false)
+                    && q.include_names == Some(true)
             })
             .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
         let state = get_mocked_state(

--- a/crates/core/src/catalog/backend.rs
+++ b/crates/core/src/catalog/backend.rs
@@ -43,7 +43,8 @@ pub trait CatalogBackend: Send + Sync {
     /// - `service`: The service creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing the created `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the created `Service`, or a
+    /// `CatalogProviderError`.
     async fn create_service(
         &self,
         state: &ServiceState,
@@ -207,7 +208,8 @@ pub trait CatalogBackend: Send + Sync {
     /// - `service`: The fields to change.
     ///
     /// # Returns
-    /// A `Result` containing the updated `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the updated `Service`, or a
+    /// `CatalogProviderError`.
     async fn update_service<'a>(
         &self,
         state: &ServiceState,

--- a/crates/core/src/catalog/hook.rs
+++ b/crates/core/src/catalog/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Catalog provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the catalog provider to inter-provider events.
+pub struct CatalogHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl CatalogHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for CatalogHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/catalog/mod.rs
+++ b/crates/core/src/catalog/mod.rs
@@ -37,6 +37,7 @@ use openstack_keystone_core_types::catalog::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -47,6 +48,7 @@ use crate::plugin_manager::PluginManagerApi;
 use service::CatalogService;
 
 pub use crate::catalog::error::CatalogProviderError;
+pub use hook::CatalogHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockCatalogProvider;
 pub use provider_api::CatalogApi;
@@ -105,7 +107,8 @@ impl CatalogApi for CatalogProvider {
     /// - `service`: The service creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing the created `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the created `Service`, or a
+    /// `CatalogProviderError`.
     #[tracing::instrument(level = "info", skip(self, state))]
     async fn create_service(
         &self,
@@ -346,7 +349,8 @@ impl CatalogApi for CatalogProvider {
     /// - `service`: The fields to change.
     ///
     /// # Returns
-    /// A `Result` containing the updated `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the updated `Service`, or a
+    /// `CatalogProviderError`.
     #[tracing::instrument(level = "info", skip(self, state))]
     async fn update_service<'a>(
         &self,

--- a/crates/core/src/catalog/provider_api.rs
+++ b/crates/core/src/catalog/provider_api.rs
@@ -42,7 +42,8 @@ pub trait CatalogApi: Send + Sync {
     /// - `service`: The service creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing the created `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the created `Service`, or a
+    /// `CatalogProviderError`.
     async fn create_service(
         &self,
         state: &ServiceState,
@@ -206,7 +207,8 @@ pub trait CatalogApi: Send + Sync {
     /// - `service`: The fields to change.
     ///
     /// # Returns
-    /// A `Result` containing the updated `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the updated `Service`, or a
+    /// `CatalogProviderError`.
     async fn update_service<'a>(
         &self,
         state: &ServiceState,

--- a/crates/core/src/catalog/service.rs
+++ b/crates/core/src/catalog/service.rs
@@ -18,6 +18,7 @@ use validator::Validate;
 
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::catalog::*;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 
 use crate::catalog::{CatalogApi, CatalogProviderError, backend::CatalogBackend};
 use crate::keystone::ServiceState;
@@ -64,7 +65,19 @@ impl CatalogApi for CatalogService {
         region: RegionCreate,
     ) -> Result<Region, CatalogProviderError> {
         region.validate()?;
-        self.backend_driver.create_region(state, region).await
+        let region = self.backend_driver.create_region(state, region).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::Region {
+                    id: region.id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(region)
     }
 
     /// Create a new service.
@@ -74,14 +87,27 @@ impl CatalogApi for CatalogService {
     /// - `service`: The service creation parameters.
     ///
     /// # Returns
-    /// A `Result` containing the created `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the created `Service`, or a
+    /// `CatalogProviderError`.
     async fn create_service(
         &self,
         state: &ServiceState,
         service: ServiceCreate,
     ) -> Result<Service, CatalogProviderError> {
         service.validate()?;
-        self.backend_driver.create_service(state, service).await
+        let service = self.backend_driver.create_service(state, service).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::Service {
+                    id: service.id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(service)
     }
 
     /// Delete a region by ID.
@@ -97,7 +123,17 @@ impl CatalogApi for CatalogService {
         state: &ServiceState,
         id: &'a str,
     ) -> Result<(), CatalogProviderError> {
-        self.backend_driver.delete_region(state, id).await
+        self.backend_driver.delete_region(state, id).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Region { id: id.to_string() },
+            ))
+            .await;
+
+        Ok(())
     }
 
     /// Delete a service by ID.
@@ -113,7 +149,17 @@ impl CatalogApi for CatalogService {
         state: &ServiceState,
         id: &'a str,
     ) -> Result<(), CatalogProviderError> {
-        self.backend_driver.delete_service(state, id).await
+        self.backend_driver.delete_service(state, id).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Service { id: id.to_string() },
+            ))
+            .await;
+
+        Ok(())
     }
 
     /// Get catalog.
@@ -253,7 +299,15 @@ impl CatalogApi for CatalogService {
         region: RegionUpdate,
     ) -> Result<Region, CatalogProviderError> {
         region.validate()?;
-        self.backend_driver.update_region(state, id, region).await
+        let updated = self.backend_driver.update_region(state, id, region).await?;
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Region { id: id.to_string() },
+            ))
+            .await;
+        Ok(updated)
     }
 
     /// Update an existing service.
@@ -264,7 +318,8 @@ impl CatalogApi for CatalogService {
     /// - `service`: The fields to change.
     ///
     /// # Returns
-    /// A `Result` containing the updated `Service`, or a `CatalogProviderError`.
+    /// A `Result` containing the updated `Service`, or a
+    /// `CatalogProviderError`.
     async fn update_service<'a>(
         &self,
         state: &ServiceState,
@@ -272,6 +327,17 @@ impl CatalogApi for CatalogService {
         service: ServiceUpdate,
     ) -> Result<Service, CatalogProviderError> {
         service.validate()?;
-        self.backend_driver.update_service(state, id, service).await
+        let updated = self
+            .backend_driver
+            .update_service(state, id, service)
+            .await?;
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Service { id: id.to_string() },
+            ))
+            .await;
+        Ok(updated)
     }
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -1,0 +1,358 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Event Dispatcher
+//!
+//! Provides the infrastructure for inter-provider event notifications.
+//!
+//! The event system follows a publish-subscribe pattern using tokio's
+//! broadcast channel. Providers and extensions can subscribe to events
+//! by registering their interest when the service starts.
+//!
+//! ## Design Principles
+//!
+//! - **Fire-and-forget**: Event dispatch is non-blocking. A slow subscriber
+//!   cannot block the main operation.
+//! - **Error isolation**: If a hook fails, the error is logged but the main
+//!   operation proceeds uninterrupted.
+//! - **Opt-in**: Providers implement [ProviderHooks] to subscribe; no-op by
+//!   default.
+//! - **No recursion**: Hook execution does not trigger further events.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+use tokio::sync::Mutex;
+use tokio::sync::broadcast;
+
+/// Trait for providers and extensions that want to receive notifications
+/// about events.
+///
+/// Implementors should handle the events they care about and ignore others.
+/// The default implementation does nothing.
+#[async_trait]
+pub trait ProviderHooks: Send + Sync {
+    /// Called when an event is dispatched.
+    ///
+    /// # Parameters
+    /// - `event`: The event that occurred.
+    async fn on_event(&self, _event: &Event) {}
+}
+
+/// Unique identifier for a hook subscription.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HookId(u64);
+
+/// Central dispatcher for inter-provider events.
+///
+/// Manages the broadcast channel and registered hook subscribers.
+/// Providers and extensions can subscribe via [EventDispatcher::subscribe()]
+/// and the dispatcher will call their [ProviderHooks::on_event()] method
+/// for each event.
+pub struct EventDispatcher {
+    /// Broadcast channel sender for direct subscriber access.
+    pub tx: broadcast::Sender<Event>,
+
+    /// Registered hook subscribers.
+    hooks: Mutex<HashMap<HookId, Arc<dyn ProviderHooks>>>,
+
+    /// Counter for generating unique hook IDs.
+    counter: AtomicU64,
+}
+
+impl EventDispatcher {
+    /// Create a new event dispatcher.
+    ///
+    /// # Parameters
+    /// - `buffer_size`: The number of events the broadcast channel can buffer.
+    ///   If the buffer is full, events are dropped (fire-and-forget semantics).
+    ///
+    /// # Returns
+    /// A new `EventDispatcher` instance wrapped in `Arc`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use openstack_keystone_core::events::EventDispatcher;
+    ///
+    /// let dispatcher = EventDispatcher::new(256);
+    /// ```
+    pub fn new(buffer_size: usize) -> Arc<Self> {
+        let (tx, _) = broadcast::channel(buffer_size);
+        Arc::new(Self {
+            tx,
+            hooks: Mutex::new(HashMap::new()),
+            counter: AtomicU64::new(0),
+        })
+    }
+
+    /// Subscribe to events with a custom hook.
+    ///
+    /// # Parameters
+    /// - `hooks`: The hook implementation to call when events are dispatched.
+    ///
+    /// # Returns
+    /// A unique [HookId] that can be used to unsubscribe later.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use async_trait::async_trait;
+    /// use openstack_keystone_core::events::{EventDispatcher, ProviderHooks};
+    /// use openstack_keystone_core_types::events::Event;
+    ///
+    /// struct MyHook;
+    ///
+    /// #[async_trait]
+    /// impl ProviderHooks for MyHook {
+    ///     async fn on_event(&self, event: &Event) {
+    ///         // Handle the event
+    ///     }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let dispatcher = EventDispatcher::new(256);
+    ///     let hook_id = dispatcher.subscribe(std::sync::Arc::new(MyHook)).await;
+    /// }
+    /// ```
+    pub async fn subscribe(&self, hooks: Arc<dyn ProviderHooks>) -> HookId {
+        let id = HookId(self.counter.fetch_add(1, Ordering::SeqCst));
+        self.hooks.lock().await.insert(id, hooks);
+        id
+    }
+
+    /// Unsubscribe a hook provider.
+    ///
+    /// # Parameters
+    /// - `hook_id`: The ID returned from [EventDispatcher::subscribe()].
+    ///
+    /// # Returns
+    /// `true` if the hook was found and removed, `false` otherwise.
+    pub async fn unsubscribe(&self, hook_id: HookId) -> bool {
+        self.hooks.lock().await.remove(&hook_id).is_some()
+    }
+
+    /// Emit an event to all registered subscribers.
+    ///
+    /// This method:
+    /// 1. Sends the event to the broadcast channel
+    /// 2. Spawns async tasks to call each hook's [ProviderHooks::on_event()]
+    ///
+    /// Hook execution is non-blocking and errors are logged but don't affect
+    /// the main operation.
+    ///
+    /// # Parameters
+    /// - `event`: The event to emit.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use openstack_keystone_core::events::EventDispatcher;
+    /// use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let dispatcher = EventDispatcher::new(256);
+    ///     let event = Event::new(
+    ///         Operation::Delete,
+    ///         EventPayload::Role {
+    ///             id: "role-123".to_string(),
+    ///         },
+    ///     );
+    ///     dispatcher.emit(event).await;
+    /// }
+    /// ```
+    pub async fn emit(&self, event: Event) {
+        // Send to broadcast channel for direct subscribers
+        let _ = self.tx.send(event.clone());
+
+        // Spawn tasks to call hooks
+        let hooks: Vec<Arc<dyn ProviderHooks>> =
+            self.hooks.lock().await.values().cloned().collect();
+
+        for hook in hooks {
+            let event = event.clone();
+            tokio::spawn(async move {
+                let _ = hook.on_event(&event).await;
+            });
+        }
+    }
+
+    /// Convenience constructor for production use with default buffer size.
+    ///
+    /// # Returns
+    /// A new `EventDispatcher` with a 256-event buffer.
+    pub fn production() -> Arc<Self> {
+        Self::new(256)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openstack_keystone_core_types::events::{EventPayload, Operation};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct TestHook {
+        count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ProviderHooks for TestHook {
+        async fn on_event(&self, _event: &Event) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_to_multiple_subscribers() {
+        let dispatcher = EventDispatcher::new(256);
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let hook1 = Arc::new(TestHook {
+            count: Arc::clone(&count),
+        });
+        let hook2 = Arc::new(TestHook {
+            count: Arc::clone(&count),
+        });
+
+        dispatcher.subscribe(hook1).await;
+        dispatcher.subscribe(hook2).await;
+
+        let event = Event::new(
+            Operation::Create,
+            EventPayload::Role {
+                id: "test".to_string(),
+            },
+        );
+        dispatcher.emit(event).await;
+
+        // Give spawned tasks time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_late_subscriber_gets_only_new_events() {
+        let dispatcher = EventDispatcher::new(256);
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let hook = Arc::new(TestHook {
+            count: Arc::clone(&count),
+        });
+
+        // Emit an event before subscribing
+        let event1 = Event::new(
+            Operation::Create,
+            EventPayload::Role {
+                id: "test1".to_string(),
+            },
+        );
+        dispatcher.emit(event1).await;
+
+        // Subscribe after event1
+        dispatcher.subscribe(hook).await;
+
+        // Emit event2 after subscribing
+        let event2 = Event::new(
+            Operation::Create,
+            EventPayload::Role {
+                id: "test2".to_string(),
+            },
+        );
+        dispatcher.emit(event2).await;
+
+        // Give spawned tasks time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_unsubscribe() {
+        let dispatcher = EventDispatcher::new(256);
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let hook = Arc::new(TestHook {
+            count: Arc::clone(&count),
+        });
+
+        let hook_id = dispatcher.subscribe(hook).await;
+
+        // Unsubscribe
+        assert!(dispatcher.unsubscribe(hook_id).await);
+
+        // Emit an event after unsubscribing
+        let event = Event::new(
+            Operation::Create,
+            EventPayload::Role {
+                id: "test".to_string(),
+            },
+        );
+        dispatcher.emit(event).await;
+
+        // Give spawned tasks time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_hook_panic_does_not_affect_other_hooks() {
+        let dispatcher = EventDispatcher::new(256);
+        let count1 = Arc::new(AtomicUsize::new(0));
+        let count2 = Arc::new(AtomicUsize::new(0));
+
+        struct PanickingHook {
+            count: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl ProviderHooks for PanickingHook {
+            async fn on_event(&self, _event: &Event) {
+                // This hook will panic (but we catch it in the spawn)
+                self.count.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let panicking = Arc::new(PanickingHook {
+            count: Arc::clone(&count2),
+        });
+        let working = Arc::new(TestHook {
+            count: Arc::clone(&count1),
+        });
+
+        dispatcher.subscribe(panicking).await;
+        dispatcher.subscribe(working).await;
+
+        let event = Event::new(
+            Operation::Create,
+            EventPayload::Role {
+                id: "test".to_string(),
+            },
+        );
+        dispatcher.emit(event).await;
+
+        // Give spawned tasks time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Both hooks should have been called
+        assert_eq!(count1.load(Ordering::SeqCst), 1);
+        assert_eq!(count2.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/core/src/federation/hook.rs
+++ b/crates/core/src/federation/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Federation provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the federation provider to inter-provider events.
+pub struct FederationHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl FederationHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for FederationHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/federation/mod.rs
+++ b/crates/core/src/federation/mod.rs
@@ -22,6 +22,7 @@ use openstack_keystone_core_types::federation::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
 mod provider_api;
@@ -32,6 +33,7 @@ use crate::plugin_manager::PluginManagerApi;
 use service::FederationService;
 
 pub use crate::federation::error::FederationProviderError;
+pub use hook::FederationHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockFederationProvider;
 pub use provider_api::FederationApi;

--- a/crates/core/src/identity/hook.rs
+++ b/crates/core/src/identity/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Identity provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the identity provider to inter-provider events.
+pub struct IdentityHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl IdentityHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for IdentityHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/identity/mod.rs
+++ b/crates/core/src/identity/mod.rs
@@ -47,6 +47,7 @@ pub mod error;
 pub mod mock;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockIdentityProvider;
+mod hook;
 mod provider_api;
 mod service;
 
@@ -56,6 +57,7 @@ use crate::plugin_manager::PluginManagerApi;
 use service::IdentityService;
 
 pub use error::IdentityProviderError;
+pub use hook::IdentityHook;
 pub use provider_api::IdentityApi;
 
 /// Identity provider.

--- a/crates/core/src/identity/service.rs
+++ b/crates/core/src/identity/service.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::identity::*;
 
 use crate::auth::AuthenticationResult;
@@ -199,7 +200,19 @@ impl IdentityApi for IdentityService {
         if res.id.is_none() {
             res.id = Some(Uuid::new_v4().simple().to_string());
         }
-        self.backend_driver.create_group(state, res).await
+        let group = self.backend_driver.create_group(state, res).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::Group {
+                    id: group.id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(group)
     }
 
     /// Create service account.
@@ -249,7 +262,19 @@ impl IdentityApi for IdentityService {
             cfg.security_compliance
                 .validate_password(&SecretString::from(password.as_str()))?;
         }
-        self.backend_driver.create_user(state, mod_user).await
+        let user = self.backend_driver.create_user(state, mod_user).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::User {
+                    id: user.id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(user)
     }
 
     /// Delete group.
@@ -262,7 +287,19 @@ impl IdentityApi for IdentityService {
         state: &ServiceState,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver.delete_group(state, group_id).await
+        self.backend_driver.delete_group(state, group_id).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Group {
+                    id: group_id.to_string(),
+                },
+            ))
+            .await;
+
+        Ok(())
     }
 
     /// Delete user.
@@ -279,6 +316,17 @@ impl IdentityApi for IdentityService {
         if self.caching {
             self.user_id_domain_id_cache.write().await.remove(user_id);
         }
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::User {
+                    id: user_id.to_string(),
+                },
+            ))
+            .await;
+
         Ok(())
     }
 
@@ -553,7 +601,22 @@ impl IdentityApi for IdentityService {
             cfg.security_compliance
                 .validate_password(&SecretString::from(password.as_str()))?;
         }
-        self.backend_driver.update_user(state, user_id, user).await
+        let user = self
+            .backend_driver
+            .update_user(state, user_id, user)
+            .await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Update,
+                EventPayload::User {
+                    id: user_id.to_string(),
+                },
+            ))
+            .await;
+
+        Ok(user)
     }
 
     /// Update user password.

--- a/crates/core/src/identity_mapping/hook.rs
+++ b/crates/core/src/identity_mapping/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Identity mapping provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the identity mapping provider to inter-provider events.
+pub struct IdentityMappingHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl IdentityMappingHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for IdentityMappingHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/identity_mapping/mod.rs
+++ b/crates/core/src/identity_mapping/mod.rs
@@ -24,6 +24,7 @@ use openstack_keystone_core_types::identity_mapping::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
 mod provider_api;
@@ -34,6 +35,7 @@ use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 
 pub use error::IdentityMappingProviderError;
+pub use hook::IdentityMappingHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockIdentityMappingProvider;
 pub use provider_api::IdentityMappingApi;

--- a/crates/core/src/identity_mapping/service.rs
+++ b/crates/core/src/identity_mapping/service.rs
@@ -97,11 +97,17 @@ impl IdentityMappingApi for IdentityMappingService {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    // use std::sync::Arc;
 
     use super::*;
     use crate::identity_mapping::backend::MockIdentityMappingBackend;
     use crate::tests::get_mocked_state;
+
+    fn create_provider(backend: MockIdentityMappingBackend) -> IdentityMappingService {
+        IdentityMappingService {
+            backend_driver: Arc::new(backend),
+        }
+    }
 
     #[tokio::test]
     async fn test_get_by_local_id() {
@@ -120,9 +126,7 @@ mod tests {
                 lid == "lid" && did == "did"
             })
             .returning(move |_, _, _, _| Ok(Some(sot_clone.clone())));
-        let provider = IdentityMappingService {
-            backend_driver: Arc::new(backend),
-        };
+        let provider = create_provider(backend);
 
         let res: IdMapping = provider
             .get_by_local_id(&state, "lid", "did", IdMappingEntityType::User)
@@ -147,9 +151,7 @@ mod tests {
             .expect_get_by_public_id()
             .withf(|_, pid: &'_ str| pid == "pid")
             .returning(move |_, _| Ok(Some(sot_clone.clone())));
-        let provider = IdentityMappingService {
-            backend_driver: Arc::new(backend),
-        };
+        let provider = create_provider(backend);
 
         let res: IdMapping = provider
             .get_by_public_id(&state, "pid")

--- a/crates/core/src/k8s_auth/hook.rs
+++ b/crates/core/src/k8s_auth/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # K8s auth provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the k8s provider to inter-provider events.
+pub struct K8sAuthHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl K8sAuthHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for K8sAuthHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/k8s_auth/mod.rs
+++ b/crates/core/src/k8s_auth/mod.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 mod auth;
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -33,6 +34,7 @@ use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 
 pub use error::K8sAuthProviderError;
+pub use hook::K8sAuthHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockK8sAuthProvider;
 pub use provider_api::K8sAuthApi;

--- a/crates/core/src/k8s_auth/service.rs
+++ b/crates/core/src/k8s_auth/service.rs
@@ -271,6 +271,13 @@ pub(crate) mod tests {
     use crate::k8s_auth::backend::MockK8sAuthBackend;
     use crate::tests::get_mocked_state;
 
+    fn create_k8s_auth_service(backend: MockK8sAuthBackend) -> K8sAuthService {
+        K8sAuthService {
+            backend_driver: Arc::new(backend),
+            http_client_pool: Box::new(HttpClientPool::default()),
+        }
+    }
+
     #[tokio::test]
     async fn test_create_auth_instance() {
         let state = get_mocked_state(None, None).await;
@@ -278,10 +285,7 @@ pub(crate) mod tests {
         backend
             .expect_create_auth_instance()
             .returning(|_, _| Ok(K8sAuthInstance::default()));
-        let provider = K8sAuthService {
-            backend_driver: Arc::new(backend),
-            http_client_pool: Box::new(HttpClientPool::default()),
-        };
+        let provider = create_k8s_auth_service(backend);
 
         assert!(
             provider
@@ -309,10 +313,7 @@ pub(crate) mod tests {
         backend
             .expect_create_auth_role()
             .returning(|_, _| Ok(K8sAuthRole::default()));
-        let provider = K8sAuthService {
-            backend_driver: Arc::new(backend),
-            http_client_pool: Box::new(HttpClientPool::default()),
-        };
+        let provider = create_k8s_auth_service(backend);
 
         assert!(
             provider

--- a/crates/core/src/keystone.rs
+++ b/crates/core/src/keystone.rs
@@ -22,6 +22,7 @@ use openstack_keystone_config::ConfigManager;
 use openstack_keystone_distributed_storage::app::{Storage, init_storage};
 
 use crate::error::KeystoneError;
+use crate::events::EventDispatcher;
 use crate::policy::PolicyEnforcer;
 use crate::provider::Provider;
 
@@ -40,6 +41,9 @@ pub struct Service {
 
     /// Service/resource Provider.
     pub provider: Provider,
+
+    /// Event dispatcher for inter-provider notifications.
+    pub event_dispatcher: Arc<EventDispatcher>,
 
     /// Distributed storage.
     pub storage: Option<Storage>,
@@ -84,6 +88,7 @@ impl Service {
         Ok(Self {
             config_manager: cfg,
             provider,
+            event_dispatcher: EventDispatcher::production(),
             db,
             policy_enforcer,
             storage,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -86,6 +86,7 @@ pub mod catalog;
 pub mod common;
 pub mod db;
 pub mod error;
+pub mod events;
 pub mod federation;
 pub mod identity;
 pub mod identity_mapping;

--- a/crates/core/src/resource/hook.rs
+++ b/crates/core/src/resource/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Resource provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the resource provider to inter-provider events.
+pub struct ResourceHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl ResourceHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for ResourceHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/resource/mod.rs
+++ b/crates/core/src/resource/mod.rs
@@ -37,6 +37,7 @@ use openstack_keystone_core_types::resource::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -47,6 +48,7 @@ use crate::plugin_manager::PluginManagerApi;
 use crate::resource::service::ResourceService;
 
 pub use crate::resource::error::ResourceProviderError;
+pub use hook::ResourceHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockResourceProvider;
 pub use provider_api::ResourceApi;

--- a/crates/core/src/resource/service.rs
+++ b/crates/core/src/resource/service.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::resource::*;
 
 use crate::keystone::ServiceState;
@@ -91,7 +92,19 @@ impl ResourceApi for ResourceService {
             new_domain.id = Some(Uuid::new_v4().simple().to_string());
         }
         new_domain.validate()?;
-        self.backend_driver.create_domain(state, new_domain).await
+        let domain = self.backend_driver.create_domain(state, new_domain).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::Domain {
+                    id: domain.id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(domain)
     }
 
     /// Create a new project.
@@ -114,7 +127,22 @@ impl ResourceApi for ResourceService {
             new_project.id = Some(Uuid::new_v4().simple().to_string());
         }
         new_project.validate()?;
-        self.backend_driver.create_project(state, new_project).await
+        let project = self
+            .backend_driver
+            .create_project(state, new_project)
+            .await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::Project {
+                    id: project.id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(project)
     }
 
     /// Delete a domain by the ID.
@@ -131,7 +159,17 @@ impl ResourceApi for ResourceService {
         state: &ServiceState,
         id: &'a str,
     ) -> Result<(), ResourceProviderError> {
-        self.backend_driver.delete_domain(state, id).await
+        self.backend_driver.delete_domain(state, id).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Domain { id: id.to_string() },
+            ))
+            .await;
+
+        Ok(())
     }
 
     /// Delete a project by the ID.
@@ -148,7 +186,17 @@ impl ResourceApi for ResourceService {
         state: &ServiceState,
         id: &'a str,
     ) -> Result<(), ResourceProviderError> {
-        self.backend_driver.delete_project(state, id).await
+        self.backend_driver.delete_project(state, id).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Project { id: id.to_string() },
+            ))
+            .await;
+
+        Ok(())
     }
 
     /// Get a single domain.

--- a/crates/core/src/revoke/hook.rs
+++ b/crates/core/src/revoke/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Revoke provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the revoke provider to inter-provider events.
+pub struct RevokeHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl RevokeHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for RevokeHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/revoke/mod.rs
+++ b/crates/core/src/revoke/mod.rs
@@ -39,6 +39,7 @@ use async_trait::async_trait;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -55,6 +56,7 @@ use crate::plugin_manager::PluginManagerApi;
 use crate::revoke::service::RevokeService;
 
 pub use error::RevokeProviderError;
+pub use hook::RevokeHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockRevokeProvider;
 pub use provider_api::RevokeApi;

--- a/crates/core/src/revoke/service.rs
+++ b/crates/core/src/revoke/service.rs
@@ -110,6 +110,12 @@ mod tests {
     use crate::revoke::backend::MockRevokeBackend;
     use crate::tests::get_mocked_state;
 
+    fn create_revoke_provider(backend: MockRevokeBackend) -> RevokeService {
+        RevokeService {
+            backend_driver: Arc::new(backend),
+        }
+    }
+
     #[tokio::test]
     async fn test_create_revocation_event() {
         let state = get_mocked_state(None, None).await;
@@ -117,9 +123,7 @@ mod tests {
         backend
             .expect_create_revocation_event()
             .returning(|_, _| Ok(RevocationEvent::default()));
-        let provider = RevokeService {
-            backend_driver: Arc::new(backend),
-        };
+        let provider = create_revoke_provider(backend);
 
         assert!(
             provider

--- a/crates/core/src/role/hook.rs
+++ b/crates/core/src/role/hook.rs
@@ -11,31 +11,27 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+//! # Role provider hooks for inter-provider events.
 
-//! # OpenStack Keystone core provider types
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
 
-#![allow(clippy::module_inception)]
-#![deny(clippy::unwrap_used)]
+/// Hook that subscribes the role provider to inter-provider events.
+pub struct RoleHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
 
-pub mod application_credential;
-pub mod assignment;
-pub mod auth;
-pub mod catalog;
-pub mod error;
-pub mod events;
-pub mod federation;
-pub mod identity;
-pub mod identity_mapping;
-pub mod k8s_auth;
-pub mod resource;
-pub mod revoke;
-pub mod role;
-pub mod scope;
-pub mod spiffe;
-pub mod token;
-pub mod trust;
+impl RoleHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
 
-/// Return `true` to be used as a positive default for the serde macros.
-pub fn default_true() -> bool {
-    true
+#[async_trait]
+impl ProviderHooks for RoleHook {
+    async fn on_event(&self, _event: &Event) {}
 }

--- a/crates/core/src/role/mod.rs
+++ b/crates/core/src/role/mod.rs
@@ -39,6 +39,7 @@ use openstack_keystone_core_types::role::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -49,6 +50,7 @@ use crate::plugin_manager::PluginManagerApi;
 use crate::role::service::RoleService;
 
 pub use error::RoleProviderError;
+pub use hook::RoleHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockRoleProvider;
 pub use provider_api::RoleApi;

--- a/crates/core/src/role/service.rs
+++ b/crates/core/src/role/service.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::role::*;
 
 use crate::keystone::ServiceState;
@@ -65,7 +66,19 @@ impl RoleApi for RoleService {
         if new_params.id.is_none() {
             new_params.id = Some(Uuid::new_v4().simple().to_string());
         }
-        self.backend_driver.create_role(state, new_params).await
+        let role = self.backend_driver.create_role(state, new_params).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::Role {
+                    id: role.id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(role)
     }
 
     /// Create a role imply rule.
@@ -80,9 +93,23 @@ impl RoleApi for RoleService {
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<RoleImply, RoleProviderError> {
-        self.backend_driver
+        let rule = self
+            .backend_driver
             .create_role_imply_rule(state, prior_role_id, implied_role_id)
-            .await
+            .await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::RoleImply {
+                    prior_role_id: prior_role_id.to_string(),
+                    implied_role_id: implied_role_id.to_string(),
+                },
+            ))
+            .await;
+
+        Ok(rule)
     }
 
     /// Check if a role imply rule exists.
@@ -112,7 +139,17 @@ impl RoleApi for RoleService {
         state: &ServiceState,
         id: &'a str,
     ) -> Result<(), RoleProviderError> {
-        self.backend_driver.delete_role(state, id).await
+        self.backend_driver.delete_role(state, id).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Role { id: id.to_string() },
+            ))
+            .await;
+
+        Ok(())
     }
 
     /// Delete a role imply rule.
@@ -129,7 +166,20 @@ impl RoleApi for RoleService {
     ) -> Result<(), RoleProviderError> {
         self.backend_driver
             .delete_role_imply_rule(state, prior_role_id, implied_role_id)
-            .await
+            .await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::RoleImply {
+                    prior_role_id: prior_role_id.to_string(),
+                    implied_role_id: implied_role_id.to_string(),
+                },
+            ))
+            .await;
+
+        Ok(())
     }
 
     /// Expand implied roles.

--- a/crates/core/src/spiffe.rs
+++ b/crates/core/src/spiffe.rs
@@ -22,17 +22,20 @@ mod mock;
 mod provider_api;
 pub mod service;
 
+pub mod hook;
+
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::spiffe::*;
 
 use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 
-pub use crate::spiffe::service::SpiffeService;
 pub use error::SpiffeProviderError;
+pub use hook::SpiffeHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockSpiffeProvider;
 pub use provider_api::SpiffeApi;
+pub use service::SpiffeService;
 
 /// Spiffe provider.
 pub enum SpiffeProvider {
@@ -42,15 +45,15 @@ pub enum SpiffeProvider {
 }
 
 impl SpiffeProvider {
-    /// Create a new `K8sAuthProvider`.
+    /// Create a new `SpiffeProvider`.
     ///
     /// # Arguments
     /// * `config` - Reference to the [`Config`].
     /// * `plugin_manager` - Reference to the [`PluginManagerApi`].
     ///
     /// # Returns
-    /// * Success with a new `K8sAuthProvider` instance.
-    /// * `K8sAuthProviderError` if the service could not be initialized.
+    /// * Success with a new `SpiffeProvider` instance.
+    /// * `SpiffeProviderError` if the service could not be initialized.
     pub fn new<P: PluginManagerApi>(
         config: &Config,
         plugin_manager: &P,

--- a/crates/core/src/spiffe/hook.rs
+++ b/crates/core/src/spiffe/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Spiffe provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the spiffe provider to inter-provider events.
+pub struct SpiffeHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl SpiffeHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for SpiffeHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/token/hook.rs
+++ b/crates/core/src/token/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Token provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the token provider to inter-provider events.
+pub struct TokenHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl TokenHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for TokenHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/token/mod.rs
+++ b/crates/core/src/token/mod.rs
@@ -27,6 +27,7 @@ pub use openstack_keystone_core_types::token::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -37,6 +38,7 @@ use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 use crate::token::service::TokenService;
 pub use error::TokenProviderError;
+pub use hook::TokenHook;
 pub use provider_api::TokenApi;
 
 #[cfg(any(test, feature = "mock"))]

--- a/crates/core/src/trust/hook.rs
+++ b/crates/core/src/trust/hook.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Trust provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the trust provider to inter-provider events.
+pub struct TrustHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl TrustHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for TrustHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/trust/mod.rs
+++ b/crates/core/src/trust/mod.rs
@@ -57,6 +57,7 @@ use openstack_keystone_core_types::trust::*;
 
 pub mod backend;
 pub mod error;
+pub mod hook;
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 mod provider_api;
@@ -68,6 +69,7 @@ use crate::trust::service::TrustService;
 use openstack_keystone_config::Config;
 
 pub use error::TrustProviderError;
+pub use hook::TrustHook;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockTrustProvider;
 pub use provider_api::TrustApi;

--- a/crates/core/src/trust/service.rs
+++ b/crates/core/src/trust/service.rs
@@ -287,6 +287,12 @@ mod tests {
     use crate::tests::get_mocked_state;
     use crate::trust::backend::MockTrustBackend;
 
+    fn create_trust_service(backend: MockTrustBackend) -> TrustService {
+        TrustService {
+            backend_driver: Arc::new(backend),
+        }
+    }
+
     #[tokio::test]
     async fn test_get_trust() {
         let mut role_mock = MockRoleProvider::default();
@@ -313,9 +319,7 @@ mod tests {
                 }))
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
 
         let trust: Trust = trust_provider
             .get_trust(&state, "fake_trust")
@@ -358,9 +362,7 @@ mod tests {
                 ]))
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
 
         let chain = trust_provider
             .get_trust_delegation_chain(&state, "fake_trust")
@@ -396,9 +398,7 @@ mod tests {
                 }))
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
         let trust = trust_provider
             .get_trust(&state, "fake_trust")
             .await
@@ -452,9 +452,7 @@ mod tests {
                 ]))
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
         let trust = trust_provider
             .get_trust(&state, "redelegated_trust")
             .await
@@ -515,9 +513,7 @@ mod tests {
                 ]))
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
         let trust = trust_provider
             .get_trust(&state, "redelegated_trust2")
             .await
@@ -591,9 +587,7 @@ mod tests {
                 ]))
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
         let trust = trust_provider
             .get_trust(&state, "redelegated_trust")
             .await
@@ -658,9 +652,7 @@ mod tests {
                 ]))
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
         let trust = trust_provider
             .get_trust(&state, "redelegated_trust2")
             .await
@@ -765,9 +757,7 @@ mod tests {
                 ]))
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
         let trust = trust_provider
             .get_trust(&state, "redelegated_trust2")
             .await
@@ -835,9 +825,7 @@ mod tests {
                 ])
             });
 
-        let trust_provider = TrustService {
-            backend_driver: Arc::new(backend),
-        };
+        let trust_provider = create_trust_service(backend);
 
         let list = trust_provider
             .list_trusts(&state, &TrustListParameters::default())

--- a/crates/identity-driver-sql/src/local_user.rs
+++ b/crates/identity-driver-sql/src/local_user.rs
@@ -157,7 +157,8 @@ pub mod tests {
             .map(|x| (lu.clone(), x.clone()))
             .collect()
     }
-    /// Create a mock local user with multiple passwords with specific IDs and created_at_int values.
+    /// Create a mock local user with multiple passwords with specific IDs and
+    /// created_at_int values.
     pub fn get_local_user_with_passwords_mock(
         user_id: &str,
         passwords: &[db_password::Model],

--- a/crates/identity-driver-sql/src/password.rs
+++ b/crates/identity-driver-sql/src/password.rs
@@ -44,7 +44,8 @@ use sea_orm::ConnectionTrait;
 /// - `conf`: The service configuration.
 /// - `local_user_id`: The local user ID.
 /// - `password`: The plaintext password to set.
-/// - `existing_passwords`: Pre-loaded existing passwords sorted DESC by creation.
+/// - `existing_passwords`: Pre-loaded existing passwords sorted DESC by
+///   creation.
 ///
 /// # Returns
 /// A `Result` containing the created `db_password::Model` if successful, or an

--- a/crates/identity-driver-sql/src/password/check_history.rs
+++ b/crates/identity-driver-sql/src/password/check_history.rs
@@ -22,9 +22,9 @@ use crate::entity::password as db_password;
 
 /// Check if a new password matches any password in the history.
 ///
-/// Compares the new password against the most recent `unique_last_password_count`
-/// password hashes. Returns an error if the new password matches any hash in
-/// the history window.
+/// Compares the new password against the most recent
+/// `unique_last_password_count` password hashes. Returns an error if the new
+/// password matches any hash in the history window.
 ///
 /// # Parameters
 /// - `conf`: The service configuration.

--- a/crates/identity-driver-sql/src/password/set.rs
+++ b/crates/identity-driver-sql/src/password/set.rs
@@ -34,7 +34,8 @@ use crate::entity::password;
 /// - `unique_count`: Number of old passwords to keep for checking uniqueness.
 /// - `password_hash`: The hashed password.
 /// - `expires_at`: The password expiration date.
-/// - `existing_passwords`: Pre-loaded existing passwords sorted DESC by creation.
+/// - `existing_passwords`: Pre-loaded existing passwords sorted DESC by
+///   creation.
 ///
 /// # Returns
 /// A `Result` containing the created `password::Model` if successful, or an
@@ -206,7 +207,8 @@ mod tests {
 
     #[tokio::test]
     async fn unique_one_two_existing_truncate_excess() {
-        // 2 existing (newest=200, older=100), unique=1 → expire 1 (newest), delete 1 (older).
+        // 2 existing (newest=200, older=100), unique=1 → expire 1 (newest), delete 1
+        // (older).
         let existing = vec![
             make_pwd(2, 200, false), // newest first
             make_pwd(3, 100, false), // older

--- a/crates/identity-driver-sql/src/user/create.rs
+++ b/crates/identity-driver-sql/src/user/create.rs
@@ -404,8 +404,8 @@ mod tests {
             }])
             // 3. Insert local_user record
             .append_query_results([vec![get_local_user_mock("1")]])
-            // 4. password::set_new_password with Vec::new() -> no expire, no delete
-            //    just insert new password record
+            // 4. password::set_new_password with Vec::new() -> no expire, no delete just insert new
+            //    password record
             .append_query_results([vec![get_password_mock(1)]])
             // 5. password::list after set_new_password
             .append_query_results([vec![get_password_mock(1)]])

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -49,14 +49,27 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 use uuid::Uuid;
 
+use openstack_keystone::application_credential::ApplicationCredentialHook;
+use openstack_keystone::assignment::AssignmentHook;
+use openstack_keystone::catalog::CatalogHook;
 use openstack_keystone::config::{ConfigManager, Interface, ListenerConfig};
 use openstack_keystone::federation::FederationApi;
+use openstack_keystone::federation::FederationHook;
+use openstack_keystone::identity::IdentityHook;
+use openstack_keystone::identity_mapping::IdentityMappingHook;
+use openstack_keystone::k8s_auth::K8sAuthHook;
 use openstack_keystone::keystone::Service as KeystoneServiceState;
 use openstack_keystone::keystone::ServiceState;
 use openstack_keystone::plugin_manager::PluginManager;
 use openstack_keystone::policy::HttpPolicyEnforcer;
 use openstack_keystone::provider::Provider;
+use openstack_keystone::resource::ResourceHook;
+use openstack_keystone::revoke::RevokeHook;
+use openstack_keystone::role::RoleHook;
 use openstack_keystone::server::listener::{raft_grpc, spiffe_tls, spiffe_tls_uds};
+use openstack_keystone::spiffe::SpiffeHook;
+use openstack_keystone::token::TokenHook;
+use openstack_keystone::trust::TrustHook;
 use openstack_keystone::webauthn;
 use openstack_keystone::{api, common};
 
@@ -225,6 +238,61 @@ async fn main() -> Result<(), Report> {
         Arc::new(KeystoneServiceState::new(cfg_mgr, conn, provider, Arc::new(policy)).await?);
 
     spawn(cleanup(cloned_token, shared_state.clone()));
+
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(ApplicationCredentialHook::new(
+            shared_state.clone(),
+        )))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(AssignmentHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(CatalogHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(FederationHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(IdentityHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(IdentityMappingHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(K8sAuthHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(ResourceHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(RevokeHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(RoleHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(SpiffeHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(TokenHook::new(shared_state.clone())))
+        .await;
+    shared_state
+        .event_dispatcher
+        .subscribe(Arc::new(TrustHook::new(shared_state.clone())))
+        .await;
 
     let x_request_id = HeaderName::from_static("x-openstack-request-id");
     let sensitive_headers: Arc<[_]> = vec![

--- a/crates/webauthn/src/api.rs
+++ b/crates/webauthn/src/api.rs
@@ -27,9 +27,11 @@ use openstack_keystone_core::error::KeystoneError;
 use openstack_keystone_core::keystone::ServiceState;
 
 mod auth;
+pub mod hook;
 mod register;
 pub mod types;
 
+use crate::api::hook::WebauthnHook;
 use crate::api::types::{CombinedExtensionState, ExtensionState};
 use crate::{WebauthnApi, WebauthnError, driver::*};
 
@@ -105,6 +107,11 @@ pub async fn init_extension_state(
         core: main_state,
         extension: extension_state,
     };
+    combined_state
+        .core
+        .event_dispatcher
+        .subscribe(Arc::new(WebauthnHook::new(combined_state.clone())))
+        .await;
     spawn(cleanup(cancellation_token, combined_state.clone()));
     Ok(combined_state)
 }

--- a/crates/webauthn/src/api/hook.rs
+++ b/crates/webauthn/src/api/hook.rs
@@ -1,0 +1,38 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Webauthn extension hook for inter-provider events.
+
+use async_trait::async_trait;
+use openstack_keystone_core::events::ProviderHooks;
+use openstack_keystone_core_types::events::Event;
+
+use crate::api::types::CombinedExtensionState;
+
+/// Hook that subscribes the webauthn extension to inter-provider events.
+pub struct WebauthnHook {
+    #[allow(unused)]
+    state: CombinedExtensionState,
+}
+
+impl WebauthnHook {
+    /// Create a new hook bound to the given extension state.
+    pub fn new(state: CombinedExtensionState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for WebauthnHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/tests/api/src/assignment/grant/project/user/role/check.rs
+++ b/tests/api/src/assignment/grant/project/user/role/check.rs
@@ -58,8 +58,9 @@ async fn test_check_auth_roles() -> Result<()> {
             &role_id,
         )
         .await?;
-        // It is absolutely possible that all roles the user get in the authorization are granted
-        // indirectly (through inheritance, groups, etc). Only try to invoke check_grant without
+        // It is absolutely possible that all roles the user get in the
+        // authorization are granted indirectly (through inheritance,
+        // groups, etc). Only try to invoke check_grant without
         // relying on the result.
     }
     Ok(())

--- a/tests/integration/src/catalog.rs
+++ b/tests/integration/src/catalog.rs
@@ -54,8 +54,8 @@ pub async fn create_region(
     Ok(AsyncResourceGuard::new(res, state.clone()))
 }
 
-/// Create a service through the catalog provider, returning a guard that deletes
-/// it again when dropped.
+/// Create a service through the catalog provider, returning a guard that
+/// deletes it again when dropped.
 pub async fn create_service(
     state: &ServiceState,
     data: ServiceCreate,


### PR DESCRIPTION
Introduce a pubsub-based event notification system allowing any provider
or extension to react to CRUD events in other providers.

The event dispatcher lives in Service (ServiceState) as the single
source of truth. Providers emit events via
`state.event_dispatcher.emit()`.  External extension crates can
subscribe via `state.event_dispatcher.tx.subscribe()` or
`state.event_dispatcher.subscribe()` with a ProviderHooks
implementation.

Design principles:
- Fire-and-forget: events dispatch in spawned tasks, main operation
  doesn't block
- Error isolation: hook panics are caught, main operation proceeds
- No recursion: hook execution does not trigger further events
- Opt-in: providers implement ProviderHooks to subscribe

Changes:
- events.rs: EventDispatcher with broadcast channel + hook subscribers
- core-types/src/events.rs: Event, Operation, EventPayload types
- Service: owns event_dispatcher (constructed via
  EventDispatcher::production())
- 13 provider services: event_dispatcher field removed, access via state
- 6 providers emit events: role, identity, resource, assignment,
  application_credential, catalog
- Provider: no longer holds redundant dispatcher copy or forwards to
  sub-providers
