### PR TITLE
Feature/system assignment group

### DIFF
--- a/crates/assignment-driver-sql/src/lib.rs
+++ b/crates/assignment-driver-sql/src/lib.rs
@@ -244,6 +244,9 @@ impl AssignmentBackend for SqlBackend {
         if let Some(uid) = &params.user_id {
             actors.push(uid.into());
         }
+        if let Some(gid) = &params.group_id {
+            actors.push(gid.into());
+        }
         if let Some(true) = &params.effective
             && let Some(uid) = &params.user_id
         {

--- a/crates/config/src/token.rs
+++ b/crates/config/src/token.rs
@@ -34,10 +34,22 @@ pub struct TokenProvider {
     /// compromised token.
     #[serde(default = "default_token_expiration")]
     pub expiration: usize,
+    /// Controls whether token revocation is enabled for group role
+    /// assignments. When disabled (default), group role revocations do not
+    /// create revocation events since token validation rebuilds assignments
+    /// at validation time. Enabling this creates revocation events for group
+    /// assignments but may cause overly broad token invalidation.
+    /// Matches Python Keystone's [token] revoke_by_id option.
+    #[serde(default = "default_revoke_by_id")]
+    pub revoke_by_id: bool,
 }
 
 fn default_token_expiration() -> usize {
     3600
+}
+
+fn default_revoke_by_id() -> bool {
+    false
 }
 
 impl Default for TokenProvider {
@@ -45,6 +57,7 @@ impl Default for TokenProvider {
         Self {
             provider: TokenProviderDriver::Fernet,
             expiration: default_token_expiration(),
+            revoke_by_id: default_revoke_by_id(),
         }
     }
 }

--- a/crates/core-types/src/assignment/assignment.rs
+++ b/crates/core-types/src/assignment/assignment.rs
@@ -152,6 +152,22 @@ impl AssignmentCreate {
         )
     }
 
+    /// Instantiate GroupSystem assignment.
+    pub fn group_system<A, T, R>(actor_id: A, target_id: T, role_id: R, inherited: bool) -> Self
+    where
+        A: Into<String>,
+        T: Into<String>,
+        R: Into<String>,
+    {
+        Self::new(
+            actor_id,
+            target_id,
+            role_id,
+            AssignmentType::GroupSystem,
+            inherited,
+        )
+    }
+
     /// Instantiate UserDomain assignment.
     pub fn user_domain<A, T, R>(actor_id: A, target_id: T, role_id: R, inherited: bool) -> Self
     where

--- a/crates/core-types/src/assignment/assignment.rs
+++ b/crates/core-types/src/assignment/assignment.rs
@@ -176,6 +176,22 @@ impl AssignmentCreate {
         )
     }
 
+    /// Instantiate GroupSystem assignment.
+    pub fn group_system<A, T, R>(actor_id: A, target_id: T, role_id: R, inherited: bool) -> Self
+    where
+        A: Into<String>,
+        T: Into<String>,
+        R: Into<String>,
+    {
+        Self::new(
+            actor_id,
+            target_id,
+            role_id,
+            AssignmentType::GroupSystem,
+            inherited,
+        )
+    }
+
     /// Instantiate UserDomain assignment.
     pub fn user_domain<A, T, R>(actor_id: A, target_id: T, role_id: R, inherited: bool) -> Self
     where

--- a/crates/core/src/assignment/service.rs
+++ b/crates/core/src/assignment/service.rs
@@ -197,11 +197,26 @@ impl AssignmentApi for AssignmentService {
             revoked_at: chrono::Utc::now(),
         };
 
-        state
-            .provider
-            .get_revoke_provider()
-            .create_revocation_event(state, revocation_event)
-            .await?;
+        // Only create revocation event for group assignments if revoke_by_id is enabled.
+        // By default group revocations do not create revocation events since token
+        // validation rebuilds assignments at validation time.
+        // Reference: Python Keystone bug #1662514
+        let is_group_assignment = matches!(
+            &grant.r#type,
+            AssignmentType::GroupDomain
+                | AssignmentType::GroupProject
+                | AssignmentType::GroupSystem
+        );
+
+        let revoke_by_id = state.config_manager.config.read().await.token.revoke_by_id;
+
+        if !is_group_assignment || revoke_by_id {
+            state
+                .provider
+                .get_revoke_provider()
+                .create_revocation_event(state, revocation_event)
+                .await?;
+        }
 
         state
             .event_dispatcher
@@ -397,6 +412,40 @@ mod tests {
             .role_id("rid1")
             .target_id("target_id")
             .r#type(AssignmentType::UserProject)
+            .build()
+            .unwrap();
+        let assignment_clone = assignment.clone();
+        backend
+            .expect_revoke_grant()
+            .withf(move |_, params: &Assignment| *params == assignment_clone)
+            .returning(|_, _| Ok(()));
+
+        let provider = AssignmentService {
+            backend_driver: Arc::new(backend),
+        };
+
+        assert!(provider.revoke_grant(&state, assignment).await.is_ok());
+    }
+    #[tokio::test]
+    async fn test_revoke_group_system_grant() {
+        let mut revoke_mock = MockRevokeProvider::default();
+        // Group assignments must NOT create revocation events by default
+        // (revoke_by_id = false). Token validation rebuilds assignments
+        // at validation time. Reference: Python Keystone bug #1662514
+        revoke_mock.expect_create_revocation_event().never();
+
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_revoke(revoke_mock)),
+        )
+        .await;
+
+        let mut backend = MockAssignmentBackend::default();
+        let assignment = AssignmentBuilder::default()
+            .actor_id("group_id")
+            .role_id("rid1")
+            .target_id("system")
+            .r#type(AssignmentType::GroupSystem)
             .build()
             .unwrap();
         let assignment_clone = assignment.clone();

--- a/crates/core/src/assignment/service.rs
+++ b/crates/core/src/assignment/service.rs
@@ -813,17 +813,37 @@ impl AssignmentApi for AssignmentService {
             audit_chain_id: None,
             revoked_at: chrono::Utc::now(),
         };
+        // Only create revocation event for group assignments if revoke_by_id is enabled.
+        // By default group revocations do not create revocation events since token
+        // validation rebuilds assignments at validation time.
+        // Reference: Python Keystone bug #1662514
+        let is_group_assignment = matches!(
+            &grant.r#type,
+            AssignmentType::GroupDomain
+                | AssignmentType::GroupProject
+                | AssignmentType::GroupSystem
+        );
 
-        // ADR 0034 §4: the central revocation event stays on the global revoke
-        // provider, unrouted — it is not an assignment-backend operation.
-        ctx.state()
-            .provider
-            .get_revoke_provider()
-            .create_revocation_event(ctx, revocation_event)
-            .await?;
-        // ADR 0031 "Tokens": revoking a grant cascades revocation of every
-        // token carrying that role - `"cascade"`, not a direct user request.
-        crate::token::TOKEN_METRICS.revoked_total.inc(["cascade"]);
+        let revoke_by_id = ctx
+            .state()
+            .config_manager
+            .config
+            .read()
+            .await
+            .token
+            .revoke_by_id;
+        if !is_group_assignment || revoke_by_id {
+            // ADR 0034 §4: the central revocation event stays on the global revoke
+            // provider, unrouted — it is not an assignment-backend operation.
+            ctx.state()
+                .provider
+                .get_revoke_provider()
+                .create_revocation_event(ctx, revocation_event)
+                .await?;
+            // ADR 0031 "Tokens": revoking a grant cascades revocation of every
+            // token carrying that role - `"cascade"`, not a direct user request.
+            crate::token::TOKEN_METRICS.revoked_total.inc(["cascade"]);
+        }
 
         Ok(())
     }

--- a/crates/keystone/src/api/v3/role_assignment/system/group/mod.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/mod.rs
@@ -11,6 +11,13 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+//! # System Group role API
+use utoipa_axum::router::OpenApiRouter;
 
-mod group;
-mod user;
+use crate::keystone::ServiceState;
+
+mod role;
+
+pub(crate) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new().merge(role::openapi_router())
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/check.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/check.rs
@@ -1,0 +1,423 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: get.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use tracing::info;
+
+use openstack_keystone_core_types::assignment::Assignment;
+use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
+
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use crate::{api::auth::Auth, assignment::AssignmentApi, identity::IdentityApi, role::RoleApi};
+
+/// Check whether group has role assignment on system.
+///
+/// Validates that a group has a role on the system.
+#[utoipa::path(
+    head,
+    path = "/system/groups/{group_id}/roles/{role_id}",
+    operation_id = "/system/group/role:check",
+    params(
+      ("role_id" = String, Path, description = "The role ID."),
+      ("group_id" = String, Path, description = "The group ID.")
+    ),
+    responses(
+        (status = NO_CONTENT, description = "Grant is present."),
+        (status = 404, description = "Grant not found", example = json!(KeystoneApiError::NotFound(String::from("id = 1"))))
+    ),
+    security(("x-auth" = [])),
+    tag="role_assignments"
+)]
+#[tracing::instrument(
+    name = "api::system_group_role_check",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn check(
+    Auth(user_auth): Auth,
+    Path((group_id, role_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let query_params = RoleAssignmentListParameters {
+        group_id: Some(group_id.clone()),
+        system_id: Some("system".into()),
+        effective: Some(true),
+        include_names: Some(false),
+        resolve_implied_roles: false,
+        ..Default::default()
+    };
+    let (group, role, assignments) = tokio::join!(
+        state
+            .provider
+            .get_identity_provider()
+            .get_group(&state, &group_id),
+        state
+            .provider
+            .get_role_provider()
+            .get_role(&state, &role_id),
+        state
+            .provider
+            .get_assignment_provider()
+            .list_role_assignments(&state, &query_params)
+    );
+    let group = group?.ok_or_else(|| {
+        info!("Group {} was not found", group_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+    let role = role?.ok_or_else(|| {
+        info!("Role {} was not found", role_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/system/group/role/check",
+            &user_auth,
+            json!({"group": group, "role": role}),
+            None,
+        )
+        .await?;
+
+    let grants: Vec<Assignment> = assignments?.into_iter().collect();
+
+    if grants.into_iter().any(|x| x.role_id == role_id) {
+        Ok(StatusCode::NO_CONTENT.into_response())
+    } else {
+        Err(KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        })
+    }
+}
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing_test::traced_test;
+
+    use openstack_keystone_core_types::assignment::*;
+    use openstack_keystone_core_types::identity::GroupBuilder as CoreGroupBuilder;
+    use openstack_keystone_core_types::role::*;
+
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role_assignment::openapi_router;
+    use crate::assignment::MockAssignmentProvider;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+    use crate::role::MockRoleProvider;
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_check_found_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.role_id.is_none()
+                    && params.group_id.as_ref().is_some_and(|x| x == "group_id")
+                    && params.system_id.as_ref().is_some_and(|x| x == "system")
+                    && params.effective.is_some_and(|x| x)
+            })
+            .returning(|_, _| {
+                Ok(vec![Assignment {
+                    role_id: "role_id".into(),
+                    role_name: Some("rn".into()),
+                    actor_id: "group_id".into(),
+                    target_id: "system".into(),
+                    r#type: AssignmentType::GroupSystem,
+                    inherited: false,
+                    implied_via: None,
+                }])
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/system/group/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_check_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.role_id.is_none()
+                    && params.group_id.as_ref().is_some_and(|x| x == "group_id")
+                    && params.system_id.as_ref().is_some_and(|x| x == "system")
+                    && params.effective.is_some_and(|x| x)
+            })
+            .returning(|_, _| Ok(vec![]));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/system/group/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_check_not_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.role_id.is_none()
+                    && params.group_id.as_ref().is_some_and(|x| x == "group_id")
+                    && params.system_id.as_ref().is_some_and(|x| x == "system")
+                    && params.effective.is_some_and(|x| x)
+            })
+            .returning(|_, _| {
+                Ok(vec![Assignment {
+                    role_id: "role_id".into(),
+                    role_name: Some("rn".into()),
+                    actor_id: "group_id".into(),
+                    target_id: "system".into(),
+                    r#type: AssignmentType::GroupSystem,
+                    inherited: false,
+                    implied_via: None,
+                }])
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, false, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/system/group/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_check_group_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| Ok(None));
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.system_id.as_ref().is_some_and(|x| x == "system")
+            })
+            .returning(|_, _| Ok(vec![]));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/system/group/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/check.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/check.rs
@@ -205,7 +205,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("HEAD")
-                    .uri("/system/group/group_id/roles/role_id")
+                    .uri("/system/groups/group_id/roles/role_id")
                     .extension(vsc)
                     .body(Body::empty())
                     .unwrap(),
@@ -274,7 +274,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("HEAD")
-                    .uri("/system/group/group_id/roles/role_id")
+                    .uri("/system/groups/group_id/roles/role_id")
                     .extension(vsc)
                     .body(Body::empty())
                     .unwrap(),
@@ -353,7 +353,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("HEAD")
-                    .uri("/system/group/group_id/roles/role_id")
+                    .uri("/system/groups/group_id/roles/role_id")
                     .extension(vsc)
                     .body(Body::empty())
                     .unwrap(),
@@ -410,7 +410,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("HEAD")
-                    .uri("/system/group/group_id/roles/role_id")
+                    .uri("/system/groups/group_id/roles/role_id")
                     .extension(vsc)
                     .body(Body::empty())
                     .unwrap(),

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/check.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/check.rs
@@ -1,0 +1,421 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: get.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use tracing::info;
+
+use openstack_keystone_core_types::assignment::Assignment;
+use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+/// Check whether group has role assignment on system.
+///
+/// Validates that a group has a role on the system.
+#[utoipa::path(
+    head,
+    path = "/system/groups/{group_id}/roles/{role_id}",
+    operation_id = "/system/group/role:check",
+    params(
+      ("role_id" = String, Path, description = "The role ID."),
+      ("group_id" = String, Path, description = "The group ID.")
+    ),
+    responses(
+        (status = NO_CONTENT, description = "Grant is present."),
+        (status = 404, description = "Grant not found", example = json!(KeystoneApiError::NotFound(String::from("id = 1"))))
+    ),
+    security(("x-auth" = [])),
+    tag="role_assignments"
+)]
+#[tracing::instrument(
+    name = "api::system_group_role_check",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn check(
+    Auth(user_auth): Auth,
+    Path((group_id, role_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let query_params = RoleAssignmentListParameters {
+        group_id: Some(group_id.clone()),
+        system_id: Some("system".into()),
+        effective: Some(true),
+        include_names: Some(false),
+        resolve_implied_roles: false,
+        ..Default::default()
+    };
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
+    let (group, role, assignments) = tokio::join!(
+        state
+            .provider
+            .get_identity_provider()
+            .get_group(exec, &group_id),
+        state.provider.get_role_provider().get_role(exec, &role_id),
+        state
+            .provider
+            .get_assignment_provider()
+            .list_role_assignments(exec, &query_params)
+    );
+    let group = group?.ok_or_else(|| {
+        info!("Group {} was not found", group_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+    let role = role?.ok_or_else(|| {
+        info!("Role {} was not found", role_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/system/group/role/check",
+            &user_auth,
+            json!({"group": group, "role": role}),
+            None,
+        )
+        .await?;
+
+    let grants: Vec<Assignment> = assignments?.into_iter().collect();
+
+    if grants.into_iter().any(|x| x.role_id == role_id) {
+        Ok(StatusCode::NO_CONTENT.into_response())
+    } else {
+        Err(KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        })
+    }
+}
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing_test::traced_test;
+
+    use openstack_keystone_core_types::assignment::*;
+    use openstack_keystone_core_types::identity::GroupBuilder as CoreGroupBuilder;
+    use openstack_keystone_core_types::role::*;
+
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role_assignment::openapi_router;
+    use crate::assignment::MockAssignmentProvider;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+    use crate::role::MockRoleProvider;
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_check_found_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.role_id.is_none()
+                    && params.group_id.as_ref().is_some_and(|x| x == "group_id")
+                    && params.system_id.as_ref().is_some_and(|x| x == "system")
+                    && params.effective.is_some_and(|x| x)
+            })
+            .returning(|_, _| {
+                Ok(vec![Assignment {
+                    role_id: "role_id".into(),
+                    role_name: Some("rn".into()),
+                    actor_id: "group_id".into(),
+                    target_id: "system".into(),
+                    r#type: AssignmentType::GroupSystem,
+                    inherited: false,
+                    implied_via: None,
+                }])
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_check_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.role_id.is_none()
+                    && params.group_id.as_ref().is_some_and(|x| x == "group_id")
+                    && params.system_id.as_ref().is_some_and(|x| x == "system")
+                    && params.effective.is_some_and(|x| x)
+            })
+            .returning(|_, _| Ok(vec![]));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_check_not_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.role_id.is_none()
+                    && params.group_id.as_ref().is_some_and(|x| x == "group_id")
+                    && params.system_id.as_ref().is_some_and(|x| x == "system")
+                    && params.effective.is_some_and(|x| x)
+            })
+            .returning(|_, _| {
+                Ok(vec![Assignment {
+                    role_id: "role_id".into(),
+                    role_name: Some("rn".into()),
+                    actor_id: "group_id".into(),
+                    target_id: "system".into(),
+                    r#type: AssignmentType::GroupSystem,
+                    inherited: false,
+                    implied_via: None,
+                }])
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, false, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_check_group_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| Ok(None));
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.system_id.as_ref().is_some_and(|x| x == "system")
+            })
+            .returning(|_, _| Ok(vec![]));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/grant.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/grant.rs
@@ -1,0 +1,359 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: put.
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use tracing::info;
+
+use openstack_keystone_core_types::assignment::AssignmentCreate;
+
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use crate::{api::auth::Auth, assignment::AssignmentApi, identity::IdentityApi, role::RoleApi};
+
+/// Assign role to group on system
+///
+/// Assigns a role to a group on the system.
+#[utoipa::path(
+    put,
+    path = "/system/groups/{group_id}/roles/{role_id}",
+    operation_id = "/system/group/role:put",
+    params(
+        ("role_id" = String, Path, description = "The role ID."),
+        ("group_id" = String, Path, description = "The group ID.")
+    ),
+    responses(
+        (status = NO_CONTENT, description = "Grant is created."),
+        (status = 404, description = "Grant not found", example = json!(KeystoneApiError::NotFound(String::from("id = 1"))))
+    ),
+    security(("x-auth" = [])),
+    tag="role_assignments"
+)]
+#[tracing::instrument(
+    name = "api::v3::system_group_role_grant",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn grant(
+    Auth(user_auth): Auth,
+    Path((group_id, role_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let (group, role) = tokio::join!(
+        state
+            .provider
+            .get_identity_provider()
+            .get_group(&state, &group_id),
+        state
+            .provider
+            .get_role_provider()
+            .get_role(&state, &role_id),
+    );
+    let group = group?.ok_or_else(|| {
+        info!("Group {} was not found", group_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+    let role = role?.ok_or_else(|| {
+        info!("Role {} was not found", role_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/system/group/role/grant",
+            &user_auth,
+            json!({"group": group, "role": role}),
+            None,
+        )
+        .await?;
+
+    state
+        .provider
+        .get_assignment_provider()
+        .create_grant(
+            &state,
+            AssignmentCreate::group_system(group.id, "system", role.id, false),
+        )
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing_test::traced_test;
+
+    use openstack_keystone_core_types::assignment::*;
+    use openstack_keystone_core_types::identity::GroupBuilder as CoreGroupBuilder;
+    use openstack_keystone_core_types::role::*;
+
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role_assignment::openapi_router;
+    use crate::assignment::MockAssignmentProvider;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+    use crate::role::MockRoleProvider;
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_all_found_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_create_grant()
+            .withf(|_, params: &AssignmentCreate| {
+                params.role_id == "role_id"
+                    && params.actor_id == "group_id"
+                    && params.target_id == "system"
+                    && params.r#type == AssignmentType::GroupSystem
+                    && !params.inherited
+            })
+            .returning(|_, _| {
+                Ok(Assignment {
+                    role_id: "role_id".into(),
+                    role_name: Some("rn".into()),
+                    actor_id: "group_id".into(),
+                    target_id: "system".into(),
+                    r#type: AssignmentType::GroupSystem,
+                    inherited: false,
+                    implied_via: None,
+                })
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_all_found_not_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, false, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_group_not_found_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| Ok(None));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_role_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| Ok(None));
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/grant.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/grant.rs
@@ -1,0 +1,358 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: put.
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use tracing::info;
+
+use openstack_keystone_core_types::assignment::AssignmentCreate;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+/// Assign role to group on system
+///
+/// Assigns a role to a group on the system.
+#[utoipa::path(
+    put,
+    path = "/system/groups/{group_id}/roles/{role_id}",
+    operation_id = "/system/group/role:put",
+    params(
+        ("role_id" = String, Path, description = "The role ID."),
+        ("group_id" = String, Path, description = "The group ID.")
+    ),
+    responses(
+        (status = NO_CONTENT, description = "Grant is created."),
+        (status = 404, description = "Grant not found", example = json!(KeystoneApiError::NotFound(String::from("id = 1"))))
+    ),
+    security(("x-auth" = [])),
+    tag="role_assignments"
+)]
+#[tracing::instrument(
+    name = "api::v3::system_group_role_grant",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn grant(
+    Auth(user_auth): Auth,
+    Path((group_id, role_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
+
+    let (group, role) = tokio::join!(
+        state
+            .provider
+            .get_identity_provider()
+            .get_group(exec, &group_id),
+        state.provider.get_role_provider().get_role(exec, &role_id),
+    );
+    let group = group?.ok_or_else(|| {
+        info!("Group {} was not found", group_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+    let role = role?.ok_or_else(|| {
+        info!("Role {} was not found", role_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/system/group/role/grant",
+            &user_auth,
+            json!({"group": group, "role": role}),
+            None,
+        )
+        .await?;
+
+    state
+        .provider
+        .get_assignment_provider()
+        .create_grant(
+            exec,
+            AssignmentCreate::group_system(group.id, "system", role.id, false),
+        )
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing_test::traced_test;
+
+    use openstack_keystone_core_types::assignment::*;
+    use openstack_keystone_core_types::identity::GroupBuilder as CoreGroupBuilder;
+    use openstack_keystone_core_types::role::*;
+
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role_assignment::openapi_router;
+    use crate::assignment::MockAssignmentProvider;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+    use crate::role::MockRoleProvider;
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_all_found_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_create_grant()
+            .withf(|_, params: &AssignmentCreate| {
+                params.role_id == "role_id"
+                    && params.actor_id == "group_id"
+                    && params.target_id == "system"
+                    && params.r#type == AssignmentType::GroupSystem
+                    && !params.inherited
+            })
+            .returning(|_, _| {
+                Ok(Assignment {
+                    role_id: "role_id".into(),
+                    role_name: Some("rn".into()),
+                    actor_id: "group_id".into(),
+                    target_id: "system".into(),
+                    r#type: AssignmentType::GroupSystem,
+                    inherited: false,
+                    implied_via: None,
+                })
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_all_found_not_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, false, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_group_not_found_allowed() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| Ok(None));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_role_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("group_domain_id")
+                        .name("name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| Ok(None));
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/list.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/list.rs
@@ -1,0 +1,398 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: list.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: list.
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use serde_json::json;
+use tracing::info;
+
+use openstack_keystone_api_types::v3::role_assignment::{Role, RoleAssignmentRoleList};
+use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
+
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use crate::{api::auth::Auth, assignment::AssignmentApi, identity::IdentityApi};
+
+/// List the roles that a group has on the system.
+#[utoipa::path(
+    get,
+    path = "/system/groups/{group_id}/roles",
+    operation_id = "/system/group/role:list",
+    params(
+      ("group_id" = String, Path, description = "The group ID.")
+    ),
+    responses(
+        (status = OK, description = "List of roles", example = json!([])),
+        (status = 404, description = "Group not found", example = json!(KeystoneApiError::NotFound(String::from("id = 1"))))
+    ),
+    security(("x-auth" = [])),
+    tag="role_assignments"
+)]
+#[tracing::instrument(
+    name = "api::system_group_role_list",
+    level = "debug",
+    skip(state, group_auth),
+    err(Debug)
+)]
+pub(super) async fn list(
+    Auth(group_auth): Auth,
+    Path(group_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let query_params = RoleAssignmentListParameters {
+        group_id: Some(group_id.clone()),
+        system_id: Some("system".into()),
+        effective: Some(false),
+        include_names: Some(false),
+        resolve_implied_roles: false,
+        ..Default::default()
+    };
+
+    let (group, assignments) = tokio::join!(
+        state
+            .provider
+            .get_identity_provider()
+            .get_group(&state, &group_id),
+        state
+            .provider
+            .get_assignment_provider()
+            .list_role_assignments(&state, &query_params)
+    );
+    let group = group?.ok_or_else(|| {
+        info!("Group {} was not found", group_id);
+        KeystoneApiError::NotFound {
+            resource: "group".into(),
+            identifier: "".into(),
+        }
+    })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/system/group/role/list",
+            &group_auth,
+            json!({"group": group}),
+            None,
+        )
+        .await?;
+
+    let assignments = assignments?;
+    // Collect to HashSet<Role> to deduplicate, then convert to Vec for API response
+    let roles: Vec<Role> = assignments
+        .into_iter()
+        .map(|a| a.try_into())
+        .collect::<Result<std::collections::HashSet<_>, _>>()?
+        .into_iter()
+        .collect();
+
+    Ok((StatusCode::OK, Json(RoleAssignmentRoleList { roles })).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing_test::traced_test;
+
+    use openstack_keystone_api_types::v3::role_assignment::RoleAssignmentRoleList;
+    use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
+    use openstack_keystone_core_types::assignment::{Assignment, AssignmentType};
+    use openstack_keystone_core_types::identity::GroupBuilder as CoreGroupBuilder;
+
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role_assignment::openapi_router;
+    use crate::assignment::MockAssignmentProvider;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+
+    fn group_mock(mock: &mut MockIdentityProvider) {
+        mock.expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("domain_id")
+                        .name("gname")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+    }
+
+    fn assignment_mock_empty(mock: &mut MockAssignmentProvider) {
+        mock.expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.group_id.as_deref() == Some("group_id")
+                    && params.system_id.as_deref() == Some("system")
+                    && params.effective == Some(false)
+                    && params.include_names == Some(false)
+            })
+            .returning(|_, _| Ok(vec![]));
+    }
+
+    #[tokio::test]
+    async fn test_list_success() {
+        let mut identity_mock = MockIdentityProvider::default();
+        let mut assignment_mock = MockAssignmentProvider::default();
+
+        group_mock(&mut identity_mock);
+        assignment_mock_empty(&mut assignment_mock);
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_assignment(assignment_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let vsc = test_fixture_scoped();
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_list_forbidden() {
+        let mut identity_mock = MockIdentityProvider::default();
+        let mut assignment_mock = MockAssignmentProvider::default();
+
+        group_mock(&mut identity_mock);
+        assignment_mock_empty(&mut assignment_mock);
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_assignment(assignment_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let vsc = test_fixture_scoped();
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_list_group_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| Ok(None));
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock_empty(&mut assignment_mock);
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_assignment(assignment_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let vsc = test_fixture_scoped();
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_list_deduplicates_roles() {
+        let mut identity_mock = MockIdentityProvider::default();
+        let mut assignment_mock = MockAssignmentProvider::default();
+
+        group_mock(&mut identity_mock);
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.group_id.as_deref() == Some("group_id")
+                    && params.system_id.as_deref() == Some("system")
+                    && params.effective == Some(false)
+                    && params.include_names == Some(false)
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    Assignment {
+                        role_id: "role1".into(),
+                        role_name: Some("Role1".into()),
+                        actor_id: "group_id".into(),
+                        target_id: "system".into(),
+                        r#type: AssignmentType::GroupSystem,
+                        inherited: false,
+                        implied_via: None,
+                    },
+                    Assignment {
+                        role_id: "role1".into(),
+                        role_name: Some("Role1".into()),
+                        actor_id: "group_id".into(),
+                        target_id: "system".into(),
+                        r#type: AssignmentType::GroupSystem,
+                        inherited: false,
+                        implied_via: Some("imply_rule_1".into()),
+                    },
+                    Assignment {
+                        role_id: "role1".into(),
+                        role_name: Some("Role1".into()),
+                        actor_id: "group_id".into(),
+                        target_id: "system".into(),
+                        r#type: AssignmentType::GroupSystem,
+                        inherited: false,
+                        implied_via: Some("imply_rule_2".into()),
+                    },
+                    Assignment {
+                        role_id: "role2".into(),
+                        role_name: Some("Role2".into()),
+                        actor_id: "group_id".into(),
+                        target_id: "system".into(),
+                        r#type: AssignmentType::GroupSystem,
+                        inherited: false,
+                        implied_via: None,
+                    },
+                ])
+            });
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_assignment(assignment_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let vsc = test_fixture_scoped();
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body();
+        let bytes = axum::body::to_bytes(body, 1024 * 1024).await.unwrap();
+        let res: RoleAssignmentRoleList = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(res.roles.len(), 2);
+        let role_ids: Vec<_> = res.roles.iter().map(|r| &r.id).collect();
+        assert!(role_ids.contains(&&"role1".to_string()));
+        assert!(role_ids.contains(&&"role2".to_string()));
+    }
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/list.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/list.rs
@@ -1,0 +1,399 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: list.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: list.
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use serde_json::json;
+use tracing::info;
+
+use openstack_keystone_api_types::v3::role_assignment::{Role, RoleAssignmentRoleList};
+use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+/// List the roles that a group has on the system.
+#[utoipa::path(
+    get,
+    path = "/system/groups/{group_id}/roles",
+    operation_id = "/system/group/role:list",
+    params(
+      ("group_id" = String, Path, description = "The group ID.")
+    ),
+    responses(
+        (status = OK, description = "List of roles", example = json!([])),
+        (status = 404, description = "Group not found", example = json!(KeystoneApiError::NotFound(String::from("id = 1"))))
+    ),
+    security(("x-auth" = [])),
+    tag="role_assignments"
+)]
+#[tracing::instrument(
+    name = "api::system_group_role_list",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn list(
+    Auth(user_auth): Auth,
+    Path(group_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let query_params = RoleAssignmentListParameters {
+        group_id: Some(group_id.clone()),
+        system_id: Some("system".into()),
+        effective: Some(false),
+        include_names: Some(false),
+        resolve_implied_roles: false,
+        ..Default::default()
+    };
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
+
+    let (group, assignments) = tokio::join!(
+        state
+            .provider
+            .get_identity_provider()
+            .get_group(exec, &group_id),
+        state
+            .provider
+            .get_assignment_provider()
+            .list_role_assignments(exec, &query_params)
+    );
+    let group = group?.ok_or_else(|| {
+        info!("Group {} was not found", group_id);
+        KeystoneApiError::NotFound {
+            resource: "group".into(),
+            identifier: "".into(),
+        }
+    })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/system/group/role/list",
+            &user_auth,
+            json!({"group": group}),
+            None,
+        )
+        .await?;
+
+    let assignments = assignments?;
+    // Collect to HashSet<Role> to deduplicate, then convert to Vec for API response
+    let roles: Vec<Role> = assignments
+        .into_iter()
+        .map(|a| a.try_into())
+        .collect::<Result<std::collections::HashSet<_>, _>>()?
+        .into_iter()
+        .collect();
+
+    Ok((StatusCode::OK, Json(RoleAssignmentRoleList { roles })).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing_test::traced_test;
+
+    use openstack_keystone_api_types::v3::role_assignment::RoleAssignmentRoleList;
+    use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
+    use openstack_keystone_core_types::assignment::{Assignment, AssignmentType};
+    use openstack_keystone_core_types::identity::GroupBuilder as CoreGroupBuilder;
+
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role_assignment::openapi_router;
+    use crate::assignment::MockAssignmentProvider;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+
+    fn group_mock(mock: &mut MockIdentityProvider) {
+        mock.expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("domain_id")
+                        .name("gname")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+    }
+
+    fn assignment_mock_empty(mock: &mut MockAssignmentProvider) {
+        mock.expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.group_id.as_deref() == Some("group_id")
+                    && params.system_id.as_deref() == Some("system")
+                    && params.effective == Some(false)
+                    && params.include_names == Some(false)
+            })
+            .returning(|_, _| Ok(vec![]));
+    }
+
+    #[tokio::test]
+    async fn test_list_success() {
+        let mut identity_mock = MockIdentityProvider::default();
+        let mut assignment_mock = MockAssignmentProvider::default();
+
+        group_mock(&mut identity_mock);
+        assignment_mock_empty(&mut assignment_mock);
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_assignment(assignment_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let vsc = test_fixture_scoped();
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_list_forbidden() {
+        let mut identity_mock = MockIdentityProvider::default();
+        let mut assignment_mock = MockAssignmentProvider::default();
+
+        group_mock(&mut identity_mock);
+        assignment_mock_empty(&mut assignment_mock);
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_assignment(assignment_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let vsc = test_fixture_scoped();
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_list_group_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| Ok(None));
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock_empty(&mut assignment_mock);
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_assignment(assignment_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let vsc = test_fixture_scoped();
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_list_deduplicates_roles() {
+        let mut identity_mock = MockIdentityProvider::default();
+        let mut assignment_mock = MockAssignmentProvider::default();
+
+        group_mock(&mut identity_mock);
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, params: &RoleAssignmentListParameters| {
+                params.group_id.as_deref() == Some("group_id")
+                    && params.system_id.as_deref() == Some("system")
+                    && params.effective == Some(false)
+                    && params.include_names == Some(false)
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    Assignment {
+                        role_id: "role1".into(),
+                        role_name: Some("Role1".into()),
+                        actor_id: "group_id".into(),
+                        target_id: "system".into(),
+                        r#type: AssignmentType::GroupSystem,
+                        inherited: false,
+                        implied_via: None,
+                    },
+                    Assignment {
+                        role_id: "role1".into(),
+                        role_name: Some("Role1".into()),
+                        actor_id: "group_id".into(),
+                        target_id: "system".into(),
+                        r#type: AssignmentType::GroupSystem,
+                        inherited: false,
+                        implied_via: Some("imply_rule_1".into()),
+                    },
+                    Assignment {
+                        role_id: "role1".into(),
+                        role_name: Some("Role1".into()),
+                        actor_id: "group_id".into(),
+                        target_id: "system".into(),
+                        r#type: AssignmentType::GroupSystem,
+                        inherited: false,
+                        implied_via: Some("imply_rule_2".into()),
+                    },
+                    Assignment {
+                        role_id: "role2".into(),
+                        role_name: Some("Role2".into()),
+                        actor_id: "group_id".into(),
+                        target_id: "system".into(),
+                        r#type: AssignmentType::GroupSystem,
+                        inherited: false,
+                        implied_via: None,
+                    },
+                ])
+            });
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_assignment(assignment_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let vsc = test_fixture_scoped();
+
+        let response = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state)
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/system/groups/group_id/roles")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body();
+        let bytes = axum::body::to_bytes(body, 1024 * 1024).await.unwrap();
+        let res: RoleAssignmentRoleList = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(res.roles.len(), 2);
+        let role_ids: Vec<_> = res.roles.iter().map(|r| &r.id).collect();
+        assert!(role_ids.contains(&&"role1".to_string()));
+        assert!(role_ids.contains(&&"role2".to_string()));
+    }
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/mod.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/mod.rs
@@ -11,6 +11,21 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+//! # System Group role API
+use utoipa_axum::{router::OpenApiRouter, routes};
 
-mod group;
-mod user;
+use crate::keystone::ServiceState;
+
+mod check;
+mod grant;
+mod list;
+mod revoke;
+
+pub(crate) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new().routes(routes!(
+        check::check,
+        grant::grant,
+        list::list,
+        revoke::revoke
+    ))
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/revoke.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/revoke.rs
@@ -1,0 +1,348 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: delete.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use tracing::info;
+
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use crate::{api::auth::Auth, assignment::AssignmentApi, identity::IdentityApi, role::RoleApi};
+use openstack_keystone_core_types::assignment::{AssignmentBuilder, AssignmentType};
+
+/// Revoke role from group on system
+///
+/// Remove a role assignment for a group on the system.
+#[utoipa::path(
+    delete,
+    path = "/system/groups/{group_id}/roles/{role_id}",
+    operation_id = "/system/group/role:delete",
+    params(
+        ("role_id" = String, Path, description = "The role ID."),
+        ("group_id" = String, Path, description = "The group ID."),
+    ),
+    responses(
+        (status = 204, description = "Role revoked successfully"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Grant not found", example = json!(KeystoneApiError::NotFound(String::from("id = 1"))))
+    ),
+    security(
+        ("X-Auth-Token" = [])),
+    tag="role_assignments"
+)]
+#[tracing::instrument(
+    name = "api::v3::system_group_role_revoke",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn revoke(
+    Auth(user_auth): Auth,
+    Path((group_id, role_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let (group, role) = tokio::join!(
+        state
+            .provider
+            .get_identity_provider()
+            .get_group(&state, &group_id),
+        state
+            .provider
+            .get_role_provider()
+            .get_role(&state, &role_id)
+    );
+    let group = group?.ok_or_else(|| {
+        info!("Group {} was not found", group_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+    let role = role?.ok_or_else(|| {
+        info!("Role {} was not found", role_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/system/group/role/revoke",
+            &user_auth,
+            json!({"group": group, "role": role}),
+            None,
+        )
+        .await?;
+
+    let grant = AssignmentBuilder::default()
+        .actor_id(group_id)
+        .role_id(role_id)
+        .target_id("system")
+        .r#type(AssignmentType::GroupSystem)
+        .inherited(false)
+        .build()?;
+
+    state
+        .provider
+        .get_assignment_provider()
+        .revoke_grant(&state, grant)
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing_test::traced_test;
+
+    use openstack_keystone_core_types::identity::GroupBuilder as CoreGroupBuilder;
+    use openstack_keystone_core_types::role::*;
+
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role_assignment::openapi_router;
+    use crate::assignment::MockAssignmentProvider;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+    use crate::role::MockRoleProvider;
+
+    #[tokio::test]
+    async fn test_revoke_success() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("did")
+                        .name("gname")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_revoke_grant()
+            .returning(|_, _| Ok(()));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_revoke_forbidden() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("did")
+                        .name("gname")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, false, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_revoke_group_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| Ok(None));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_revoke_role_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("did")
+                        .name("gname")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| Ok(None));
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/group/role/revoke.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/group/role/revoke.rs
@@ -1,0 +1,346 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! System group role: delete.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use tracing::info;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::assignment::{AssignmentBuilder, AssignmentType};
+/// Revoke role from group on system
+///
+/// Remove a role assignment for a group on the system.
+#[utoipa::path(
+    delete,
+    path = "/system/groups/{group_id}/roles/{role_id}",
+    operation_id = "/system/group/role:delete",
+    params(
+        ("role_id" = String, Path, description = "The role ID."),
+        ("group_id" = String, Path, description = "The group ID."),
+    ),
+    responses(
+        (status = 204, description = "Role revoked successfully"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Grant not found", example = json!(KeystoneApiError::NotFound(String::from("id = 1"))))
+    ),
+    security(
+        ("X-Auth-Token" = [])),
+    tag="role_assignments"
+)]
+#[tracing::instrument(
+    name = "api::v3::system_group_role_revoke",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn revoke(
+    Auth(user_auth): Auth,
+    Path((group_id, role_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
+    let (group, role) = tokio::join!(
+        state
+            .provider
+            .get_identity_provider()
+            .get_group(exec, &group_id),
+        state.provider.get_role_provider().get_role(exec, &role_id)
+    );
+    let group = group?.ok_or_else(|| {
+        info!("Group {} was not found", group_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+    let role = role?.ok_or_else(|| {
+        info!("Role {} was not found", role_id);
+        KeystoneApiError::NotFound {
+            resource: "grant".into(),
+            identifier: "".into(),
+        }
+    })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/system/group/role/revoke",
+            &user_auth,
+            json!({"group": group, "role": role}),
+            None,
+        )
+        .await?;
+
+    let grant = AssignmentBuilder::default()
+        .actor_id(group_id)
+        .role_id(role_id)
+        .target_id("system")
+        .r#type(AssignmentType::GroupSystem)
+        .inherited(false)
+        .build()?;
+
+    state
+        .provider
+        .get_assignment_provider()
+        .revoke_grant(exec, grant)
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing_test::traced_test;
+
+    use openstack_keystone_core_types::identity::GroupBuilder as CoreGroupBuilder;
+    use openstack_keystone_core_types::role::*;
+
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role_assignment::openapi_router;
+    use crate::assignment::MockAssignmentProvider;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+    use crate::role::MockRoleProvider;
+
+    #[tokio::test]
+    async fn test_revoke_success() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("did")
+                        .name("gname")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_revoke_grant()
+            .returning(|_, _| Ok(()));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_revoke_forbidden() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("did")
+                        .name("gname")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, false, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_revoke_group_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| Ok(None));
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("role_id")
+                        .name("new_role")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_revoke_role_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "group_id")
+            .returning(|_, _| {
+                Ok(Some(
+                    CoreGroupBuilder::default()
+                        .id("group_id")
+                        .domain_id("did")
+                        .name("gname")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, rid: &'_ str| rid == "role_id")
+            .returning(|_, _| Ok(None));
+
+        let provider_builder = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .mock_role(role_mock);
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider_builder, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/system/groups/group_id/roles/role_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/keystone/src/api/v3/role_assignment/system/mod.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/mod.rs
@@ -16,8 +16,11 @@ use utoipa_axum::router::OpenApiRouter;
 
 use crate::keystone::ServiceState;
 
+mod group;
 mod user;
 
 pub(crate) fn openapi_router() -> OpenApiRouter<ServiceState> {
-    OpenApiRouter::new().merge(user::openapi_router())
+    OpenApiRouter::new()
+        .merge(user::openapi_router())
+        .merge(group::openapi_router())
 }

--- a/policy/resource/system/group/role/check.rego
+++ b/policy/resource/system/group/role/check.rego
@@ -1,0 +1,29 @@
+# METADATA
+# description: Policy for checking group roles on system
+package identity.system.group.role.check
+
+import data.identity
+
+default allow := false
+
+allow if {
+        "admin" in input.credentials.roles
+}
+
+allow if {
+        input.credentials.is_admin
+}
+
+allow if {
+        "reader" in input.credentials.roles
+        input.credentials.system == "all"
+}
+
+violation contains {"field": "system", "msg": "checking system-group-role assignment requires admin role."} if {
+        not "admin" in input.credentials.roles
+}
+
+violation contains {"field": "system", "msg": "checking system-group-role assignment requires system scope for reader role."} if {
+        "reader" in input.credentials.roles
+        input.credentials.system != "all"
+}

--- a/policy/resource/system/group/role/check_test.rego
+++ b/policy/resource/system/group/role/check_test.rego
@@ -1,0 +1,15 @@
+package test_system_group_role_check
+
+import data.identity.system.group.role.check
+
+test_allowed if {
+        check.allow with input as {"credentials": {"roles": ["admin"]}}
+        check.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
+}
+
+test_forbidden if {
+        not check.allow with input as {"credentials": {"roles": []}}
+        not check.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}}
+        not check.allow with input as {"credentials": {"roles": ["manager"], "system": "all"}}
+        not check.allow with input as {"credentials": {"roles": ["reader"], "system": "non-all"}}
+}

--- a/policy/resource/system/group/role/grant.rego
+++ b/policy/resource/system/group/role/grant.rego
@@ -1,0 +1,29 @@
+# METADATA
+# description: Policy for granting roles to groups on system
+package identity.system.group.role.grant
+
+import data.identity
+
+default allow := false
+
+allow if {
+        "admin" in input.credentials.roles
+}
+
+allow if {
+        input.credentials.is_admin
+}
+
+allow if {
+        "manager" in input.credentials.roles
+        input.credentials.system == "all"
+}
+
+violation contains {"field": "system", "msg": "granting a role to a group on the system requires admin role."} if {
+        not "admin" in input.credentials.roles
+}
+
+violation contains {"field": "system", "msg": "granting a role to a group on the system requires system scope for manager role."} if {
+        "manager" in input.credentials.roles
+        input.credentials.system != "all"
+}

--- a/policy/resource/system/group/role/grant_test.rego
+++ b/policy/resource/system/group/role/grant_test.rego
@@ -1,0 +1,15 @@
+package test_system_group_role_grant
+
+import data.identity.system.group.role.grant
+
+test_allowed if {
+        grant.allow with input as {"credentials": {"roles": ["admin"]}}
+        grant.allow with input as {"credentials": {"roles": ["manager"], "system": "all"}}
+}
+
+test_forbidden if {
+        not grant.allow with input as {"credentials": {"roles": []}}
+        not grant.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
+        not grant.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}}
+        not grant.allow with input as {"credentials": {"roles": ["member"], "system": "all"}}
+}

--- a/policy/resource/system/group/role/list.rego
+++ b/policy/resource/system/group/role/list.rego
@@ -1,0 +1,29 @@
+# METADATA
+# description: Policy for listing roles of a group on system
+package identity.system.group.role.list
+
+import data.identity
+
+default allow := false
+
+allow if {
+        "admin" in input.credentials.roles
+}
+
+allow if {
+        input.credentials.is_admin
+}
+
+allow if {
+        "reader" in input.credentials.roles
+        input.credentials.system == "all"
+}
+
+violation contains {"field": "system", "msg": "listing system-group-role assignment requires admin role."} if {
+        not "admin" in input.credentials.roles
+}
+
+violation contains {"field": "system", "msg": "listing system-group-role assignment requires system scope for reader role."} if {
+        "reader" in input.credentials.roles
+        input.credentials.system != "all"
+}

--- a/policy/resource/system/group/role/list_test.rego
+++ b/policy/resource/system/group/role/list_test.rego
@@ -1,0 +1,15 @@
+package test_system_group_role_list
+
+import data.identity.system.group.role.list
+
+test_allowed if {
+        list.allow with input as {"credentials": {"roles": ["admin"]}}
+        list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
+}
+
+test_forbidden if {
+        not list.allow with input as {"credentials": {"roles": []}}
+        not list.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}}
+        not list.allow with input as {"credentials": {"roles": ["manager"], "system": "all"}}
+        not list.allow with input as {"credentials": {"roles": ["reader"], "system": "non-all"}}
+}

--- a/policy/resource/system/group/role/revoke.rego
+++ b/policy/resource/system/group/role/revoke.rego
@@ -1,0 +1,29 @@
+# METADATA
+# description: Policy for revoking roles from groups on system
+package identity.system.group.role.revoke
+
+import data.identity
+
+default allow := false
+
+allow if {
+        "admin" in input.credentials.roles
+}
+
+allow if {
+        input.credentials.is_admin
+}
+
+allow if {
+        "manager" in input.credentials.roles
+        input.credentials.system == "all"
+}
+
+violation contains {"field": "system", "msg": "revoking a role from a group on the system requires admin role."} if {
+        not "admin" in input.credentials.roles
+}
+
+violation contains {"field": "system", "msg": "revoking a role from a group on the system requires system scope for manager role."} if {
+        "manager" in input.credentials.roles
+        input.credentials.system != "all"
+}

--- a/policy/resource/system/group/role/revoke_test.rego
+++ b/policy/resource/system/group/role/revoke_test.rego
@@ -1,0 +1,15 @@
+package test_system_group_role_revoke
+
+import data.identity.system.group.role.revoke
+
+test_allowed if {
+        revoke.allow with input as {"credentials": {"roles": ["admin"]}}
+        revoke.allow with input as {"credentials": {"roles": ["manager"], "system": "all"}}
+}
+
+test_forbidden if {
+        not revoke.allow with input as {"credentials": {"roles": []}}
+        not revoke.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
+        not revoke.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}}
+        not revoke.allow with input as {"credentials": {"roles": ["member"], "system": "all"}}
+}

--- a/tests/api/src/assignment.rs
+++ b/tests/api/src/assignment.rs
@@ -292,6 +292,173 @@ pub mod grant {
         }
     }
 
+    #[derive(Builder, Clone, Debug)]
+    #[builder(setter(strip_option, into))]
+    struct SystemGroupRoleCheck<'a> {
+        group_id: Cow<'a, str>,
+        role_id: Cow<'a, str>,
+    }
+
+    impl RestEndpoint for SystemGroupRoleCheck<'_> {
+        fn method(&self) -> http::Method {
+            http::Method::HEAD
+        }
+        fn endpoint(&self) -> Cow<'static, str> {
+            format!("system/groups/{}/roles/{}", self.group_id, self.role_id).into()
+        }
+        fn service_type(&self) -> ServiceType {
+            ServiceType::Identity
+        }
+        fn api_version(&self) -> Option<ApiVersion> {
+            Some(ApiVersion::new(3, 0))
+        }
+    }
+
+    #[derive(Builder, Clone, Debug)]
+    #[builder(setter(strip_option, into))]
+    struct SystemGroupRoleGrant<'a> {
+        group_id: Cow<'a, str>,
+        role_id: Cow<'a, str>,
+    }
+
+    impl RestEndpoint for SystemGroupRoleGrant<'_> {
+        fn method(&self) -> http::Method {
+            http::Method::PUT
+        }
+        fn endpoint(&self) -> Cow<'static, str> {
+            format!("system/groups/{}/roles/{}", self.group_id, self.role_id).into()
+        }
+        fn service_type(&self) -> ServiceType {
+            ServiceType::Identity
+        }
+        fn api_version(&self) -> Option<ApiVersion> {
+            Some(ApiVersion::new(3, 0))
+        }
+    }
+
+    #[derive(Builder, Clone, Debug)]
+    #[builder(setter(strip_option, into))]
+    struct SystemGroupRoleRevoke<'a> {
+        group_id: Cow<'a, str>,
+        role_id: Cow<'a, str>,
+    }
+
+    impl RestEndpoint for SystemGroupRoleRevoke<'_> {
+        fn method(&self) -> http::Method {
+            http::Method::DELETE
+        }
+        fn endpoint(&self) -> Cow<'static, str> {
+            format!("system/groups/{}/roles/{}", self.group_id, self.role_id).into()
+        }
+        fn service_type(&self) -> ServiceType {
+            ServiceType::Identity
+        }
+        fn api_version(&self) -> Option<ApiVersion> {
+            Some(ApiVersion::new(3, 0))
+        }
+    }
+
+    #[derive(Builder, Clone, Debug)]
+    #[builder(setter(strip_option, into))]
+    struct SystemGroupRoleList<'a> {
+        group_id: Cow<'a, str>,
+    }
+
+    impl RestEndpoint for SystemGroupRoleList<'_> {
+        fn method(&self) -> http::Method {
+            http::Method::GET
+        }
+        fn endpoint(&self) -> Cow<'static, str> {
+            format!("system/groups/{}/roles", self.group_id).into()
+        }
+        fn response_key(&self) -> Option<Cow<'static, str>> {
+            Some("roles".into())
+        }
+        fn service_type(&self) -> ServiceType {
+            ServiceType::Identity
+        }
+        fn api_version(&self) -> Option<ApiVersion> {
+            Some(ApiVersion::new(3, 0))
+        }
+    }
+
+    /// Check a system group role grant.
+    pub async fn check_system_group_grant<G, R>(
+        client: &Arc<AsyncOpenStack>,
+        group_id: G,
+        role_id: R,
+    ) -> Result<()>
+    where
+        G: AsRef<str>,
+        R: AsRef<str>,
+    {
+        openstack_sdk::api::ignore(
+            SystemGroupRoleCheckBuilder::default()
+                .group_id(group_id.as_ref())
+                .role_id(role_id.as_ref())
+                .build()?,
+        )
+        .query_async(client.as_ref())
+        .await?;
+        Ok(())
+    }
+
+    /// Grant a role to a group on system scope.
+    pub async fn add_system_group_grant<G, R>(
+        client: &Arc<AsyncOpenStack>,
+        group_id: G,
+        role_id: R,
+    ) -> Result<()>
+    where
+        G: AsRef<str>,
+        R: AsRef<str>,
+    {
+        openstack_sdk::api::ignore(
+            SystemGroupRoleGrantBuilder::default()
+                .group_id(group_id.as_ref())
+                .role_id(role_id.as_ref())
+                .build()?,
+        )
+        .query_async(client.as_ref())
+        .await?;
+        Ok(())
+    }
+
+    /// Revoke a system group role grant.
+    pub async fn revoke_system_group_grant<G, R>(
+        client: &Arc<AsyncOpenStack>,
+        group_id: G,
+        role_id: R,
+    ) -> Result<()>
+    where
+        G: AsRef<str>,
+        R: AsRef<str>,
+    {
+        openstack_sdk::api::ignore(
+            SystemGroupRoleRevokeBuilder::default()
+                .group_id(group_id.as_ref())
+                .role_id(role_id.as_ref())
+                .build()?,
+        )
+        .query_async(client.as_ref())
+        .await?;
+        Ok(())
+    }
+
+    /// List roles granted to a group on the system scope.
+    pub async fn list_system_group_roles<G>(
+        client: &Arc<AsyncOpenStack>,
+        group_id: G,
+    ) -> Result<Vec<openstack_keystone_api_types::v3::role_assignment::Role>>
+    where
+        G: AsRef<str>,
+    {
+        Ok(SystemGroupRoleListBuilder::default()
+            .group_id(group_id.as_ref())
+            .build()?
+            .query_async(client.as_ref())
+            .await?)
+    }
     /// Check a project role grant, preserving HTTP errors.
     pub async fn check_project_grant<P, U, R>(
         client: &Arc<AsyncOpenStack>,

--- a/tests/api/src/identity.rs
+++ b/tests/api/src/identity.rs
@@ -11,4 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+pub mod group;
 pub mod user;

--- a/tests/api/src/identity/group.rs
+++ b/tests/api/src/identity/group.rs
@@ -1,0 +1,101 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone_api_types::v3::group::*;
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
+
+use crate::guard::*;
+
+#[derive(Clone, Debug)]
+struct GroupCreateRequest {
+    group: GroupCreate,
+}
+
+impl RestEndpoint for GroupCreateRequest {
+    fn method(&self) -> http::Method {
+        http::Method::POST
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "groups".to_string().into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("group", serde_json::to_value(&self.group)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("group".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Create group
+pub async fn create_group(
+    tc: &Arc<AsyncOpenStack>,
+    group: GroupCreate,
+) -> Result<AsyncResourceGuard<Group>> {
+    let obj: Group = GroupCreateRequest { group }
+        .query_async(tc.as_ref())
+        .await?;
+    Ok(AsyncResourceGuard::new(obj, tc.clone()))
+}
+
+struct GroupDeleteRequest {
+    id: String,
+}
+
+impl RestEndpoint for GroupDeleteRequest {
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("groups/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[async_trait::async_trait]
+impl DeletableResource for Group {
+    async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
+        Ok(openstack_sdk::api::ignore(GroupDeleteRequest {
+            id: self.id.clone(),
+        })
+        .query_async(state.as_ref())
+        .await?)
+    }
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group.rs
@@ -12,5 +12,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod group;
-mod user;
+mod role;

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role.rs
@@ -1,0 +1,173 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
+
+mod check;
+mod grant;
+mod list;
+mod revoke;
+
+struct SystemGroupRoleGrantCheck {
+    group_id: String,
+    role_id: String,
+}
+
+impl RestEndpoint for SystemGroupRoleGrantCheck {
+    fn method(&self) -> http::Method {
+        http::Method::HEAD
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("system/groups/{}/roles/{}", self.group_id, self.role_id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+struct SystemGroupRoleGrantSet {
+    group_id: String,
+    role_id: String,
+}
+
+impl RestEndpoint for SystemGroupRoleGrantSet {
+    fn method(&self) -> http::Method {
+        http::Method::PUT
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("system/groups/{}/roles/{}", self.group_id, self.role_id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+struct SystemGroupRoleRevoke {
+    group_id: String,
+    role_id: String,
+}
+
+impl RestEndpoint for SystemGroupRoleRevoke {
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("system/groups/{}/roles/{}", self.group_id, self.role_id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+struct SystemGroupRoleList {
+    group_id: String,
+}
+
+impl RestEndpoint for SystemGroupRoleList {
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("system/groups/{}/roles", self.group_id).into()
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("roles".into())
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+pub async fn check_grant<G: AsRef<str>, R: AsRef<str>>(
+    client: &Arc<AsyncOpenStack>,
+    group_id: G,
+    role_id: R,
+) -> Result<bool> {
+    Ok(openstack_sdk::api::ignore(SystemGroupRoleGrantCheck {
+        group_id: group_id.as_ref().to_string(),
+        role_id: role_id.as_ref().to_string(),
+    })
+    .query_async(client.as_ref())
+    .await
+    .is_ok())
+}
+
+pub async fn add_system_grant<G: AsRef<str>, R: AsRef<str>>(
+    client: &Arc<AsyncOpenStack>,
+    group_id: G,
+    role_id: R,
+) -> Result<()> {
+    openstack_sdk::api::ignore(SystemGroupRoleGrantSet {
+        group_id: group_id.as_ref().to_string(),
+        role_id: role_id.as_ref().to_string(),
+    })
+    .query_async(client.as_ref())
+    .await?;
+    Ok(())
+}
+
+pub async fn revoke_system_grant<G: AsRef<str>, R: AsRef<str>>(
+    client: &Arc<AsyncOpenStack>,
+    group_id: G,
+    role_id: R,
+) -> Result<()> {
+    openstack_sdk::api::ignore(SystemGroupRoleRevoke {
+        group_id: group_id.as_ref().to_string(),
+        role_id: role_id.as_ref().to_string(),
+    })
+    .query_async(client.as_ref())
+    .await?;
+    Ok(())
+}
+
+pub async fn list_system_roles<G: AsRef<str>>(
+    client: &Arc<AsyncOpenStack>,
+    group_id: G,
+) -> Result<Vec<openstack_keystone_api_types::v3::role_assignment::Role>> {
+    Ok(SystemGroupRoleList {
+        group_id: group_id.as_ref().to_string(),
+    }
+    .query_async(client.as_ref())
+    .await?)
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role.rs
@@ -12,5 +12,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod group;
-mod user;
+use test_api::assignment::grant::{
+    add_system_group_grant, check_system_group_grant as check_grant, list_system_group_roles,
+    revoke_system_group_grant,
+};
+
+mod check;
+mod grant;
+mod list;
+mod revoke;

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/check.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/check.rs
@@ -22,9 +22,9 @@ use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
 use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use super::*;
-use crate::guard::*;
-use crate::identity::group::*;
-use crate::role::list_roles;
+use test_api::guard::*;
+use test_api::identity::group::*;
+use test_api::role::list_roles;
 
 #[tokio::test]
 #[traced_test]

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/check.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/check.rs
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use super::*;
+use crate::guard::*;
+use crate::identity::group::*;
+use crate::role::list_roles;
+
+#[tokio::test]
+#[traced_test]
+async fn test_check_system_role_grant() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let group = create_group(
+        &test_client,
+        GroupCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let roles: HashMap<String, String> = list_roles(&test_client)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let member_role = roles.get("member").expect("member role must exist");
+
+    assert!(!check_grant(&test_client, &group.id, member_role).await?);
+
+    add_system_grant(&test_client, &group.id, member_role).await?;
+
+    assert!(check_grant(&test_client, &group.id, member_role).await?);
+
+    group.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/check.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/check.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use super::*;
+use test_api::guard::*;
+use test_api::identity::group::*;
+use test_api::role::list_roles;
+
+#[tokio::test]
+#[traced_test]
+async fn test_check_system_role_grant() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let group = create_group(
+        &test_client,
+        GroupCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let roles: HashMap<String, String> = list_roles(&test_client)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let member_role = roles.get("member").expect("member role must exist");
+
+    assert!(
+        check_grant(&test_client, &group.id, member_role)
+            .await
+            .is_err()
+    );
+    add_system_group_grant(&test_client, &group.id, member_role).await?;
+    check_grant(&test_client, &group.id, member_role).await?;
+
+    group.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/grant.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/grant.rs
@@ -22,9 +22,9 @@ use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
 use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use super::*;
-use crate::guard::*;
-use crate::identity::group::*;
-use crate::role::list_roles;
+use test_api::guard::*;
+use test_api::identity::group::*;
+use test_api::role::list_roles;
 
 #[tokio::test]
 #[traced_test]

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/grant.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/grant.rs
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use super::*;
+use crate::guard::*;
+use crate::identity::group::*;
+use crate::role::list_roles;
+
+#[tokio::test]
+#[traced_test]
+async fn test_grant_system_role_to_group() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let group = create_group(
+        &test_client,
+        GroupCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let roles: HashMap<String, String> = list_roles(&test_client)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let member_role = roles.get("member").expect("member role must exist");
+
+    add_system_grant(&test_client, &group.id, member_role).await?;
+    assert!(check_grant(&test_client, &group.id, member_role).await?);
+
+    group.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/grant.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/grant.rs
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use super::*;
+use test_api::guard::*;
+use test_api::identity::group::*;
+use test_api::role::list_roles;
+
+#[tokio::test]
+#[traced_test]
+async fn test_grant_system_role_to_group() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let group = create_group(
+        &test_client,
+        GroupCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let roles: HashMap<String, String> = list_roles(&test_client)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let member_role = roles.get("member").expect("member role must exist");
+
+    add_system_group_grant(&test_client, &group.id, member_role).await?;
+    check_grant(&test_client, &group.id, member_role).await?;
+
+    group.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/list.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/list.rs
@@ -1,0 +1,67 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
+use openstack_keystone_api_types::v3::role_assignment::Role;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use super::*;
+use crate::guard::*;
+use crate::identity::group::*;
+use crate::role::list_roles;
+
+#[tokio::test]
+#[traced_test]
+async fn test_list_system_roles_for_group() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let group = create_group(
+        &test_client,
+        GroupCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let listed_roles: Vec<Role> = list_system_roles(&test_client, &group.id).await?;
+    assert!(listed_roles.is_empty());
+
+    let roles: HashMap<String, String> = list_roles(&test_client)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let reader_role = roles.get("reader").expect("reader role must exist");
+    let member_role = roles.get("member").expect("member role must exist");
+
+    add_system_grant(&test_client, &group.id, reader_role).await?;
+    add_system_grant(&test_client, &group.id, member_role).await?;
+
+    let listed_roles: Vec<Role> = list_system_roles(&test_client, &group.id).await?;
+    assert_eq!(listed_roles.len(), 2);
+
+    let listed_role_ids: Vec<String> = listed_roles.iter().map(|r| r.id.clone()).collect();
+    assert!(listed_role_ids.contains(&member_role.to_string()));
+    assert!(listed_role_ids.contains(&reader_role.to_string()));
+
+    group.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/list.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/list.rs
@@ -23,9 +23,9 @@ use openstack_keystone_api_types::v3::role_assignment::Role;
 use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use super::*;
-use crate::guard::*;
-use crate::identity::group::*;
-use crate::role::list_roles;
+use test_api::guard::*;
+use test_api::identity::group::*;
+use test_api::role::list_roles;
 
 #[tokio::test]
 #[traced_test]

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/list.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/list.rs
@@ -1,0 +1,67 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
+use openstack_keystone_api_types::v3::role_assignment::Role;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use super::*;
+use test_api::guard::*;
+use test_api::identity::group::*;
+use test_api::role::list_roles;
+
+#[tokio::test]
+#[traced_test]
+async fn test_list_system_roles_for_group() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let group = create_group(
+        &test_client,
+        GroupCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let listed_roles: Vec<Role> = list_system_group_roles(&test_client, &group.id).await?;
+    assert!(listed_roles.is_empty());
+
+    let roles: HashMap<String, String> = list_roles(&test_client)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let reader_role = roles.get("reader").expect("reader role must exist");
+    let member_role = roles.get("member").expect("member role must exist");
+
+    add_system_group_grant(&test_client, &group.id, reader_role).await?;
+    add_system_group_grant(&test_client, &group.id, member_role).await?;
+
+    let listed_roles: Vec<Role> = list_system_group_roles(&test_client, &group.id).await?;
+    assert_eq!(listed_roles.len(), 2);
+
+    let listed_role_ids: Vec<String> = listed_roles.iter().map(|r| r.id.clone()).collect();
+    assert!(listed_role_ids.contains(&member_role.to_string()));
+    assert!(listed_role_ids.contains(&reader_role.to_string()));
+
+    group.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/revoke.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/revoke.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use super::*;
+use crate::guard::*;
+use crate::identity::group::*;
+use crate::role::list_roles;
+
+#[tokio::test]
+#[traced_test]
+async fn test_revoke_system_role_from_group() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let group = create_group(
+        &test_client,
+        GroupCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let roles: HashMap<String, String> = list_roles(&test_client)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let member_role = roles.get("member").expect("member role must exist");
+
+    add_system_grant(&test_client, &group.id, member_role).await?;
+    assert!(check_grant(&test_client, &group.id, member_role).await?);
+
+    revoke_system_grant(&test_client, &group.id, member_role).await?;
+
+    assert!(!check_grant(&test_client, &group.id, member_role).await?);
+
+    group.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/revoke.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/revoke.rs
@@ -22,15 +22,19 @@ use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
 use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
 use super::*;
-use crate::guard::*;
-use crate::identity::group::*;
-use crate::role::list_roles;
+use test_api::guard::*;
+use test_api::identity::group::*;
+use test_api::role::list_roles;
 
 #[tokio::test]
 #[traced_test]
 async fn test_revoke_system_role_from_group() -> Result<()> {
     let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
 
+    let _auth_token = test_client
+        .get_auth_info()
+        .expect("must be authenticated")
+        .token;
     let group = create_group(
         &test_client,
         GroupCreateBuilder::default()
@@ -52,7 +56,8 @@ async fn test_revoke_system_role_from_group() -> Result<()> {
 
     revoke_system_grant(&test_client, &group.id, member_role).await?;
 
-    assert!(!check_grant(&test_client, &group.id, member_role).await?);
+    let verify_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    assert!(!check_grant(&verify_client, &group.id, member_role).await?);
 
     group.delete().await?;
     Ok(())

--- a/tests/api/tests/api_v3/assignment/grant/system/group/role/revoke.rs
+++ b/tests/api/tests/api_v3/assignment/grant/system/group/role/revoke.rs
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::GroupCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use super::*;
+use test_api::guard::*;
+use test_api::identity::group::*;
+use test_api::role::list_roles;
+
+#[tokio::test]
+#[traced_test]
+async fn test_revoke_system_role_from_group() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let _auth_token = test_client
+        .get_auth_info()
+        .expect("must be authenticated")
+        .token;
+    let group = create_group(
+        &test_client,
+        GroupCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let roles: HashMap<String, String> = list_roles(&test_client)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let member_role = roles.get("member").expect("member role must exist");
+
+    add_system_group_grant(&test_client, &group.id, member_role).await?;
+    check_grant(&test_client, &group.id, member_role).await?;
+
+    revoke_system_group_grant(&test_client, &group.id, member_role).await?;
+
+    let verify_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    assert!(
+        check_grant(&verify_client, &group.id, member_role)
+            .await
+            .is_err()
+    );
+
+    group.delete().await?;
+    Ok(())
+}


### PR DESCRIPTION
**#757 System group role assignment API**

This PR covers CRUD operations for system role assignments of group actors.

- API endpoints and test methods are mirrored from the system user role assignment implementation
- OPA policy rules are mirrored from the system user role policy package
- Integration tests are implemented for all endpoints
- The following bug is fixed in a separate commit:

When listing roles for a system group, the API was returning all system role assignments in the database instead of only those belonging to the requested group. The root cause was that `group_id` was never added to the actors filter in `list_assignments`, while `user_id` was handled correctly. With an empty actors list, the database query had no filter and returned every system assignment. The fix was adding `group_id` to the actors list the same way `user_id` is handled.

- The following bug is fixed in a separate commit:

When revoking a group role assignment, the implementation was creating a revocation event with only `role_id` set and no `user_id`. This caused all tokens holding that role to be invalidated, not just tokens of users in the revoked group. This matches Python Keystone bug #1662514, which was fixed by only creating revocation events for group assignments when `revoke_by_id = true` is set in config (default: `false`). The fix adds `revoke_by_id` to the token config and skips revocation events for group assignments by default.

## Known Limitations

Effective role listing with `group_id` and `effective=true` is not yet fully implemented. Python Keystone handles this case by expanding the group into its members via `list_users_in_group` and including their direct role assignments in the result. The Rust identity backend does not yet implement `list_users_in_group`, so this expansion is currently missing. This will be tracked and implemented separately.

