### PR TITLE
fix(k8s_auth): Flatten k8s.aud claim from JWT TokenReview

### DIFF
--- a/crates/core-types/src/k8s_auth.rs
+++ b/crates/core-types/src/k8s_auth.rs
@@ -18,7 +18,23 @@ mod claims;
 mod error;
 mod instance;
 
+use serde_json::Value;
+
 pub use auth::*;
 pub use claims::*;
 pub use error::*;
 pub use instance::*;
+
+/// Combined result of a successful TokenReview call.
+///
+/// Contains both the K8s API response (JSON) and the decoded JWT claims that
+/// were validated before the round-trip, so the caller can propagate `aud`
+/// (and other fields) into the flattened claims map for the mapping engine.
+#[derive(Debug, Clone)]
+pub struct QueryTokenReviewResult {
+    /// Decoded JWT claims from the presented token.
+    pub claims: K8sClaims,
+
+    /// TokenReview response body.
+    pub token_review: Value,
+}

--- a/crates/core-types/src/k8s_auth/claims.rs
+++ b/crates/core-types/src/k8s_auth/claims.rs
@@ -15,7 +15,7 @@
 use serde::{Deserialize, Serialize};
 
 /// K8s JWT claims structure.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct K8sClaims {
     pub aud: Vec<String>,
     pub exp: u64,

--- a/crates/core/src/k8s_auth/auth.rs
+++ b/crates/core/src/k8s_auth/auth.rs
@@ -19,7 +19,9 @@ use secrecy::{ExposeSecret, SecretString};
 use serde_json::Value;
 
 use openstack_keystone_core_types::auth::AuthenticationResult;
-use openstack_keystone_core_types::k8s_auth::{K8sAuthInstance, K8sAuthRequest};
+use openstack_keystone_core_types::k8s_auth::{
+    K8sAuthInstance, K8sAuthRequest, K8sClaims, QueryTokenReviewResult,
+};
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
 
@@ -28,29 +30,67 @@ use crate::k8s_auth::{K8sAuthProviderError, service::K8sAuthService};
 use crate::keystone::ServiceState;
 
 impl K8sAuthService {
-    /// Query the K8s Token Review endpoint.
+    /// Authenticate via K8s TokenReview + mapping engine.
     ///
-    /// JWT decoding and validation is delegated to the [`K8sHttpClient`]
-    /// implementation.
+    /// Validates the JWT through the K8s TokenReview API, flattens the
+    /// response into claims, and delegates to the unified mapping engine
+    /// for identity resolution and shadow registry upsert.
     ///
     /// # Arguments
-    /// * `token` - [`SecretString`] with the JWT token.
-    /// * `instance` - reference to the [`K8sAuthInstance`].
+    /// * `state` - Service state.
+    /// * `req` - A reference to the [`K8sAuthRequest`].
     ///
     /// # Returns
-    /// * Success with the TokenReview response as `Value`.
-    /// * `K8sAuthProviderError` if the token is invalid.
-    pub(super) async fn query_k8s_token_review(
+    /// * Success with [`AuthenticationResult`] via mapping engine.
+    /// * `K8sAuthProviderError` if authentication fails.
+    pub(super) async fn authenticate_by_mapping(
         &self,
-        token: &SecretString,
-        instance: &K8sAuthInstance,
-    ) -> Result<Value, K8sAuthProviderError> {
-        let token_review_json = self
-            .http_client
-            .query_token_review(instance, token.expose_secret())
-            .await?;
+        state: &ServiceState,
+        req: &K8sAuthRequest,
+    ) -> Result<AuthenticationResult, K8sAuthProviderError> {
+        // Fetch k8s auth instance.
+        let instance = self
+            .get_auth_instance(state, &req.auth_instance_id)
+            .await?
+            .ok_or(K8sAuthProviderError::AuthInstanceNotFound(
+                req.auth_instance_id.clone(),
+            ))?;
+        if !instance.enabled {
+            return Err(K8sAuthProviderError::AuthInstanceNotActive(
+                req.auth_instance_id.clone(),
+            ));
+        }
 
-        Ok(token_review_json)
+        // Call the TokenReview.
+        let review = self.query_k8s_token_review(&req.jwt, &instance).await?;
+
+        // Flatten TokenReview response and JWT claims.
+        let claims = self.flatten_k8s_claims(&review.token_review, &review.claims)?;
+
+        // Derive unique workload ID from claims: "<sa>:<ns>" per ADR-0020 §11.2.
+        let sa_name = &claims["k8s.serviceaccount.name"][0];
+        let namespace = &claims["k8s.serviceaccount.namespace"][0];
+        let unique_workload_id = format!("{sa_name}:{namespace}");
+
+        // Delegate to the unified mapping engine.
+        let mapping_req = MappingAuthRequest {
+            domain_id: Some(instance.domain_id.clone()),
+            source: IdentitySource::K8s {
+                cluster_id: instance.id.clone(),
+            },
+            unique_workload_id,
+            claims,
+            rule_name: req.rule_name.clone(),
+        };
+
+        let auth_result = state
+            .provider
+            .get_mapping_provider()
+            .authenticate_by_mapping(state, &mapping_req)
+            .await
+            .map_err(|e| K8sAuthProviderError::MappingEngine(e.to_string()))?;
+
+        Ok(auth_result)
     }
 
     /// Validate K8s Token Review response and extract service account info.
@@ -87,95 +127,58 @@ impl K8sAuthService {
         }
     }
 
-    /// Flatten TokenReview response into a claims map for the mapping engine.
+    /// Flatten TokenReview response and JWT claims into a claims map for
+    /// the mapping engine.
     ///
     /// Per ADR-0020 §11.2, produces claims with keys:
     /// - `k8s.serviceaccount.name`
     /// - `k8s.serviceaccount.namespace`
-    /// - `k8s.aud` (from `sub` claim of the service account token).
+    /// - `k8s.aud` (from `aud` claim of the service account token).
     ///
     /// # Arguments
     /// * `token_review_data` - TokenReview JSON response.
+    /// * `jwt_claims` - Decoded JWT claims containing `aud`.
     ///
     /// # Returns
     /// A flattened claims map.
     pub(super) fn flatten_k8s_claims(
         &self,
         token_review_data: &Value,
+        jwt_claims: &K8sClaims,
     ) -> Result<HashMap<String, Vec<String>>, K8sAuthProviderError> {
         let (namespace, sa_name) = self.extract_k8s_service_account(token_review_data)?;
 
-        let mut claims = HashMap::new();
-        claims.insert("k8s.serviceaccount.name".to_string(), vec![sa_name.clone()]);
-        claims.insert(
+        let mut result = HashMap::new();
+        result.insert("k8s.serviceaccount.name".to_string(), vec![sa_name.clone()]);
+        result.insert(
             "k8s.serviceaccount.namespace".to_string(),
             vec![namespace.clone()],
         );
+        result.insert("k8s.aud".to_string(), jwt_claims.aud.clone());
 
-        Ok(claims)
+        Ok(result)
     }
 
-    /// Authenticate via K8s TokenReview + mapping engine.
+    /// Query the K8s Token Review endpoint.
     ///
-    /// Validates the JWT through the K8s TokenReview API, flattens the
-    /// response into claims, and delegates to the unified mapping engine
-    /// for identity resolution and shadow registry upsert.
+    /// JWT decoding and validation is delegated to the [`K8sHttpClient`]
+    /// implementation.
     ///
     /// # Arguments
-    /// * `state` - Service state.
-    /// * `req` - A reference to the [`K8sAuthRequest`].
+    /// * `token` - [`SecretString`] with the JWT token.
+    /// * `instance` - reference to the [`K8sAuthInstance`].
     ///
     /// # Returns
-    /// * Success with [`AuthenticationResult`] via mapping engine.
-    /// * `K8sAuthProviderError` if authentication fails.
-    pub(super) async fn authenticate_by_mapping(
+    /// * Success with [`QueryTokenReviewResult`].
+    /// * `K8sAuthProviderError` if the token is invalid.
+    pub(super) async fn query_k8s_token_review(
         &self,
-        state: &ServiceState,
-        req: &K8sAuthRequest,
-    ) -> Result<AuthenticationResult, K8sAuthProviderError> {
-        // Fetch k8s auth instance.
-        let instance = self
-            .get_auth_instance(state, &req.auth_instance_id)
-            .await?
-            .ok_or(K8sAuthProviderError::AuthInstanceNotFound(
-                req.auth_instance_id.clone(),
-            ))?;
-        if !instance.enabled {
-            return Err(K8sAuthProviderError::AuthInstanceNotActive(
-                req.auth_instance_id.clone(),
-            ));
-        }
-
-        // Call the TokenReview.
-        let token_review_data = self.query_k8s_token_review(&req.jwt, &instance).await?;
-
-        // Flatten TokenReview response into claims.
-        let claims = self.flatten_k8s_claims(&token_review_data)?;
-
-        // Derive unique workload ID from claims: "<sa>:<ns>" per ADR-0020 §11.2.
-        let sa_name = &claims["k8s.serviceaccount.name"][0];
-        let namespace = &claims["k8s.serviceaccount.namespace"][0];
-        let unique_workload_id = format!("{sa_name}:{namespace}");
-
-        // Delegate to the unified mapping engine.
-        let mapping_req = MappingAuthRequest {
-            domain_id: Some(instance.domain_id.clone()),
-            source: IdentitySource::K8s {
-                cluster_id: instance.id.clone(),
-            },
-            unique_workload_id,
-            claims,
-            rule_name: req.rule_name.clone(),
-        };
-
-        let auth_result = state
-            .provider
-            .get_mapping_provider()
-            .authenticate_by_mapping(state, &mapping_req)
+        token: &SecretString,
+        instance: &K8sAuthInstance,
+    ) -> Result<QueryTokenReviewResult, K8sAuthProviderError> {
+        self.http_client
+            .query_token_review(instance, token.expose_secret())
             .await
-            .map_err(|e| K8sAuthProviderError::MappingEngine(e.to_string()))?;
-
-        Ok(auth_result)
     }
 }
 
@@ -190,6 +193,7 @@ mod tests {
     use crate::k8s_auth::K8sHttpClient;
     use crate::k8s_auth::backend::MockK8sAuthBackend;
     use crate::tests::get_mocked_state;
+    use openstack_keystone_core_types::k8s_auth::{K8sClaims, QueryTokenReviewResult};
 
     struct TestK8sHttpClient;
 
@@ -199,8 +203,15 @@ mod tests {
             &self,
             _instance: &K8sAuthInstance,
             _jwt: &str,
-        ) -> Result<serde_json::Value, K8sAuthProviderError> {
-            Ok(json!({}))
+        ) -> Result<QueryTokenReviewResult, K8sAuthProviderError> {
+            Ok(QueryTokenReviewResult {
+                claims: K8sClaims {
+                    aud: vec![],
+                    exp: 0,
+                    sub: String::new(),
+                },
+                token_review: json!({}),
+            })
         }
     }
 
@@ -261,6 +272,28 @@ mod tests {
 
         assert_eq!(ns, "my_ns");
         assert_eq!(sa, "my_sa");
+    }
+
+    #[test]
+    fn test_flatten_k8s_claims() {
+        let provider = make_service(MockK8sAuthBackend::default());
+
+        let claims = provider
+            .flatten_k8s_claims(
+                &json!({
+                    "status": {"authenticated": true, "user": {"username": "system:serviceaccount:target_ns:target_sa"}}
+                }),
+                &K8sClaims {
+                    aud: vec!["10.0.0.1".to_string(), "kubernetes".to_string()],
+                    exp: 1234567890,
+                    sub: "system:serviceaccount:target_ns:target_sa".to_string(),
+                },
+            )
+            .expect("valid claims should succeed");
+
+        assert_eq!(claims["k8s.serviceaccount.name"], vec!["target_sa"]);
+        assert_eq!(claims["k8s.serviceaccount.namespace"], vec!["target_ns"]);
+        assert_eq!(claims["k8s.aud"], vec!["10.0.0.1", "kubernetes"]);
     }
 
     #[tokio::test]

--- a/crates/core/src/k8s_auth/client.rs
+++ b/crates/core/src/k8s_auth/client.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
-use serde_json::Value;
 
 use crate::k8s_auth::K8sAuthProviderError;
-use openstack_keystone_core_types::k8s_auth::K8sAuthInstance;
+use openstack_keystone_core_types::k8s_auth::{K8sAuthInstance, QueryTokenReviewResult};
 
 /// Abstraction for HTTP communication with the Kubernetes API.
 ///
@@ -13,16 +12,21 @@ pub trait K8sHttpClient: Send + Sync {
     /// Decode JWT, validate expiration, then query the K8s TokenReview
     /// endpoint.
     ///
+    /// Returns a [`QueryTokenReviewResult`] containing the TokenReview
+    /// response alongside the decoded JWT claims (`aud`, `exp`, `sub`)
+    /// so the caller can propagate `aud` into the flattened claims map
+    /// for the mapping engine.
+    ///
     /// # Arguments
     /// * `instance` - K8s auth instance configuration (host, CA cert, etc).
     /// * `jwt` - The JWT service account token.
     ///
     /// # Returns
-    /// * `Ok(Value)` with the TokenReview response.
+    /// * `Ok(QueryTokenReviewResult)` on success.
     /// * `K8sAuthProviderError` on JWT decode, validation, or HTTP failure.
     async fn query_token_review(
         &self,
         instance: &K8sAuthInstance,
         jwt: &str,
-    ) -> Result<Value, K8sAuthProviderError>;
+    ) -> Result<QueryTokenReviewResult, K8sAuthProviderError>;
 }

--- a/crates/core/src/k8s_auth/service.rs
+++ b/crates/core/src/k8s_auth/service.rs
@@ -182,6 +182,7 @@ mod tests {
     use crate::k8s_auth::K8sHttpClient;
     use crate::k8s_auth::backend::MockK8sAuthBackend;
     use crate::tests::get_mocked_state;
+    use openstack_keystone_core_types::k8s_auth::{K8sClaims, QueryTokenReviewResult};
 
     struct TestK8sHttpClient;
 
@@ -191,8 +192,15 @@ mod tests {
             &self,
             _instance: &K8sAuthInstance,
             _jwt: &str,
-        ) -> Result<serde_json::Value, K8sAuthProviderError> {
-            Ok(json!({}))
+        ) -> Result<QueryTokenReviewResult, K8sAuthProviderError> {
+            Ok(QueryTokenReviewResult {
+                claims: K8sClaims {
+                    aud: vec![],
+                    exp: 0,
+                    sub: String::new(),
+                },
+                token_review: json!({}),
+            })
         }
     }
 

--- a/crates/keystone/src/k8s_auth_client.rs
+++ b/crates/keystone/src/k8s_auth_client.rs
@@ -26,7 +26,7 @@ use tracing::debug;
 
 use openstack_keystone_core::k8s_auth::K8sAuthProviderError;
 pub use openstack_keystone_core::k8s_auth::K8sHttpClient;
-use openstack_keystone_core_types::k8s_auth::{K8sAuthInstance, K8sClaims};
+use openstack_keystone_core_types::k8s_auth::{K8sAuthInstance, K8sClaims, QueryTokenReviewResult};
 
 /// Path to the service account CA cert mounted in a K8s pod.
 const SERVICE_ACCOUNT_CERT_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
@@ -105,8 +105,8 @@ impl K8sHttpClient for KeystoneK8sHttpClient {
         &self,
         instance: &K8sAuthInstance,
         jwt: &str,
-    ) -> Result<Value, K8sAuthProviderError> {
-        Self::validate_jwt(jwt)?;
+    ) -> Result<QueryTokenReviewResult, K8sAuthProviderError> {
+        let claims = Self::validate_jwt(jwt)?;
         let client = self.get_or_create_client(instance).await?;
 
         let body = serde_json::json!({
@@ -129,9 +129,10 @@ impl K8sHttpClient for KeystoneK8sHttpClient {
             .map_err(K8sAuthProviderError::http)?;
 
         match response.status() {
-            StatusCode::OK | StatusCode::CREATED => {
-                Ok(response.json().await.map_err(K8sAuthProviderError::http)?)
-            }
+            StatusCode::OK | StatusCode::CREATED => Ok(QueryTokenReviewResult {
+                claims,
+                token_review: response.json().await.map_err(K8sAuthProviderError::http)?,
+            }),
             status if status.is_client_error() => {
                 debug!("Kubernetes returned {:?}", response);
                 Err(K8sAuthProviderError::InvalidToken)
@@ -151,7 +152,7 @@ impl K8sHttpClient for KeystoneK8sHttpClient {
 /// Performs JWT decode + expiration validation (shared with production impl),
 /// then returns a pre-configured response.
 pub struct MockK8sHttpClient {
-    response: Mutex<Option<Result<Value, K8sAuthProviderError>>>,
+    response: Mutex<Option<Result<QueryTokenReviewResult, K8sAuthProviderError>>>,
 }
 
 impl Default for MockK8sHttpClient {
@@ -163,7 +164,7 @@ impl Default for MockK8sHttpClient {
 }
 
 impl MockK8sHttpClient {
-    pub fn with_response(response: Result<Value, K8sAuthProviderError>) -> Self {
+    pub fn with_response(response: Result<QueryTokenReviewResult, K8sAuthProviderError>) -> Self {
         Self {
             response: Mutex::new(Some(response)),
         }
@@ -176,20 +177,21 @@ impl K8sHttpClient for MockK8sHttpClient {
         &self,
         _instance: &K8sAuthInstance,
         jwt: &str,
-    ) -> Result<Value, K8sAuthProviderError> {
-        // Reuse production validation logic
-        let _claims = KeystoneK8sHttpClient::validate_jwt(jwt)?;
+    ) -> Result<QueryTokenReviewResult, K8sAuthProviderError> {
+        let claims = KeystoneK8sHttpClient::validate_jwt(jwt)?;
 
-        // Return pre-configured response or default authenticated response
         let response = self.response.lock().unwrap().take();
         match response {
             Some(r) => r,
-            None => Ok(serde_json::json!({
-                "status": {
-                    "authenticated": true,
-                    "user": {"username": "system:serviceaccount:ns:sa"}
-                }
-            })),
+            None => Ok(QueryTokenReviewResult {
+                claims,
+                token_review: serde_json::json!({
+                    "status": {
+                        "authenticated": true,
+                        "user": {"username": "system:serviceaccount:ns:sa"}
+                    }
+                }),
+            }),
         }
     }
 }
@@ -209,7 +211,9 @@ impl std::error::Error for K8sServerResponseError {}
 #[cfg(test)]
 mod tests {
     use httpmock::{Method, MockServer};
-    use openstack_keystone_core_types::k8s_auth::{K8sAuthInstance, K8sClaims};
+    use openstack_keystone_core_types::k8s_auth::{
+        K8sAuthInstance, K8sClaims, QueryTokenReviewResult,
+    };
 
     use super::*;
 
@@ -360,29 +364,51 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
                 "user": {"username": "system:serviceaccount:test:sa"}
             }
         });
-        let mock = MockK8sHttpClient::with_response(Ok(resp));
+        let mock = MockK8sHttpClient::with_response(Ok(QueryTokenReviewResult {
+            claims: K8sClaims {
+                aud: vec![],
+                exp: 0,
+                sub: String::new(),
+            },
+            token_review: resp,
+        }));
         let jwt = make_token(60);
         let instance = make_instance_no_ca();
-        let result = mock
+        let review = mock
             .query_token_review(&instance, &jwt)
             .await
             .expect("should be ok");
-        assert!(result["status"]["authenticated"].as_bool().unwrap());
+        assert!(
+            review.token_review["status"]["authenticated"]
+                .as_bool()
+                .unwrap()
+        );
     }
 
     #[tokio::test]
     async fn mock_response_used_once() {
         let resp = serde_json::json!({"custom": true});
-        let mock = MockK8sHttpClient::with_response(Ok(resp));
+        let mock = MockK8sHttpClient::with_response(Ok(QueryTokenReviewResult {
+            claims: K8sClaims {
+                aud: vec![],
+                exp: 0,
+                sub: String::new(),
+            },
+            token_review: resp,
+        }));
         let jwt = make_token(60);
         let instance = make_instance_no_ca();
 
         let r1 = mock.query_token_review(&instance, &jwt).await.unwrap();
-        assert!(r1["custom"].as_bool().unwrap());
+        assert!(r1.token_review["custom"].as_bool().unwrap());
 
         let r2 = mock.query_token_review(&instance, &jwt).await.unwrap();
-        assert!(r2["custom"].is_null());
-        assert!(r2["status"]["authenticated"].as_bool().unwrap());
+        assert!(r2.token_review["custom"].is_null());
+        assert!(
+            r2.token_review["status"]["authenticated"]
+                .as_bool()
+                .unwrap()
+        );
     }
 
     // --- Full HTTP round-trip tests ---
@@ -392,7 +418,7 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
         let mock_srv = MockServer::start();
         let jwt = make_token(60);
 
-        let mock = mock_srv.mock(|when, then| {
+        let _mock = mock_srv.mock(|when, then| {
             when.method(Method::POST)
                 .path("/apis/authentication.k8s.io/v1/tokenreviews")
                 .header("authorization", format!("Bearer {}", jwt))
@@ -422,16 +448,19 @@ FPrC1HpT3dzIAiEAtEB0so+KoJb/2Opn1RycVzxke1CQrWgjS8ySnnFK5ok=
             name: Some("t".into()),
         };
 
-        let result = client.query_token_review(&instance, &jwt).await;
-        assert!(result.is_ok());
-
-        let body = result.unwrap();
-        assert!(body["status"]["authenticated"].as_bool().unwrap());
+        let body = client.query_token_review(&instance, &jwt).await.unwrap();
+        assert!(
+            body.token_review["status"]["authenticated"]
+                .as_bool()
+                .unwrap()
+        );
         assert_eq!(
-            body["status"]["user"]["username"].as_str().unwrap(),
+            body.token_review["status"]["user"]["username"]
+                .as_str()
+                .unwrap(),
             "system:serviceaccount:test_ns:test_sa"
         );
-        mock.assert();
+        assert_eq!(body.claims.aud, vec!["aud".to_string()]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Changes query_token_review to return both TokenReview result and
JWT claims struct. The flatten_k8s_claims function now includes the
k8s.aud claim (extracted from JWT aud field) in the flattened claims
map, allowing it to be used in mapping rulesets.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
