### PR TITLE
chore: Update raft drivers mocking

### DIFF
--- a/crates/k8s-auth-driver-raft/src/lib.rs
+++ b/crates/k8s-auth-driver-raft/src/lib.rs
@@ -160,7 +160,6 @@ impl RaftBackend {
         format!("k8s_auth:role:instance:{}:", instance_id.as_ref(),)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn create_auth_instance_impl(
         &self,
         storage: &impl StorageApi,
@@ -183,7 +182,6 @@ impl RaftBackend {
         Ok(obj)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn create_auth_role_impl(
         &self,
         storage: &impl StorageApi,
@@ -209,7 +207,6 @@ impl RaftBackend {
         Ok(obj)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn delete_auth_instance_impl(
         &self,
         storage: &impl StorageApi,
@@ -231,7 +228,6 @@ impl RaftBackend {
         Ok(())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn delete_auth_role_impl(
         &self,
         storage: &impl StorageApi,
@@ -256,7 +252,6 @@ impl RaftBackend {
         Ok(())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn get_auth_instance_impl(
         &self,
         storage: &impl StorageApi,
@@ -268,7 +263,6 @@ impl RaftBackend {
             .map(|x| x.data))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn get_auth_role_impl(
         &self,
         storage: &impl StorageApi,
@@ -280,7 +274,6 @@ impl RaftBackend {
             .map(|x| x.data))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn list_auth_instances_impl(
         &self,
         storage: &impl StorageApi,
@@ -342,7 +335,6 @@ impl RaftBackend {
         Ok(res)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn list_auth_roles_impl(
         &self,
         storage: &impl StorageApi,
@@ -422,62 +414,62 @@ impl RaftBackend {
         Ok(res)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn update_auth_instance_impl(
         &self,
         storage: &impl StorageApi,
         id: &str,
         data: K8sAuthInstanceUpdate,
-    ) -> Result<K8sAuthInstance, StoreError> {
-        let curr: StoreDataEnvelope<K8sAuthInstance> = storage
+    ) -> Result<Option<K8sAuthInstance>, StoreError> {
+        let curr: Option<StoreDataEnvelope<K8sAuthInstance>> = storage
             .get_by_key(self.get_auth_instance_id_key_name(id), None::<&str>)
-            .await?
-            .ok_or_else(|| StoreError::IO {
-                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
-            })?;
-        let new = curr.data.with_update(data);
-        let new_meta = curr.metadata.new_revision();
-        storage
-            .set_value(
-                self.get_auth_instance_id_key_name(id),
-                StoreDataEnvelope {
-                    data: new.clone(),
-                    metadata: new_meta,
-                },
-                None::<&str>,
-                Some(curr.metadata.revision),
-            )
             .await?;
-        Ok(new)
+        if let Some(curr) = curr {
+            let new = curr.data.with_update(data);
+            let new_meta = curr.metadata.new_revision();
+            storage
+                .set_value(
+                    self.get_auth_instance_id_key_name(id),
+                    StoreDataEnvelope {
+                        data: new.clone(),
+                        metadata: new_meta,
+                    },
+                    None::<&str>,
+                    Some(curr.metadata.revision),
+                )
+                .await?;
+            Ok(Some(new))
+        } else {
+            Ok(None)
+        }
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn update_auth_role_impl(
         &self,
         storage: &impl StorageApi,
         id: &str,
         data: K8sAuthRoleUpdate,
-    ) -> Result<K8sAuthRole, StoreError> {
-        let curr: StoreDataEnvelope<K8sAuthRole> = storage
+    ) -> Result<Option<K8sAuthRole>, StoreError> {
+        let curr: Option<StoreDataEnvelope<K8sAuthRole>> = storage
             .get_by_key(self.get_auth_role_id_key_name(id), None::<&str>)
-            .await?
-            .ok_or_else(|| StoreError::IO {
-                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
-            })?;
-        let new = curr.data.with_update(data);
-        let new_meta = curr.metadata.new_revision();
-        storage
-            .set_value(
-                self.get_auth_role_id_key_name(id),
-                StoreDataEnvelope {
-                    data: new.clone(),
-                    metadata: new_meta,
-                },
-                None::<&str>,
-                Some(curr.metadata.revision),
-            )
             .await?;
-        Ok(new)
+        if let Some(curr) = curr {
+            let new = curr.data.with_update(data);
+            let new_meta = curr.metadata.new_revision();
+            storage
+                .set_value(
+                    self.get_auth_role_id_key_name(id),
+                    StoreDataEnvelope {
+                        data: new.clone(),
+                        metadata: new_meta,
+                    },
+                    None::<&str>,
+                    Some(curr.metadata.revision),
+                )
+                .await?;
+            Ok(Some(new))
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -498,7 +490,8 @@ impl K8sAuthBackend for RaftBackend {
         instance: K8sAuthInstanceCreate,
     ) -> Result<K8sAuthInstance, K8sAuthProviderError> {
         let raft = state
-            .get_storage()
+            .storage
+            .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
         self.create_auth_instance_impl(raft, instance)
             .await
@@ -688,16 +681,10 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        match self.update_auth_instance_impl(raft, id, data).await {
-            Ok(i) => Ok(i),
-            Err(e) => {
-                if e.to_string().contains("NotFound") {
-                    Err(K8sAuthProviderError::AuthInstanceNotFound(id.to_string()))
-                } else {
-                    Err(K8sAuthProviderError::raft(e))
-                }
-            }
-        }
+        self.update_auth_instance_impl(raft, id, data)
+            .await
+            .map_err(K8sAuthProviderError::raft)?
+            .ok_or_else(|| K8sAuthProviderError::AuthInstanceNotFound(id.to_string()))
     }
 
     /// Update K8s auth role.
@@ -720,16 +707,14 @@ impl K8sAuthBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
-        match self.update_auth_role_impl(raft, id, data).await {
-            Ok(r) => Ok(r),
-            Err(e) => {
-                if e.to_string().contains("NotFound") {
-                    Err(K8sAuthProviderError::RoleNotFound(id.to_string()))
-                } else {
-                    Err(K8sAuthProviderError::raft(e))
-                }
-            }
-        }
+        let raft = state
+            .storage
+            .as_ref()
+            .ok_or(K8sAuthProviderError::RaftNotAvailable)?;
+        self.update_auth_role_impl(raft, id, data)
+            .await
+            .map_err(K8sAuthProviderError::raft)?
+            .ok_or_else(|| K8sAuthProviderError::RoleNotFound(id.to_string()))
     }
 }
 
@@ -950,7 +935,7 @@ mod tests {
             .update_auth_instance_impl(&storage, "inst-1", update)
             .await;
         assert!(result.is_ok());
-        assert!(!result.unwrap().enabled);
+        assert!(!result.unwrap().unwrap().enabled);
     }
 
     #[tokio::test]
@@ -962,7 +947,8 @@ mod tests {
         let result = backend
             .update_auth_instance_impl(&storage, "nonexistent", update)
             .await;
-        assert!(result.is_err());
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -983,7 +969,7 @@ mod tests {
             .update_auth_role_impl(&storage, "role-1", update)
             .await;
         assert!(result.is_ok());
-        assert!(!result.unwrap().enabled);
+        assert!(!result.unwrap().unwrap().enabled);
     }
 
     #[tokio::test]

--- a/crates/spiffe-driver-raft/src/lib.rs
+++ b/crates/spiffe-driver-raft/src/lib.rs
@@ -79,7 +79,6 @@ impl RaftBackend {
         format!("spiffe:binding:domain:{}:", domain_id.as_ref(),)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn create_binding_impl(
         &self,
         storage: &impl StorageApi,
@@ -102,7 +101,6 @@ impl RaftBackend {
         Ok(obj)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn delete_binding_impl(
         &self,
         storage: &impl StorageApi,
@@ -124,7 +122,6 @@ impl RaftBackend {
         Ok(())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn get_binding_impl(
         &self,
         storage: &impl StorageApi,
@@ -136,7 +133,6 @@ impl RaftBackend {
             .map(|x| x.data))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn list_bindings_impl(
         &self,
         storage: &impl StorageApi,
@@ -191,33 +187,33 @@ impl RaftBackend {
         Ok(res)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn update_binding_impl(
         &self,
         storage: &impl StorageApi,
         svid: &str,
         data: SpiffeBindingUpdate,
-    ) -> Result<SpiffeBinding, StoreError> {
-        let curr: StoreDataEnvelope<SpiffeBinding> = storage
+    ) -> Result<Option<SpiffeBinding>, StoreError> {
+        let curr: Option<StoreDataEnvelope<SpiffeBinding>> = storage
             .get_by_key(self.get_binding_id_key_name(svid), None::<&str>)
-            .await?
-            .ok_or_else(|| StoreError::IO {
-                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
-            })?;
-        let new = curr.data.with_update(data);
-        let new_meta = curr.metadata.new_revision();
-        storage
-            .set_value(
-                self.get_binding_id_key_name(svid),
-                StoreDataEnvelope {
-                    data: new.clone(),
-                    metadata: new_meta,
-                },
-                None::<&str>,
-                Some(curr.metadata.revision),
-            )
             .await?;
-        Ok(new)
+        if let Some(curr) = curr {
+            let new = curr.data.with_update(data);
+            let new_meta = curr.metadata.new_revision();
+            storage
+                .set_value(
+                    self.get_binding_id_key_name(svid),
+                    StoreDataEnvelope {
+                        data: new.clone(),
+                        metadata: new_meta,
+                    },
+                    None::<&str>,
+                    Some(curr.metadata.revision),
+                )
+                .await?;
+            Ok(Some(new))
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -334,16 +330,10 @@ impl SpiffeBackend for RaftBackend {
             .storage
             .as_ref()
             .ok_or(SpiffeProviderError::RaftNotAvailable)?;
-        match self.update_binding_impl(raft, svid, data).await {
-            Ok(b) => Ok(b),
-            Err(e) => {
-                if e.to_string().contains("NotFound") {
-                    Err(SpiffeProviderError::BindingNotFound(svid.to_string()))
-                } else {
-                    Err(SpiffeProviderError::raft(e))
-                }
-            }
-        }
+        self.update_binding_impl(raft, svid, data)
+            .await
+            .map_err(SpiffeProviderError::raft)?
+            .ok_or_else(|| SpiffeProviderError::BindingNotFound(svid.to_string()))
     }
 }
 
@@ -538,7 +528,7 @@ mod tests {
             .update_binding_impl(&storage, "spiffe://example/test", update)
             .await;
         assert!(result.is_ok());
-        let binding = result.unwrap();
+        let binding = result.unwrap().unwrap();
         assert!(binding.authorizations.is_some());
         assert_eq!(binding.authorizations.unwrap().len(), 1);
     }
@@ -555,7 +545,8 @@ mod tests {
         let result = backend
             .update_binding_impl(&storage, "spiffe://example/nonexistent", update)
             .await;
-        assert!(result.is_err());
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/storage/src/mock.rs
+++ b/crates/storage/src/mock.rs
@@ -14,6 +14,7 @@
 //! In-memory implementation of `StorageApi` for unit testing raft drivers.
 
 use std::collections::HashMap;
+use std::io;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
@@ -42,6 +43,12 @@ pub struct MockStorage {
     indexes: Mutex<HashMap<Vec<u8>, ()>>,
 }
 
+fn lock<'a, T>(m: &'a Mutex<T>) -> Result<std::sync::MutexGuard<'a, T>, StoreError> {
+    m.lock().map_err(|_| StoreError::IO {
+        source: io::Error::other("mutex poisoned"),
+    })
+}
+
 fn resolve_keyspace<S: Into<String>>(ks: Option<S>) -> String {
     ks.map(Into::into).unwrap_or_else(|| "data".to_string())
 }
@@ -57,29 +64,27 @@ impl MockStorage {
         value_bytes: Vec<u8>,
         metadata: &Metadata,
         expected_revision: Option<u64>,
-    ) -> Option<Violation> {
-        if let Some(exp_rev) = expected_revision {
-            if let Some(stored_meta_bytes) = metadata_map.get(key) {
-                if let Ok(stored_meta) = Metadata::unpack(stored_meta_bytes) {
-                    if stored_meta.revision != exp_rev {
-                        return Some(Violation {
-                            r#type: "CONFLICT".to_string(),
-                            subject: key.to_string(),
-                            description: format!(
-                                "Current revision is {}, expected {}",
-                                stored_meta.revision, exp_rev
-                            ),
-                        });
-                    }
-                }
-            }
-        }
+    ) -> Result<Option<Violation>, StoreError> {
+        let violation = expected_revision.and_then(|exp_rev| {
+            metadata_map
+                .get(key)
+                .and_then(|m| Metadata::unpack(m).ok())
+                .filter(|stored_meta| stored_meta.revision != exp_rev)
+                .map(|stored_meta| Violation {
+                    r#type: "CONFLICT".to_string(),
+                    subject: key.to_string(),
+                    description: format!(
+                        "Current revision is {}, expected {}",
+                        stored_meta.revision, exp_rev
+                    ),
+                })
+        });
 
         data.entry(keyspace.to_string())
             .or_default()
             .insert(key.to_string(), value_bytes);
-        metadata_map.insert(key.to_string(), metadata.pack().unwrap());
-        None
+        metadata_map.insert(key.to_string(), metadata.pack()?);
+        Ok(violation)
     }
 
     /// Fetch `Metadata` for a key, returning a default if absent.
@@ -87,7 +92,7 @@ impl MockStorage {
         metadata_map
             .get(key)
             .and_then(|m| Metadata::unpack(m).ok())
-            .unwrap_or_else(Metadata::new)
+            .unwrap_or_default()
     }
 }
 
@@ -103,12 +108,9 @@ impl StorageApi for MockStorage {
             None => "data".to_string(),
         };
         let key_str = String::from_utf8(key.as_ref().to_vec())?;
-        Ok(self
-            .data
-            .lock()
-            .unwrap()
+        Ok(lock(&self.data)?
             .get(&ks)
-            .map_or(false, |m| m.contains_key(&key_str)))
+            .is_some_and(|m| m.contains_key(&key_str)))
     }
 
     async fn get_by_key<T, K, S>(
@@ -127,8 +129,8 @@ impl StorageApi for MockStorage {
         };
         let key_str = String::from_utf8(key.as_ref().to_vec())?;
 
-        let data = self.data.lock().unwrap();
-        let metadata_map = self.metadata.lock().unwrap();
+        let data = lock(&self.data)?;
+        let metadata_map = lock(&self.metadata)?;
 
         let Some(data_map) = data.get(&ks) else {
             return Ok(None);
@@ -162,8 +164,8 @@ impl StorageApi for MockStorage {
         };
         let prefix_str = String::from_utf8(prefix.as_ref().to_vec())?;
 
-        let data = self.data.lock().unwrap();
-        let metadata_map = self.metadata.lock().unwrap();
+        let data = lock(&self.data)?;
+        let metadata_map = lock(&self.metadata)?;
 
         let Some(data_map) = data.get(&ks) else {
             return Ok(Vec::new());
@@ -193,7 +195,7 @@ impl StorageApi for MockStorage {
     where
         K: AsRef<[u8]> + Send,
     {
-        let indexes = self.indexes.lock().unwrap();
+        let indexes = lock(&self.indexes)?;
 
         let mut result: Vec<String> = indexes
             .keys()
@@ -214,8 +216,8 @@ impl StorageApi for MockStorage {
         let ks = resolve_keyspace(keyspace);
         let key_str = String::from_utf8(key_bytes)?;
 
-        let mut data = self.data.lock().unwrap();
-        let mut metadata_map = self.metadata.lock().unwrap();
+        let mut data = lock(&self.data)?;
+        let mut metadata_map = lock(&self.metadata)?;
         if let Some(data_map) = data.get_mut(&ks) {
             data_map.remove(&key_str);
         }
@@ -229,7 +231,7 @@ impl StorageApi for MockStorage {
         K: Into<Vec<u8>> + Send,
     {
         let key_bytes = key.into();
-        self.indexes.lock().unwrap().remove(&key_bytes);
+        lock(&self.indexes)?.remove(&key_bytes);
         Ok(Response::default())
     }
 
@@ -249,17 +251,17 @@ impl StorageApi for MockStorage {
         let ks = resolve_keyspace(keyspace);
         let value_bytes = rmp_serde::to_vec(&value.data)?;
 
-        let mut data = self.data.lock().unwrap();
-        let mut metadata_map = self.metadata.lock().unwrap();
+        let mut data = lock(&self.data)?;
+        let mut metadata_map = lock(&self.metadata)?;
         let violation = Self::set_value_inner(
-            &mut *data,
-            &mut *metadata_map,
+            &mut data,
+            &mut metadata_map,
             &key_str,
             &ks,
             value_bytes,
             &value.metadata,
             expected_revision,
-        );
+        )?;
 
         let violations = violation.map_or(Vec::new(), |v| vec![v]);
         Ok(Response {
@@ -273,16 +275,16 @@ impl StorageApi for MockStorage {
         K: Into<String> + Send,
     {
         let key_bytes: Vec<u8> = key.into().into_bytes();
-        self.indexes.lock().unwrap().insert(key_bytes, ());
+        lock(&self.indexes)?.insert(key_bytes, ());
         Ok(Response::default())
     }
 
     async fn transaction(&self, mutations: Vec<Mutation>) -> Result<Response, StoreError> {
         let mut violations: Vec<Violation> = Vec::new();
 
-        let mut data = self.data.lock().unwrap();
-        let mut metadata_map = self.metadata.lock().unwrap();
-        let mut indexes = self.indexes.lock().unwrap();
+        let mut data = lock(&self.data)?;
+        let mut metadata_map = lock(&self.metadata)?;
+        let mut indexes = lock(&self.indexes)?;
 
         for mutation in mutations {
             match mutation {
@@ -307,14 +309,14 @@ impl StorageApi for MockStorage {
                 } => {
                     let key_str = String::from_utf8_lossy(&key).to_string();
                     if let Some(v) = Self::set_value_inner(
-                        &mut *data,
-                        &mut *metadata_map,
+                        &mut data,
+                        &mut metadata_map,
                         &key_str,
                         &keyspace,
                         value,
                         &metadata,
                         expected_revision,
-                    ) {
+                    )? {
                         violations.push(v);
                     }
                 }

--- a/crates/webauthn/src/driver/raft.rs
+++ b/crates/webauthn/src/driver/raft.rs
@@ -134,7 +134,6 @@ impl RaftDriver {
         format!("{}:cred", user_id.as_ref())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn create_user_webauthn_credential_impl(
         &self,
         storage: &impl StorageApi,
@@ -154,7 +153,6 @@ impl RaftDriver {
         Ok(credential.clone())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn get_user_webauthn_credential_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -168,7 +166,6 @@ impl RaftDriver {
             .map(|x| x.data))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn delete_user_webauthn_credential_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -180,7 +177,6 @@ impl RaftDriver {
         Ok(())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn list_user_webauthn_credentials_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -195,14 +191,13 @@ impl RaftDriver {
             .collect())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn update_user_webauthn_credential_impl<'a>(
         &self,
         storage: &impl StorageApi,
         user_id: &'a str,
         credential_id: &'a str,
         credential: &WebauthnCredential,
-    ) -> Result<WebauthnCredential, StoreError> {
+    ) -> Result<Option<WebauthnCredential>, StoreError> {
         let key = self.get_cred_key_name(user_id, credential_id);
         if let Some(curr) = storage
             .get_by_key::<WebauthnCredential, String, &str>(key, Some(DATA_KEYSPACE))
@@ -221,15 +216,12 @@ impl RaftDriver {
                     Some(curr_revision),
                 )
                 .await?;
-            Ok(credential.clone())
+            Ok(Some(credential.clone()))
         } else {
-            Err(StoreError::IO {
-                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
-            })
+            Ok(None)
         }
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn save_user_webauthn_credential_authentication_state_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -251,7 +243,6 @@ impl RaftDriver {
         Ok(())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn get_user_webauthn_credential_authentication_state_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -265,7 +256,6 @@ impl RaftDriver {
             .map(|x| x.data))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn delete_user_webauthn_credential_authentication_state_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -277,7 +267,6 @@ impl RaftDriver {
         Ok(())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn save_user_webauthn_credential_registration_state_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -299,7 +288,6 @@ impl RaftDriver {
         Ok(())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn get_user_webauthn_credential_registration_state_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -313,7 +301,6 @@ impl RaftDriver {
             .map(|x| x.data))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn delete_user_webauthn_credential_registration_state_impl<'a>(
         &self,
         storage: &impl StorageApi,
@@ -623,15 +610,14 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_ref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        self.update_user_webauthn_credential_impl(raft, user_id, credential_id, credential)
+        match self
+            .update_user_webauthn_credential_impl(raft, user_id, credential_id, credential)
             .await
-            .map_err(|e| {
-                if e.to_string().contains("NotFound") {
-                    WebauthnError::CredentialNotFound(credential_id.to_string())
-                } else {
-                    e.into()
-                }
-            })
+        {
+            Ok(Some(c)) => Ok(c),
+            Ok(None) => Err(WebauthnError::CredentialNotFound(credential_id.to_string())),
+            Err(e) => Err(e.into()),
+        }
     }
 }
 


### PR DESCRIPTION
Previous change introduced interim artefacts with unnecessary
decorators. Remove them and address further clippy warnings.
