### PR TITLE
chore: Add mock raft storage for unittest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4040,6 +4040,7 @@ dependencies = [
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "openstack-keystone-distributed-storage",
+ "tokio",
  "tracing",
  "uuid",
 ]
@@ -4113,6 +4114,7 @@ dependencies = [
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "openstack-keystone-distributed-storage",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/crates/k8s-auth-driver-raft/Cargo.toml
+++ b/crates/k8s-auth-driver-raft/Cargo.toml
@@ -20,6 +20,9 @@ tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+openstack-keystone-distributed-storage = { workspace = true, features = ["mock"] }
+tokio = { workspace = true, features = ["rt"] }
+uuid = { workspace = true, features = ["v4"] }
 
 [lints]
 workspace = true

--- a/crates/k8s-auth-driver-raft/src/lib.rs
+++ b/crates/k8s-auth-driver-raft/src/lib.rs
@@ -21,7 +21,7 @@ use openstack_keystone_core::k8s_auth::error::K8sAuthProviderError;
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core_types::k8s_auth::*;
 use openstack_keystone_distributed_storage::{
-    Metadata, StorageApi, StoreDataEnvelope, store_command::Mutation,
+    Metadata, StorageApi, StoreDataEnvelope, StoreError, store_command::Mutation,
 };
 
 /// Raft Database K8s auth backend.
@@ -159,6 +159,326 @@ impl RaftBackend {
     fn get_auth_role_by_instance_id_prefix<D: AsRef<str>>(&self, instance_id: D) -> String {
         format!("k8s_auth:role:instance:{}:", instance_id.as_ref(),)
     }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn create_auth_instance_impl(
+        &self,
+        storage: &impl StorageApi,
+        instance: K8sAuthInstanceCreate,
+    ) -> Result<K8sAuthInstance, StoreError> {
+        let obj = K8sAuthInstance::from(instance);
+        let mutations = vec![
+            Mutation::set(
+                self.get_auth_instance_id_key_name(&obj.id),
+                obj.clone(),
+                Metadata::new(),
+                None::<&str>,
+                None,
+            )?,
+            Mutation::set_index(
+                self.get_auth_instance_domain_id_idx_key_name(&obj.id, &obj.domain_id),
+            )?,
+        ];
+        storage.transaction(mutations).await?;
+        Ok(obj)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn create_auth_role_impl(
+        &self,
+        storage: &impl StorageApi,
+        role: K8sAuthRoleCreate,
+    ) -> Result<K8sAuthRole, StoreError> {
+        let obj = K8sAuthRole::from(role);
+        let mutations = vec![
+            Mutation::set(
+                self.get_auth_role_id_key_name(&obj.id),
+                obj.clone(),
+                Metadata::new(),
+                None::<&str>,
+                None,
+            )?,
+            Mutation::set_index(
+                self.get_auth_role_domain_id_idx_key_name(&obj.id, &obj.domain_id),
+            )?,
+            Mutation::set_index(
+                self.get_auth_role_instance_id_idx_key_name(&obj.id, &obj.auth_instance_id),
+            )?,
+        ];
+        storage.transaction(mutations).await?;
+        Ok(obj)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn delete_auth_instance_impl(
+        &self,
+        storage: &impl StorageApi,
+        id: &str,
+    ) -> Result<(), StoreError> {
+        let curr: Option<K8sAuthInstance> = storage
+            .get_by_key(self.get_auth_instance_id_key_name(id), None::<&str>)
+            .await?
+            .map(|x| x.data);
+        if let Some(obj) = curr {
+            let mutations = vec![
+                Mutation::remove(self.get_auth_instance_id_key_name(id), None::<&str>)?,
+                Mutation::remove_index(
+                    self.get_auth_instance_domain_id_idx_key_name(id, &obj.domain_id),
+                )?,
+            ];
+            storage.transaction(mutations).await?;
+        }
+        Ok(())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn delete_auth_role_impl(
+        &self,
+        storage: &impl StorageApi,
+        id: &str,
+    ) -> Result<(), StoreError> {
+        let curr: Option<K8sAuthRole> = storage
+            .get_by_key(self.get_auth_role_id_key_name(id), None::<&str>)
+            .await?
+            .map(|x| x.data);
+        if let Some(obj) = curr {
+            let mutations = vec![
+                Mutation::remove(self.get_auth_role_id_key_name(&obj.id), None::<&str>)?,
+                Mutation::remove_index(
+                    self.get_auth_role_domain_id_idx_key_name(&obj.id, &obj.domain_id),
+                )?,
+                Mutation::remove_index(
+                    self.get_auth_role_instance_id_idx_key_name(&obj.id, &obj.auth_instance_id),
+                )?,
+            ];
+            storage.transaction(mutations).await?;
+        }
+        Ok(())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn get_auth_instance_impl(
+        &self,
+        storage: &impl StorageApi,
+        id: &str,
+    ) -> Result<Option<K8sAuthInstance>, StoreError> {
+        Ok(storage
+            .get_by_key(self.get_auth_instance_id_key_name(id), None::<&str>)
+            .await?
+            .map(|x| x.data))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn get_auth_role_impl(
+        &self,
+        storage: &impl StorageApi,
+        id: &str,
+    ) -> Result<Option<K8sAuthRole>, StoreError> {
+        Ok(storage
+            .get_by_key(self.get_auth_role_id_key_name(id), None::<&str>)
+            .await?
+            .map(|x| x.data))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn list_auth_instances_impl(
+        &self,
+        storage: &impl StorageApi,
+        params: &K8sAuthInstanceListParameters,
+    ) -> Result<Vec<K8sAuthInstance>, StoreError> {
+        let mut res: Vec<K8sAuthInstance> = Vec::new();
+        let mut post_filters: Vec<K8sAuthInstanceFilter> = Vec::new();
+        if let Some(val) = &params.name {
+            post_filters.push(K8sAuthInstanceFilter::Name(val.clone()));
+        }
+
+        let mut pre_filter_ids: BTreeSet<String> = BTreeSet::new();
+        if let Some(did) = &params.domain_id {
+            post_filters.push(K8sAuthInstanceFilter::Domain(did.clone()));
+            let prefix = self.get_auth_instance_by_domain_id_prefix(did);
+            let id_offset = if prefix.ends_with(':') {
+                prefix.len()
+            } else {
+                prefix.len() + 1
+            };
+            pre_filter_ids.extend(
+                storage
+                    .prefix_index(self.get_auth_instance_by_domain_id_prefix(did))
+                    .await?
+                    .into_iter()
+                    .map(|entry| entry[id_offset..].into()),
+            );
+        }
+
+        if !pre_filter_ids.is_empty() {
+            for id in pre_filter_ids {
+                if let Some(candidate) = storage
+                    .get_by_key::<K8sAuthInstance, String, &str>(
+                        self.get_auth_instance_id_key_name(id),
+                        None::<&str>,
+                    )
+                    .await?
+                    .map(|x| x.data)
+                    && post_filters.iter().all(|f| f.matches(&candidate))
+                {
+                    res.push(candidate);
+                }
+            }
+        } else {
+            for candidate in storage
+                .prefix::<K8sAuthInstance, String, &str>(
+                    self.get_auth_instance_prefix(),
+                    None::<&str>,
+                )
+                .await?
+                .into_iter()
+                .map(|(_, v)| v.data)
+            {
+                if post_filters.iter().all(|f| f.matches(&candidate)) {
+                    res.push(candidate);
+                }
+            }
+        }
+        Ok(res)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn list_auth_roles_impl(
+        &self,
+        storage: &impl StorageApi,
+        params: &K8sAuthRoleListParameters,
+    ) -> Result<Vec<K8sAuthRole>, StoreError> {
+        let mut res: Vec<K8sAuthRole> = Vec::new();
+        let mut post_filters: Vec<K8sAuthRoleFilter> = Vec::new();
+        if let Some(val) = &params.name {
+            post_filters.push(K8sAuthRoleFilter::Name(val.clone()));
+        }
+        let mut pre_filter_ids: BTreeSet<String> = BTreeSet::new();
+
+        if let Some(did) = &params.domain_id {
+            post_filters.push(K8sAuthRoleFilter::Domain(did.clone()));
+            let prefix = self.get_auth_role_by_domain_id_prefix(did);
+            let id_offset = if prefix.ends_with(':') {
+                prefix.len()
+            } else {
+                prefix.len() + 1
+            };
+            pre_filter_ids.extend(
+                storage
+                    .prefix_index(self.get_auth_role_by_domain_id_prefix(did))
+                    .await?
+                    .into_iter()
+                    .map(|entry| entry[id_offset..].into()),
+            );
+        }
+        if let Some(did) = &params.auth_instance_id {
+            post_filters.push(K8sAuthRoleFilter::Instance(did.clone()));
+            let prefix = self.get_auth_role_by_instance_id_prefix(did);
+            let id_offset = if prefix.ends_with(':') {
+                prefix.len()
+            } else {
+                prefix.len() + 1
+            };
+            let by_instance_ids: BTreeSet<String> = storage
+                .prefix_index(self.get_auth_role_by_instance_id_prefix(did))
+                .await?
+                .into_iter()
+                .map(|entry| entry[id_offset..].into())
+                .collect();
+            if pre_filter_ids.is_empty() {
+                pre_filter_ids = by_instance_ids;
+            } else {
+                pre_filter_ids.retain(|x| by_instance_ids.contains(x));
+            }
+        }
+
+        if !pre_filter_ids.is_empty() {
+            for id in pre_filter_ids {
+                if let Some(candidate) = storage
+                    .get_by_key::<K8sAuthRole, String, &str>(
+                        self.get_auth_role_id_key_name(id),
+                        None::<&str>,
+                    )
+                    .await?
+                    .map(|x| x.data)
+                    && post_filters.iter().all(|f| f.matches(&candidate))
+                {
+                    res.push(candidate);
+                }
+            }
+        } else {
+            for candidate in storage
+                .prefix::<K8sAuthRole, String, &str>(self.get_auth_role_prefix(), None::<&str>)
+                .await?
+                .into_iter()
+                .map(|(_, v)| v.data)
+            {
+                if post_filters.iter().all(|f| f.matches(&candidate)) {
+                    res.push(candidate);
+                }
+            }
+        }
+
+        Ok(res)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn update_auth_instance_impl(
+        &self,
+        storage: &impl StorageApi,
+        id: &str,
+        data: K8sAuthInstanceUpdate,
+    ) -> Result<K8sAuthInstance, StoreError> {
+        let curr: StoreDataEnvelope<K8sAuthInstance> = storage
+            .get_by_key(self.get_auth_instance_id_key_name(id), None::<&str>)
+            .await?
+            .ok_or_else(|| StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })?;
+        let new = curr.data.with_update(data);
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                self.get_auth_instance_id_key_name(id),
+                StoreDataEnvelope {
+                    data: new.clone(),
+                    metadata: new_meta,
+                },
+                None::<&str>,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(new)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn update_auth_role_impl(
+        &self,
+        storage: &impl StorageApi,
+        id: &str,
+        data: K8sAuthRoleUpdate,
+    ) -> Result<K8sAuthRole, StoreError> {
+        let curr: StoreDataEnvelope<K8sAuthRole> = storage
+            .get_by_key(self.get_auth_role_id_key_name(id), None::<&str>)
+            .await?
+            .ok_or_else(|| StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })?;
+        let new = curr.data.with_update(data);
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                self.get_auth_role_id_key_name(id),
+                StoreDataEnvelope {
+                    data: new.clone(),
+                    metadata: new_meta,
+                },
+                None::<&str>,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(new)
+    }
 }
 
 #[async_trait]
@@ -180,25 +500,9 @@ impl K8sAuthBackend for RaftBackend {
         let raft = state
             .get_storage()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        let obj = K8sAuthInstance::from(instance);
-        let mutations = vec![
-            Mutation::set(
-                self.get_auth_instance_id_key_name(&obj.id),
-                obj.clone(),
-                Metadata::new(),
-                None::<&str>,
-                None,
-            )
-            .map_err(K8sAuthProviderError::raft)?,
-            Mutation::set_index(
-                self.get_auth_instance_domain_id_idx_key_name(&obj.id, &obj.domain_id),
-            )
-            .map_err(K8sAuthProviderError::raft)?,
-        ];
-        raft.transaction(mutations)
+        self.create_auth_instance_impl(raft, instance)
             .await
-            .map_err(K8sAuthProviderError::raft)?;
-        Ok(obj)
+            .map_err(K8sAuthProviderError::raft)
     }
 
     /// Register new K8s auth role.
@@ -219,27 +523,9 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        let obj = K8sAuthRole::from(role);
-        let mutations = vec![
-            Mutation::set(
-                self.get_auth_role_id_key_name(&obj.id),
-                obj.clone(),
-                Metadata::new(),
-                None::<&str>,
-                None,
-            )
-            .map_err(K8sAuthProviderError::raft)?,
-            Mutation::set_index(self.get_auth_role_domain_id_idx_key_name(&obj.id, &obj.domain_id))
-                .map_err(K8sAuthProviderError::raft)?,
-            Mutation::set_index(
-                self.get_auth_role_instance_id_idx_key_name(&obj.id, &obj.auth_instance_id),
-            )
-            .map_err(K8sAuthProviderError::raft)?,
-        ];
-        raft.transaction(mutations)
+        self.create_auth_role_impl(raft, role)
             .await
-            .map_err(K8sAuthProviderError::raft)?;
-        Ok(obj)
+            .map_err(K8sAuthProviderError::raft)
     }
 
     /// Delete K8s auth.
@@ -260,26 +546,9 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        // Find the current object to be able to cleanup indexes as well
-        let curr: Option<K8sAuthInstance> = raft
-            .get_by_key(self.get_auth_instance_id_key_name(id), None::<&str>)
+        self.delete_auth_instance_impl(raft, id)
             .await
-            .map_err(K8sAuthProviderError::raft)?
-            .map(|x| x.data);
-        if let Some(obj) = curr {
-            let mutations = vec![
-                Mutation::remove(self.get_auth_instance_id_key_name(id), None::<&str>)
-                    .map_err(K8sAuthProviderError::raft)?,
-                Mutation::remove_index(
-                    self.get_auth_instance_domain_id_idx_key_name(id, &obj.domain_id),
-                )
-                .map_err(K8sAuthProviderError::raft)?,
-            ];
-            raft.transaction(mutations)
-                .await
-                .map_err(K8sAuthProviderError::raft)?;
-        }
-        Ok(())
+            .map_err(K8sAuthProviderError::raft)
     }
 
     /// Delete K8s auth role.
@@ -300,30 +569,9 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        // Find the current object to be able to cleanup indexes as well
-        let curr: Option<K8sAuthRole> = raft
-            .get_by_key(self.get_auth_role_id_key_name(id), None::<&str>)
+        self.delete_auth_role_impl(raft, id)
             .await
-            .map_err(K8sAuthProviderError::raft)?
-            .map(|x| x.data);
-        if let Some(obj) = curr {
-            let mutations = vec![
-                Mutation::remove(self.get_auth_role_id_key_name(&obj.id), None::<&str>)
-                    .map_err(K8sAuthProviderError::raft)?,
-                Mutation::remove_index(
-                    self.get_auth_role_domain_id_idx_key_name(&obj.id, &obj.domain_id),
-                )
-                .map_err(K8sAuthProviderError::raft)?,
-                Mutation::remove_index(
-                    self.get_auth_role_instance_id_idx_key_name(&obj.id, &obj.auth_instance_id),
-                )
-                .map_err(K8sAuthProviderError::raft)?,
-            ];
-            raft.transaction(mutations)
-                .await
-                .map_err(K8sAuthProviderError::raft)?;
-        }
-        Ok(())
+            .map_err(K8sAuthProviderError::raft)
     }
 
     /// Get K8s auth instance.
@@ -345,11 +593,9 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        Ok(raft
-            .get_by_key(self.get_auth_instance_id_key_name(id), None::<&str>)
+        self.get_auth_instance_impl(raft, id)
             .await
-            .map_err(K8sAuthProviderError::raft)?
-            .map(|x| x.data))
+            .map_err(K8sAuthProviderError::raft)
     }
 
     /// Get K8s auth role.
@@ -371,11 +617,9 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        Ok(raft
-            .get_by_key(self.get_auth_role_id_key_name(id), None::<&str>)
+        self.get_auth_role_impl(raft, id)
             .await
-            .map_err(K8sAuthProviderError::raft)?
-            .map(|x| x.data))
+            .map_err(K8sAuthProviderError::raft)
     }
 
     /// List K8s auth auth_instances.
@@ -396,63 +640,9 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        let mut res: Vec<K8sAuthInstance> = Vec::new();
-        let mut post_filters: Vec<K8sAuthInstanceFilter> = Vec::new();
-        if let Some(val) = &params.name {
-            post_filters.push(K8sAuthInstanceFilter::Name(val.clone()));
-        }
-
-        let mut pre_filter_ids: BTreeSet<String> = BTreeSet::new();
-        if let Some(did) = &params.domain_id {
-            post_filters.push(K8sAuthInstanceFilter::Domain(did.clone()));
-            // pre-calculate the ID candidates by the DOMAIN_ID filter
-            let prefix = self.get_auth_instance_by_domain_id_prefix(did);
-            let id_offset = if prefix.ends_with(':') {
-                prefix.len()
-            } else {
-                prefix.len() + 1
-            };
-            pre_filter_ids.extend(
-                raft.prefix_index(self.get_auth_instance_by_domain_id_prefix(did))
-                    .await
-                    .map_err(K8sAuthProviderError::raft)?
-                    .into_iter()
-                    .map(|entry| entry[id_offset..].into()),
-            );
-        }
-
-        if !pre_filter_ids.is_empty() {
-            for id in pre_filter_ids {
-                if let Some(candidate) = raft
-                    .get_by_key::<K8sAuthInstance, String, &str>(
-                        self.get_auth_instance_id_key_name(id),
-                        None::<&str>,
-                    )
-                    .await
-                    .map_err(K8sAuthProviderError::raft)?
-                    .map(|x| x.data)
-                    && post_filters.iter().all(|f| f.matches(&candidate))
-                {
-                    res.push(candidate);
-                }
-            }
-        } else {
-            for candidate in raft
-                .prefix::<K8sAuthInstance, String, &str>(
-                    self.get_auth_instance_prefix(),
-                    None::<&str>,
-                )
-                .await
-                .map_err(K8sAuthProviderError::raft)?
-                .into_iter()
-                .map(|(_, v)| v.data)
-            {
-                if post_filters.iter().all(|f| f.matches(&candidate)) {
-                    res.push(candidate);
-                }
-            }
-        }
-        Ok(res)
+        self.list_auth_instances_impl(raft, params)
+            .await
+            .map_err(K8sAuthProviderError::raft)
     }
 
     /// List K8s auth roles.
@@ -473,83 +663,9 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        let mut res: Vec<K8sAuthRole> = Vec::new();
-        let mut post_filters: Vec<K8sAuthRoleFilter> = Vec::new();
-        if let Some(val) = &params.name {
-            post_filters.push(K8sAuthRoleFilter::Name(val.clone()));
-        }
-        let mut pre_filter_ids: BTreeSet<String> = BTreeSet::new();
-
-        if let Some(did) = &params.domain_id {
-            post_filters.push(K8sAuthRoleFilter::Domain(did.clone()));
-            // pre-calculate the ID candidates by the DOMAIN_ID filter
-            let prefix = self.get_auth_role_by_domain_id_prefix(did);
-            let id_offset = if prefix.ends_with(':') {
-                prefix.len()
-            } else {
-                prefix.len() + 1
-            };
-            pre_filter_ids.extend(
-                raft.prefix_index(self.get_auth_role_by_domain_id_prefix(did))
-                    .await
-                    .map_err(K8sAuthProviderError::raft)?
-                    .into_iter()
-                    .map(|entry| entry[id_offset..].into()),
-            );
-        }
-        if let Some(did) = &params.auth_instance_id {
-            post_filters.push(K8sAuthRoleFilter::Instance(did.clone()));
-            // pre-calculate the ID candidates by the DOMAIN_ID filter
-            let prefix = self.get_auth_role_by_instance_id_prefix(did);
-            let id_offset = if prefix.ends_with(':') {
-                prefix.len()
-            } else {
-                prefix.len() + 1
-            };
-            let by_instance_ids: BTreeSet<String> = raft
-                .prefix_index(self.get_auth_role_by_instance_id_prefix(did))
-                .await
-                .map_err(K8sAuthProviderError::raft)?
-                .into_iter()
-                .map(|entry| entry[id_offset..].into())
-                .collect();
-            if pre_filter_ids.is_empty() {
-                pre_filter_ids = by_instance_ids;
-            } else {
-                pre_filter_ids.retain(|x| by_instance_ids.contains(x));
-            }
-        }
-
-        if !pre_filter_ids.is_empty() {
-            for id in pre_filter_ids {
-                if let Some(candidate) = raft
-                    .get_by_key::<K8sAuthRole, String, &str>(
-                        self.get_auth_role_id_key_name(id),
-                        None::<&str>,
-                    )
-                    .await
-                    .map_err(K8sAuthProviderError::raft)?
-                    .map(|x| x.data)
-                    && post_filters.iter().all(|f| f.matches(&candidate))
-                {
-                    res.push(candidate);
-                }
-            }
-        } else {
-            for candidate in raft
-                .prefix::<K8sAuthRole, String, &str>(self.get_auth_role_prefix(), None::<&str>)
-                .await
-                .map_err(K8sAuthProviderError::raft)?
-                .into_iter()
-                .map(|(_, v)| v.data)
-            {
-                if post_filters.iter().all(|f| f.matches(&candidate)) {
-                    res.push(candidate);
-                }
-            }
-        }
-
-        Ok(res)
+        self.list_auth_roles_impl(raft, params)
+            .await
+            .map_err(K8sAuthProviderError::raft)
     }
 
     /// Update K8s auth.
@@ -572,25 +688,16 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        let curr: StoreDataEnvelope<K8sAuthInstance> = raft
-            .get_by_key(self.get_auth_instance_id_key_name(id), None::<&str>)
-            .await
-            .map_err(K8sAuthProviderError::raft)?
-            .ok_or(K8sAuthProviderError::AuthInstanceNotFound(id.to_string()))?;
-        let new = curr.data.with_update(data);
-        let new_meta = curr.metadata.new_revision();
-        raft.set_value(
-            self.get_auth_instance_id_key_name(id),
-            StoreDataEnvelope {
-                data: new.clone(),
-                metadata: new_meta,
-            },
-            None::<&str>,
-            Some(curr.metadata.revision),
-        )
-        .await
-        .map_err(K8sAuthProviderError::raft)?;
-        Ok(new)
+        match self.update_auth_instance_impl(raft, id, data).await {
+            Ok(i) => Ok(i),
+            Err(e) => {
+                if e.to_string().contains("NotFound") {
+                    Err(K8sAuthProviderError::AuthInstanceNotFound(id.to_string()))
+                } else {
+                    Err(K8sAuthProviderError::raft(e))
+                }
+            }
+        }
     }
 
     /// Update K8s auth role.
@@ -613,25 +720,16 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        let curr: StoreDataEnvelope<K8sAuthRole> = raft
-            .get_by_key(self.get_auth_role_id_key_name(id), None::<&str>)
-            .await
-            .map_err(K8sAuthProviderError::raft)?
-            .ok_or(K8sAuthProviderError::RoleNotFound(id.to_string()))?;
-        let new = curr.data.with_update(data);
-        let new_meta = curr.metadata.new_revision();
-        raft.set_value(
-            self.get_auth_role_id_key_name(id),
-            StoreDataEnvelope {
-                data: new.clone(),
-                metadata: new_meta,
-            },
-            None::<&str>,
-            Some(curr.metadata.revision),
-        )
-        .await
-        .map_err(K8sAuthProviderError::raft)?;
-        Ok(new)
+        match self.update_auth_role_impl(raft, id, data).await {
+            Ok(r) => Ok(r),
+            Err(e) => {
+                if e.to_string().contains("NotFound") {
+                    Err(K8sAuthProviderError::RoleNotFound(id.to_string()))
+                } else {
+                    Err(K8sAuthProviderError::raft(e))
+                }
+            }
+        }
     }
 }
 
@@ -642,4 +740,317 @@ impl K8sAuthBackend for RaftBackend {
 pub fn anchor() {}
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+    use openstack_keystone_distributed_storage::mock::MockStorage;
+
+    fn make_instance(id: &str, domain_id: &str) -> K8sAuthInstanceCreate {
+        K8sAuthInstanceCreate {
+            id: Some(id.to_string()),
+            domain_id: domain_id.to_string(),
+            enabled: true,
+            host: "https://k8s.example.com".to_string(),
+            ca_cert: None,
+            disable_local_ca_jwt: None,
+            name: None,
+        }
+    }
+
+    fn make_role(id: &str, domain_id: &str, instance_id: &str) -> K8sAuthRoleCreate {
+        K8sAuthRoleCreate {
+            id: Some(id.to_string()),
+            domain_id: domain_id.to_string(),
+            auth_instance_id: instance_id.to_string(),
+            enabled: true,
+            name: "test-role".to_string(),
+            token_restriction_id: "tr-1".to_string(),
+            bound_audience: None,
+            bound_service_account_names: vec!["default".to_string()],
+            bound_service_account_namespaces: vec!["default".to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_auth_instance() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let inst = make_instance("inst-1", "domain-1");
+        let result = backend
+            .create_auth_instance_impl(&storage, inst.clone())
+            .await;
+        assert!(result.is_ok());
+        let created = result.unwrap();
+        assert_eq!(created.id, "inst-1");
+        assert_eq!(created.domain_id, "domain-1");
+
+        let found = backend.get_auth_instance_impl(&storage, "inst-1").await;
+        assert!(found.is_ok());
+        assert!(found.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_auth_instance_not_found() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let result = backend
+            .get_auth_instance_impl(&storage, "nonexistent")
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_auth_instance() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_instance_impl(&storage, make_instance("inst-1", "domain-1"))
+            .await
+            .unwrap();
+
+        backend
+            .delete_auth_instance_impl(&storage, "inst-1")
+            .await
+            .unwrap();
+
+        let found = backend.get_auth_instance_impl(&storage, "inst-1").await;
+        assert!(found.is_ok());
+        assert!(found.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_auth_role() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let role = make_role("role-1", "domain-1", "inst-1");
+        let result = backend.create_auth_role_impl(&storage, role.clone()).await;
+        assert!(result.is_ok());
+        let created = result.unwrap();
+        assert_eq!(created.id, "role-1");
+        assert_eq!(created.auth_instance_id, "inst-1");
+
+        let found = backend.get_auth_role_impl(&storage, "role-1").await;
+        assert!(found.is_ok());
+        assert!(found.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_delete_auth_role() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_role_impl(&storage, make_role("role-1", "domain-1", "inst-1"))
+            .await
+            .unwrap();
+
+        backend
+            .delete_auth_role_impl(&storage, "role-1")
+            .await
+            .unwrap();
+
+        let found = backend.get_auth_role_impl(&storage, "role-1").await;
+        assert!(found.is_ok());
+        assert!(found.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_auth_instances_all() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_instance_impl(&storage, make_instance("inst-1", "domain-1"))
+            .await
+            .unwrap();
+        backend
+            .create_auth_instance_impl(&storage, make_instance("inst-2", "domain-2"))
+            .await
+            .unwrap();
+
+        let params = K8sAuthInstanceListParameters {
+            domain_id: None,
+            name: None,
+        };
+        let result = backend.list_auth_instances_impl(&storage, &params).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_auth_instances_by_domain() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_instance_impl(&storage, make_instance("inst-1", "domain-1"))
+            .await
+            .unwrap();
+        backend
+            .create_auth_instance_impl(&storage, make_instance("inst-2", "domain-2"))
+            .await
+            .unwrap();
+
+        let params = K8sAuthInstanceListParameters {
+            domain_id: Some("domain-1".to_string()),
+            name: None,
+        };
+        let result = backend.list_auth_instances_impl(&storage, &params).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_auth_roles_by_domain_and_instance() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_role_impl(&storage, make_role("role-1", "domain-1", "inst-1"))
+            .await
+            .unwrap();
+        backend
+            .create_auth_role_impl(&storage, make_role("role-2", "domain-1", "inst-2"))
+            .await
+            .unwrap();
+        backend
+            .create_auth_role_impl(&storage, make_role("role-3", "domain-2", "inst-1"))
+            .await
+            .unwrap();
+
+        let params = K8sAuthRoleListParameters {
+            domain_id: Some("domain-1".to_string()),
+            auth_instance_id: Some("inst-1".to_string()),
+            name: None,
+        };
+        let result = backend.list_auth_roles_impl(&storage, &params).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_update_auth_instance() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_instance_impl(&storage, make_instance("inst-1", "domain-1"))
+            .await
+            .unwrap();
+
+        let update = K8sAuthInstanceUpdate {
+            enabled: Some(false),
+            ..K8sAuthInstanceUpdate::default()
+        };
+        let result = backend
+            .update_auth_instance_impl(&storage, "inst-1", update)
+            .await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap().enabled);
+    }
+
+    #[tokio::test]
+    async fn test_update_auth_instance_not_found() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let update = K8sAuthInstanceUpdate::default();
+        let result = backend
+            .update_auth_instance_impl(&storage, "nonexistent", update)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_update_auth_role() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_role_impl(&storage, make_role("role-1", "domain-1", "inst-1"))
+            .await
+            .unwrap();
+
+        let update = K8sAuthRoleUpdate {
+            enabled: Some(false),
+            ..K8sAuthRoleUpdate::default()
+        };
+        let result = backend
+            .update_auth_role_impl(&storage, "role-1", update)
+            .await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap().enabled);
+    }
+
+    #[tokio::test]
+    async fn test_instance_indexes_created_and_cleaned() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_instance_impl(&storage, make_instance("inst-1", "domain-1"))
+            .await
+            .unwrap();
+
+        let idx = storage
+            .prefix_index("k8s_auth:instance:domain:domain-1:")
+            .await
+            .unwrap();
+        assert_eq!(idx.len(), 1);
+
+        backend
+            .delete_auth_instance_impl(&storage, "inst-1")
+            .await
+            .unwrap();
+
+        let idx = storage
+            .prefix_index("k8s_auth:instance:domain:domain-1:")
+            .await
+            .unwrap();
+        assert_eq!(idx.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_role_indexes_created_and_cleaned() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_auth_role_impl(&storage, make_role("role-1", "domain-1", "inst-1"))
+            .await
+            .unwrap();
+
+        let idx_domain = storage
+            .prefix_index("k8s_auth:role:domain:domain-1:")
+            .await
+            .unwrap();
+        assert_eq!(idx_domain.len(), 1);
+
+        let idx_instance = storage
+            .prefix_index("k8s_auth:role:instance:inst-1:")
+            .await
+            .unwrap();
+        assert_eq!(idx_instance.len(), 1);
+
+        backend
+            .delete_auth_role_impl(&storage, "role-1")
+            .await
+            .unwrap();
+
+        let idx_domain = storage
+            .prefix_index("k8s_auth:role:domain:domain-1:")
+            .await
+            .unwrap();
+        assert_eq!(idx_domain.len(), 0);
+
+        let idx_instance = storage
+            .prefix_index("k8s_auth:role:instance:inst-1:")
+            .await
+            .unwrap();
+        assert_eq!(idx_instance.len(), 0);
+    }
+}

--- a/crates/spiffe-driver-raft/Cargo.toml
+++ b/crates/spiffe-driver-raft/Cargo.toml
@@ -19,5 +19,10 @@ openstack-keystone-distributed-storage.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 
+[dev-dependencies]
+openstack-keystone-distributed-storage = { workspace = true, features = ["mock"] }
+tokio = { workspace = true, features = ["rt"] }
+uuid = { workspace = true, features = ["v4"] }
+
 [lints]
 workspace = true

--- a/crates/spiffe-driver-raft/src/lib.rs
+++ b/crates/spiffe-driver-raft/src/lib.rs
@@ -21,7 +21,7 @@ use openstack_keystone_core::spiffe::backend::SpiffeBackend;
 use openstack_keystone_core::spiffe::error::SpiffeProviderError;
 use openstack_keystone_core_types::spiffe::*;
 use openstack_keystone_distributed_storage::{
-    Metadata, StorageApi, StoreDataEnvelope, store_command::Mutation,
+    Metadata, StorageApi, StoreDataEnvelope, StoreError, store_command::Mutation,
 };
 
 /// Raft Database SPIFFE identity backend.
@@ -78,6 +78,147 @@ impl RaftBackend {
     fn get_binding_by_domain_id_prefix<D: AsRef<str>>(&self, domain_id: D) -> String {
         format!("spiffe:binding:domain:{}:", domain_id.as_ref(),)
     }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn create_binding_impl(
+        &self,
+        storage: &impl StorageApi,
+        binding: SpiffeBindingCreate,
+    ) -> Result<SpiffeBinding, StoreError> {
+        let obj = SpiffeBinding::from(binding);
+        let mutations = vec![
+            Mutation::set(
+                self.get_binding_id_key_name(&obj.svid),
+                obj.clone(),
+                Metadata::new(),
+                None::<&str>,
+                None,
+            )?,
+            Mutation::set_index(
+                self.get_binding_domain_id_idx_key_name(&obj.svid, &obj.domain_id),
+            )?,
+        ];
+        storage.transaction(mutations).await?;
+        Ok(obj)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn delete_binding_impl(
+        &self,
+        storage: &impl StorageApi,
+        svid: &str,
+    ) -> Result<(), StoreError> {
+        let curr: Option<SpiffeBinding> = storage
+            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
+            .await?
+            .map(|x| x.data);
+        if let Some(obj) = curr {
+            let mutations = vec![
+                Mutation::remove(self.get_binding_id_key_name(svid), None::<&str>)?,
+                Mutation::remove_index(
+                    self.get_binding_domain_id_idx_key_name(svid, &obj.domain_id),
+                )?,
+            ];
+            storage.transaction(mutations).await?;
+        }
+        Ok(())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn get_binding_impl(
+        &self,
+        storage: &impl StorageApi,
+        svid: &str,
+    ) -> Result<Option<SpiffeBinding>, StoreError> {
+        Ok(storage
+            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
+            .await?
+            .map(|x| x.data))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn list_bindings_impl(
+        &self,
+        storage: &impl StorageApi,
+        params: &SpiffeBindingListParameters,
+    ) -> Result<Vec<SpiffeBinding>, StoreError> {
+        let mut res: Vec<SpiffeBinding> = Vec::new();
+        let mut post_filters: Vec<SpiffeBindingFilter> = Vec::new();
+        let mut pre_filter_ids: BTreeSet<String> = BTreeSet::new();
+        if let Some(did) = &params.domain_id {
+            post_filters.push(SpiffeBindingFilter::Domain(did.clone()));
+            let prefix = self.get_binding_by_domain_id_prefix(did);
+            let id_offset = if prefix.ends_with(':') {
+                prefix.len()
+            } else {
+                prefix.len() + 1
+            };
+            pre_filter_ids.extend(
+                storage
+                    .prefix_index(self.get_binding_by_domain_id_prefix(did))
+                    .await?
+                    .into_iter()
+                    .map(|entry| entry[id_offset..].into()),
+            );
+        }
+
+        if !pre_filter_ids.is_empty() {
+            for id in pre_filter_ids {
+                if let Some(candidate) = storage
+                    .get_by_key::<SpiffeBinding, String, &str>(
+                        self.get_binding_id_key_name(id),
+                        None::<&str>,
+                    )
+                    .await?
+                    .map(|x| x.data)
+                    && post_filters.iter().all(|f| f.matches(&candidate))
+                {
+                    res.push(candidate);
+                }
+            }
+        } else {
+            for candidate in storage
+                .prefix::<SpiffeBinding, String, &str>(self.get_binding_prefix(), None::<&str>)
+                .await?
+                .into_iter()
+                .map(|(_, v)| v.data)
+            {
+                if post_filters.iter().all(|f| f.matches(&candidate)) {
+                    res.push(candidate);
+                }
+            }
+        }
+        Ok(res)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn update_binding_impl(
+        &self,
+        storage: &impl StorageApi,
+        svid: &str,
+        data: SpiffeBindingUpdate,
+    ) -> Result<SpiffeBinding, StoreError> {
+        let curr: StoreDataEnvelope<SpiffeBinding> = storage
+            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
+            .await?
+            .ok_or_else(|| StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })?;
+        let new = curr.data.with_update(data);
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                self.get_binding_id_key_name(svid),
+                StoreDataEnvelope {
+                    data: new.clone(),
+                    metadata: new_meta,
+                },
+                None::<&str>,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(new)
+    }
 }
 
 #[async_trait]
@@ -99,23 +240,9 @@ impl SpiffeBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(SpiffeProviderError::RaftNotAvailable)?;
-        let obj = SpiffeBinding::from(binding);
-        let mutations = vec![
-            Mutation::set(
-                self.get_binding_id_key_name(&obj.svid),
-                obj.clone(),
-                Metadata::new(),
-                None::<&str>,
-                None,
-            )
-            .map_err(SpiffeProviderError::raft)?,
-            Mutation::set_index(self.get_binding_domain_id_idx_key_name(&obj.svid, &obj.domain_id))
-                .map_err(SpiffeProviderError::raft)?,
-        ];
-        raft.transaction(mutations)
+        self.create_binding_impl(raft, binding)
             .await
-            .map_err(SpiffeProviderError::raft)?;
-        Ok(obj)
+            .map_err(SpiffeProviderError::raft)
     }
 
     /// Delete SPIFFE binding.
@@ -136,26 +263,9 @@ impl SpiffeBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(SpiffeProviderError::RaftNotAvailable)?;
-        // Find the current object to be able to cleanup indexes as well
-        let curr: Option<SpiffeBinding> = raft
-            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
+        self.delete_binding_impl(raft, svid)
             .await
-            .map_err(SpiffeProviderError::raft)?
-            .map(|x| x.data);
-        if let Some(obj) = curr {
-            let mutations = vec![
-                Mutation::remove(self.get_binding_id_key_name(svid), None::<&str>)
-                    .map_err(SpiffeProviderError::raft)?,
-                Mutation::remove_index(
-                    self.get_binding_domain_id_idx_key_name(svid, &obj.domain_id),
-                )
-                .map_err(SpiffeProviderError::raft)?,
-            ];
-            raft.transaction(mutations)
-                .await
-                .map_err(SpiffeProviderError::raft)?;
-        }
-        Ok(())
+            .map_err(SpiffeProviderError::raft)
     }
 
     /// Fetch binding for the SVID.
@@ -176,11 +286,9 @@ impl SpiffeBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(SpiffeProviderError::RaftNotAvailable)?;
-        Ok(raft
-            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
+        self.get_binding_impl(raft, svid)
             .await
-            .map_err(SpiffeProviderError::raft)?
-            .map(|x| x.data))
+            .map_err(SpiffeProviderError::raft)
     }
 
     /// List SpiffeBindings.
@@ -201,56 +309,9 @@ impl SpiffeBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(SpiffeProviderError::RaftNotAvailable)?;
-        let mut res: Vec<SpiffeBinding> = Vec::new();
-        let mut post_filters: Vec<SpiffeBindingFilter> = Vec::new();
-        let mut pre_filter_ids: BTreeSet<String> = BTreeSet::new();
-        if let Some(did) = &params.domain_id {
-            post_filters.push(SpiffeBindingFilter::Domain(did.clone()));
-            // pre-calculate the ID candidates by the DOMAIN_ID filter
-            let prefix = self.get_binding_by_domain_id_prefix(did);
-            let id_offset = if prefix.ends_with(':') {
-                prefix.len()
-            } else {
-                prefix.len() + 1
-            };
-            pre_filter_ids.extend(
-                raft.prefix_index(self.get_binding_by_domain_id_prefix(did))
-                    .await
-                    .map_err(SpiffeProviderError::raft)?
-                    .into_iter()
-                    .map(|entry| entry[id_offset..].into()),
-            );
-        }
-
-        if !pre_filter_ids.is_empty() {
-            for id in pre_filter_ids {
-                if let Some(candidate) = raft
-                    .get_by_key::<SpiffeBinding, String, &str>(
-                        self.get_binding_id_key_name(id),
-                        None::<&str>,
-                    )
-                    .await
-                    .map_err(SpiffeProviderError::raft)?
-                    .map(|x| x.data)
-                    && post_filters.iter().all(|f| f.matches(&candidate))
-                {
-                    res.push(candidate);
-                }
-            }
-        } else {
-            for candidate in raft
-                .prefix::<SpiffeBinding, String, &str>(self.get_binding_prefix(), None::<&str>)
-                .await
-                .map_err(SpiffeProviderError::raft)?
-                .into_iter()
-                .map(|(_, v)| v.data)
-            {
-                if post_filters.iter().all(|f| f.matches(&candidate)) {
-                    res.push(candidate);
-                }
-            }
-        }
-        Ok(res)
+        self.list_bindings_impl(raft, params)
+            .await
+            .map_err(SpiffeProviderError::raft)
     }
 
     /// Update binding.
@@ -273,25 +334,16 @@ impl SpiffeBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(SpiffeProviderError::RaftNotAvailable)?;
-        let curr: StoreDataEnvelope<SpiffeBinding> = raft
-            .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
-            .await
-            .map_err(SpiffeProviderError::raft)?
-            .ok_or(SpiffeProviderError::BindingNotFound(svid.to_string()))?;
-        let new = curr.data.with_update(data);
-        let new_meta = curr.metadata.new_revision();
-        raft.set_value(
-            self.get_binding_id_key_name(svid),
-            StoreDataEnvelope {
-                data: new.clone(),
-                metadata: new_meta,
-            },
-            None::<&str>,
-            Some(curr.metadata.revision),
-        )
-        .await
-        .map_err(SpiffeProviderError::raft)?;
-        Ok(new)
+        match self.update_binding_impl(raft, svid, data).await {
+            Ok(b) => Ok(b),
+            Err(e) => {
+                if e.to_string().contains("NotFound") {
+                    Err(SpiffeProviderError::BindingNotFound(svid.to_string()))
+                } else {
+                    Err(SpiffeProviderError::raft(e))
+                }
+            }
+        }
     }
 }
 
@@ -300,3 +352,239 @@ impl SpiffeBackend for RaftBackend {
 /// members, keeping `inventory::submit!` sections visible at runtime.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openstack_keystone_distributed_storage::mock::MockStorage;
+
+    fn make_binding(svid: &str, domain_id: &str) -> SpiffeBindingCreate {
+        SpiffeBindingCreate {
+            svid: svid.to_string(),
+            domain_id: domain_id.to_string(),
+            is_system: false,
+            user_id: None,
+            authorizations: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_binding() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let binding = make_binding("spiffe://example/test", "domain-1");
+        let result = backend.create_binding_impl(&storage, binding.clone()).await;
+        assert!(result.is_ok());
+        let created = result.unwrap();
+        assert_eq!(created.svid, "spiffe://example/test");
+        assert_eq!(created.domain_id, "domain-1");
+    }
+
+    #[tokio::test]
+    async fn test_get_binding_exists() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/test", "domain-1"))
+            .await
+            .unwrap();
+
+        let result = backend
+            .get_binding_impl(&storage, "spiffe://example/test")
+            .await;
+        assert!(result.is_ok());
+        let binding = result.unwrap();
+        assert!(binding.is_some());
+        assert_eq!(binding.unwrap().svid, "spiffe://example/test");
+    }
+
+    #[tokio::test]
+    async fn test_get_binding_not_found() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let result = backend
+            .get_binding_impl(&storage, "spiffe://example/nonexistent")
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_binding() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/test", "domain-1"))
+            .await
+            .unwrap();
+
+        let result = backend
+            .delete_binding_impl(&storage, "spiffe://example/test")
+            .await;
+        assert!(result.is_ok());
+
+        let found = backend
+            .get_binding_impl(&storage, "spiffe://example/test")
+            .await;
+        assert!(found.is_ok());
+        assert!(found.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_binding_not_found() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let result = backend
+            .delete_binding_impl(&storage, "spiffe://example/nonexistent")
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_list_bindings_all() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/a", "domain-1"))
+            .await
+            .unwrap();
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/b", "domain-2"))
+            .await
+            .unwrap();
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/c", "domain-1"))
+            .await
+            .unwrap();
+
+        let params = SpiffeBindingListParameters {
+            domain_id: None,
+            user_id: None,
+        };
+        let result = backend.list_bindings_impl(&storage, &params).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_list_bindings_by_domain() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/a", "domain-1"))
+            .await
+            .unwrap();
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/b", "domain-2"))
+            .await
+            .unwrap();
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/c", "domain-1"))
+            .await
+            .unwrap();
+
+        let params = SpiffeBindingListParameters {
+            domain_id: Some("domain-1".to_string()),
+            user_id: None,
+        };
+        let result = backend.list_bindings_impl(&storage, &params).await;
+        assert!(result.is_ok());
+        let bindings = result.unwrap();
+        assert_eq!(bindings.len(), 2);
+        for b in &bindings {
+            assert_eq!(b.domain_id, "domain-1");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_bindings_empty() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let params = SpiffeBindingListParameters {
+            domain_id: None,
+            user_id: None,
+        };
+        let result = backend.list_bindings_impl(&storage, &params).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_update_binding() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/test", "domain-1"))
+            .await
+            .unwrap();
+
+        let update = SpiffeBindingUpdate {
+            authorizations: Some(vec![SpiffeAuthorization::Domain {
+                domain_id: "domain-1".to_string(),
+                role_ids: Some(vec!["admin".to_string()]),
+            }]),
+        };
+
+        let result = backend
+            .update_binding_impl(&storage, "spiffe://example/test", update)
+            .await;
+        assert!(result.is_ok());
+        let binding = result.unwrap();
+        assert!(binding.authorizations.is_some());
+        assert_eq!(binding.authorizations.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_update_binding_not_found() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let update = SpiffeBindingUpdate {
+            authorizations: None,
+        };
+
+        let result = backend
+            .update_binding_impl(&storage, "spiffe://example/nonexistent", update)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_index_is_created_and_cleaned() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_binding_impl(&storage, make_binding("spiffe://example/test", "domain-1"))
+            .await
+            .unwrap();
+
+        // Check index exists
+        let idx = storage
+            .prefix_index("spiffe:binding:domain:domain-1:")
+            .await
+            .unwrap();
+        assert_eq!(idx.len(), 1);
+
+        backend
+            .delete_binding_impl(&storage, "spiffe://example/test")
+            .await
+            .unwrap();
+
+        // Check index is removed
+        let idx = storage
+            .prefix_index("spiffe:binding:domain:domain-1:")
+            .await
+            .unwrap();
+        assert_eq!(idx.len(), 0);
+    }
+}

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -44,7 +44,6 @@ secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes.workspace = true
 serde_json.workspace = true
-tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tonic = { workspace = true, features = ["router", "_tls-any"] }
 tonic-prost.workspace = true
@@ -71,4 +70,4 @@ tonic-prost-build.workspace = true
 [features]
 default = []
 bench_internals = []
-mock = ["dep:tempfile"]
+mock = []

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -26,6 +26,8 @@ use openraft::RaftTypeConfig;
 pub mod api;
 pub mod app;
 pub mod grpc;
+#[cfg(feature = "mock")]
+pub mod mock;
 pub mod network;
 mod proto_impl;
 mod types;

--- a/crates/storage/src/mock.rs
+++ b/crates/storage/src/mock.rs
@@ -1,0 +1,333 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! In-memory implementation of `StorageApi` for unit testing raft drivers.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::StoreError;
+use crate::api::StorageApi;
+use crate::pb::api::{Response, response::Violation};
+use crate::store_command::*;
+use crate::types::{Metadata, StoreDataEnvelope};
+
+/// In-memory storage that implements the `StorageApi` trait.
+///
+/// Uses `Mutex` for interior mutability so it is `Send + Sync`,
+/// satisfying the trait bounds required by raft drivers.
+#[derive(Default)]
+pub struct MockStorage {
+    /// keyspace -> data_key -> serialized data bytes.
+    data: Mutex<HashMap<String, HashMap<String, Vec<u8>>>>,
+    /// data_key -> serialized `Metadata`.
+    /// Stored flat, regardless of keyspace, matching the real Fjall
+    /// state machine which keeps metadata in a single "meta" keyspace.
+    metadata: Mutex<HashMap<String, Vec<u8>>>,
+    /// index_key -> ()  (flat, no keyspace).
+    indexes: Mutex<HashMap<Vec<u8>, ()>>,
+}
+
+fn resolve_keyspace<S: Into<String>>(ks: Option<S>) -> String {
+    ks.map(Into::into).unwrap_or_else(|| "data".to_string())
+}
+
+impl MockStorage {
+    /// Store a value under `key` in `keyspace`, recording `metadata`.
+    /// Returns a `Violation` when `expected_revision` mismatches.
+    fn set_value_inner(
+        data: &mut HashMap<String, HashMap<String, Vec<u8>>>,
+        metadata_map: &mut HashMap<String, Vec<u8>>,
+        key: &str,
+        keyspace: &str,
+        value_bytes: Vec<u8>,
+        metadata: &Metadata,
+        expected_revision: Option<u64>,
+    ) -> Option<Violation> {
+        if let Some(exp_rev) = expected_revision {
+            if let Some(stored_meta_bytes) = metadata_map.get(key) {
+                if let Ok(stored_meta) = Metadata::unpack(stored_meta_bytes) {
+                    if stored_meta.revision != exp_rev {
+                        return Some(Violation {
+                            r#type: "CONFLICT".to_string(),
+                            subject: key.to_string(),
+                            description: format!(
+                                "Current revision is {}, expected {}",
+                                stored_meta.revision, exp_rev
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+
+        data.entry(keyspace.to_string())
+            .or_default()
+            .insert(key.to_string(), value_bytes);
+        metadata_map.insert(key.to_string(), metadata.pack().unwrap());
+        None
+    }
+
+    /// Fetch `Metadata` for a key, returning a default if absent.
+    fn get_metadata(metadata_map: &HashMap<String, Vec<u8>>, key: &str) -> Metadata {
+        metadata_map
+            .get(key)
+            .and_then(|m| Metadata::unpack(m).ok())
+            .unwrap_or_else(Metadata::new)
+    }
+}
+
+#[async_trait]
+impl StorageApi for MockStorage {
+    async fn contains_key<K, S>(&self, key: K, keyspace: Option<S>) -> Result<bool, StoreError>
+    where
+        K: AsRef<[u8]> + Send,
+        S: AsRef<str> + Send,
+    {
+        let ks = match keyspace {
+            Some(name) => name.as_ref().to_string(),
+            None => "data".to_string(),
+        };
+        let key_str = String::from_utf8(key.as_ref().to_vec())?;
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .get(&ks)
+            .map_or(false, |m| m.contains_key(&key_str)))
+    }
+
+    async fn get_by_key<T, K, S>(
+        &self,
+        key: K,
+        keyspace: Option<S>,
+    ) -> Result<Option<StoreDataEnvelope<T>>, StoreError>
+    where
+        T: DeserializeOwned + Send,
+        K: AsRef<[u8]> + Send,
+        S: AsRef<str> + Send,
+    {
+        let ks = match keyspace {
+            Some(name) => name.as_ref().to_string(),
+            None => "data".to_string(),
+        };
+        let key_str = String::from_utf8(key.as_ref().to_vec())?;
+
+        let data = self.data.lock().unwrap();
+        let metadata_map = self.metadata.lock().unwrap();
+
+        let Some(data_map) = data.get(&ks) else {
+            return Ok(None);
+        };
+        let Some(value_bytes) = data_map.get(&key_str) else {
+            return Ok(None);
+        };
+
+        let t: T = rmp_serde::from_slice(value_bytes)?;
+        let meta = Self::get_metadata(&metadata_map, &key_str);
+
+        Ok(Some(StoreDataEnvelope {
+            data: t,
+            metadata: meta,
+        }))
+    }
+
+    async fn prefix<T, K, S>(
+        &self,
+        prefix: K,
+        keyspace: Option<S>,
+    ) -> Result<Vec<(String, StoreDataEnvelope<T>)>, StoreError>
+    where
+        T: DeserializeOwned + Send,
+        K: AsRef<[u8]> + Send,
+        S: AsRef<str> + Send,
+    {
+        let ks = match keyspace {
+            Some(name) => name.as_ref().to_string(),
+            None => "data".to_string(),
+        };
+        let prefix_str = String::from_utf8(prefix.as_ref().to_vec())?;
+
+        let data = self.data.lock().unwrap();
+        let metadata_map = self.metadata.lock().unwrap();
+
+        let Some(data_map) = data.get(&ks) else {
+            return Ok(Vec::new());
+        };
+
+        let mut result: Vec<(String, StoreDataEnvelope<T>)> = data_map
+            .iter()
+            .filter(|(k, _)| k.starts_with(&prefix_str))
+            .map(|(k, v)| {
+                let t: T = rmp_serde::from_slice(v)?;
+                let meta = Self::get_metadata(&metadata_map, k);
+                Ok::<_, StoreError>((
+                    k.clone(),
+                    StoreDataEnvelope {
+                        data: t,
+                        metadata: meta,
+                    },
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        result.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(result)
+    }
+
+    async fn prefix_index<K>(&self, prefix: K) -> Result<Vec<String>, StoreError>
+    where
+        K: AsRef<[u8]> + Send,
+    {
+        let indexes = self.indexes.lock().unwrap();
+
+        let mut result: Vec<String> = indexes
+            .keys()
+            .filter(|k| k.starts_with(prefix.as_ref()))
+            .filter_map(|k| String::from_utf8(k.clone()).ok())
+            .collect();
+
+        result.sort();
+        Ok(result)
+    }
+
+    async fn remove<K, S>(&self, key: K, keyspace: Option<S>) -> Result<Response, StoreError>
+    where
+        K: Into<Vec<u8>> + Send,
+        S: Into<String> + Send,
+    {
+        let key_bytes = key.into();
+        let ks = resolve_keyspace(keyspace);
+        let key_str = String::from_utf8(key_bytes)?;
+
+        let mut data = self.data.lock().unwrap();
+        let mut metadata_map = self.metadata.lock().unwrap();
+        if let Some(data_map) = data.get_mut(&ks) {
+            data_map.remove(&key_str);
+        }
+        metadata_map.remove(&key_str);
+
+        Ok(Response::default())
+    }
+
+    async fn remove_index<K>(&self, key: K) -> Result<Response, StoreError>
+    where
+        K: Into<Vec<u8>> + Send,
+    {
+        let key_bytes = key.into();
+        self.indexes.lock().unwrap().remove(&key_bytes);
+        Ok(Response::default())
+    }
+
+    async fn set_value<K, V, S>(
+        &self,
+        key: K,
+        value: StoreDataEnvelope<V>,
+        keyspace: Option<S>,
+        expected_revision: Option<u64>,
+    ) -> Result<Response, StoreError>
+    where
+        K: Into<String> + Send,
+        V: Serialize + Send,
+        S: Into<String> + Send,
+    {
+        let key_str = key.into();
+        let ks = resolve_keyspace(keyspace);
+        let value_bytes = rmp_serde::to_vec(&value.data)?;
+
+        let mut data = self.data.lock().unwrap();
+        let mut metadata_map = self.metadata.lock().unwrap();
+        let violation = Self::set_value_inner(
+            &mut *data,
+            &mut *metadata_map,
+            &key_str,
+            &ks,
+            value_bytes,
+            &value.metadata,
+            expected_revision,
+        );
+
+        let violations = violation.map_or(Vec::new(), |v| vec![v]);
+        Ok(Response {
+            value: None,
+            violations,
+        })
+    }
+
+    async fn set_index_key<K>(&self, key: K) -> Result<Response, StoreError>
+    where
+        K: Into<String> + Send,
+    {
+        let key_bytes: Vec<u8> = key.into().into_bytes();
+        self.indexes.lock().unwrap().insert(key_bytes, ());
+        Ok(Response::default())
+    }
+
+    async fn transaction(&self, mutations: Vec<Mutation>) -> Result<Response, StoreError> {
+        let mut violations: Vec<Violation> = Vec::new();
+
+        let mut data = self.data.lock().unwrap();
+        let mut metadata_map = self.metadata.lock().unwrap();
+        let mut indexes = self.indexes.lock().unwrap();
+
+        for mutation in mutations {
+            match mutation {
+                Mutation::Remove { key, keyspace } => {
+                    let key_str = String::from_utf8(key)?;
+                    if let Some(data_map) = data.get_mut(&keyspace) {
+                        data_map.remove(&key_str);
+                    }
+                    metadata_map.remove(&key_str);
+                }
+
+                Mutation::RemoveIndex { key } => {
+                    indexes.remove(&key);
+                }
+
+                Mutation::Set {
+                    key,
+                    keyspace,
+                    value,
+                    metadata,
+                    expected_revision,
+                } => {
+                    let key_str = String::from_utf8_lossy(&key).to_string();
+                    if let Some(v) = Self::set_value_inner(
+                        &mut *data,
+                        &mut *metadata_map,
+                        &key_str,
+                        &keyspace,
+                        value,
+                        &metadata,
+                        expected_revision,
+                    ) {
+                        violations.push(v);
+                    }
+                }
+
+                Mutation::SetIndex { key } => {
+                    indexes.insert(key, ());
+                }
+            }
+        }
+
+        Ok(Response {
+            value: None,
+            violations,
+        })
+    }
+}

--- a/crates/webauthn/Cargo.toml
+++ b/crates/webauthn/Cargo.toml
@@ -19,7 +19,7 @@ inventory.workspace = true
 openstack-keystone-api-types = { workspace = true, features = ["openapi", "validate", "conv"] }
 openstack-keystone-core = { workspace = true, features = ["api"] }
 openstack-keystone-core-types.workspace = true
-openstack-keystone-distributed-storage.workspace = true
+openstack-keystone-distributed-storage = { workspace = true, features = ["mock"] }
 sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
 serde.workspace = true

--- a/crates/webauthn/src/driver/raft.rs
+++ b/crates/webauthn/src/driver/raft.rs
@@ -18,7 +18,7 @@ use webauthn_rs::prelude::{PasskeyAuthentication, PasskeyRegistration};
 
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_distributed_storage::{
-    Metadata, StorageApi, StoreDataEnvelope, app::Storage,
+    Metadata, StorageApi, StoreDataEnvelope, StoreError, app::Storage,
 };
 
 use crate::{
@@ -133,6 +133,197 @@ impl RaftDriver {
     fn get_user_cred_list_prefix<S: AsRef<str>>(&self, user_id: S) -> String {
         format!("{}:cred", user_id.as_ref())
     }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn create_user_webauthn_credential_impl(
+        &self,
+        storage: &impl StorageApi,
+        credential: &WebauthnCredential,
+    ) -> Result<WebauthnCredential, StoreError> {
+        storage
+            .set_value(
+                self.get_cred_key_name(&credential.user_id, &credential.credential_id),
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: credential.clone(),
+                },
+                Some(DATA_KEYSPACE),
+                None,
+            )
+            .await?;
+        Ok(credential.clone())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn get_user_webauthn_credential_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        credential_id: &'a str,
+    ) -> Result<Option<WebauthnCredential>, StoreError> {
+        let key = self.get_cred_key_name(user_id, credential_id);
+        Ok(storage
+            .get_by_key(key, Some(DATA_KEYSPACE))
+            .await?
+            .map(|x| x.data))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn delete_user_webauthn_credential_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        credential_id: &'a str,
+    ) -> Result<(), StoreError> {
+        let key = self.get_cred_key_name(user_id, credential_id);
+        storage.remove(key, Some(DATA_KEYSPACE)).await?;
+        Ok(())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn list_user_webauthn_credentials_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+    ) -> Result<Vec<WebauthnCredential>, StoreError> {
+        let prefix = self.get_user_cred_list_prefix(user_id);
+        Ok(storage
+            .prefix(prefix, Some(DATA_KEYSPACE))
+            .await?
+            .into_iter()
+            .map(|(_, v)| v.data)
+            .collect())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn update_user_webauthn_credential_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        credential_id: &'a str,
+        credential: &WebauthnCredential,
+    ) -> Result<WebauthnCredential, StoreError> {
+        let key = self.get_cred_key_name(user_id, credential_id);
+        if let Some(curr) = storage
+            .get_by_key::<WebauthnCredential, String, &str>(key, Some(DATA_KEYSPACE))
+            .await?
+        {
+            let new_meta = curr.metadata.new_revision();
+            let curr_revision = curr.metadata.revision;
+            storage
+                .set_value(
+                    self.get_cred_key_name(user_id, credential_id),
+                    StoreDataEnvelope {
+                        metadata: new_meta,
+                        data: credential,
+                    },
+                    Some(DATA_KEYSPACE),
+                    Some(curr_revision),
+                )
+                .await?;
+            Ok(credential.clone())
+        } else {
+            Err(StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn save_user_webauthn_credential_authentication_state_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        auth_state: &PasskeyAuthentication,
+        state_keysapce: &str,
+    ) -> Result<(), StoreError> {
+        storage
+            .set_value(
+                self.get_user_cred_auth_state_key_name(user_id),
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: auth_state,
+                },
+                Some(state_keysapce),
+                None,
+            )
+            .await?;
+        Ok(())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn get_user_webauthn_credential_authentication_state_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        state_keysapce: &str,
+    ) -> Result<Option<PasskeyAuthentication>, StoreError> {
+        let key = self.get_user_cred_auth_state_key_name(user_id);
+        Ok(storage
+            .get_by_key(key, Some(state_keysapce))
+            .await?
+            .map(|x| x.data))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn delete_user_webauthn_credential_authentication_state_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        state_keysapce: &str,
+    ) -> Result<(), StoreError> {
+        let key = self.get_user_cred_auth_state_key_name(user_id);
+        storage.remove(key, Some(state_keysapce)).await?;
+        Ok(())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn save_user_webauthn_credential_registration_state_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        reg_state: &PasskeyRegistration,
+        state_keysapce: &str,
+    ) -> Result<(), StoreError> {
+        storage
+            .set_value(
+                self.get_user_cred_registration_state_key_name(user_id),
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: reg_state,
+                },
+                Some(state_keysapce),
+                None,
+            )
+            .await?;
+        Ok(())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn get_user_webauthn_credential_registration_state_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        state_keysapce: &str,
+    ) -> Result<Option<PasskeyRegistration>, StoreError> {
+        let key = self.get_user_cred_registration_state_key_name(user_id);
+        Ok(storage
+            .get_by_key(key, Some(state_keysapce))
+            .await?
+            .map(|x| x.data))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn delete_user_webauthn_credential_registration_state_impl<'a>(
+        &self,
+        storage: &impl StorageApi,
+        user_id: &'a str,
+        state_keysapce: &str,
+    ) -> Result<(), StoreError> {
+        let key = self.get_user_cred_registration_state_key_name(user_id);
+        storage.remove(key, Some(state_keysapce)).await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -167,17 +358,9 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        raft.set_value(
-            self.get_cred_key_name(&credential.user_id, &credential.credential_id),
-            StoreDataEnvelope {
-                metadata: Metadata::new(),
-                data: credential.clone(),
-            },
-            Some(DATA_KEYSPACE),
-            None,
-        )
-        .await?;
-        Ok(credential.clone())
+        self.create_user_webauthn_credential_impl(raft, credential)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Get webauthn credential of the user by the credential_id.
@@ -201,13 +384,9 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        Ok(raft
-            .get_by_key(
-                self.get_cred_key_name(user_id, credential_id),
-                Some(DATA_KEYSPACE),
-            )
-            .await?
-            .map(|x| x.data))
+        self.get_user_webauthn_credential_impl(raft, user_id, credential_id)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Delete credential for the user.
@@ -230,12 +409,9 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        raft.remove(
-            self.get_cred_key_name(user_id, credential_id),
-            Some(DATA_KEYSPACE),
-        )
-        .await?;
-        Ok(())
+        self.delete_user_webauthn_credential_impl(raft, user_id, credential_id)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Delete webauthn credential auth state for a user.
@@ -256,12 +432,14 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        raft.remove(
-            self.get_user_cred_auth_state_key_name(user_id),
-            Some(self.get_current_state_keyspace_name(raft).await?),
+        let state_keysapce = self.get_current_state_keyspace_name(raft).await?;
+        self.delete_user_webauthn_credential_authentication_state_impl(
+            raft,
+            user_id,
+            &state_keysapce,
         )
-        .await?;
-        Ok(())
+        .await
+        .map_err(|e| e.into())
     }
 
     /// Delete webauthn credential registration state for the user.
@@ -282,12 +460,10 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        raft.remove(
-            self.get_user_cred_registration_state_key_name(user_id),
-            Some(self.get_current_state_keyspace_name(raft).await?),
-        )
-        .await?;
-        Ok(())
+        let state_keysapce = self.get_current_state_keyspace_name(raft).await?;
+        self.delete_user_webauthn_credential_registration_state_impl(raft, user_id, &state_keysapce)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Get webauthn credential auth state.
@@ -309,13 +485,10 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        Ok(raft
-            .get_by_key(
-                self.get_user_cred_auth_state_key_name(user_id),
-                Some(self.get_current_state_keyspace_name(raft).await?),
-            )
-            .await?
-            .map(|x| x.data))
+        let state_keysapce = self.get_current_state_keyspace_name(raft).await?;
+        self.get_user_webauthn_credential_authentication_state_impl(raft, user_id, &state_keysapce)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Get webauthn credential registration state.
@@ -337,13 +510,10 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        Ok(raft
-            .get_by_key(
-                self.get_user_cred_registration_state_key_name(user_id),
-                Some(self.get_current_state_keyspace_name(raft).await?),
-            )
-            .await?
-            .map(|x| x.data))
+        let state_keysapce = self.get_current_state_keyspace_name(raft).await?;
+        self.get_user_webauthn_credential_registration_state_impl(raft, user_id, &state_keysapce)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// List user webauthn credentials.
@@ -364,12 +534,9 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        Ok(raft
-            .prefix(self.get_user_cred_list_prefix(user_id), Some(DATA_KEYSPACE))
-            .await?
-            .into_iter()
-            .map(|(_, v)| v.data)
-            .collect())
+        self.list_user_webauthn_credentials_impl(raft, user_id)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Save webauthn credential auth state.
@@ -392,17 +559,15 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        raft.set_value(
-            self.get_user_cred_auth_state_key_name(user_id),
-            StoreDataEnvelope {
-                metadata: Metadata::new(),
-                data: auth_state,
-            },
-            Some(self.get_current_state_keyspace_name(raft).await?),
-            None,
+        let state_keysapce = self.get_current_state_keyspace_name(raft).await?;
+        self.save_user_webauthn_credential_authentication_state_impl(
+            raft,
+            user_id,
+            auth_state,
+            &state_keysapce,
         )
-        .await?;
-        Ok(())
+        .await
+        .map_err(|e| e.into())
     }
 
     /// Save webauthn credential registration state.
@@ -425,17 +590,15 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        raft.set_value(
-            self.get_user_cred_registration_state_key_name(user_id),
-            StoreDataEnvelope {
-                metadata: Metadata::new(),
-                data: reg_state,
-            },
-            Some(self.get_current_state_keyspace_name(raft).await?),
-            None,
+        let state_keysapce = self.get_current_state_keyspace_name(raft).await?;
+        self.save_user_webauthn_credential_registration_state_impl(
+            raft,
+            user_id,
+            reg_state,
+            &state_keysapce,
         )
-        .await?;
-        Ok(())
+        .await
+        .map_err(|e| e.into())
     }
 
     /// Update credential data.
@@ -460,28 +623,201 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        if let Some(curr) = raft
-            .get_by_key::<WebauthnCredential, String, &str>(
-                self.get_cred_key_name(user_id, credential_id),
-                Some(DATA_KEYSPACE),
-            )
-            .await?
-        {
-            let new_meta = curr.metadata.new_revision();
-            let curr_revision = curr.metadata.revision;
-            raft.set_value(
-                self.get_cred_key_name(user_id, credential_id),
+        self.update_user_webauthn_credential_impl(raft, user_id, credential_id, credential)
+            .await
+            .map_err(|e| {
+                if e.to_string().contains("NotFound") {
+                    WebauthnError::CredentialNotFound(credential_id.to_string())
+                } else {
+                    e.into()
+                }
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openstack_keystone_distributed_storage::mock::MockStorage;
+    use openstack_keystone_distributed_storage::{Metadata, StoreDataEnvelope};
+
+    const DATA_KEYSPACE_TEST: &str = "data";
+    const STATE_KEYSPACE: &str = "webauth_state_test";
+
+    #[tokio::test]
+    async fn test_credential_storage() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+
+        let cred_key = driver.get_cred_key_name("user-1", "cred-1");
+        let cred_value: String = "test-credential-data".to_string();
+
+        storage
+            .set_value(
+                &cred_key,
                 StoreDataEnvelope {
-                    metadata: new_meta,
-                    data: credential,
+                    metadata: Metadata::new(),
+                    data: cred_value.clone(),
                 },
-                Some(DATA_KEYSPACE),
-                Some(curr_revision),
+                Some(DATA_KEYSPACE_TEST),
+                None,
             )
-            .await?;
-            Ok(credential.clone())
-        } else {
-            return Err(WebauthnError::CredentialNotFound(credential_id.to_string()));
-        }
+            .await
+            .unwrap();
+
+        let found = storage
+            .get_by_key::<String, &str, &str>(&cred_key, Some(DATA_KEYSPACE_TEST))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.data, "test-credential-data");
+    }
+
+    #[tokio::test]
+    async fn test_credential_keys() {
+        let driver = RaftDriver::default();
+        assert_eq!(
+            driver.get_cred_key_name("user-1", "cred-1"),
+            "user-1:cred:cred-1"
+        );
+        assert_eq!(driver.get_user_cred_list_prefix("user-1"), "user-1:cred");
+    }
+
+    #[tokio::test]
+    async fn test_state_auth_key() {
+        let driver = RaftDriver::default();
+        assert_eq!(
+            driver.get_user_cred_auth_state_key_name("user-1"),
+            "user-1:auth"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_state_reg_key() {
+        let driver = RaftDriver::default();
+        assert_eq!(
+            driver.get_user_cred_registration_state_key_name("user-1"),
+            "user-1:registration"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auth_state_save_and_get() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+
+        let auth_value: String = "auth-state-data".to_string();
+        let key = driver.get_user_cred_auth_state_key_name("user-1");
+
+        storage
+            .set_value(
+                &key,
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: auth_value.clone(),
+                },
+                Some(STATE_KEYSPACE),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let found = storage
+            .get_by_key::<String, &str, &str>(&key, Some(STATE_KEYSPACE))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.data, "auth-state-data");
+    }
+
+    #[tokio::test]
+    async fn test_reg_state_save_and_get() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+
+        let reg_value: String = "reg-state-data".to_string();
+        let key = driver.get_user_cred_registration_state_key_name("user-1");
+
+        storage
+            .set_value(
+                &key,
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: reg_value.clone(),
+                },
+                Some(STATE_KEYSPACE),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let found = storage
+            .get_by_key::<String, &str, &str>(&key, Some(STATE_KEYSPACE))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.data, "reg-state-data");
+    }
+
+    #[tokio::test]
+    async fn test_credential_deletion() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+
+        let cred_key = driver.get_cred_key_name("user-1", "cred-1");
+        storage
+            .set_value(
+                &cred_key,
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: "test".to_string(),
+                },
+                Some(DATA_KEYSPACE_TEST),
+                None,
+            )
+            .await
+            .unwrap();
+
+        storage
+            .remove(cred_key.clone(), Some(DATA_KEYSPACE_TEST))
+            .await
+            .unwrap();
+
+        let found = storage
+            .get_by_key::<String, &str, &str>(&cred_key, Some(DATA_KEYSPACE_TEST))
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_state_deletion() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+
+        let key = driver.get_user_cred_auth_state_key_name("user-1");
+        storage
+            .set_value(
+                &key,
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: "test".to_string(),
+                },
+                Some(STATE_KEYSPACE),
+                None,
+            )
+            .await
+            .unwrap();
+
+        storage
+            .remove(key.clone(), Some(STATE_KEYSPACE))
+            .await
+            .unwrap();
+
+        let found = storage
+            .get_by_key::<String, &str, &str>(&key, Some(STATE_KEYSPACE))
+            .await
+            .unwrap();
+        assert!(found.is_none());
     }
 }


### PR DESCRIPTION
Improve raft drivers unit testing capabilities with the mocked
(in-memory) storage implementing the StorageApi.
