### PR TITLE
feat(api): capture client connection info via ConnectInfo

### DIFF
--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -129,8 +129,13 @@ async fn version(
 pub(crate) mod tests {
     pub use openstack_keystone_core::api::tests::{get_mocked_state, test_fixture_scoped};
 
+    use std::net::SocketAddr;
+
     use axum::body::Body;
+    use axum::extract::ConnectInfo;
     use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::{Router, ServiceExt as AxumServiceExt};
     use tower::{Layer, ServiceExt};
     use tower_http::normalize_path::NormalizePathLayer;
 
@@ -164,5 +169,48 @@ pub(crate) mod tests {
         assert_ne!(with_slash.status(), StatusCode::NOT_FOUND);
         assert!(!with_slash.status().is_redirection());
         assert_eq!(with_slash.status(), canonical.status());
+    }
+
+    /// Issue #358: the public listener captures the raw TCP peer address into a
+    /// `ConnectInfo<SocketAddr>` request extension (the keystone-ng analogue of
+    /// Python Keystone's WSGI `REMOTE_ADDR`). This verifies the capture works and
+    /// composes with the #734 `NormalizePathLayer` wrap: a trailing-slash request
+    /// still normalizes while `ConnectInfo` is populated. Driven fully in-process
+    /// via `Connected<SocketAddr> for SocketAddr`, so no real socket is needed.
+    #[tokio::test]
+    async fn connect_info_is_captured_and_normalizes() {
+        async fn echo_addr(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> String {
+            addr.to_string()
+        }
+
+        let router = Router::new().route("/echo", get(echo_addr));
+        let app = NormalizePathLayer::trim_trailing_slash().layer(router);
+
+        // Same make-service path the public listener uses; the explicit request
+        // type satisfies inference (E0284), as in the binary.
+        let make =
+            AxumServiceExt::<Request<Body>>::into_make_service_with_connect_info::<SocketAddr>(app);
+        let addr: SocketAddr = "192.0.2.4:5555".parse().unwrap();
+        // `Connected<SocketAddr> for SocketAddr` lets us drive the make-service
+        // with a fixed peer address instead of a live TCP connection.
+        let svc = make.oneshot(addr).await.unwrap();
+
+        // `/echo/` (trailing slash) must normalize to `/echo` AND the handler
+        // must observe the injected peer address.
+        let response = svc
+            .oneshot(
+                Request::builder()
+                    .uri("/echo/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"192.0.2.4:5555");
     }
 }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -16,13 +16,14 @@
 //! This is the entry point of the `keystone` binary.
 
 use std::io;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{
     Router, ServiceExt,
-    extract::DefaultBodyLimit,
+    extract::{ConnectInfo, DefaultBodyLimit},
     http::{self, HeaderName, Request, header},
 };
 use clap::{Parser, ValueEnum};
@@ -348,10 +349,19 @@ async fn main() -> Result<(), Report> {
         .layer(
             TraceLayer::new(common::KeystoneResponseClassifier)
                 .make_span_with(|request: &Request<_>| {
+                    // Raw TCP peer address captured by
+                    // `into_make_service_with_connect_info` on the public
+                    // listener (the keystone-ng analogue of Python Keystone's
+                    // WSGI REMOTE_ADDR / flask.request.remote_addr). `None` for
+                    // the SPIFFE interfaces, which do not populate ConnectInfo.
+                    let client_addr = request
+                        .extensions()
+                        .get::<ConnectInfo<SocketAddr>>()
+                        .map(|ConnectInfo(addr)| *addr);
                     info_span!(
                         "request",
                         method = ?request.method(),
-                        some_other_field = tracing::field::Empty,
+                        client.addr = ?client_addr,
                         uri = ?request.uri().path(),
                         x_request_id = ?request.headers().get("x-openstack-request-id")
                     )
@@ -486,12 +496,25 @@ async fn main() -> Result<(), Report> {
             let rest_cancel_token = token.clone();
             let rest_app = app.clone();
             handles.spawn(async move {
-                // `rest_app` is `NormalizePath<Router>`, which has no
-                // `Router::into_make_service`; use axum's `ServiceExt` with an
+                // `rest_app` is `NormalizePath<Router>` (issue #734 wraps the
+                // Router from the outside), which has no
+                // `Router::into_make_service_with_connect_info`; use axum's
+                // `ServiceExt` (blanket-impl'd for any `Service`) with an
                 // explicit request type to satisfy inference (E0284).
+                //
+                // `into_make_service_with_connect_info::<SocketAddr>` stores the
+                // raw TCP peer address in a `ConnectInfo<SocketAddr>` request
+                // extension (the analogue of Python Keystone's WSGI REMOTE_ADDR).
+                // This is the *raw* peer, not proxy-resolved: behind a reverse
+                // proxy/LB it is the proxy's address. A trusted forwarded-header
+                // layer (mirroring oslo_middleware's `enable_proxy_headers_parsing`,
+                // off by default) is a deliberate follow-up before this is used
+                // for any IP-based login control. See issue #358.
                 axum::serve(
                     listener,
-                    ServiceExt::<axum::extract::Request>::into_make_service(rest_app),
+                    ServiceExt::<axum::extract::Request>::into_make_service_with_connect_info::<
+                        SocketAddr,
+                    >(rest_app),
                 )
                 .with_graceful_shutdown(async move {
                     rest_cancel_token.cancelled().await;


### PR DESCRIPTION
Closes #358.

## What this does

Starts capturing client connection information (the client IP) in request processing, as the enabling step for a future IP-based login-control feature. The lockout/rate-limit mechanism itself is **out of scope** here — this is the plumbing that makes the client address available to handlers and middleware.

- Switches the **public** listener's make-service to `into_make_service_with_connect_info::<SocketAddr>()`, so the raw TCP peer address is stored in a `ConnectInfo<SocketAddr>` request extension.
- Surfaces it on the existing `request` tracing span as a `client.addr` field (reusing the previously-empty placeholder slot), so the capture is verifiable in request logs.

## Mirrors Python Keystone

This deliberately follows how upstream Python Keystone captures the client address:

| Python | This PR |
|---|---|
| WSGI `REMOTE_ADDR` / `flask.request.remote_addr` (raw peer when no proxy parsing applies) | `ConnectInfo<SocketAddr>` |
| `remote_addr` surfaced in the auth-failure log line | `client.addr` field on the `request` span |
| Proxy-header parsing kept separate, **config-gated** via `[oslo_middleware] enable_proxy_headers_parsing` (default off) | deliberately deferred — see follow-up below |

Python captures a single `REMOTE_ADDR` at the WSGI front door; the analogue here is the public HTTP interface. The internal (SPIFFE mTLS/TCP) and admin (SPIFFE mTLS/UDS) interfaces are intentionally **not** covered: they bypass `axum::serve`, and a Unix socket has no meaningful `SocketAddr`.

## Important: raw peer only — not proxy-aware

The captured address is the **raw TCP peer**. Behind a reverse proxy / load balancer (the normal production topology) it is the proxy's address, not the real client. It must **not** be used directly for IP-based login control until a trusted forwarded-header layer exists.

## Required follow-up (after this merges)

A config-gated forwarded-header layer that parses `X-Forwarded-For` / RFC 7239 `Forwarded`, mirroring Python's `[oslo_middleware] enable_proxy_headers_parsing` — **off by default**, so a deployment that is not actually behind a trusted proxy cannot be tricked into trusting a spoofed header. (`axum-client-ip` is a candidate, or a hand-rolled middleware.) This is required before any IP-based login control is built on top of this capture.

## Composition with #734

Issue #734 wraps the router with `NormalizePathLayer` from the outside, so the public listener serves a `NormalizePath<Router>`, not a plain `Router`. `into_make_service_with_connect_info` is available on the same `axum::ServiceExt` trait already in use (blanket impl for any `Service`), so it applies directly — no restructuring needed.

## Tests

Added `connect_info_is_captured_and_normalizes`, which drives the exact production make-service path fully in-process and asserts a `/echo/` request **both** normalizes the trailing slash **and** delivers the injected peer address to the handler — proving #358 and #734 compose. The existing `trailing_slash_is_normalized` regression still passes.