### PR TITLE
fix(auth): Fix token-from-token auth bounds

### DIFF
--- a/crates/keystone/src/api/v3/auth/token/create.rs
+++ b/crates/keystone/src/api/v3/auth/token/create.rs
@@ -58,11 +58,6 @@ pub(super) async fn create(
     let provider_scope: Option<ProviderScope> = req.auth.scope.clone().map(Into::into);
     let authz_info = get_authz_info(&state, provider_scope.as_ref()).await?;
 
-    if let Some(bound) = ctx.authorization()
-        && bound.scope != authz_info
-    {
-        return Err(AuthenticationError::ScopeNotAllowed.into());
-    }
     // This is a new authentication/reauthentication. Check if that is allowed at
     // all
     if let Some(token_restriction) = ctx.token_restriction()


### PR DESCRIPTION
After SecurityContext introduction authentication endpoint should not
verify whether the current authentication is bound to the certain
authorization or not, this is solely task of the
ValidatedSecurityContext. The authorization in the SecurityContext
represents the authorization of the current scope and not whether it is
fixed to it or not.
