### PR TITLE
feat: Add endpoint CRUD to the catalog provider

### DIFF
--- a/crates/catalog-driver-sql/src/endpoint.rs
+++ b/crates/catalog-driver-sql/src/endpoint.rs
@@ -12,19 +12,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use sea_orm::entity::*;
 use serde_json::Value;
 use tracing::error;
+use uuid::Uuid;
 
 use openstack_keystone_core::catalog::CatalogProviderError;
 use openstack_keystone_core_types::catalog::*;
 
 use crate::entity::endpoint as db_endpoint;
 
+mod create;
+mod delete;
 mod get;
 mod list;
+mod update;
 
+pub use create::create;
+pub use delete::delete;
 pub use get::get;
 pub use list::list;
+pub use update::update;
 
 impl TryFrom<db_endpoint::Model> for Endpoint {
     type Error = CatalogProviderError;
@@ -60,6 +68,33 @@ impl TryFrom<db_endpoint::Model> for Endpoint {
         }
 
         Ok(builder.build()?)
+    }
+}
+
+impl TryFrom<EndpointCreate> for db_endpoint::ActiveModel {
+    type Error = CatalogProviderError;
+
+    /// Tries to convert endpoint creation parameters into a database active
+    /// model.
+    ///
+    /// # Parameters
+    /// - `value`: The endpoint creation parameters.
+    ///
+    /// # Returns
+    /// A `Result` containing the `ActiveModel`, or a `CatalogProviderError`.
+    fn try_from(value: EndpointCreate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: Set(value
+                .id
+                .unwrap_or_else(|| Uuid::new_v4().simple().to_string())),
+            legacy_endpoint_id: Set(None),
+            interface: Set(value.interface),
+            service_id: Set(value.service_id),
+            url: Set(value.url),
+            extra: Set(Some(serde_json::to_string(&value.extra)?)),
+            enabled: Set(value.enabled),
+            region_id: Set(value.region_id),
+        })
     }
 }
 

--- a/crates/catalog-driver-sql/src/endpoint/create.rs
+++ b/crates/catalog-driver-sql/src/endpoint/create.rs
@@ -1,0 +1,86 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Create Endpoint
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::catalog::{Endpoint, EndpointCreate};
+
+use crate::entity::endpoint as db_endpoint;
+
+/// Creates a new endpoint.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `endpoint`: The endpoint creation parameters.
+///
+/// # Returns
+/// A `Result` containing the created `Endpoint`, or an `Error`.
+pub async fn create(
+    db: &DatabaseConnection,
+    endpoint: EndpointCreate,
+) -> Result<Endpoint, CatalogProviderError> {
+    TryInto::<db_endpoint::ActiveModel>::try_into(endpoint)?
+        .insert(db)
+        .await
+        .context("creating endpoint")?
+        .try_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![db_endpoint::Model {
+                id: "ep-1".into(),
+                legacy_endpoint_id: None,
+                interface: "public".into(),
+                service_id: "svc-1".into(),
+                url: "http://localhost".into(),
+                extra: None,
+                enabled: true,
+                region_id: Some("region-1".into()),
+            }]])
+            .into_connection();
+
+        let endpoint_create = EndpointCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: Some("ep-1".to_string()),
+            interface: "public".to_string(),
+            region_id: Some("region-1".to_string()),
+            service_id: "svc-1".to_string(),
+            url: "http://localhost".to_string(),
+        };
+
+        let created = create(&db, endpoint_create).await.unwrap();
+
+        assert_eq!(created.id, "ep-1");
+        assert_eq!(created.interface, "public");
+        assert_eq!(created.service_id, "svc-1");
+        assert_eq!(created.url, "http://localhost");
+        assert_eq!(created.region_id.as_deref(), Some("region-1"));
+        assert!(created.enabled);
+    }
+}

--- a/crates/catalog-driver-sql/src/endpoint/delete.rs
+++ b/crates/catalog-driver-sql/src/endpoint/delete.rs
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Delete Endpoint
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core::error::DbContextExt;
+
+use crate::entity::prelude::Endpoint as DbEndpoint;
+
+/// Deletes an existing endpoint.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `id`: The endpoint ID.
+///
+/// # Returns
+/// A `Result` indicating success or an `Error`.
+pub async fn delete<S: AsRef<str>>(
+    db: &DatabaseConnection,
+    id: S,
+) -> Result<(), CatalogProviderError> {
+    DbEndpoint::delete_by_id(id.as_ref())
+        .exec(db)
+        .await
+        .context("deleting endpoint")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Transaction};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_delete() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
+            .into_connection();
+
+        delete(&db, "id").await.unwrap();
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"DELETE FROM "endpoint" WHERE "endpoint"."id" = $1"#,
+                ["id".into()]
+            ),]
+        );
+    }
+}

--- a/crates/catalog-driver-sql/src/endpoint/update.rs
+++ b/crates/catalog-driver-sql/src/endpoint/update.rs
@@ -1,0 +1,113 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Update Endpoint
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::catalog::CatalogProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::catalog::{Endpoint, EndpointUpdate};
+
+use crate::entity::{endpoint as db_endpoint, prelude::Endpoint as DbEndpoint};
+
+/// Updates an existing endpoint.
+///
+/// Only the fields set in `endpoint` are changed; the rest are left as-is.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `id`: The ID of the endpoint to update.
+/// - `endpoint`: The fields to change.
+///
+/// # Returns
+/// A `Result` containing the updated `Endpoint`, or an `Error` (including
+/// `EndpointNotFound` if no endpoint with that ID exists).
+pub async fn update<I: AsRef<str>>(
+    db: &DatabaseConnection,
+    id: I,
+    endpoint: EndpointUpdate,
+) -> Result<Endpoint, CatalogProviderError> {
+    let existing = DbEndpoint::find_by_id(id.as_ref())
+        .one(db)
+        .await
+        .context("fetching endpoint for update")?
+        .ok_or_else(|| CatalogProviderError::EndpointNotFound(id.as_ref().to_string()))?;
+
+    let mut update_model: db_endpoint::ActiveModel = existing.into();
+
+    if let Some(enabled) = endpoint.enabled {
+        update_model.enabled = Set(enabled);
+    }
+    if let Some(interface) = endpoint.interface {
+        update_model.interface = Set(interface);
+    }
+    if let Some(region_id) = endpoint.region_id {
+        update_model.region_id = Set(Some(region_id));
+    }
+    if let Some(service_id) = endpoint.service_id {
+        update_model.service_id = Set(service_id);
+    }
+    if let Some(url) = endpoint.url {
+        update_model.url = Set(url);
+    }
+    if let Some(extra) = endpoint.extra {
+        update_model.extra = Set(Some(serde_json::to_string(&extra)?));
+    }
+
+    update_model
+        .update(db)
+        .await
+        .context("updating endpoint")?
+        .try_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    use super::super::tests::get_endpoint_mock;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // 1. fetch the existing endpoint
+            .append_query_results([vec![get_endpoint_mock("1")]])
+            // 2. the UPDATE returns the updated row
+            .append_query_results([vec![get_endpoint_mock("1")]])
+            .into_connection();
+
+        let req = EndpointUpdate {
+            enabled: Some(false),
+            ..Default::default()
+        };
+
+        let result = update(&db, "1", req).await;
+        assert!(result.is_ok(), "update failed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<db_endpoint::Model>::new()])
+            .into_connection();
+
+        let result = update(&db, "missing", EndpointUpdate::default()).await;
+        assert!(matches!(
+            result,
+            Err(CatalogProviderError::EndpointNotFound(_))
+        ));
+    }
+}

--- a/crates/catalog-driver-sql/src/lib.rs
+++ b/crates/catalog-driver-sql/src/lib.rs
@@ -55,6 +55,23 @@ inventory::submit! {
 
 #[async_trait]
 impl CatalogBackend for SqlBackend {
+    /// Create a new endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `endpoint_data`: The endpoint creation parameters.
+    ///
+    /// # Returns
+    /// A `Result` containing the created `Endpoint`, or a `CatalogProviderError`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn create_endpoint(
+        &self,
+        state: &ServiceState,
+        endpoint_data: EndpointCreate,
+    ) -> Result<Endpoint, CatalogProviderError> {
+        Ok(endpoint::create(&state.db, endpoint_data).await?)
+    }
+
     /// Create a new region.
     ///
     /// # Parameters
@@ -88,6 +105,23 @@ impl CatalogBackend for SqlBackend {
         service_data: ServiceCreate,
     ) -> Result<Service, CatalogProviderError> {
         Ok(service::create(&state.db, service_data).await?)
+    }
+
+    /// Delete an endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `id`: The ID of the endpoint to delete.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn delete_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError> {
+        Ok(endpoint::delete(&state.db, id).await?)
     }
 
     /// Delete a region by ID.
@@ -248,6 +282,25 @@ impl CatalogBackend for SqlBackend {
         params: &ServiceListParameters,
     ) -> Result<Vec<Service>, CatalogProviderError> {
         Ok(service::list(&state.db, params).await?)
+    }
+
+    /// Update an existing endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The service state containing the database connection.
+    /// - `id`: The ID of the endpoint to update.
+    /// - `endpoint_data`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Endpoint`, or a `CatalogProviderError`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn update_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        endpoint_data: EndpointUpdate,
+    ) -> Result<Endpoint, CatalogProviderError> {
+        Ok(endpoint::update(&state.db, id, endpoint_data).await?)
     }
 
     /// Update an existing region.

--- a/crates/core-types/src/catalog/endpoint.rs
+++ b/crates/core-types/src/catalog/endpoint.rs
@@ -12,16 +12,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use derive_builder::Builder;
 use serde_json::Value;
+use validator::Validate;
 
 use crate::error::BuilderError;
 
-#[derive(Builder, Clone, Debug, Default, PartialEq)]
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Endpoint {
     /// The ID of the endpoint.
+    #[validate(length(min = 1, max = 64))]
     pub id: String,
     /// The interface type, which describes the visibility of the endpoint.
     /// Value is:
@@ -34,11 +38,14 @@ pub struct Endpoint {
     ///   - admin. Visible by administrative users on a secure network
     ///     interface.
     #[builder(default)]
+    #[validate(length(max = 8))]
     pub interface: String,
     /// The ID of the region that contains the service endpoint.
     #[builder(default)]
+    #[validate(length(max = 255))]
     pub region_id: Option<String>,
     /// The UUID of the service to which the endpoint belongs.
+    #[validate(length(max = 64))]
     pub service_id: String,
     /// The endpoint URL.
     pub url: String,
@@ -51,14 +58,74 @@ pub struct Endpoint {
     pub extra: Option<Value>,
 }
 
-#[derive(Builder, Clone, Debug, Default, PartialEq)]
+/// Parameters for creating a new endpoint.
+#[derive(Clone, Debug, Default, PartialEq, Validate)]
+pub struct EndpointCreate {
+    /// Whether the endpoint appears in the service catalog.
+    pub enabled: bool,
+
+    /// Additional endpoint properties.
+    pub extra: HashMap<String, Value>,
+
+    /// The ID of the endpoint. A UUID is generated when omitted.
+    #[validate(length(min = 1, max = 64))]
+    pub id: Option<String>,
+
+    /// The interface type (`public`, `internal`, or `admin`).
+    #[validate(length(max = 8))]
+    pub interface: String,
+
+    /// The ID of the region that contains the endpoint.
+    #[validate(length(max = 255))]
+    pub region_id: Option<String>,
+
+    /// The UUID of the service to which the endpoint belongs.
+    #[validate(length(max = 64))]
+    pub service_id: String,
+
+    /// The endpoint URL.
+    pub url: String,
+}
+
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct EndpointListParameters {
     /// Filters the response by an interface.
+    #[validate(length(max = 8))]
     pub interface: Option<String>,
     /// Filters the response by a service ID.
+    #[validate(length(max = 64))]
     pub service_id: Option<String>,
     /// Filters the response by a region ID.
+    #[validate(length(max = 255))]
     pub region_id: Option<String>,
+}
+
+/// Fields that can be changed when updating an endpoint.
+///
+/// Each field is `None` when the caller did not provide it (leave unchanged) and
+/// `Some(..)` to set a new value.
+#[derive(Clone, Debug, Default, PartialEq, Validate)]
+pub struct EndpointUpdate {
+    /// New enabled flag.
+    pub enabled: Option<bool>,
+
+    /// New additional endpoint properties (replaces the existing `extra`).
+    pub extra: Option<HashMap<String, Value>>,
+
+    /// New interface type.
+    #[validate(length(max = 8))]
+    pub interface: Option<String>,
+
+    /// New region ID.
+    #[validate(length(max = 255))]
+    pub region_id: Option<String>,
+
+    /// New service ID.
+    #[validate(length(max = 64))]
+    pub service_id: Option<String>,
+
+    /// New endpoint URL.
+    pub url: Option<String>,
 }

--- a/crates/core-types/src/catalog/error.rs
+++ b/crates/core-types/src/catalog/error.rs
@@ -31,6 +31,10 @@ pub enum CatalogProviderError {
         #[from]
         source: serde_json::Error,
     },
+    /// The endpoint has not been found.
+    #[error("endpoint {0} not found")]
+    EndpointNotFound(String),
+
     /// The service has not been found.
     #[error("service {0} not found")]
     ServiceNotFound(String),

--- a/crates/core/src/catalog/backend.rs
+++ b/crates/core/src/catalog/backend.rs
@@ -22,6 +22,20 @@ use crate::keystone::ServiceState;
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait CatalogBackend: Send + Sync {
+    /// Create a new endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `endpoint`: The endpoint creation parameters.
+    ///
+    /// # Returns
+    /// A `Result` containing the created `Endpoint`, or a `CatalogProviderError`.
+    async fn create_endpoint(
+        &self,
+        state: &ServiceState,
+        endpoint: EndpointCreate,
+    ) -> Result<Endpoint, CatalogProviderError>;
+
     /// Create a new region.
     ///
     /// # Parameters
@@ -50,6 +64,20 @@ pub trait CatalogBackend: Send + Sync {
         state: &ServiceState,
         service: ServiceCreate,
     ) -> Result<Service, CatalogProviderError>;
+
+    /// Delete an endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    async fn delete_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError>;
 
     /// Delete a region by ID.
     ///
@@ -183,6 +211,22 @@ pub trait CatalogBackend: Send + Sync {
         state: &ServiceState,
         params: &ServiceListParameters,
     ) -> Result<Vec<Service>, CatalogProviderError>;
+
+    /// Update an existing endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    /// - `endpoint`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Endpoint`, or a `CatalogProviderError`.
+    async fn update_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        endpoint: EndpointUpdate,
+    ) -> Result<Endpoint, CatalogProviderError>;
 
     /// Update an existing region.
     ///

--- a/crates/core/src/catalog/mock.rs
+++ b/crates/core/src/catalog/mock.rs
@@ -26,6 +26,12 @@ mock! {
 
     #[async_trait]
     impl CatalogApi for CatalogProvider {
+        async fn create_endpoint(
+            &self,
+            state: &ServiceState,
+            endpoint: EndpointCreate,
+        ) -> Result<Endpoint, CatalogProviderError>;
+
         async fn create_region(
             &self,
             state: &ServiceState,
@@ -37,6 +43,12 @@ mock! {
             state: &ServiceState,
             service: ServiceCreate,
         ) -> Result<Service, CatalogProviderError>;
+
+        async fn delete_endpoint<'a>(
+            &self,
+            state: &ServiceState,
+            id: &'a str,
+        ) -> Result<(), CatalogProviderError>;
 
         async fn delete_region<'a>(
             &self,
@@ -91,6 +103,13 @@ mock! {
             state: &ServiceState,
             params: &ServiceListParameters
         ) -> Result<Vec<Service>, CatalogProviderError>;
+
+        async fn update_endpoint<'a>(
+            &self,
+            state: &ServiceState,
+            id: &'a str,
+            endpoint: EndpointUpdate,
+        ) -> Result<Endpoint, CatalogProviderError>;
 
         async fn update_region<'a>(
             &self,

--- a/crates/core/src/catalog/mod.rs
+++ b/crates/core/src/catalog/mod.rs
@@ -79,6 +79,27 @@ impl CatalogProvider {
 
 #[async_trait]
 impl CatalogApi for CatalogProvider {
+    /// Create a new endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `endpoint`: The endpoint creation parameters.
+    ///
+    /// # Returns
+    /// A `Result` containing the created `Endpoint`, or a `CatalogProviderError`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn create_endpoint(
+        &self,
+        state: &ServiceState,
+        endpoint: EndpointCreate,
+    ) -> Result<Endpoint, CatalogProviderError> {
+        match self {
+            Self::Service(provider) => provider.create_endpoint(state, endpoint).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.create_endpoint(state, endpoint).await,
+        }
+    }
+
     /// Create a new region.
     ///
     /// # Parameters
@@ -119,6 +140,27 @@ impl CatalogApi for CatalogProvider {
             Self::Service(provider) => provider.create_service(state, service).await,
             #[cfg(any(test, feature = "mock"))]
             Self::Mock(provider) => provider.create_service(state, service).await,
+        }
+    }
+
+    /// Delete an endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn delete_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError> {
+        match self {
+            Self::Service(provider) => provider.delete_endpoint(state, id).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.delete_endpoint(state, id).await,
         }
     }
 
@@ -315,6 +357,29 @@ impl CatalogApi for CatalogProvider {
             Self::Service(provider) => provider.list_services(state, params).await,
             #[cfg(any(test, feature = "mock"))]
             Self::Mock(provider) => provider.list_services(state, params).await,
+        }
+    }
+
+    /// Update an existing endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    /// - `endpoint`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Endpoint`, or a `CatalogProviderError`.
+    #[tracing::instrument(level = "info", skip(self, state))]
+    async fn update_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        endpoint: EndpointUpdate,
+    ) -> Result<Endpoint, CatalogProviderError> {
+        match self {
+            Self::Service(provider) => provider.update_endpoint(state, id, endpoint).await,
+            #[cfg(any(test, feature = "mock"))]
+            Self::Mock(provider) => provider.update_endpoint(state, id, endpoint).await,
         }
     }
 

--- a/crates/core/src/catalog/provider_api.rs
+++ b/crates/core/src/catalog/provider_api.rs
@@ -21,6 +21,20 @@ use crate::keystone::ServiceState;
 
 #[async_trait]
 pub trait CatalogApi: Send + Sync {
+    /// Create a new endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `endpoint`: The endpoint creation parameters.
+    ///
+    /// # Returns
+    /// A `Result` containing the created `Endpoint`, or a `CatalogProviderError`.
+    async fn create_endpoint(
+        &self,
+        state: &ServiceState,
+        endpoint: EndpointCreate,
+    ) -> Result<Endpoint, CatalogProviderError>;
+
     /// Create a new region.
     ///
     /// # Parameters
@@ -49,6 +63,20 @@ pub trait CatalogApi: Send + Sync {
         state: &ServiceState,
         service: ServiceCreate,
     ) -> Result<Service, CatalogProviderError>;
+
+    /// Delete an endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    async fn delete_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError>;
 
     /// Delete a region by ID.
     ///
@@ -182,6 +210,22 @@ pub trait CatalogApi: Send + Sync {
         state: &ServiceState,
         params: &ServiceListParameters,
     ) -> Result<Vec<Service>, CatalogProviderError>;
+
+    /// Update an existing endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    /// - `endpoint`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Endpoint`, or a `CatalogProviderError`.
+    async fn update_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        endpoint: EndpointUpdate,
+    ) -> Result<Endpoint, CatalogProviderError>;
 
     /// Update an existing region.
     ///

--- a/crates/core/src/catalog/service.rs
+++ b/crates/core/src/catalog/service.rs
@@ -51,6 +51,35 @@ impl CatalogService {
 
 #[async_trait]
 impl CatalogApi for CatalogService {
+    /// Create a new endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `endpoint`: The endpoint creation parameters.
+    ///
+    /// # Returns
+    /// A `Result` containing the created `Endpoint`, or a `CatalogProviderError`.
+    async fn create_endpoint(
+        &self,
+        state: &ServiceState,
+        endpoint: EndpointCreate,
+    ) -> Result<Endpoint, CatalogProviderError> {
+        endpoint.validate()?;
+        let endpoint = self.backend_driver.create_endpoint(state, endpoint).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Create,
+                EventPayload::Endpoint {
+                    id: endpoint.id.clone(),
+                },
+            ))
+            .await;
+
+        Ok(endpoint)
+    }
+
     /// Create a new region.
     ///
     /// # Parameters
@@ -108,6 +137,32 @@ impl CatalogApi for CatalogService {
             .await;
 
         Ok(service)
+    }
+
+    /// Delete an endpoint by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `CatalogProviderError`.
+    async fn delete_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CatalogProviderError> {
+        self.backend_driver.delete_endpoint(state, id).await?;
+
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Delete,
+                EventPayload::Endpoint { id: id.to_string() },
+            ))
+            .await;
+
+        Ok(())
     }
 
     /// Delete a region by ID.
@@ -244,6 +299,7 @@ impl CatalogApi for CatalogService {
         state: &ServiceState,
         params: &EndpointListParameters,
     ) -> Result<Vec<Endpoint>, CatalogProviderError> {
+        params.validate()?;
         self.backend_driver.list_endpoints(state, params).await
     }
 
@@ -281,6 +337,36 @@ impl CatalogApi for CatalogService {
     ) -> Result<Vec<Service>, CatalogProviderError> {
         params.validate()?;
         self.backend_driver.list_services(state, params).await
+    }
+
+    /// Update an existing endpoint.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The unique identifier of the endpoint.
+    /// - `endpoint`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Endpoint`, or a `CatalogProviderError`.
+    async fn update_endpoint<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        endpoint: EndpointUpdate,
+    ) -> Result<Endpoint, CatalogProviderError> {
+        endpoint.validate()?;
+        let updated = self
+            .backend_driver
+            .update_endpoint(state, id, endpoint)
+            .await?;
+        state
+            .event_dispatcher
+            .emit(Event::new(
+                Operation::Update,
+                EventPayload::Endpoint { id: id.to_string() },
+            ))
+            .await;
+        Ok(updated)
     }
 
     /// Update an existing region.

--- a/tests/integration/src/catalog.rs
+++ b/tests/integration/src/catalog.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+mod endpoint;
 mod region;
 mod service;
 
@@ -31,6 +32,7 @@ use openstack_keystone_core_types::catalog::*;
 use crate::common::*;
 use crate::impl_deleter;
 
+impl_deleter!(Service, Endpoint, get_catalog_provider, delete_endpoint);
 impl_deleter!(Service, Region, get_catalog_provider, delete_region);
 impl_deleter!(
     Service,
@@ -38,6 +40,21 @@ impl_deleter!(
     get_catalog_provider,
     delete_service
 );
+
+/// Create an endpoint through the catalog provider, returning a guard that
+/// deletes it again when dropped.
+pub async fn create_endpoint(
+    state: &ServiceState,
+    data: EndpointCreate,
+) -> Result<AsyncResourceGuard<Endpoint, ServiceState>> {
+    let res = state
+        .provider
+        .get_catalog_provider()
+        .create_endpoint(state, data)
+        .await
+        .unwrap();
+    Ok(AsyncResourceGuard::new(res, state.clone()))
+}
 
 /// Create a region through the catalog provider, returning a guard that deletes
 /// it again when dropped.

--- a/tests/integration/src/catalog/endpoint.rs
+++ b/tests/integration/src/catalog/endpoint.rs
@@ -1,0 +1,19 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod create;
+mod delete;
+mod get;
+mod list;
+mod update;

--- a/tests/integration/src/catalog/endpoint/create.rs
+++ b/tests/integration/src/catalog/endpoint/create.rs
@@ -1,0 +1,93 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test endpoint creation.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::{EndpointCreate, ServiceCreate};
+
+use crate::catalog::{create_endpoint, create_service};
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_create() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let service = create_service(
+        &state,
+        ServiceCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: None,
+            r#type: Some("compute".to_string()),
+        },
+    )
+    .await?;
+
+    let endpoint = create_endpoint(
+        &state,
+        EndpointCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: None,
+            interface: "public".to_string(),
+            region_id: None,
+            service_id: service.id.clone(),
+            url: "http://localhost:8774".to_string(),
+        },
+    )
+    .await?;
+
+    // An ID is generated when none is provided.
+    assert!(!endpoint.id.is_empty());
+    assert_eq!(endpoint.interface, "public");
+    assert_eq!(endpoint.service_id, service.id);
+    assert_eq!(endpoint.url, "http://localhost:8774");
+    assert!(endpoint.enabled);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_id_too_long() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    // The endpoint id is limited to 64 characters by the validator.
+    let too_long = "x".repeat(65);
+    let result = state
+        .provider
+        .get_catalog_provider()
+        .create_endpoint(
+            &state,
+            EndpointCreate {
+                enabled: true,
+                extra: HashMap::new(),
+                id: Some(too_long),
+                interface: "public".to_string(),
+                region_id: None,
+                service_id: "some-service".to_string(),
+                url: "http://localhost".to_string(),
+            },
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected a validation error for an id longer than 64 characters"
+    );
+    Ok(())
+}

--- a/tests/integration/src/catalog/endpoint/delete.rs
+++ b/tests/integration/src/catalog/endpoint/delete.rs
@@ -1,0 +1,64 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test deleting an endpoint.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::{EndpointCreate, ServiceCreate};
+
+use crate::catalog::create_service;
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_delete() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let provider = state.provider.get_catalog_provider();
+
+    let service = create_service(
+        &state,
+        ServiceCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: None,
+            r#type: Some("compute".to_string()),
+        },
+    )
+    .await?;
+
+    let endpoint = provider
+        .create_endpoint(
+            &state,
+            EndpointCreate {
+                enabled: true,
+                extra: HashMap::new(),
+                id: Some("del-ep".to_string()),
+                interface: "public".to_string(),
+                region_id: None,
+                service_id: service.id.clone(),
+                url: "http://localhost".to_string(),
+            },
+        )
+        .await?;
+
+    provider.delete_endpoint(&state, &endpoint.id).await?;
+
+    let fetched = provider.get_endpoint(&state, &endpoint.id).await?;
+    assert!(fetched.is_none(), "endpoint should be gone after delete");
+    Ok(())
+}

--- a/tests/integration/src/catalog/endpoint/get.rs
+++ b/tests/integration/src/catalog/endpoint/get.rs
@@ -1,0 +1,82 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test fetching a single endpoint.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::{EndpointCreate, ServiceCreate};
+
+use crate::catalog::{create_endpoint, create_service};
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_get() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let service = create_service(
+        &state,
+        ServiceCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: None,
+            r#type: Some("image".to_string()),
+        },
+    )
+    .await?;
+
+    let endpoint = create_endpoint(
+        &state,
+        EndpointCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: Some("endpoint-get".to_string()),
+            interface: "internal".to_string(),
+            region_id: None,
+            service_id: service.id.clone(),
+            url: "http://localhost:9292".to_string(),
+        },
+    )
+    .await?;
+
+    let fetched = state
+        .provider
+        .get_catalog_provider()
+        .get_endpoint(&state, &endpoint.id)
+        .await?;
+
+    assert!(fetched.is_some());
+    let fetched = fetched.unwrap();
+    assert_eq!(fetched.id, "endpoint-get");
+    assert_eq!(fetched.interface, "internal");
+    assert_eq!(fetched.service_id, service.id);
+    assert_eq!(fetched.url, "http://localhost:9292");
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let fetched = state
+        .provider
+        .get_catalog_provider()
+        .get_endpoint(&state, "does-not-exist")
+        .await?;
+    assert!(fetched.is_none());
+    Ok(())
+}

--- a/tests/integration/src/catalog/endpoint/list.rs
+++ b/tests/integration/src/catalog/endpoint/list.rs
@@ -1,0 +1,106 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test listing endpoints.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::{
+    EndpointCreate, EndpointListParameters, ServiceCreate,
+};
+
+use crate::catalog::{create_endpoint, create_service};
+use crate::common::get_state;
+
+fn endpoint(id: &str, interface: &str, service_id: &str) -> EndpointCreate {
+    EndpointCreate {
+        enabled: true,
+        extra: HashMap::new(),
+        id: Some(id.to_string()),
+        interface: interface.to_string(),
+        region_id: None,
+        service_id: service_id.to_string(),
+        url: "http://localhost".to_string(),
+    }
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_list() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let service = create_service(
+        &state,
+        ServiceCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: None,
+            r#type: Some("compute".to_string()),
+        },
+    )
+    .await?;
+
+    let _e1 = create_endpoint(&state, endpoint("list-e1", "public", &service.id)).await?;
+    let _e2 = create_endpoint(&state, endpoint("list-e2", "internal", &service.id)).await?;
+
+    let endpoints = state
+        .provider
+        .get_catalog_provider()
+        .list_endpoints(&state, &EndpointListParameters::default())
+        .await?;
+
+    let ids: Vec<&str> = endpoints.iter().map(|e| e.id.as_str()).collect();
+    assert!(ids.contains(&"list-e1"));
+    assert!(ids.contains(&"list-e2"));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_list_filter_by_interface() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let service = create_service(
+        &state,
+        ServiceCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: None,
+            r#type: Some("compute".to_string()),
+        },
+    )
+    .await?;
+
+    let _p1 = create_endpoint(&state, endpoint("pub-1", "public", &service.id)).await?;
+    let _i1 = create_endpoint(&state, endpoint("int-1", "internal", &service.id)).await?;
+
+    let endpoints = state
+        .provider
+        .get_catalog_provider()
+        .list_endpoints(
+            &state,
+            &EndpointListParameters {
+                interface: Some("public".to_string()),
+                service_id: Some(service.id.clone()),
+                region_id: None,
+            },
+        )
+        .await?;
+
+    let ids: Vec<&str> = endpoints.iter().map(|e| e.id.as_str()).collect();
+    assert!(ids.contains(&"pub-1"));
+    assert!(!ids.contains(&"int-1"));
+    Ok(())
+}

--- a/tests/integration/src/catalog/endpoint/update.rs
+++ b/tests/integration/src/catalog/endpoint/update.rs
@@ -1,0 +1,154 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test updating an endpoint.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core_types::catalog::{EndpointCreate, EndpointUpdate, ServiceCreate};
+
+use crate::catalog::{create_endpoint, create_service};
+use crate::common::get_state;
+
+#[traced_test]
+#[tokio::test]
+async fn test_update() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let service = create_service(
+        &state,
+        ServiceCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: None,
+            r#type: Some("compute".to_string()),
+        },
+    )
+    .await?;
+
+    let endpoint = create_endpoint(
+        &state,
+        EndpointCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: Some("upd-ep".to_string()),
+            interface: "public".to_string(),
+            region_id: None,
+            service_id: service.id.clone(),
+            url: "http://localhost:8774".to_string(),
+        },
+    )
+    .await?;
+
+    let updated = state
+        .provider
+        .get_catalog_provider()
+        .update_endpoint(
+            &state,
+            &endpoint.id,
+            EndpointUpdate {
+                enabled: Some(false),
+                url: Some("http://localhost:9999".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(!updated.enabled);
+    assert_eq!(updated.url, "http://localhost:9999");
+
+    // Confirm the change was persisted.
+    let fetched = state
+        .provider
+        .get_catalog_provider()
+        .get_endpoint(&state, &endpoint.id)
+        .await?
+        .unwrap();
+    assert!(!fetched.enabled);
+    assert_eq!(fetched.url, "http://localhost:9999");
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let result = state
+        .provider
+        .get_catalog_provider()
+        .update_endpoint(
+            &state,
+            "missing",
+            EndpointUpdate {
+                enabled: Some(true),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected a not-found error when updating an endpoint that does not exist"
+    );
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_interface_too_long() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let service = create_service(
+        &state,
+        ServiceCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: None,
+            r#type: Some("compute".to_string()),
+        },
+    )
+    .await?;
+
+    let endpoint = create_endpoint(
+        &state,
+        EndpointCreate {
+            enabled: true,
+            extra: HashMap::new(),
+            id: Some("upd-long".to_string()),
+            interface: "public".to_string(),
+            region_id: None,
+            service_id: service.id.clone(),
+            url: "http://localhost".to_string(),
+        },
+    )
+    .await?;
+
+    let too_long = "x".repeat(256);
+    let result = state
+        .provider
+        .get_catalog_provider()
+        .update_endpoint(
+            &state,
+            &endpoint.id,
+            EndpointUpdate {
+                interface: Some(too_long),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected a validation error for a too-long interface"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Extends the catalog with endpoint CRUD, following the same pattern as service 

* Adds EndpointCreate and EndpointUpdate types in core-types with validator length limits (id and service_id max 64, interface and region_id max 255; url is left unbounded since it maps to a Text column) and alphabetized fields.
* Adds create, update, and delete to the catalog-sql driver. Read, list, and get already existed. Unlike service, an endpoint's interface, service_id, url, and region_id are real database columns, so no extra-blob merging is needed.
* Wires the new methods through the CatalogApi provider including provider_api, service, mock, and mod, calling validate() early in create, update, and list.
* Adds integration tests under tests/integration/src/catalog/endpoint/ covering create, get, list with interface filter, update, and delete, plus not-found and over-length validation cases.

Closes #725 

Note: this contribution was developed with AI assistance.