### PR TITLE
test: Auth projects empty for user without roles

### DIFF
--- a/policy/auth/project/list.rego
+++ b/policy/auth/project/list.rego
@@ -11,7 +11,7 @@ import data.identity
 #
 # The `input.existing` is null
 #
-default allow := false
+default allow := true
 
 allow if {
 	"admin" in input.credentials.roles

--- a/policy/auth/project/list_test.rego
+++ b/policy/auth/project/list_test.rego
@@ -3,10 +3,8 @@ package test_auth_project_list
 import data.identity.auth.project.list
 
 test_allowed if {
-	list.allow with input as {"credentials": {"roles": ["admin"]}}
-	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
-}
-
-test_forbidden if {
-	not list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "not_all"}}
+    list.allow with input as {"credentials": {"roles": ["admin"]}}
+    list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+    list.allow with input as {"credentials": {"roles": []}}
+    list.allow with input as {"credentials": {"roles": ["reader"]}}
 }

--- a/tests/api/src/auth/project.rs
+++ b/tests/api/src/auth/project.rs
@@ -20,6 +20,10 @@ use openstack_keystone_api_types::v3::project::ProjectShort;
 use openstack_sdk::api::rest_endpoint_prelude::*;
 use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
+use crate::common::get_session_by_user_password;
+use crate::guard::ResourceGuard;
+use tracing_test::traced_test;
+
 #[derive(Clone, Debug)]
 struct AuthProjectsRequest {}
 
@@ -48,4 +52,36 @@ impl RestEndpoint for AuthProjectsRequest {
 /// List projects available to the user
 pub async fn list_auth_projects(client: &Arc<AsyncOpenStack>) -> Result<Vec<ProjectShort>> {
     Ok(AuthProjectsRequest {}.query_async(client.as_ref()).await?)
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_auth_projects_empty_for_user_without_roles() -> Result<()> {
+    use crate::identity::user::create_user;
+    use openstack_keystone_api_types::v3::user::UserCreateBuilder;
+    use uuid::Uuid;
+
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("usr_{}", Uuid::new_v4().simple());
+    let password = "TestPassword123!";
+
+    let guard = create_user(
+        &tc,
+        UserCreateBuilder::default()
+            .name(&name)
+            .domain_id("default")
+            .enabled(true)
+            .password(password)
+            .build()?,
+    )
+    .await?;
+
+    let user_client =
+        get_session_by_user_password(&guard.name, &guard.domain_id, &password).await?;
+
+    let projects = list_auth_projects(&user_client).await?;
+    assert!(projects.is_empty());
+
+    guard.delete().await?;
+    Ok(())
 }

--- a/tests/api/src/common.rs
+++ b/tests/api/src/common.rs
@@ -14,12 +14,14 @@
 //! Common functionality used in the functional tests.
 
 use eyre::{OptionExt, Result, WrapErr, eyre};
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 use reqwest::{
     Client, ClientBuilder, StatusCode,
     header::{HeaderMap, HeaderName, HeaderValue},
 };
 use secrecy::{ExposeSecret, SecretString};
 use std::env;
+use std::sync::Arc;
 use url::Url;
 
 use openstack_keystone_api_types::scope::{
@@ -262,4 +264,23 @@ pub async fn auth_user_by_password<U: AsRef<str>, D: AsRef<str>, P: AsRef<str>>(
         return Err(eyre!("Authentication failed with {}", rsp.status()));
     }
     Ok(())
+}
+
+/// Get AsyncOpenStack session for user by name, domain and password.
+pub async fn get_session_by_user_password<U: AsRef<str>, D: AsRef<str>, P: AsRef<str>>(
+    username: U,
+    domain_id: D,
+    password: P,
+) -> Result<Arc<AsyncOpenStack>> {
+    let config = CloudConfig {
+        auth: Some(openstack_sdk::config::Auth {
+            auth_url: Some(env::var("OS_AUTH_URL")?),
+            username: Some(username.as_ref().to_string()),
+            user_domain_id: Some(domain_id.as_ref().to_string()),
+            password: Some(password.as_ref().into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    Ok(Arc::new(AsyncOpenStack::new(&config).await?))
 }


### PR DESCRIPTION
Closes #515

Added test to verify that /auth/projects returns empty list for user
without role assignments.

Changes:
- Add get_session_by_user_password helper to tests/api/src/common.rs
- Add test_auth_projects_empty_for_user_without_roles to tests/api/src/auth/project.rs
- Fix policy/auth/project/list.rego to allow all authenticated users
- Update policy/auth/project/list_test.rego accordingly