### PR TITLE
fix(auth): Close admin SVID impersonation gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 
       - name: Run tests (unit)
-        run: cargo nextest run
+        run: cargo nextest run --all-features
 
       - name: Run tests (sqlite)
         run: cargo nextest run -p test_integration

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -44,9 +44,11 @@ uuid = { workspace = true, features = ["v4"] }
 validator.workspace = true
 
 [dev-dependencies]
+axum = { workspace = true, default-features = false, features = ["json"] }
 config = { workspace = true }
 httpmock = { version = "0.8", features = ["http2"] }
 mockall.workspace = true
+openstack-keystone-api-types = { workspace = true, features = ["builder", "conv"] }
 openstack-keystone-core-types = { workspace = true, features = ["mock"] }
 rstest.workspace = true
 tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -92,7 +92,7 @@ where
         if let Some(svid) = parts.extensions.get::<SpiffeId>() {
             tracing::debug!("authenticating the spiffe svid {}", svid);
 
-            if let Some(admin_svid) = &state
+            if let Some(config_admin_svid) = &state
                 .config_manager
                 .config
                 .read()
@@ -100,6 +100,7 @@ where
                 .interface_admin
                 .as_ref()
                 .and_then(|admin_if| admin_if.admin_svid.as_ref())
+                && **config_admin_svid == svid.to_string()
                 && interface == Interface::Admin
             {
                 // The admin_svid was configured and it is it over the admin interface - short
@@ -110,7 +111,7 @@ where
                         PrincipalInfoBuilder::default()
                             .identity(IdentityInfo::Principal(
                                 PrincipalIdentityInfoBuilder::default()
-                                    .id(*admin_svid)
+                                    .id(svid.to_string())
                                     .issuer(svid.trust_domain_name())
                                     .build()?,
                             ))
@@ -207,7 +208,7 @@ mod tests {
         let config = Config::default();
         let config_manager = ConfigManager::not_watched(config);
         let policy_enforcer = Arc::new(MockPolicy::default());
-        let db = sea_orm::Database::connect("sqlite::memory:").await.unwrap();
+        let db = sea_orm::DatabaseConnection::Disconnected;
         let provider = Provider::mocked_builder()
             .mock_mapping(mapping_provider)
             .build()
@@ -313,7 +314,7 @@ mod tests {
 
         let state = Arc::new(Service {
             config_manager,
-            db: sea_orm::Database::connect("sqlite::memory:").await.unwrap(),
+            db: sea_orm::DatabaseConnection::Disconnected,
             policy_enforcer: Arc::new(MockPolicy::default()),
             provider: Provider::mocked_builder()
                 .mock_mapping(mapping_mock)
@@ -407,7 +408,7 @@ mod tests {
             ..Default::default()
         };
         let config_manager = ConfigManager::not_watched(config);
-        let db = sea_orm::Database::connect("sqlite::memory:").await.unwrap();
+        let db = sea_orm::DatabaseConnection::Disconnected;
         let provider = Provider::mocked_builder()
             .mock_mapping(mapping_mock)
             .build()
@@ -436,11 +437,15 @@ mod tests {
     async fn test_admin_svid_mismatch_falls_to_mapping() {
         use crate::role::MockRoleProvider;
 
-        // When admin_svid is configured and interface is Admin, the shortcut
-        // activates regardless of the client's actual SVID (security gap:
-        // SVID identity is not verified against the configured admin_svid).
-        // This test documents the current behavior.
-        let mapping_mock = MockMappingProvider::new();
+        // When admin_svid is configured and interface is Admin, but the client's
+        // SVID does not match the configured admin_svid, the shortcut is bypassed
+        // and the request falls through to the mapping engine. If no mapping rule
+        // matches, authentication fails.
+        let mut mapping_mock = MockMappingProvider::new();
+        mapping_mock
+            .expect_authenticate_by_mapping()
+            .once()
+            .returning(|_, _| Err(MappingProviderError::NoMatchingRule));
         let config = Config {
             interface_admin: Some(AdminInterface {
                 admin_svid: Some("spiffe://admin".to_string()),
@@ -467,7 +472,7 @@ mod tests {
 
         let state = Arc::new(Service {
             config_manager,
-            db: sea_orm::Database::connect("sqlite::memory:").await.unwrap(),
+            db: sea_orm::DatabaseConnection::Disconnected,
             policy_enforcer: Arc::new(MockPolicy::default()),
             provider: Provider::mocked_builder()
                 .mock_mapping(mapping_mock)
@@ -479,17 +484,16 @@ mod tests {
             shutdown: false,
         });
 
-        // Different SVID than configured admin_svid, but on admin interface
+        // Different SVID than configured admin_svid, on admin interface
         let mut parts = make_parts();
         parts
             .extensions
             .insert(SpiffeId::new("spiffe://other-domain/workload").unwrap());
         parts.extensions.insert(Interface::Admin);
 
-        // Shortcut activates because admin_svid is configured + admin interface
-        // (security gap: SVID not compared to configured admin_svid)
+        // No mapping rule matches, no X-Auth-Token fallback — authentication fails
         let result = Auth::from_request_parts(&mut parts, &state).await;
-        assert!(result.is_ok());
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -499,7 +503,7 @@ mod tests {
         let config = Config::default();
         let config_manager = ConfigManager::not_watched(config);
         let policy_enforcer = Arc::new(MockPolicy::default());
-        let db = sea_orm::Database::connect("sqlite::memory:").await.unwrap();
+        let db = sea_orm::DatabaseConnection::Disconnected;
 
         let mut token_mock = MockTokenProvider::new();
         token_mock.expect_authorize_by_token().once().returning(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -76,7 +76,7 @@
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
 
-#[cfg(feature = "api")]
+#[cfg(any(feature = "api", test))]
 pub mod api;
 pub mod application_credential;
 pub mod assignment;


### PR DESCRIPTION
- Added SVID identity verification against configured admin_svid to
  prevent arbitrary workloads from gaining admin access on admin
  interface
- Use actual client SVID in PrincipalIdentityInfo instead of config
  value
- Update test_admin_svid_mismatch_falls_to_mapping to verify mismatched
  SVID is rejected by admin shortcut and falls through to mapping engine
- Fix all test sqlite::memory: connections to use
  DatabaseConnection::Disconnected
- Added axum and openstack-keystone-api-types to dev-dependencies
- Changed cfg in lib.rs from feature = "api" to any(feature = "api",
  test) to run auth tests also when the feature is not explicitly
  enabled.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
