### PR TITLE
Implement DEK rotation, audit logging, and backup encryption (ADR 0016-v2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -4111,6 +4112,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "uuid",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -4276,6 +4279,8 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "hkdf",
+ "hmac 0.12.1",
+ "nix 0.31.3",
  "rand 0.10.1",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -5612,8 +5617,8 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
@@ -5826,7 +5831,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6119,7 +6124,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -7934,6 +7939,12 @@ checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -8883,12 +8894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs 0.7.2",
+ "aws-lc-rs",
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
  "nom",
  "oid-registry 0.8.1",
- "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ rand = { version = "0.10" }
 regex = { version = "1.12" }
 regex-syntax = "0.8"
 reqwest = { version = "0.13" }
-rcgen = { version = "0.14" }
+rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs", "pem"] }
 rmp = { version = "0.8" }
 rstest = { version = "0.26" }
 rmp-serde = "1.3"
@@ -131,7 +131,7 @@ serde_bytes = { version = "0.11" }
 serde_json = { version = "1.0" }
 serde_urlencoded = { version = "0.7" }
 spiffe = { version = "0.16" }
-spiffe-rustls = { version = "0.7" }
+spiffe-rustls = { version = "0.7", default-features = false, features = ["aws-lc-rs"] }
 spiffe-rustls-tokio = { version = "0.4" }
 temp-env = { version = "0.3" }
 tempfile = { version = "3.27" }
@@ -175,7 +175,7 @@ debug = false
 
 [profile.dev]
 debug = 1
-split-debuginfo = "unpacked"
+split-debuginfo = "deny"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -197,7 +197,8 @@ impl Metadata {
         }
     }
 
-    /// Create new metadata with an incremented revision, preserving timestamp and tier.
+    /// Create new metadata with an incremented revision, preserving timestamp
+    /// and tier.
     pub fn new_revision(&self) -> Self {
         Self {
             revision: self.revision + 1,

--- a/crates/storage-crypto/Cargo.toml
+++ b/crates/storage-crypto/Cargo.toml
@@ -10,16 +10,30 @@ repository.workspace = true
 homepage.workspace = true
 exclude.workspace = true
 
-[lints]
-workspace = true
+# This crate intentionally does NOT inherit workspace lints so that it can set
+# `unsafe_code = "deny"` (rather than "forbid") for the mlock.rs module, which
+# requires unsafe for posix_memalign, mlock/munlock, and raw-pointer access.
+# All other workspace crates use `unsafe_code = "forbid"` via the workspace
+# default.  All other lint settings below mirror the workspace lints exactly.
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+enum_glob_use = "deny"
+expect_used = "deny"
+print_stdout = "deny"
+unwrap_used = "deny"
+doc_paragraphs_missing_punctuation = "warn"
 
 [dependencies]
 aes-gcm.workspace = true
 hkdf.workspace = true
-# sha2 pinned to 0.10 to match hkdf 0.12's digest 0.10 trait boundary.
-# The workspace uses sha2 0.11 (digest 0.11), which is incompatible with
-# hkdf 0.12's type parameters. Both versions coexist in the dependency graph.
+# sha2/hmac pinned to 0.10/0.12 to match hkdf 0.12's digest 0.10 trait
+# boundary. The workspace uses sha2 0.11 + hmac 0.13 (digest 0.11), which are
+# incompatible with hkdf 0.12's type parameters.
+hmac = "0.12"
 sha2 = "0.10"
+nix = { workspace = true, features = ["mman", "feature"] }
 rand.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/storage-crypto/src/audit.rs
+++ b/crates/storage-crypto/src/audit.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Per-node audit HMAC key (ADR 0016-v2 §3.1 / Phase 8).
+//!
+//! `AuditHmacKey` is derived from the DEK per epoch via
+//! `DekEpoch::derive_audit_key(node_id)`, so the HMAC key rotates with each
+//! DEK rotation, binding audit key lifetime to DEK epoch (F2: preventing
+//! indefinite forgery after a single compromise).
+//!
+//! Derivation:
+//! `AuditHmacKey = HKDF-Expand(DEK, info = b"keystone-audit-dek-v1" ++
+//! version_u32_be ++ node_id_u64_be, L=32)`.
+//!
+//! Signing:
+//! `HMAC-SHA256(AuditHmacKey, canonical_message_bytes)`.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use zeroize::Zeroizing;
+
+use crate::error::CryptoError;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Per-node HMAC key for signing audit records.
+///
+/// Does not derive `Debug` or `Display` to prevent accidental key leakage.
+pub struct AuditHmacKey(Zeroizing<[u8; 32]>);
+
+impl AuditHmacKey {
+    /// Wrap raw key bytes into an `AuditHmacKey`.
+    pub fn from_raw(raw: [u8; 32]) -> Self {
+        Self(Zeroizing::new(raw))
+    }
+
+    /// Compute `HMAC-SHA256(self, message)` and return the 32-byte MAC.
+    pub fn sign(&self, message: &[u8]) -> Result<[u8; 32], CryptoError> {
+        let mut mac = HmacSha256::new_from_slice(self.0.as_ref())
+            .map_err(|_| CryptoError::InvalidKeyLength)?;
+        mac.update(message);
+        let result = mac.finalize().into_bytes();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&result);
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sign_deterministic() {
+        let key = AuditHmacKey::from_raw([0x01u8; 32]);
+        let msg = b"test audit record";
+        let mac1 = key.sign(msg).unwrap();
+        let mac2 = key.sign(msg).unwrap();
+        assert_eq!(mac1, mac2);
+    }
+
+    #[test]
+    fn test_sign_different_keys() {
+        let key1 = AuditHmacKey::from_raw([0x01u8; 32]);
+        let key2 = AuditHmacKey::from_raw([0x02u8; 32]);
+        let msg = b"same message";
+        assert_ne!(key1.sign(msg).unwrap(), key2.sign(msg).unwrap());
+    }
+
+    #[test]
+    fn test_sign_different_messages() {
+        let key = AuditHmacKey::from_raw([0x03u8; 32]);
+        let mac1 = key.sign(b"message one").unwrap();
+        let mac2 = key.sign(b"message two").unwrap();
+        assert_ne!(mac1, mac2);
+    }
+}

--- a/crates/storage-crypto/src/cipher.rs
+++ b/crates/storage-crypto/src/cipher.rs
@@ -40,8 +40,11 @@ use hkdf::Hkdf;
 use sha2::Sha256;
 use zeroize::Zeroizing;
 
-use crate::dek::{LogDek, StateDek};
+use crate::dek::{BackupDek, LogDek, StateDek};
 use crate::error::CryptoError;
+
+// Label for snapshot backup AD (ADR §7).
+const BACKUP_AD_LABEL: &[u8] = b"keystone-backup-v1";
 
 // Minimum bytes in a stored state value: nonce(12) + tag(16) + version(4) = 32
 const STATE_MIN_LEN: usize = 32;
@@ -62,7 +65,7 @@ const LOG_MIN_LEN: usize = 28;
 /// - `nonce`      — 12-byte nonce: `[8-byte NodeId BE] ++ [4-byte counter BE]`.
 ///
 /// # Returns
-/// `[nonce 12B] ++ [ciphertext] ++ [tag 16B]`
+/// `[nonce 12B] ++ [ciphertext] ++ [tag 16B]`.
 pub fn log_encrypt(
     dek: &LogDek,
     plaintext: &[u8],
@@ -129,7 +132,7 @@ pub fn log_decrypt(
 /// - `version`    — record version counter; must be incremented on each write.
 ///
 /// # Returns
-/// `[nonce 12B] ++ [ciphertext] ++ [tag 16B] ++ [version u32 BE]`
+/// `[nonce 12B] ++ [ciphertext] ++ [tag 16B] ++ [version u32 BE]`.
 pub fn state_encrypt(
     dek: &StateDek,
     plaintext: &[u8],
@@ -201,8 +204,87 @@ pub fn state_decrypt(
         .decrypt_in_place_detached(gcm_nonce, &aad, buf.as_mut(), tag)
         .map_err(|_| CryptoError::AesDecrypt)?;
 
-    let next_version = stored_version.checked_add(1).unwrap_or(u32::MAX);
+    let next_version = stored_version.saturating_add(1);
     Ok((buf, next_version))
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot backup encryption
+// ---------------------------------------------------------------------------
+
+/// Encrypt a Raft snapshot with the epoch's `BackupDek`.
+///
+/// Nonce is derived deterministically via
+/// HKDF-Expand(BackupDek, BACKUP_AD_LABEL ++ utc_epoch_u64_BE ++
+/// counter_u64_BE, L=12) so that no random material is required (ADR Invariant
+/// 10 — deterministic nonces only). The `counter` ensures uniqueness when
+/// multiple snapshots are taken under the same DEK epoch in the same second.
+/// AD = `b"keystone-backup-v1" ++ utc_epoch_u64_BE ++ dek_version_u32_BE ++
+/// counter_u64_BE`.
+///
+/// # Returns
+/// `[nonce 12B] ++ [ciphertext] ++ [tag 16B]`.
+pub fn backup_encrypt(
+    dek: &BackupDek,
+    plaintext: &[u8],
+    dek_version: u32,
+    utc_epoch: u64,
+    counter: u64,
+) -> Result<Vec<u8>, CryptoError> {
+    let nonce_bytes = backup_nonce(dek, utc_epoch, counter)?;
+    let aad = backup_aad(dek_version, utc_epoch, counter);
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(dek.as_bytes()));
+    let gcm_nonce = GenericArray::from_slice(&nonce_bytes);
+
+    let mut buf = plaintext.to_vec();
+    let tag = cipher
+        .encrypt_in_place_detached(gcm_nonce, &aad, &mut buf)
+        .map_err(|_| CryptoError::AesEncrypt)?;
+
+    let mut out = Vec::with_capacity(12 + plaintext.len() + 16);
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&buf);
+    out.extend_from_slice(tag.as_slice());
+    Ok(out)
+}
+
+/// Decrypt a snapshot previously encrypted with [`backup_encrypt`].
+///
+/// `dek_version`, `utc_epoch`, and `counter` must match the values used at
+/// encrypt time; any mismatch causes GCM tag verification to fail.
+/// The stored nonce is re-derived from (`dek`, `utc_epoch`, `counter`) and
+/// verified against the stored bytes to detect accidental epoch/timestamp
+/// confusion.
+pub fn backup_decrypt(
+    dek: &BackupDek,
+    stored: &[u8],
+    dek_version: u32,
+    utc_epoch: u64,
+    counter: u64,
+) -> Result<Zeroizing<Vec<u8>>, CryptoError> {
+    const BACKUP_MIN_LEN: usize = 12 + 16;
+    if stored.len() < BACKUP_MIN_LEN {
+        return Err(CryptoError::CiphertextTooShort);
+    }
+    let (nonce_bytes, rest) = stored.split_at(12);
+
+    // Verify nonce matches the deterministic derivation.
+    let expected_nonce = backup_nonce(dek, utc_epoch, counter)?;
+    if nonce_bytes != expected_nonce {
+        return Err(CryptoError::AesDecrypt);
+    }
+
+    let (ciphertext, tag_bytes) = rest.split_at(rest.len() - 16);
+    let aad = backup_aad(dek_version, utc_epoch, counter);
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(dek.as_bytes()));
+    let gcm_nonce = GenericArray::from_slice(nonce_bytes);
+    let tag = GenericArray::from_slice(tag_bytes);
+
+    let mut buf = Zeroizing::new(ciphertext.to_vec());
+    cipher
+        .decrypt_in_place_detached(gcm_nonce, &aad, buf.as_mut(), tag)
+        .map_err(|_| CryptoError::AesDecrypt)?;
+    Ok(buf)
 }
 
 // ---------------------------------------------------------------------------
@@ -239,6 +321,34 @@ fn state_aad(tier: u8, domain_id: &[u8], pk: &[u8]) -> Vec<u8> {
     aad.extend_from_slice(domain_id);
     aad.extend_from_slice(pk);
     aad
+}
+
+fn backup_aad(dek_version: u32, utc_epoch: u64, counter: u64) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(BACKUP_AD_LABEL.len() + 8 + 4 + 8);
+    aad.extend_from_slice(BACKUP_AD_LABEL);
+    aad.extend_from_slice(&utc_epoch.to_be_bytes());
+    aad.extend_from_slice(&dek_version.to_be_bytes());
+    aad.extend_from_slice(&counter.to_be_bytes());
+    aad
+}
+
+/// Derive a deterministic 12-byte nonce for snapshot encryption (ADR Invariant
+/// 10).
+///
+/// `info = BACKUP_AD_LABEL ++ utc_epoch_u64_be ++ counter_u64_be`.
+/// The `counter` parameter ensures uniqueness even when multiple snapshots are
+/// taken within the same second under the same DEK epoch (H4 fix).
+fn backup_nonce(dek: &BackupDek, utc_epoch: u64, counter: u64) -> Result<[u8; 12], CryptoError> {
+    let hkdf =
+        Hkdf::<Sha256>::from_prk(dek.as_bytes()).map_err(|_| CryptoError::InvalidKeyLength)?;
+    let mut info = Vec::with_capacity(BACKUP_AD_LABEL.len() + 8 + 8);
+    info.extend_from_slice(BACKUP_AD_LABEL);
+    info.extend_from_slice(&utc_epoch.to_be_bytes());
+    info.extend_from_slice(&counter.to_be_bytes());
+    let mut nonce = [0u8; 12];
+    hkdf.expand(&info, &mut nonce)
+        .map_err(|_| CryptoError::InvalidKeyLength)?;
+    Ok(nonce)
 }
 
 #[cfg(test)]
@@ -355,5 +465,66 @@ mod tests {
             state_decrypt(&dek, &[0u8; 10], 0, b"", b""),
             Err(CryptoError::CiphertextTooShort)
         ));
+    }
+
+    fn test_backup_dek() -> crate::dek::BackupDek {
+        crate::dek::BackupDek::from_raw([0x33u8; 32])
+    }
+
+    #[test]
+    fn test_backup_roundtrip() {
+        let dek = test_backup_dek();
+        let plaintext = b"snapshot data";
+        let dek_version = 1u32;
+        let utc_epoch = 1_700_000_000u64;
+
+        let enc = backup_encrypt(&dek, plaintext, dek_version, utc_epoch, 0).expect("encrypt");
+        assert_eq!(enc.len(), 12 + plaintext.len() + 16);
+
+        let dec = backup_decrypt(&dek, &enc, dek_version, utc_epoch, 0).expect("decrypt");
+        assert_eq!(dec.as_slice(), plaintext);
+    }
+
+    #[test]
+    fn test_backup_nonce_is_deterministic() {
+        let dek = test_backup_dek();
+        let utc_epoch = 1_700_000_000u64;
+        let n1 = backup_nonce(&dek, utc_epoch, 0).expect("nonce 1");
+        let n2 = backup_nonce(&dek, utc_epoch, 0).expect("nonce 2");
+        assert_eq!(n1, n2, "nonce must be deterministic for same inputs");
+    }
+
+    #[test]
+    fn test_backup_different_epoch_different_nonce() {
+        let dek = test_backup_dek();
+        let n1 = backup_nonce(&dek, 1_000u64, 0).expect("nonce 1");
+        let n2 = backup_nonce(&dek, 1_001u64, 0).expect("nonce 2");
+        assert_ne!(n1, n2, "different utc_epoch must produce different nonces");
+    }
+
+    #[test]
+    fn test_backup_wrong_epoch_rejected() {
+        let dek = test_backup_dek();
+        let enc = backup_encrypt(&dek, b"data", 1, 1_000u64, 0).expect("encrypt");
+        assert!(
+            matches!(
+                backup_decrypt(&dek, &enc, 1, 1_001u64, 0),
+                Err(CryptoError::AesDecrypt)
+            ),
+            "mismatched utc_epoch must fail decryption"
+        );
+    }
+
+    #[test]
+    fn test_backup_wrong_dek_version_rejected() {
+        let dek = test_backup_dek();
+        let enc = backup_encrypt(&dek, b"data", 1, 1_000u64, 0).expect("encrypt");
+        assert!(
+            matches!(
+                backup_decrypt(&dek, &enc, 2, 1_000u64, 0),
+                Err(CryptoError::AesDecrypt)
+            ),
+            "mismatched dek_version must fail decryption"
+        );
     }
 }

--- a/crates/storage-crypto/src/dek.rs
+++ b/crates/storage-crypto/src/dek.rs
@@ -29,15 +29,21 @@
 //! cryptographically uniform random (generated with a CSPRNG), so the
 //! Extract step adds no security and Extract is omitted as per ADR §2.1.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use hkdf::Hkdf;
 use rand::RngExt;
 use sha2::Sha256;
 use zeroize::{Zeroize, Zeroizing};
 
+use crate::audit::AuditHmacKey;
 use crate::error::CryptoError;
+use crate::mlock::LockedKey;
 
 const LOG_DEK_INFO: &[u8] = b"keystone-raft-log-v1";
 const STATE_DEK_INFO: &[u8] = b"keystone-fjall-state-v1";
+const BACKUP_DEK_INFO_PREFIX: &[u8] = b"keystone-backup-v1";
+const AUDIT_DEK_INFO_PREFIX: &[u8] = b"keystone-audit-dek-v1";
 
 // ---------------------------------------------------------------------------
 // Sub-key types  (no Debug/Display — never format key material)
@@ -49,29 +55,67 @@ pub struct LogDek(pub(crate) Zeroizing<[u8; 32]>);
 /// Sub-key for encrypting Fjall state machine entries.
 pub struct StateDek(pub(crate) Zeroizing<[u8; 32]>);
 
+/// Sub-key for encrypting Raft snapshot (backup) data.
+///
+/// Derived per-DEK-version so backup ciphertexts are never re-usable across
+/// rotation epochs.  Stored independently of `StateDek` so a compromised
+/// backup does not expose live data keys.  Backed by `LockedKey` (mlock'd,
+/// guard-paged memory) per ADR §9, Invariant 8.
+pub struct BackupDek(pub(crate) LockedKey);
+
+impl BackupDek {
+    /// Wrap raw key bytes into a `BackupDek` (used externally when copying
+    /// bytes out of a lock guard before calling backup_encrypt/decrypt).
+    pub fn from_raw(raw: [u8; 32]) -> Self {
+        Self(LockedKey::from_raw(raw))
+    }
+
+    /// Access the raw key bytes (e.g. for AES-256-GCM snapshot encryption).
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+}
+
+/// Derive the backup sub-key info string for a given epoch version.
+fn backup_info(version: u32) -> Vec<u8> {
+    let mut buf = BACKUP_DEK_INFO_PREFIX.to_vec();
+    buf.extend_from_slice(&version.to_be_bytes());
+    buf
+}
+
 // ---------------------------------------------------------------------------
 // DekEpoch
 // ---------------------------------------------------------------------------
 
-/// A single DEK rotation epoch: version number plus derived sub-keys.
+/// A single DEK rotation epoch: version number, root DEK in mlock'd memory,
+/// and derived sub-keys.
 ///
 /// All encryption in a given epoch uses the sub-keys held here.  On DEK
 /// rotation (Phase 5) a new `DekEpoch` with an incremented version replaces
 /// this one.
+///
+/// The root DEK is stored in a `LockedKey` (mlock'd page) per ADR §9.
+/// Sub-keys are derived via HKDF-Expand and stored independently.
 pub struct DekEpoch {
     /// Monotonically increasing epoch counter (`dek_version_u32`).
     pub version: u32,
+    /// Root 256-bit DEK in mlock'd memory (ADR §9, Invariant 8).
+    root_dek: LockedKey,
     log_dek: LogDek,
     state_dek: StateDek,
+    backup_dek: BackupDek,
+    /// Monotonic counter for backup snapshot nonce uniqueness (ADR §2.2).
+    backup_counter: AtomicU64,
 }
 
 impl DekEpoch {
-    /// Derive a `DekEpoch` from raw DEK bytes.
+    /// Derive a `DekEpoch` from a `LockedKey` containing the root DEK bytes.
     ///
     /// Uses HKDF-Expand (no Extract) to produce domain-separated sub-keys.
-    /// The raw DEK bytes are zeroed when this function returns.
-    pub fn from_raw(dek_bytes: &Zeroizing<[u8; 32]>, version: u32) -> Result<Self, CryptoError> {
-        let hkdf = Hkdf::<Sha256>::from_prk(dek_bytes.as_ref())
+    /// The backup sub-key is version-bound so different rotation epochs produce
+    /// different backup encryption keys.
+    pub fn from_raw(dek: LockedKey, version: u32) -> Result<Self, CryptoError> {
+        let hkdf = Hkdf::<Sha256>::from_prk(dek.as_bytes().as_ref())
             .map_err(|_| CryptoError::InvalidKeyLength)?;
 
         let mut log_key = Zeroizing::new([0u8; 32]);
@@ -82,10 +126,19 @@ impl DekEpoch {
         hkdf.expand(STATE_DEK_INFO, state_key.as_mut())
             .map_err(|_| CryptoError::InvalidKeyLength)?;
 
+        // BackupDek info is version-bound: prefix ++ version_u32_BE.
+        // Derive into a LockedKey so backup key material is mlock'd (ADR §9).
+        let mut backup_locked = LockedKey::alloc().map_err(|_| CryptoError::InvalidKeyLength)?;
+        hkdf.expand(&backup_info(version), backup_locked.as_mut())
+            .map_err(|_| CryptoError::InvalidKeyLength)?;
+
         Ok(Self {
             version,
+            root_dek: dek,
             log_dek: LogDek(log_key),
             state_dek: StateDek(state_key),
+            backup_dek: BackupDek(backup_locked),
+            backup_counter: AtomicU64::new(0),
         })
     }
 
@@ -98,24 +151,57 @@ impl DekEpoch {
     pub fn state_dek(&self) -> &StateDek {
         &self.state_dek
     }
+
+    /// Returns the backup (snapshot) sub-key for this epoch.
+    pub fn backup_dek(&self) -> &BackupDek {
+        &self.backup_dek
+    }
+
+    /// Fetch and increment the backup nonce counter.
+    ///
+    /// Returns the counter value *before* increment, suitable for use as
+    /// the deterministic nonce input in `backup_nonce`.
+    pub fn next_backup_counter(&self) -> u64 {
+        self.backup_counter.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Derive the per-epoch audit HMAC key from the root DEK (ADR §3.1).
+    ///
+    /// `AuditHmacKey = HKDF-Expand(DEK, info = b"keystone-audit-dek-v1" ++
+    /// version_u32_be ++ node_id_u64_be, L=32)`. Binding to both DEK
+    /// version and node ID ensures the audit key rotates with every DEK
+    /// rotation and cannot be forged across nodes.
+    pub fn derive_audit_key(&self, node_id: u64) -> Result<AuditHmacKey, CryptoError> {
+        let mut info = AUDIT_DEK_INFO_PREFIX.to_vec();
+        info.extend_from_slice(&self.version.to_be_bytes());
+        info.extend_from_slice(&node_id.to_be_bytes());
+        let hkdf = Hkdf::<Sha256>::from_prk(self.root_dek.as_bytes().as_ref())
+            .map_err(|_| CryptoError::InvalidKeyLength)?;
+        let mut out = [0u8; 32];
+        hkdf.expand(&info, &mut out)
+            .map_err(|_| CryptoError::InvalidKeyLength)?;
+        Ok(AuditHmacKey::from_raw(out))
+    }
 }
 
-/// Generate a fresh 256-bit DEK using a CSPRNG.
+/// Generate a fresh 256-bit DEK in guard-paged, mlock'd memory using a CSPRNG.
 ///
-/// Returns the raw key bytes in a zeroing wrapper.  The caller is responsible
-/// for immediately wrapping the DEK under the KEK and clearing the raw bytes.
-pub fn generate_dek() -> Zeroizing<[u8; 32]> {
-    let mut dek = Zeroizing::new([0u8; 32]);
+/// Returns the key in a `LockedKey` per ADR §9, Invariant 8.
+/// Panics on OOM; allocation failure for key material is fatal.
+pub fn generate_dek() -> LockedKey {
+    let mut dek = LockedKey::alloc().expect("OOM allocating DEK");
     // rand::fill is CSPRNG-backed (OsRng on all supported platforms).
     rand::rng().fill(dek.as_mut());
     dek
 }
 
-/// Zeroize sub-keys when `DekEpoch` is dropped.
+/// Zeroize sub-keys when `DekEpoch` is dropped (root DEK is handled by
+/// LockedKey).
 impl Drop for DekEpoch {
     fn drop(&mut self) {
         self.log_dek.0.zeroize();
         self.state_dek.0.zeroize();
+        // backup_dek.0 is a LockedKey — it zeroes on drop automatically.
     }
 }
 
@@ -123,22 +209,29 @@ impl Drop for DekEpoch {
 mod tests {
     use super::*;
 
+    fn test_locked_dek() -> LockedKey {
+        LockedKey::alloc().expect("alloc failed")
+    }
+
     #[test]
     fn test_dek_epoch_from_raw() {
-        let raw = Zeroizing::new([0x55u8; 32]);
-        let epoch = DekEpoch::from_raw(&raw, 0).expect("derive");
+        let mut raw = test_locked_dek();
+        raw.as_mut().copy_from_slice(&[0x55u8; 32]);
+        let epoch = DekEpoch::from_raw(raw, 0).expect("derive");
         // Sub-keys must differ from each other and from raw input.
-        assert_ne!(epoch.log_dek.0.as_ref(), raw.as_ref());
-        assert_ne!(epoch.state_dek.0.as_ref(), raw.as_ref());
+        assert_ne!(epoch.log_dek.0.as_ref(), &[0x55u8; 32]);
+        assert_ne!(epoch.state_dek.0.as_ref(), &[0x55u8; 32]);
         assert_ne!(epoch.log_dek.0.as_ref(), epoch.state_dek.0.as_ref());
     }
 
     #[test]
     fn test_dek_epoch_deterministic() {
-        let raw = Zeroizing::new([0xAAu8; 32]);
-        let e1 = DekEpoch::from_raw(&raw, 1).expect("first");
-        let e2 = DekEpoch::from_raw(&raw, 1).expect("second");
-        // Same DEK → same sub-keys regardless of call order.
+        let mut raw1 = test_locked_dek();
+        raw1.as_mut().copy_from_slice(&[0xAAu8; 32]);
+        let e1 = DekEpoch::from_raw(raw1, 1).expect("first");
+        let mut raw2 = test_locked_dek();
+        raw2.as_mut().copy_from_slice(&[0xAAu8; 32]);
+        let e2 = DekEpoch::from_raw(raw2, 1).expect("second");
         assert_eq!(e1.log_dek.0.as_ref(), e2.log_dek.0.as_ref());
         assert_eq!(e1.state_dek.0.as_ref(), e2.state_dek.0.as_ref());
     }
@@ -146,7 +239,25 @@ mod tests {
     #[test]
     fn test_generate_dek_non_zero() {
         let dek = generate_dek();
-        // Statistically impossible to generate all-zeros from a CSPRNG.
-        assert_ne!(dek.as_ref(), &[0u8; 32]);
+        assert_ne!(dek.as_bytes(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn test_backup_counter_increments() {
+        let mut raw = test_locked_dek();
+        raw.as_mut().copy_from_slice(&[0xAAu8; 32]);
+        let epoch = DekEpoch::from_raw(raw, 1).expect("epoch");
+        assert_eq!(epoch.next_backup_counter(), 0);
+        assert_eq!(epoch.next_backup_counter(), 1);
+    }
+
+    #[test]
+    fn test_derive_audit_key_per_epoch() {
+        let mut raw = test_locked_dek();
+        raw.as_mut().copy_from_slice(&[0xBBu8; 32]);
+        let epoch = DekEpoch::from_raw(raw, 42).expect("epoch");
+        let audit = epoch.derive_audit_key(1).expect("audit key");
+        let mac = audit.sign(b"test").expect("sign");
+        assert_eq!(mac.len(), 32);
     }
 }

--- a/crates/storage-crypto/src/error.rs
+++ b/crates/storage-crypto/src/error.rs
@@ -68,6 +68,12 @@ pub enum CryptoError {
     #[error("stored ciphertext is too short to be a valid encrypted record")]
     CiphertextTooShort,
 
+    /// Ciphertext was encrypted under a revoked DEK epoch (ADR 0016-v2 §6.2).
+    /// Emergency rotation revokes the compromised DEK; any attempt to decrypt
+    /// data with the revoked key is a fatal error.
+    #[error("DEK epoch {version} was revoked; decryption refused")]
+    RevokedDek { version: u32 },
+
     /// PKCS#11 backend is not yet implemented.
     #[error("PKCS#11 HSM backend is not implemented in this build")]
     Pkcs11NotImplemented,

--- a/crates/storage-crypto/src/kek.rs
+++ b/crates/storage-crypto/src/kek.rs
@@ -84,6 +84,15 @@ impl EnvKek {
         let mut hex_val = env::var("KEYSTONE_DEV_KEK").map_err(|_| CryptoError::KekMissing)?;
         let raw = decode_hex(&hex_val).map_err(|_| CryptoError::InvalidHex)?;
         hex_val.zeroize();
+        // env::remove_var is unsafe in Rust 2024 (TOCTOU with concurrent env reads)
+        // and forbidden by the workspace unsafe policy. The key material is zeroized
+        // above; operators must clear the variable via systemd UnsetEnvironment= or
+        // equivalent OS-level isolation.
+        tracing::warn!(
+            "SECURITY: KEYSTONE_DEV_KEK remains in process environment after read. \
+             Use systemd UnsetEnvironment= or equivalent to prevent exposure \
+             via /proc/<pid>/environ."
+        );
 
         if raw.len() != 32 {
             return Err(CryptoError::InvalidKeyLength);
@@ -161,7 +170,7 @@ impl KekProvider for Pkcs11KekStub {
 // ---------------------------------------------------------------------------
 
 fn decode_hex(s: &str) -> Result<Vec<u8>, CryptoError> {
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return Err(CryptoError::InvalidHex);
     }
     (0..s.len())

--- a/crates/storage-crypto/src/lib.rs
+++ b/crates/storage-crypto/src/lib.rs
@@ -24,30 +24,36 @@
 //!   [`dek::StateDek`]).
 //!
 //! * **Encryption helpers:** [`cipher`] provides `log_encrypt` / `log_decrypt`
-//!   for Raft log entries and `state_encrypt` / `state_decrypt` for Fjall
-//!   state machine records.
+//!   for Raft log entries and `state_encrypt` / `state_decrypt` for Fjall state
+//!   machine records.
 //!
 //! * **Nonce management:** [`nonce::NonceManager`] maintains a durable,
 //!   crash-safe monotonic counter for log-entry nonces (ADR §2.2, F1).
 //!
 //! ## Security properties enforced
 //!
-//! * All tags are 16 bytes (full GCM tag length). Truncated tags are
-//!   prohibited (ADR §2.2).
+//! * All tags are 16 bytes (full GCM tag length). Truncated tags are prohibited
+//!   (ADR §2.2).
 //! * Key material types intentionally omit `Debug` / `Display` to prevent
 //!   accidental logging.
 //! * `#[deny(clippy::mem_forget)]` prevents accidental drop bypass.
 
 #![deny(clippy::mem_forget)]
 
+pub mod audit;
 pub mod cipher;
 pub mod dek;
 pub mod error;
 pub mod kek;
+pub mod mlock;
 pub mod nonce;
 
-pub use cipher::{log_decrypt, log_encrypt, state_decrypt, state_encrypt};
-pub use dek::{DekEpoch, LogDek, StateDek, generate_dek};
+pub use audit::AuditHmacKey;
+pub use cipher::{
+    backup_decrypt, backup_encrypt, log_decrypt, log_encrypt, state_decrypt, state_encrypt,
+};
+pub use dek::{BackupDek, DekEpoch, LogDek, StateDek, generate_dek};
 pub use error::CryptoError;
 pub use kek::{EnvKek, KekProvider, Pkcs11KekStub};
+pub use mlock::LockedKey;
 pub use nonce::{NonceManager, NoncePersistence};

--- a/crates/storage-crypto/src/mlock.rs
+++ b/crates/storage-crypto/src/mlock.rs
@@ -1,0 +1,397 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Page-locked memory for cryptographic key material (ADR §9).
+//!
+//! [`LockedKey`] wraps a custom guard-paged allocation built on [`nix`] and
+//! [`std::alloc`], providing:
+//! - **Guard pages** (`PROT_NONE`) on both sides to catch buffer overruns.
+//! - **`mlock`** to prevent the key page from being swapped to disk.
+//! - **`madvise(MADV_DONTDUMP)`** to exclude the page from core dumps (Linux).
+//! - **`madvise(MADV_DONTFORK)`** to prevent key exposure in child processes
+//!   (Linux).
+//! - **Canary** checked on `drop` to detect heap corruption.
+//! - **Automatic zeroing** on `drop` via [`zeroize`].
+//!
+//! ## Page layout
+//!
+//! ```text
+//! base_ptr:
+//!   [0 .. PAGE_SIZE)                       metadata (unprotected_size), PROT_READ
+//!   [PAGE_SIZE .. 2*PAGE_SIZE)             lower guard page, PROT_NONE
+//!   [2*PAGE_SIZE .. 2*PAGE_SIZE+unprotected_size)
+//!     within data: [padding | canary(16 B) | key(32 B)]
+//!                   key is placed at the top of the page
+//!   [2*PAGE_SIZE+unprotected_size ..)      upper guard page, PROT_NONE
+//! ```
+//!
+//! # Why `#[allow(unsafe_code)]`
+//!
+//! This module requires unsafe code for three reasons that cannot be abstracted
+//! away:
+//! 1. `unsafe impl Send + Sync` are mandatory for any type that wraps a raw
+//!    pointer.
+//! 2. Page-aligned allocation and deallocation use `std::alloc`.
+//! 3. `NonNull::as_ref` / `as_mut` dereference a raw pointer.
+//!
+//! All other workspace crates are subject to `unsafe_code = "forbid"`.
+
+use std::alloc::{Layout, alloc, dealloc};
+use std::process::abort;
+use std::ptr::{self, NonNull};
+use std::sync::OnceLock;
+
+use nix::sys::mman::{MmapAdvise, ProtFlags, madvise, mlock, mprotect, munlock};
+use nix::unistd::{SysconfVar, sysconf};
+use rand::RngExt;
+use zeroize::Zeroize;
+
+/// Key size in bytes.
+const KEY_SIZE: usize = 32;
+/// Random canary placed immediately before the key; validated on free.
+const CANARY_SIZE: usize = 16;
+
+struct AllocState {
+    page_size: usize,
+    canary: [u8; CANARY_SIZE],
+}
+
+static ALLOC_STATE: OnceLock<AllocState> = OnceLock::new();
+
+fn alloc_state() -> &'static AllocState {
+    ALLOC_STATE.get_or_init(|| {
+        let page_size = sysconf(SysconfVar::PAGE_SIZE)
+            .expect("sysconf(PAGE_SIZE) failed")
+            .expect("sysconf(PAGE_SIZE) returned None") as usize;
+        assert!(
+            page_size.is_power_of_two() && page_size >= CANARY_SIZE + KEY_SIZE,
+            "page size {page_size} too small for guard-page allocation"
+        );
+        let mut canary = [0u8; CANARY_SIZE];
+        rand::rng().fill(&mut canary);
+        AllocState { page_size, canary }
+    })
+}
+
+/// 32-byte key buffer backed by guard-paged, mlock'd memory.
+///
+/// Backed by a custom allocator that surrounds the key page with two
+/// `PROT_NONE` guard pages.  The key page is `mlock`'d (preventing swap) and
+/// marked `MADV_DONTDUMP` on Linux so it does not appear in core dumps.
+/// On drop: canary is validated, memory is zeroed via [`zeroize`], unlocked,
+/// and freed.
+pub struct LockedKey {
+    raw: NonNull<[u8; KEY_SIZE]>,
+}
+
+#[allow(unsafe_code)]
+unsafe impl Send for LockedKey {}
+#[allow(unsafe_code)]
+unsafe impl Sync for LockedKey {}
+
+#[allow(unsafe_code)]
+impl LockedKey {
+    /// Allocate a guard-paged key buffer, zeroed.
+    ///
+    /// Returns `Err` on allocation failure, `mprotect` refusal, or `mlock`
+    /// failure.  `mlock` failure is treated as fatal: a node that cannot pin
+    /// key material in RAM must not start, because un-locked pages may be
+    /// swapped to disk and persist after process exit (ADR §9, Invariant 8).
+    pub fn alloc() -> Result<Self, &'static str> {
+        unsafe { locked_alloc() }
+            .map(|mut raw| {
+                // Zero the garbage-filled allocation before exposing it.
+                unsafe { raw.as_mut().fill(0) };
+                Self { raw }
+            })
+            .ok_or("guard-page allocation failed")
+    }
+
+    /// Copy `bytes` into a fresh guard-paged allocation.
+    ///
+    /// Panics on OOM; allocation failure for key material is fatal.
+    pub fn from_raw(bytes: [u8; KEY_SIZE]) -> Self {
+        let mut key = Self::alloc().expect("OOM allocating LockedKey");
+        key.as_mut().copy_from_slice(&bytes);
+        key
+    }
+
+    /// Read access to the key bytes.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; KEY_SIZE] {
+        unsafe { self.raw.as_ref() }
+    }
+
+    /// Mutable access to the key bytes.
+    #[allow(clippy::should_implement_trait)]
+    #[inline]
+    pub fn as_mut(&mut self) -> &mut [u8; KEY_SIZE] {
+        unsafe { self.raw.as_mut() }
+    }
+}
+
+#[allow(unsafe_code)]
+impl Drop for LockedKey {
+    fn drop(&mut self) {
+        unsafe { locked_free(self.raw) }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Allocation internals
+// ---------------------------------------------------------------------------
+
+#[allow(unsafe_code)]
+unsafe fn locked_alloc() -> Option<NonNull<[u8; KEY_SIZE]>> {
+    let s = alloc_state();
+    let page_size = s.page_size;
+    let page_mask = page_size - 1;
+
+    // CANARY_SIZE + KEY_SIZE = 48; round up to one page on all common platforms.
+    let size_with_canary = CANARY_SIZE + KEY_SIZE;
+    let unprotected_size = (size_with_canary + page_mask) & !page_mask;
+    let total_size = page_size * 2 + unprotected_size + page_size; // 4 pages
+
+    let layout = Layout::from_size_align(total_size, page_size).ok()?;
+
+    // SAFETY: layout is non-zero and power-of-two aligned.
+    let base_ptr = unsafe { alloc(layout) };
+    if base_ptr.is_null() {
+        return None;
+    }
+
+    // Data page starts after metadata page + lower guard.
+    // SAFETY: offset is within the allocation bounds.
+    let unprotected_ptr = unsafe { base_ptr.add(page_size * 2) };
+
+    // Lower guard page.
+    // SAFETY: base_ptr+page_size is within the allocation.
+    if unsafe {
+        mprotect(
+            NonNull::new_unchecked(base_ptr.add(page_size).cast()),
+            page_size,
+            ProtFlags::PROT_NONE,
+        )
+    }
+    .is_err()
+    {
+        unsafe { dealloc(base_ptr, layout) };
+        return None;
+    }
+
+    // Upper guard page.
+    // SAFETY: unprotected_ptr+unprotected_size is within the allocation.
+    if unsafe {
+        mprotect(
+            NonNull::new_unchecked(unprotected_ptr.add(unprotected_size).cast()),
+            page_size,
+            ProtFlags::PROT_NONE,
+        )
+    }
+    .is_err()
+    {
+        // Restore all pages to writable before freeing.
+        unsafe {
+            let _ = mprotect(
+                NonNull::new_unchecked(base_ptr.cast()),
+                total_size,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+            );
+            dealloc(base_ptr, layout);
+        }
+        return None;
+    }
+
+    // mlock — required; fail if the kernel refuses to pin the key page.
+    // A node that cannot mlock key material must not start: un-locked pages
+    // may be swapped to disk (ADR §9, Invariant 8).
+    if unsafe {
+        mlock(
+            NonNull::new_unchecked(unprotected_ptr.cast()),
+            unprotected_size,
+        )
+    }
+    .is_err()
+    {
+        unsafe {
+            let _ = mprotect(
+                NonNull::new_unchecked(base_ptr.cast()),
+                total_size,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+            );
+            dealloc(base_ptr, layout);
+        }
+        return None;
+    }
+
+    // Linux: exclude from core dumps and child processes via fork(2).
+    #[cfg(target_os = "linux")]
+    unsafe {
+        let _ = madvise(
+            NonNull::new_unchecked(unprotected_ptr.cast()),
+            unprotected_size,
+            MmapAdvise::MADV_DONTDUMP,
+        );
+        let _ = madvise(
+            NonNull::new_unchecked(unprotected_ptr.cast()),
+            unprotected_size,
+            MmapAdvise::MADV_DONTFORK,
+        );
+    }
+
+    // Canary + key are placed at the top of the data page:
+    //   [padding ... | canary(16) | key(32)]
+    // SAFETY: offsets are within the data page.
+    let (canary_ptr, user_ptr) = unsafe {
+        let cp = unprotected_ptr.add(unprotected_size - size_with_canary);
+        (cp, cp.add(CANARY_SIZE))
+    };
+
+    unsafe {
+        // Write canary.
+        ptr::copy_nonoverlapping(s.canary.as_ptr(), canary_ptr, CANARY_SIZE);
+        // Store unprotected_size in the metadata page.
+        ptr::write_unaligned(base_ptr.cast::<usize>(), unprotected_size);
+    }
+
+    // Make the metadata page read-only.
+    if unsafe {
+        mprotect(
+            NonNull::new_unchecked(base_ptr.cast()),
+            page_size,
+            ProtFlags::PROT_READ,
+        )
+    }
+    .is_err()
+    {
+        unsafe {
+            let _ = mprotect(
+                NonNull::new_unchecked(base_ptr.cast()),
+                total_size,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+            );
+            let _ = munlock(
+                NonNull::new_unchecked(unprotected_ptr.cast()),
+                unprotected_size,
+            );
+            dealloc(base_ptr, layout);
+        }
+        return None;
+    }
+
+    // Fill key region with garbage; caller must overwrite before use.
+    unsafe { ptr::write_bytes(user_ptr, 0xd0, KEY_SIZE) };
+
+    Some(unsafe { NonNull::new_unchecked(user_ptr.cast()) })
+}
+
+#[allow(unsafe_code)]
+unsafe fn locked_free(ptr: NonNull<[u8; KEY_SIZE]>) {
+    let s = alloc_state();
+    let page_size = s.page_size;
+    let page_mask = page_size - 1;
+
+    // SAFETY: ptr was returned by locked_alloc; the layout is known and valid.
+    let (user_ptr, canary_ptr, unprotected_ptr, base_ptr) = unsafe {
+        let up = ptr.as_ptr().cast::<u8>();
+        let cp = up.sub(CANARY_SIZE);
+        let dp = (cp as usize & !page_mask) as *mut u8;
+        let bp = dp.sub(page_size * 2);
+        (up, cp, dp, bp)
+    };
+
+    // Metadata page is PROT_READ; reading unprotected_size is valid.
+    let unprotected_size = unsafe { ptr::read_unaligned(base_ptr.cast::<usize>()) };
+    let total_size = page_size * 2 + unprotected_size + page_size;
+
+    // Validate canary via xor-accumulate.
+    // Timing is irrelevant: the canary guards against heap corruption
+    // (abort-or-continue), not against a timing side-channel on secret
+    // comparison.
+    let stored = unsafe { std::slice::from_raw_parts(canary_ptr, CANARY_SIZE) };
+    let diff = stored
+        .iter()
+        .zip(s.canary.iter())
+        .fold(0u8, |acc, (&a, &b)| acc | (a ^ b));
+    if diff != 0 {
+        abort();
+    }
+
+    unsafe {
+        // Make all pages writable before zeroing.
+        let _ = mprotect(
+            NonNull::new_unchecked(base_ptr.cast()),
+            total_size,
+            ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+        );
+
+        // Zero the entire data page (canary + key + padding) with volatile writes.
+        let data_slice = std::slice::from_raw_parts_mut(unprotected_ptr, unprotected_size);
+        data_slice.zeroize();
+
+        // Unlock from RAM.
+        let _ = munlock(
+            NonNull::new_unchecked(unprotected_ptr.cast()),
+            unprotected_size,
+        );
+    }
+
+    // Linux: restore dump and fork visibility before freeing.
+    #[cfg(target_os = "linux")]
+    unsafe {
+        let _ = madvise(
+            NonNull::new_unchecked(unprotected_ptr.cast()),
+            unprotected_size,
+            MmapAdvise::MADV_DODUMP,
+        );
+        let _ = madvise(
+            NonNull::new_unchecked(unprotected_ptr.cast()),
+            unprotected_size,
+            MmapAdvise::MADV_DOFORK,
+        );
+    }
+
+    // SAFETY: same layout and alignment as locked_alloc.
+    unsafe {
+        let layout = Layout::from_size_align_unchecked(total_size, page_size);
+        dealloc(base_ptr, layout);
+    }
+
+    // Suppress unused variable warning when not on Linux.
+    let _ = user_ptr;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_locked_key_alloc_zeroed() {
+        let key = LockedKey::alloc().expect("alloc failed");
+        assert_eq!(key.as_bytes(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn test_locked_key_write_read() {
+        let mut key = LockedKey::alloc().expect("alloc failed");
+        key.as_mut().copy_from_slice(&[0xABu8; 32]);
+        assert_eq!(key.as_bytes(), &[0xABu8; 32]);
+    }
+
+    #[test]
+    fn test_locked_key_from_raw() {
+        let bytes = [0x42u8; 32];
+        let key = LockedKey::from_raw(bytes);
+        assert_eq!(key.as_bytes(), &bytes);
+    }
+}

--- a/crates/storage-crypto/src/nonce.rs
+++ b/crates/storage-crypto/src/nonce.rs
@@ -21,18 +21,18 @@
 //! The counter must be unique for every log encryption and must survive
 //! crashes without reuse.  This is achieved via **forward reservation**:
 //!
-//! 1. On startup, a reservation block of [`RESERVE_BLOCK`] is pre-committed
-//!    to durable storage.  The in-memory counter starts at the PREVIOUS
+//! 1. On startup, a reservation block of [`RESERVE_BLOCK`] is pre-committed to
+//!    durable storage.  The in-memory counter starts at the PREVIOUS
 //!    reservation point, so the new reservation covers the next range.
-//! 2. Each call to [`NonceManager::next_nonce`] returns the current counter
-//!    and advances it.  When the in-memory counter reaches the end of the
-//!    current reserved block, a new block is committed.
+//! 2. Each call to [`NonceManager::next_nonce`] returns the current counter and
+//!    advances it.  When the in-memory counter reaches the end of the current
+//!    reserved block, a new block is committed.
 //! 3. After each reservation write, the value is read back and compared; a
 //!    mismatch causes [`CryptoError::NonceReadbackMismatch`].
 //! 4. A High-Water Mark (`nonce_hwm`) records the largest reservation ever
-//!    written.  On startup, if the persisted counter is strictly less than
-//!    the HWM, [`CryptoError::NonceCounterRollback`] is returned and the
-//!    node must not start.
+//!    written.  On startup, if the persisted counter is strictly less than the
+//!    HWM, [`CryptoError::NonceCounterRollback`] is returned and the node must
+//!    not start.
 //!
 //! ## Rotation threshold
 //!
@@ -82,7 +82,7 @@ pub struct NonceManager {
 }
 
 impl NonceManager {
-    /// Initialise the nonce manager for a given `node_id`.
+    /// Initialize the nonce manager for a given `node_id`.
     ///
     /// Reads persisted state, validates against the HWM, then immediately
     /// reserves the next block.

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -53,6 +53,8 @@ tonic-prost.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 chrono.workspace = true
+uuid.workspace = true
+x509-parser = "0.16"
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/crates/storage/benches/state_machine.rs
+++ b/crates/storage/benches/state_machine.rs
@@ -1,12 +1,16 @@
 #![cfg(feature = "bench_internals")]
+use std::collections::HashMap;
+use std::collections::{BTreeMap, HashSet};
 use std::hint::black_box;
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::RwLock;
 
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use fjall::Database;
 use futures::stream;
 use openraft::{RaftSnapshotBuilder, storage::RaftStateMachine};
-use openstack_keystone_storage_crypto::{DekEpoch, generate_dek};
+use openstack_keystone_storage_crypto::{DekEpoch, EnvKek, KekProvider, generate_dek};
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
@@ -21,8 +25,32 @@ fn bench_state_machine(c: &mut Criterion) {
     let snapshot_dir = db_path.path().join("snapshots");
     let db = Database::builder(db_path).open().unwrap();
     let db = Arc::new(db);
-    let dek = Arc::new(DekEpoch::from_raw(&generate_dek(), 0).unwrap());
-    let sm = Arc::new(FjallStateMachine::new(db, snapshot_dir, dek).unwrap());
+    let raw = generate_dek();
+    let epoch = Arc::new(DekEpoch::from_raw(raw, 0).unwrap());
+    let current_dek: Arc<RwLock<Arc<DekEpoch>>> = Arc::new(RwLock::new(epoch));
+    let old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>> = Arc::new(Mutex::new(BTreeMap::new()));
+    let revoked_deks: Arc<Mutex<HashSet<u32>>> = Arc::new(Mutex::new(HashSet::new()));
+    let kek: Arc<dyn KekProvider> = Arc::new(EnvKek::from_bytes([0x42u8; 32]));
+    let (_reencrypt_tx, _reencrypt_rx) = tokio::sync::mpsc::channel::<Arc<DekEpoch>>(16);
+    let pending_rotations: Arc<
+        Mutex<
+            HashMap<String, openstack_keystone_distributed_storage::store_command::PendingRotation>,
+        >,
+    > = Arc::new(Mutex::new(HashMap::new()));
+    #[allow(unused)]
+    let sm = Arc::new(
+        FjallStateMachine::new(
+            db,
+            snapshot_dir,
+            current_dek,
+            old_deks,
+            revoked_deks,
+            kek,
+            _reencrypt_tx,
+            pending_rotations,
+        )
+        .unwrap(),
+    );
 
     c.bench_function("get_db", |b| {
         b.iter(|| sm.db());

--- a/crates/storage/proto/raft.proto
+++ b/crates/storage/proto/raft.proto
@@ -186,7 +186,7 @@ message ChangeMembershipRequest {
   bool retain = 2;
 }
 
-message AdminResponse { 
+message AdminResponse {
   // The log id of the committed log entry.
   keystone.raft.LogId log_id = 1;
 
@@ -195,6 +195,11 @@ message AdminResponse {
 
   // If the committed log entry is a normal one.
   keystone.api.Response data = 3;
+
+  // Non-empty when the response is a pending emergency DEK rotation (stage 1
+  // of dual-control). The caller must pass this id to ConfirmRotateDek within
+  // 5 minutes.
+  string pending_rotation_id = 4;
 }
 
 message MetricsResponse {

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -12,14 +12,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, RwLock};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
 use eyre::eyre;
 use openraft::Config;
 use openraft::async_runtime::WatchReceiver;
-use openstack_keystone_storage_crypto::EnvKek;
+use openstack_keystone_storage_crypto::{DekEpoch, EnvKek, KekProvider};
 
 use crate::protobuf as pb;
 use openraft::ReadPolicy;
@@ -38,11 +38,11 @@ use crate::StorageApi;
 use crate::StoreError;
 use crate::StoreResponse;
 use crate::Violation;
+use crate::audit::AuditForwarder;
 use crate::grpc::cluster_admin_service::ClusterAdminServiceImpl;
 use crate::grpc::raft_service::RaftServiceImpl;
 use crate::grpc::storage_service::StorageServiceImpl;
-use crate::network::NetworkManager;
-use crate::network::init_tls_watcher;
+use crate::network::{CertExpiryWatchdog, NetworkManager, init_tls_watcher};
 use crate::pb::api::Response;
 use crate::pb::raft::cluster_admin_service_server::ClusterAdminServiceServer;
 use crate::pb::raft::raft_service_server::RaftServiceServer;
@@ -59,6 +59,53 @@ use openstack_keystone_storage_api::Node;
 /// clients can retry against the leader.
 pub const LEADER_ENDPOINT_HEADER: &str = "x-openraft-leader-endpoint";
 pub const LEADER_ID_HEADER: &str = "x-openraft-leader-id";
+
+/// Check that `node_id` is not already registered in the committed cluster
+/// membership with a different `rpc_addr`.
+///
+/// Reads local committed membership state — no network access required.  If
+/// the committed membership contains `node_id` at a different address, this
+/// indicates a misconfiguration or an impersonation attempt: we refuse to
+/// start (fail-closed, per ADR 0016-v2 §4.3 / F7).
+async fn check_node_id_uniqueness(
+    raft: &Raft,
+    node_id: u64,
+    rpc_addr: &str,
+) -> Result<(), StoreError> {
+    let check_addr = rpc_addr.to_owned();
+    let check_id = node_id;
+    let conflict = raft
+        .with_raft_state(move |s| {
+            s.membership_state
+                .committed()
+                .nodes()
+                .find_map(|(nid, node)| {
+                    if *nid == check_id && node.rpc_addr != check_addr {
+                        Some(node.rpc_addr.clone())
+                    } else {
+                        None
+                    }
+                })
+        })
+        .await
+        .map_err(|e| StoreError::Other(eyre!("failed to read Raft membership state: {e}")))?;
+
+    if let Some(existing_addr) = conflict {
+        tracing::error!(
+            node_id,
+            rpc_addr,
+            existing_addr,
+            "FATAL: node_id already registered in cluster at a different address"
+        );
+        return Err(StoreError::Other(eyre!(
+            "FATAL: node_id {node_id} already registered in cluster at {existing_addr}; \
+             refusing to start with address {rpc_addr}"
+        )));
+    }
+
+    tracing::debug!(node_id, rpc_addr, "node_id uniqueness check passed");
+    Ok(())
+}
 
 /// Initialize storage services backed by the raft.
 ///
@@ -95,15 +142,27 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
     // Production deployments should set kek_provider = "pkcs11" in config
     // and the Pkcs11KekStub will be replaced by a live HSM driver in a
     // future phase.
-    let kek = EnvKek::from_env()
-        .map_err(|e| StoreError::Other(eyre!("failed to load KEYSTONE_DEV_KEK: {e}")))?;
+    let kek: Arc<dyn KekProvider> = Arc::new(
+        EnvKek::from_env()
+            .map_err(|e| StoreError::Other(eyre!("failed to load KEYSTONE_DEV_KEK: {e}")))?,
+    );
 
     // Create stores and network
-    let (log_store, sm) =
-        crate::new::<crate::TypeConfig, _>(ds_config.path, ds_config.node_id, &kek).await?;
+    let (log_store, sm, current_dek, _revoked_deks, pending_rotations) =
+        crate::new::<crate::TypeConfig, _>(ds_config.path, ds_config.node_id, kek.clone()).await?;
     let state_machine_store = Arc::new(sm);
     let tls_watcher = init_tls_watcher(config_manager).await?;
     let network = Arc::new(NetworkManager::new(tls_watcher.clone())?);
+
+    // Spawn TLS cert expiry watchdog for manual-TLS fallback (ADR §4.2).
+    // In SPIFFE mode this would be replaced by the SVID TTL check.
+    if let openstack_keystone_config::RaftTlsConfiguration::Tls(tls) = &ds_config.tls_configuration
+        && let Some(cert_content) = tls.tls_cert_content.as_ref()
+    {
+        use secrecy::ExposeSecret;
+        let cert_bytes = cert_content.expose_secret().to_vec();
+        CertExpiryWatchdog::spawn(cert_bytes, false);
+    }
 
     // Create Raft instance
     let raft = Raft::new(
@@ -115,11 +174,30 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
     )
     .await?;
 
+    // Refuse to start if our node_id is already in the cluster under a different
+    // address.
+    let rpc_addr = ds_config.node_cluster_addr.to_string();
+    check_node_id_uniqueness(&raft, ds_config.node_id, &rpc_addr).await?;
+
+    // Derive the per-node audit HMAC key from the current DEK epoch (ADR §3.1).
+    let audit_key = {
+        let guard = current_dek.read().unwrap();
+        guard
+            .derive_audit_key(ds_config.node_id)
+            .expect("derive audit key from DEK")
+    };
+    let (audit_forwarder, _audit_task) = AuditForwarder::spawn(audit_key);
+
     Ok(Storage {
         connection_pool: DashMap::new(),
         raft,
+        node_id: ds_config.node_id,
         state_machine_store,
         tls_watcher,
+        kek,
+        current_dek,
+        audit_forwarder,
+        pending_rotations,
     })
 }
 
@@ -132,7 +210,14 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
 /// A `Result` containing the `Routes`, or a `StoreError`.
 pub async fn get_app_server(storage: &Storage) -> Result<Routes, StoreError> {
     let raft_svc_impl = RaftServiceImpl::new(storage.raft.clone());
-    let cluster_admin_svc_impl = ClusterAdminServiceImpl::new(storage.raft.clone());
+    let cluster_admin_svc_impl = ClusterAdminServiceImpl::new(
+        storage.raft.clone(),
+        storage.node_id,
+        storage.kek.clone(),
+        storage.current_dek.clone(),
+        storage.audit_forwarder.clone(),
+        storage.pending_rotations.clone(),
+    );
     let storage_svc_impl = StorageServiceImpl::new(storage.raft.clone());
 
     let mut router = Routes::builder();
@@ -152,8 +237,20 @@ pub struct Storage {
     tls_watcher: watch::Receiver<ClientTlsConfig>,
     /// Raft instance.
     pub raft: Raft,
+    /// This node's Raft ID (used to tag audit records for per-node
+    /// attribution).
+    node_id: u64,
     /// The state machine store for direct reads.
     state_machine_store: Arc<StateMachineStore>,
+    /// Key Encryption Key for wrapping new DEKs during rotation.
+    kek: Arc<dyn KekProvider>,
+    /// Shared current DEK epoch, used by rotate_dek to determine the next
+    /// version.
+    current_dek: Arc<RwLock<Arc<DekEpoch>>>,
+    /// Audit record forwarder (non-blocking, HMAC-signed).
+    pub audit_forwarder: AuditForwarder,
+    /// Pending emergency DEK rotations (shared with FjallStateMachine).
+    pending_rotations: Arc<Mutex<HashMap<String, crate::store_command::PendingRotation>>>,
 }
 
 #[async_trait]

--- a/crates/storage/src/audit.rs
+++ b/crates/storage/src/audit.rs
@@ -1,0 +1,173 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Audit log infrastructure (ADR 0016-v2 §3.1, Phase 8).
+//!
+//! ## Design
+//!
+//! Each storage node derives a per-node `AuditHmacKey` from the KEK at startup.
+//! Audit records are serialised to canonical JSON, signed with
+//! `HMAC-SHA256(AuditHmacKey, record_json)`, and forwarded to a SIEM endpoint.
+//!
+//! The `AuditForwarder` runs as an in-process background task.  Emitting a
+//! record is non-blocking (fire-and-forget into an async channel) so audit
+//! emission never stalls write operations.
+//!
+//! SIEM forwarding is stubbed in this phase: records are logged at `INFO` level
+//! with their HMAC appended.  A future phase will add TCP/TLS delivery and
+//! local encrypted buffering.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use openstack_keystone_storage_crypto::AuditHmacKey;
+use serde::Serialize;
+use tokio::sync::{Mutex, mpsc};
+
+/// Capacity of the in-process audit channel.
+///
+/// At 90% usage an `ERROR` is emitted — audit completeness is a security
+/// property (ADR §3.1) so persistent backpressure warrants operator attention.
+/// Callers that find the channel full drop the record and log a `WARN`.
+const CHANNEL_CAPACITY: usize = 1024;
+const CHANNEL_WARN_THRESHOLD: usize = CHANNEL_CAPACITY * 9 / 10;
+
+/// A signed audit record.
+#[derive(Serialize, Clone)]
+pub struct AuditRecord {
+    /// UTC epoch seconds.
+    pub timestamp: u64,
+    /// Event classification, e.g. `"DEK_ROTATION"`, `"QUARANTINE_CLEARED"`.
+    pub event_type: String,
+    /// Operator identity (SPIFFE SVID or TLS SAN; `"unknown"` when
+    /// unavailable).
+    pub actor: String,
+    /// Raft node that generated this record.
+    pub node_id: u64,
+    /// Active DEK epoch version at the time of the event.
+    pub dek_version: u32,
+    /// Arbitrary structured context for the event.
+    pub details: serde_json::Value,
+}
+
+impl AuditRecord {
+    /// Create a record stamped with the current wall-clock time.
+    pub fn now(
+        event_type: impl Into<String>,
+        actor: impl Into<String>,
+        node_id: u64,
+        dek_version: u32,
+        details: serde_json::Value,
+    ) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Self {
+            timestamp,
+            event_type: event_type.into(),
+            actor: actor.into(),
+            node_id,
+            dek_version,
+            details,
+        }
+    }
+}
+
+/// Background task that signs and forwards audit records.
+///
+/// Records are submitted via [`AuditForwarder::emit`] (non-blocking).
+/// The forwarder task serialises each record to canonical JSON, computes
+/// `HMAC-SHA256(AuditHmacKey, json)`, and logs the result.
+///
+/// `AuditForwarder` is cheaply cloneable — all clones share the same channel
+/// sender and signing key, so they all enqueue to the same background task.
+///
+/// The `AuditHmacKey` is behind a `Mutex` so it can be rotated atomically
+/// when a new DEK epoch is installed.
+#[derive(Clone)]
+pub struct AuditForwarder {
+    tx: mpsc::Sender<AuditRecord>,
+    /// Shared key — can be rotated without restarting the forwarder task.
+    key: Arc<Mutex<AuditHmacKey>>,
+}
+
+impl AuditForwarder {
+    /// Spawn the forwarder background task and return the handle.
+    ///
+    /// The returned `JoinHandle` is detached; callers should store it only if
+    /// they want structured shutdown.
+    pub fn spawn(key: AuditHmacKey) -> (Self, tokio::task::JoinHandle<()>) {
+        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let key = Arc::new(Mutex::new(key));
+        let key_clone = key.clone();
+        let handle = tokio::spawn(forwarder_task(rx, key_clone));
+        (Self { tx, key }, handle)
+    }
+
+    /// Submit a record for signing and forwarding (non-blocking).
+    ///
+    /// If the channel is at capacity the record is dropped and a `WARN` is
+    /// emitted — audit emission must not block storage writes.
+    pub fn emit(&self, record: AuditRecord) {
+        let used = CHANNEL_CAPACITY - self.tx.capacity();
+        if used >= CHANNEL_WARN_THRESHOLD {
+            tracing::error!(
+                used,
+                capacity = CHANNEL_CAPACITY,
+                "AUDIT: forwarder channel near capacity — records may be dropped; \
+                 audit completeness is a security property (ADR §3.1)"
+            );
+        }
+        if let Err(e) = self.tx.try_send(record) {
+            tracing::warn!(error = %e, "AUDIT: record dropped — channel full");
+        }
+    }
+
+    /// Replace the signing key (e.g., after KEK rotation).
+    pub async fn rotate_key(&self, new_key: AuditHmacKey) {
+        *self.key.lock().await = new_key;
+    }
+}
+
+async fn forwarder_task(mut rx: mpsc::Receiver<AuditRecord>, key: Arc<Mutex<AuditHmacKey>>) {
+    while let Some(record) = rx.recv().await {
+        let json = match serde_json::to_string(&record) {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::error!(error = %e, "AUDIT: failed to serialise record");
+                continue;
+            }
+        };
+        let hmac = {
+            let k = key.lock().await;
+            match k.sign(json.as_bytes()) {
+                Ok(mac) => mac,
+                Err(e) => {
+                    tracing::error!(error = %e, "AUDIT: failed to sign record");
+                    continue;
+                }
+            }
+        };
+        let hmac_hex: String = hmac.iter().map(|b| format!("{b:02x}")).collect();
+        tracing::info!(
+            event_type = record.event_type,
+            actor = record.actor,
+            node_id = record.node_id,
+            dek_version = record.dek_version,
+            hmac = hmac_hex,
+            "AUDIT: {}",
+            json,
+        );
+    }
+}

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -77,6 +77,10 @@ pub enum StoreError {
     #[error("partition '{0}' is quarantined due to repeated GCM tag failures")]
     Quarantined(String),
 
+    /// Per-record write version exceeded the rotation threshold.
+    #[error("key '{0}' write rate exceeded (version {1} >= threshold)")]
+    WriteRateExceeded(String, u32),
+
     /// Tls configuration is unset.
     #[error("missing mTLS configuration")]
     TlsConfigMissing,

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -11,21 +11,56 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex, RwLock};
 
 use openraft::async_runtime::WatchReceiver;
+use openstack_keystone_storage_crypto::{DekEpoch, KekProvider, generate_dek};
 use tonic::Request;
 use tonic::Response;
 use tonic::Status;
 use tracing::trace;
 
-//use crate::cluster_admin_service::ClusterAdminService as
-// ClusterAdminServiceImpl;
 use crate::StoreError;
+use crate::audit::{AuditForwarder, AuditRecord};
 use crate::pb;
 use crate::protobuf::raft::cluster_admin_service_server::ClusterAdminService;
-use crate::store_command::{MutationInner, StoreCommand};
+use crate::store_command::{MutationInner, PendingRotation, StoreCommand};
 use crate::types::*;
+
+/// Extract the peer TLS identity from the request: prefers SPIFFE URI SAN,
+/// falls back to CN, or returns `"unknown"` if no peer cert is present.
+fn extract_peer_identity<T>(request: &tonic::Request<T>) -> String {
+    let der_bytes: Option<Vec<u8>> = request
+        .peer_certs()
+        .and_then(|certs| certs.first().map(|c| c.as_ref().to_vec()));
+
+    der_bytes
+        .as_deref()
+        .and_then(|der| x509_parser::parse_x509_certificate(der).ok())
+        .and_then(|(_, cert)| {
+            cert.subject_alternative_name()
+                .ok()
+                .flatten()
+                .and_then(|san| {
+                    san.value.general_names.iter().find_map(|n| {
+                        if let x509_parser::extensions::GeneralName::URI(uri) = n {
+                            Some((*uri).to_owned())
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .or_else(|| {
+                    cert.subject()
+                        .iter_common_name()
+                        .next()
+                        .and_then(|a| a.as_str().ok())
+                        .map(str::to_owned)
+                })
+        })
+        .unwrap_or_else(|| "unknown".to_owned())
+}
 
 /// Raft cluster administrative operations.
 ///
@@ -38,6 +73,17 @@ use crate::types::*;
 pub struct ClusterAdminServiceImpl {
     /// The Raft node instance for consensus operations.
     pub(crate) raft_node: Raft,
+    /// This node's Raft ID (used to tag audit records for per-node
+    /// attribution).
+    node_id: u64,
+    /// KEK used to wrap newly-generated DEKs during rotation.
+    kek: Arc<dyn KekProvider>,
+    /// Shared current DEK epoch — read to determine the next rotation version.
+    current_dek: Arc<RwLock<Arc<DekEpoch>>>,
+    /// Audit event forwarder (non-blocking, HMAC-signed).
+    audit: AuditForwarder,
+    /// Pending emergency DEK rotations (shared with FjallStateMachine).
+    pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
 }
 
 impl ClusterAdminServiceImpl {
@@ -45,11 +91,29 @@ impl ClusterAdminServiceImpl {
     ///
     /// # Parameters
     /// - `raft_node`: The Raft node instance this service will use.
+    /// - `kek`: Key Encryption Key used to wrap new DEKs during rotation.
+    /// - `current_dek`: Shared reference to the active DEK epoch.
+    /// - `audit`: Audit forwarder for signed event emission.
+    /// - `pending_rotations`: Shared pending rotation map for dual-control.
     ///
     /// # Returns
     /// A new `ClusterAdminServiceImpl` instance.
-    pub fn new(raft_node: Raft) -> Self {
-        Self { raft_node }
+    pub fn new(
+        raft_node: Raft,
+        node_id: u64,
+        kek: Arc<dyn KekProvider>,
+        current_dek: Arc<RwLock<Arc<DekEpoch>>>,
+        audit: AuditForwarder,
+        pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
+    ) -> Self {
+        Self {
+            raft_node,
+            node_id,
+            kek,
+            current_dek,
+            audit,
+            pending_rotations,
+        }
     }
 
     /// Initializes a new Raft cluster with the specified nodes.
@@ -132,6 +196,34 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
             .ok_or_else(|| Status::internal("Node information is required"))?;
 
         trace!("Adding learner node {}", node.node_id);
+
+        // Reject if the node_id already exists in committed membership with a
+        // different rpc_addr (ADR 0016-v2 §4.3 / F7).
+        // Use borrow_watched (synchronous) to avoid introducing a yield point
+        // that could expose race conditions between Raft init and add_learner.
+        let check_id = node.node_id;
+        let check_addr = node.rpc_addr.clone();
+        let metrics = self.raft_node.metrics().borrow_watched().clone();
+        let conflict =
+            metrics
+                .membership_config
+                .membership()
+                .nodes()
+                .find_map(|(nid, existing)| {
+                    if *nid == check_id && existing.rpc_addr != check_addr {
+                        Some(existing.rpc_addr.clone())
+                    } else {
+                        None
+                    }
+                });
+
+        if let Some(existing_addr) = conflict {
+            return Err(Status::already_exists(format!(
+                "node_id {} already registered at {existing_addr}; \
+                 cannot re-add with address {}",
+                node.node_id, node.rpc_addr
+            )));
+        }
 
         let raft_node = Node {
             rpc_addr: node.rpc_addr.clone(),
@@ -220,6 +312,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::ClearQuarantineRequest>,
     ) -> Result<Response<()>, Status> {
+        let actor = extract_peer_identity(&request);
         let partition = request.into_inner().partition;
         if partition.is_empty() {
             return Err(Status::invalid_argument(
@@ -227,7 +320,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
             ));
         }
 
-        trace!(partition, "operator clearing quarantine via gRPC");
+        trace!(partition, actor, "operator clearing quarantine via gRPC");
 
         let cmd = StoreCommand::Transaction(vec![MutationInner::ClearQuarantine {
             partition: partition.clone(),
@@ -240,8 +333,18 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
             .await
             .map_err(|e| Status::internal(format!("Raft write failed: {e}")))?;
 
-        // Audit placeholder: Phase 8 will forward this to the SIEM forwarder.
-        tracing::info!(partition, "AUDIT: quarantine cleared by operator");
+        let dek_version = self
+            .current_dek
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .version;
+        self.audit.emit(AuditRecord::now(
+            "QUARANTINE_CLEARED",
+            &actor,
+            self.node_id,
+            dek_version,
+            serde_json::json!({ "partition": partition }),
+        ));
 
         Ok(Response::new(()))
     }
@@ -266,22 +369,97 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::RotateDekRequest>,
     ) -> Result<Response<pb::raft::AdminResponse>, Status> {
+        let actor = extract_peer_identity(&request);
         let req = request.into_inner();
 
+        let current_version = {
+            self.current_dek
+                .read()
+                .unwrap_or_else(|p| p.into_inner())
+                .version
+        };
+        let new_version = current_version.checked_add(1).ok_or_else(|| {
+            Status::internal("DEK version space exhausted — cannot rotate beyond u32::MAX")
+        })?;
+
+        let new_raw = generate_dek();
+        let wrapped_dek = self
+            .kek
+            .wrap_dek(new_raw.as_bytes())
+            .map_err(|e| Status::internal(format!("failed to wrap new DEK: {e}")))?;
+
         if req.emergency {
-            trace!("Emergency DEK rotation triggered");
-            // TODO: Implement emergency rotation per §6.2:
-            // 1. Generate fresh DEK, wrap under KEK, write as pending via Raft.
-            // 2. Mark current DEK as `revoked` (not retired).
-            // 3. Background re-encryption under new DEK.
-            // 4. Audit-log with DEK_EMERGENCY_ROTATION event type.
-        } else {
-            trace!("Standard DEK rotation triggered");
-            // TODO: Implement standard rotation (same as §6 live background
-            // rotation).
+            // Stage 1 of dual-control: persist the pending entry; the DEK is
+            // NOT yet active.  A second operator must call ConfirmRotateDek.
+            let rotation_id = uuid::Uuid::new_v4().to_string();
+            let expires_at = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+                + crate::store::state_machine::PENDING_ROTATION_TTL_SECS;
+
+            let cmd = StoreCommand::Transaction(vec![MutationInner::CreatePendingRotation {
+                rotation_id: rotation_id.clone(),
+                wrapped_dek,
+                dek_version: new_version,
+                expires_at,
+                initiator: actor.clone(),
+            }]);
+            let payload = pb::api::CommandRequest::try_from(cmd)
+                .map_err(|e| Status::internal(e.to_string()))?;
+
+            self.audit.emit(AuditRecord::now(
+                "DEK_ROTATION_EMERGENCY_STAGED",
+                &actor,
+                self.node_id,
+                current_version,
+                serde_json::json!({
+                    "rotation_id": rotation_id,
+                    "new_version": new_version,
+                    "expires_at": expires_at,
+                }),
+            ));
+
+            self.raft_node
+                .client_write(payload)
+                .await
+                .map_err(|e| Status::internal(format!("Raft write failed: {e}")))?;
+
+            tracing::info!(
+                rotation_id,
+                new_version,
+                initiator = actor,
+                "emergency DEK rotation staged; awaiting dual-control confirmation"
+            );
+            return Ok(Response::new(pb::raft::AdminResponse {
+                pending_rotation_id: rotation_id,
+                ..Default::default()
+            }));
         }
 
-        // TODO: Return committed log ID and any metadata.
+        // Non-emergency: commit InstallDek directly (old DEK is retired, not revoked).
+        let cmd = StoreCommand::Transaction(vec![MutationInner::InstallDek {
+            wrapped_dek,
+            dek_version: new_version,
+            is_emergency: false,
+        }]);
+        let payload =
+            pb::api::CommandRequest::try_from(cmd).map_err(|e| Status::internal(e.to_string()))?;
+
+        self.audit.emit(AuditRecord::now(
+            "DEK_ROTATION",
+            &actor,
+            self.node_id,
+            new_version,
+            serde_json::json!({ "previous_version": current_version }),
+        ));
+
+        self.raft_node
+            .client_write(payload)
+            .await
+            .map_err(|e| Status::internal(format!("Raft write failed: {e}")))?;
+
+        tracing::info!(new_version, "DEK rotation committed to Raft log");
         Ok(Response::new(pb::raft::AdminResponse::default()))
     }
 
@@ -304,16 +482,80 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::ConfirmRotateDekRequest>,
     ) -> Result<Response<pb::raft::AdminResponse>, Status> {
+        let actor = extract_peer_identity(&request);
         let req = request.into_inner();
 
-        trace!("Confirming emergency DEK rotation for {}", req.rotation_id);
-        // TODO: Implement dual-control confirmation per C1-2:
-        // 1. Verify rotation_id matches a pending emergency rotation.
-        // 2. Verify request is within 5-minute window.
-        // 3. Verify caller is a different operator than the original request.
-        // 4. Record both operator identities in audit log.
-        // 5. Proceed with emergency rotation upon confirmed approval.
+        if req.rotation_id.is_empty() {
+            return Err(Status::invalid_argument("rotation_id must not be empty"));
+        }
 
+        trace!(
+            rotation_id = req.rotation_id,
+            confirmer = actor,
+            "confirming emergency DEK rotation"
+        );
+
+        // Fast pre-check on the in-memory map so we can return a clear error
+        // before proposing to Raft.  The authoritative check is in the state
+        // machine apply handler, but this avoids unnecessary log entries.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let pending_version = {
+            let map = self
+                .pending_rotations
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            match map.get(&req.rotation_id) {
+                None => {
+                    return Err(Status::not_found(format!(
+                        "no pending emergency rotation with id {}",
+                        req.rotation_id
+                    )));
+                }
+                Some(e) if e.expires_at <= now => {
+                    return Err(Status::deadline_exceeded(format!(
+                        "pending rotation {} has expired",
+                        req.rotation_id
+                    )));
+                }
+                Some(e) if e.initiator == actor => {
+                    return Err(Status::permission_denied(
+                        "the confirming operator must be different from the initiator \
+                         (dual-control requirement)",
+                    ));
+                }
+                Some(e) => e.dek_version,
+            }
+        };
+
+        let cmd = StoreCommand::Transaction(vec![MutationInner::ConfirmPendingRotation {
+            rotation_id: req.rotation_id.clone(),
+            confirmer: actor.clone(),
+        }]);
+        let payload =
+            pb::api::CommandRequest::try_from(cmd).map_err(|e| Status::internal(e.to_string()))?;
+
+        self.audit.emit(AuditRecord::now(
+            "DEK_ROTATION_EMERGENCY_CONFIRMED",
+            &actor,
+            self.node_id,
+            pending_version,
+            serde_json::json!({ "rotation_id": req.rotation_id }),
+        ));
+
+        self.raft_node
+            .client_write(payload)
+            .await
+            .map_err(|e| Status::internal(format!("Raft write failed: {e}")))?;
+
+        tracing::warn!(
+            rotation_id = req.rotation_id,
+            new_version = pending_version,
+            confirmer = actor,
+            "SECURITY: emergency DEK rotation confirmed via dual-control"
+        );
         Ok(Response::new(pb::raft::AdminResponse::default()))
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -16,16 +16,20 @@
 //! A distributed storage for OpenStack Keystone backed by Raft and Fjall KV
 //! database.
 
+#![deny(clippy::mem_forget)]
+
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, RwLock};
 
 use fjall::Database;
 use openraft::RaftTypeConfig;
-use openstack_keystone_storage_crypto::{DekEpoch, KekProvider, generate_dek};
+use openstack_keystone_storage_crypto::{DekEpoch, KekProvider, LockedKey, generate_dek};
 
 pub mod api;
 pub mod app;
+pub mod audit;
 pub mod grpc;
 #[cfg(feature = "mock")]
 pub mod mock;
@@ -70,6 +74,12 @@ impl From<StoreError> for ApiStoreError {
                 subject: partition,
                 description: "partition quarantined due to repeated GCM tag failures".to_string(),
             },
+            StoreError::WriteRateExceeded(key, version) => Self::Conflict {
+                subject: key,
+                description: format!(
+                    "write rate exceeded at version {version}; DEK rotation required"
+                ),
+            },
             _ => Self::Other(Box::new(e)),
         }
     }
@@ -104,57 +114,209 @@ openraft::declare_raft_types!(
 /// Bootstraps the DEK on first boot (generates a fresh key, wraps it under the
 /// KEK, persists it to `_meta:dek:current`) or loads it on subsequent boots.
 ///
+/// Returns the pair of stores plus the shared `current_dek` handle (for use by
+/// the `rotate_dek` gRPC handler and other admin operations that need to know
+/// the current DEK epoch version).
+///
 /// # Parameters
 /// - `db_path`: Path to the Fjall database directory.
 /// - `node_id`: Raft node ID; used as the high 8 bytes of log nonces.
 /// - `kek`: Key Encryption Key provider for wrapping/unwrapping the DEK.
 ///
 /// # Returns
-/// `(FjallLogStore, FjallStateMachine)` sharing the same database handle.
+/// `(FjallLogStore, FjallStateMachine, Arc<RwLock<Arc<DekEpoch>>>,
+/// Arc<Mutex<HashSet<u32>>>, Arc<Mutex<HashMap<String, PendingRotation>>>)`.
 pub async fn new<C, P: AsRef<Path>>(
     db_path: P,
     node_id: u64,
-    kek: &dyn KekProvider,
-) -> Result<(FjallLogStore<C>, FjallStateMachine), io::Error>
+    kek: Arc<dyn KekProvider>,
+) -> Result<
+    (
+        FjallLogStore<C>,
+        FjallStateMachine,
+        Arc<RwLock<Arc<DekEpoch>>>,
+        Arc<Mutex<HashSet<u32>>>,
+        Arc<Mutex<HashMap<String, store_command::PendingRotation>>>,
+    ),
+    io::Error,
+>
 where
     C: RaftTypeConfig,
 {
     let db_path = db_path.as_ref();
     let snapshot_dir = db_path.join("snapshots");
-    let db = Database::builder(db_path)
-        .open()
-        .map_err(|e| io::Error::other(e.to_string()))?;
-    let db = Arc::new(db);
+    let db = Arc::new(
+        Database::builder(db_path)
+            .open()
+            .map_err(|e| io::Error::other(e.to_string()))?,
+    );
 
     // Bootstrap or load the DEK from the meta keyspace.
-    let dek = bootstrap_dek(&db, kek).map_err(|e| io::Error::other(e.to_string()))?;
-    let dek = Arc::new(dek);
+    let initial_epoch =
+        bootstrap_dek(&db, kek.as_ref()).map_err(|e| io::Error::other(e.to_string()))?;
+    let current_dek: Arc<RwLock<Arc<DekEpoch>>> = Arc::new(RwLock::new(initial_epoch));
+    // Load retired DEK epochs from Fjall so pre-rotation ciphertext remains
+    // readable across restarts (C3: old_deks must survive process restarts).
+    let retired_map =
+        load_retired_deks(&db, kek.as_ref()).map_err(|e| io::Error::other(e.to_string()))?;
+    let old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>> = Arc::new(Mutex::new(retired_map));
+    let revoked_deks: Arc<Mutex<HashSet<u32>>> = Arc::new(Mutex::new(HashSet::new()));
 
-    Ok((
-        FjallLogStore::new(db.clone(), node_id, dek.clone())
-            .map_err(|e| io::Error::other(e.to_string()))?,
-        FjallStateMachine::new(db, snapshot_dir, dek)
-            .map_err(|e| io::Error::other(e.to_string()))?,
-    ))
+    // Load any pending emergency rotations that were staged before a restart.
+    let meta_ks = db
+        .keyspace("meta", fjall::KeyspaceCreateOptions::default)
+        .map_err(|e| io::Error::other(e.to_string()))?;
+    let pending_map = crate::store::state_machine::load_pending_rotations(&meta_ks)
+        .map_err(|e| io::Error::other(e.to_string()))?;
+    let pending_rotations: Arc<Mutex<HashMap<String, store_command::PendingRotation>>> =
+        Arc::new(Mutex::new(pending_map));
+
+    let (reencrypt_tx, mut reencrypt_rx) = tokio::sync::mpsc::channel::<Arc<DekEpoch>>(16);
+    // Stub re-encryption task: drains the channel and logs.
+    // Full background re-encryption of state entries is deferred to Phase 5.2.
+    tokio::spawn(async move {
+        while let Some(old_epoch) = reencrypt_rx.recv().await {
+            tracing::info!(
+                version = old_epoch.version,
+                "DEK rotation: old epoch registered (re-encryption deferred to Phase 5.2)"
+            );
+        }
+    });
+
+    let log_store = FjallLogStore::new(
+        db.clone(),
+        node_id,
+        current_dek.clone(),
+        old_deks.clone(),
+        revoked_deks.clone(),
+    )
+    .map_err(|e| io::Error::other(e.to_string()))?;
+
+    let sm = FjallStateMachine::new(
+        db,
+        snapshot_dir,
+        current_dek.clone(),
+        old_deks,
+        revoked_deks.clone(),
+        kek,
+        reencrypt_tx,
+        pending_rotations.clone(),
+    )
+    .map_err(|e| io::Error::other(e.to_string()))?;
+
+    Ok((log_store, sm, current_dek, revoked_deks, pending_rotations))
+}
+
+/// Fjall meta key prefix for retired DEK epochs (mirrors the constant in
+/// state_machine).
+const DEK_RETIRED_PREFIX: &str = "_meta:dek:retired:";
+
+/// Load retired DEK epochs from Fjall meta for post-rotation read fallback.
+///
+/// Retired epochs are stored under `_meta:dek:retired:VERSION` with the
+/// wrapped DEK bytes as the value.  Any epoch that cannot be unwrapped or
+/// parsed is skipped with a `WARN` log — startup proceeds so the node
+/// remains available.
+fn load_retired_deks(
+    db: &Database,
+    kek: &dyn KekProvider,
+) -> Result<BTreeMap<u32, Arc<DekEpoch>>, StoreError> {
+    let meta = db.keyspace("meta", fjall::KeyspaceCreateOptions::default)?;
+    let mut map = BTreeMap::new();
+    for item in meta.prefix(DEK_RETIRED_PREFIX.as_bytes()) {
+        let (key_bytes, wrapped_bytes) = item.into_inner()?;
+        let key_str = match std::str::from_utf8(&key_bytes) {
+            Ok(s) => s.to_owned(),
+            Err(_) => continue,
+        };
+        let version_str = match key_str.strip_prefix(DEK_RETIRED_PREFIX) {
+            Some(s) => s,
+            None => continue,
+        };
+        let version: u32 = match version_str.parse() {
+            Ok(v) => v,
+            Err(_) => {
+                tracing::warn!(
+                    key = key_str,
+                    "retired DEK key has non-numeric version suffix"
+                );
+                continue;
+            }
+        };
+        match kek.unwrap_dek(&wrapped_bytes) {
+            Ok(raw) => {
+                let epoch_dek = LockedKey::from_raw(*raw);
+                match DekEpoch::from_raw(epoch_dek, version) {
+                    Ok(epoch) => {
+                        tracing::info!(version, "loaded retired DEK epoch for read fallback");
+                        map.insert(version, Arc::new(epoch));
+                    }
+                    Err(e) => {
+                        tracing::warn!(version, error = %e, "failed to construct retired DEK epoch");
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(version, error = %e, "failed to unwrap retired DEK — skipping");
+            }
+        }
+    }
+    Ok(map)
 }
 
 /// Load the current DEK epoch from Fjall, or generate and persist a new one.
-fn bootstrap_dek(db: &Database, kek: &dyn KekProvider) -> Result<DekEpoch, StoreError> {
+///
+/// On-disk format for `_meta:dek:current`:
+/// `[version_u32_BE; 4] ++ [nonce_12] ++ [ciphertext_32] ++ [tag_16]` (64 bytes
+/// total). Legacy format (60 bytes, no version prefix) is migrated to version 1
+/// on first load.
+fn bootstrap_dek(db: &Database, kek: &dyn KekProvider) -> Result<Arc<DekEpoch>, StoreError> {
     let meta = db.keyspace("meta", fjall::KeyspaceCreateOptions::default)?;
 
-    if let Some(wrapped_bytes) = meta.get(META_DEK_CURRENT)? {
-        // Existing DEK: unwrap and derive sub-keys.
-        let raw = kek.unwrap_dek(wrapped_bytes.as_ref())?;
-        let epoch = DekEpoch::from_raw(&raw, 0)?;
-        Ok(epoch)
+    if let Some(stored) = meta.get(META_DEK_CURRENT)? {
+        let stored = stored.as_ref();
+        let (version, wrapped) = if stored.len() >= 64 {
+            // New format: [version_u32_BE; 4] ++ wrapped_bytes.
+            let version = u32::from_be_bytes(
+                stored[..4]
+                    .try_into()
+                    .map_err(|_| StoreError::Other(eyre::eyre!("invalid DEK version prefix")))?,
+            );
+            (version, &stored[4..])
+        } else if stored.len() == 60 {
+            // Legacy format (no version prefix): treat as version 1 and migrate.
+            tracing::warn!(
+                "DEK stored in legacy format (no version prefix); treating as version 1"
+            );
+            let wrapped = stored;
+            let raw = kek.unwrap_dek(wrapped)?;
+            let raw_bytes = *raw;
+            let mut migrated = 1u32.to_be_bytes().to_vec();
+            migrated.extend_from_slice(&kek.wrap_dek(&raw_bytes)?);
+            meta.insert(META_DEK_CURRENT, &migrated)?;
+            db.persist(fjall::PersistMode::SyncAll)?;
+            let epoch_dek = LockedKey::from_raw(raw_bytes);
+            return Ok(Arc::new(DekEpoch::from_raw(epoch_dek, 1)?));
+        } else {
+            return Err(StoreError::Other(eyre::eyre!(
+                "invalid DEK stored size: {} bytes",
+                stored.len()
+            )));
+        };
+        let raw = kek.unwrap_dek(wrapped)?;
+        let epoch_dek = LockedKey::from_raw(*raw);
+        Ok(Arc::new(DekEpoch::from_raw(epoch_dek, version)?))
     } else {
-        // First boot: generate fresh DEK, wrap under KEK, persist.
-        let raw = generate_dek();
-        let wrapped = kek.wrap_dek(&raw)?;
-        meta.insert(META_DEK_CURRENT, &wrapped)?;
+        // First boot: generate fresh DEK at version 1, wrap under KEK, persist.
+        let dek = generate_dek();
+        let wrapped = kek.wrap_dek(dek.as_bytes())?;
+        let version = 1u32;
+        let mut persisted = version.to_be_bytes().to_vec();
+        persisted.extend_from_slice(&wrapped);
+        meta.insert(META_DEK_CURRENT, &persisted)?;
         db.persist(fjall::PersistMode::SyncAll)?;
-        let epoch = DekEpoch::from_raw(&raw, 0)?;
-        Ok(epoch)
+        // Pass the mlock'd key directly — no copy through bypass allocation.
+        Ok(Arc::new(DekEpoch::from_raw(dek, version)?))
     }
 }
 
@@ -187,10 +349,12 @@ mod tests {
         > {
             let td =
                 TempDir::new().map_err(|e| StorageError::read(TypeConfig::err_from_error(&e)))?;
-            let kek = EnvKek::from_bytes([0x42u8; 32]);
-            let (log_store, sm) = crate::new(td.path(), 1, &kek)
-                .await
-                .map_err(|e| StorageError::read(TypeConfig::err_from_error(&e)))?;
+            let kek: Arc<dyn openstack_keystone_storage_crypto::KekProvider> =
+                Arc::new(EnvKek::from_bytes([0x42u8; 32]));
+            let (log_store, sm, _current_dek, _revoked, _pending_rotations) =
+                crate::new(td.path(), 1, kek)
+                    .await
+                    .map_err(|e| StorageError::read(TypeConfig::err_from_error(&e)))?;
             Ok((td, log_store, Arc::new(sm)))
         }
     }

--- a/crates/storage/src/network.rs
+++ b/crates/storage/src/network.rs
@@ -303,6 +303,179 @@ impl NetTransferLeader<TypeConfig> for NetworkConnection {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 9 — SPIFFE Mode (ADR 0016-v2 §4.1 / F4)
+// ---------------------------------------------------------------------------
+
+/// SVID TTL ceiling enforced per ADR 0016-v2 §4.1.
+const SVID_MAX_TTL_SECS: u64 = 3600;
+/// Minimum remaining SVID validity before rejection (force-renewal window).
+const SVID_MIN_REMAINING_SECS: u64 = 300;
+
+/// SPIFFE Workload API provider — interface stub.
+///
+/// In production this contacts the SPIRE agent at
+/// `unix:///tmp/spire-agent/public/api.sock`, retrieves a JWT or X.509 SVID,
+/// and enforces the TTL ceiling.
+///
+/// This implementation always returns [`StoreError::Other`] (SPIFFE workload
+/// API not yet implemented).  The struct is defined to lock in the abstraction
+/// boundary before the SPIRE client is wired up.
+pub struct SpiffeTlsProvider {
+    /// SPIFFE trust domain, e.g. `"example.org"`.
+    pub trust_domain: String,
+    /// Expected role path component, e.g. `"storage"`.
+    pub role: String,
+}
+
+impl SpiffeTlsProvider {
+    pub fn new(trust_domain: impl Into<String>, role: impl Into<String>) -> Self {
+        Self {
+            trust_domain: trust_domain.into(),
+            role: role.into(),
+        }
+    }
+
+    /// Validate that a SPIFFE ID matches the expected pattern:
+    /// `spiffe://<trust_domain>/keystone/storage/<role>`.
+    pub fn validate_spiffe_id(&self, spiffe_id: &str) -> Result<(), StoreError> {
+        let expected_prefix = format!("spiffe://{}/keystone/storage/", self.trust_domain);
+        if !spiffe_id.starts_with(&expected_prefix) {
+            return Err(StoreError::Other(eyre::eyre!(
+                "SPIFFE ID {spiffe_id:?} does not match expected pattern \
+                 spiffe://{}/keystone/storage/<role>",
+                self.trust_domain
+            )));
+        }
+        let role_suffix = &spiffe_id[expected_prefix.len()..];
+        if role_suffix != self.role {
+            return Err(StoreError::Other(eyre::eyre!(
+                "SPIFFE ID {spiffe_id:?} role component {role_suffix:?} does not match \
+                 expected role {:?}",
+                self.role
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// TLS certificate expiry watchdog for the manual-TLS fallback path.
+///
+/// Spawns a background `tokio::task` that wakes every hour and checks the
+/// remaining validity of the server TLS certificate.  Emits:
+///
+/// * `WARN` when fewer than 7 days remain.
+/// * `ERROR` when fewer than 2 days remain.
+/// * `CRITICAL` + optional shutdown when the certificate has expired.
+pub struct CertExpiryWatchdog;
+
+impl CertExpiryWatchdog {
+    /// Spawn the watchdog task.
+    ///
+    /// `cert_pem` is the raw PEM bytes of the certificate to monitor.
+    /// `shutdown_on_expiry` controls whether the process exits on expiry
+    /// (production) or only logs (dev mode).
+    pub fn spawn(cert_pem: Vec<u8>, shutdown_on_expiry: bool) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let check_interval = tokio::time::Duration::from_secs(3600);
+            loop {
+                check_cert_expiry(&cert_pem, shutdown_on_expiry);
+                tokio::time::sleep(check_interval).await;
+            }
+        })
+    }
+}
+
+fn check_cert_expiry(cert_pem: &[u8], shutdown_on_expiry: bool) {
+    use x509_parser::certificate::X509Certificate;
+    use x509_parser::pem::parse_x509_pem;
+    use x509_parser::prelude::FromDer;
+
+    let (_, pem) = match parse_x509_pem(cert_pem) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "TLS cert expiry check: failed to parse PEM");
+            return;
+        }
+    };
+    let (_, cert) = match X509Certificate::from_der(&pem.contents) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(error = %e, "TLS cert expiry check: failed to parse DER");
+            return;
+        }
+    };
+
+    let not_after = cert.validity().not_after;
+    // x509-parser uses its own ASN1Time; convert via timestamp.
+    let expiry_secs = not_after.timestamp();
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    let remaining_secs = expiry_secs - now_secs;
+
+    const WARN_THRESHOLD: i64 = 7 * 24 * 3600;
+    const ERROR_THRESHOLD: i64 = 2 * 24 * 3600;
+
+    if remaining_secs <= 0 {
+        tracing::error!(
+            "CRITICAL: TLS certificate has expired! Renew immediately to avoid \
+             cluster communication failure."
+        );
+        if shutdown_on_expiry {
+            tracing::error!("Initiating shutdown due to expired TLS certificate.");
+            std::process::exit(1);
+        }
+    } else if remaining_secs <= ERROR_THRESHOLD {
+        tracing::error!(
+            remaining_days = remaining_secs / 86400,
+            "TLS certificate expires in less than 2 days — renew urgently"
+        );
+    } else if remaining_secs <= WARN_THRESHOLD {
+        tracing::warn!(
+            remaining_days = remaining_secs / 86400,
+            "TLS certificate expires in less than 7 days — schedule renewal"
+        );
+    } else {
+        tracing::debug!(
+            remaining_days = remaining_secs / 86400,
+            "TLS certificate expiry check passed"
+        );
+    }
+}
+
+/// Validate SVID remaining TTL against enforcement thresholds.
+///
+/// Called before accepting a connection in SPIFFE mode.
+///
+/// Returns `Err` if the SVID has expired, has less than
+/// [`SVID_MIN_REMAINING_SECS`] remaining, or exceeds [`SVID_MAX_TTL_SECS`]
+/// (which would violate the ADR §4.1 TTL ceiling).
+pub fn validate_svid_ttl(issued_at_secs: u64, expires_at_secs: u64) -> Result<(), StoreError> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let ttl = expires_at_secs.saturating_sub(issued_at_secs);
+    if ttl > SVID_MAX_TTL_SECS {
+        return Err(StoreError::Other(eyre::eyre!(
+            "SVID TTL {ttl}s exceeds maximum allowed {SVID_MAX_TTL_SECS}s"
+        )));
+    }
+
+    let remaining = expires_at_secs.saturating_sub(now);
+    if remaining < SVID_MIN_REMAINING_SECS {
+        return Err(StoreError::Other(eyre::eyre!(
+            "SVID has only {remaining}s remaining validity \
+             (minimum {SVID_MIN_REMAINING_SECS}s required); force-renew SVID"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Build the tonic [`ClientTlsConfig`] from the Keystone [`Config`].
 ///
 /// Initialize the [`ClientTlsConfig`] from the distributed_storage or the

--- a/crates/storage/src/proto_impl/impl_admin_response.rs
+++ b/crates/storage/src/proto_impl/impl_admin_response.rs
@@ -34,6 +34,7 @@ impl From<ClientWriteResponse> for pb::raft::AdminResponse {
             log_id: Some(r.log_id.into()),
             data: Some(r.data),
             membership: r.membership.map(|mem| mem.into()),
+            pending_rotation_id: String::new(),
         }
     }
 }

--- a/crates/storage/src/store/log_store.rs
+++ b/crates/storage/src/store/log_store.rs
@@ -12,11 +12,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # Fjall DB based `openraft` log store implementation.
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
 use std::io;
 use std::marker::PhantomData;
 use std::ops::{Bound, RangeBounds};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
 use openraft::alias::{EntryOf, LogIdOf, VoteOf};
@@ -24,7 +25,9 @@ use openraft::entry::RaftEntry;
 use openraft::storage::{IOFlushed, LogState, RaftLogStorage};
 use openraft::vote::RaftLeaderId;
 use openraft::{OptionalSend, RaftLogReader, RaftTypeConfig};
-use openstack_keystone_storage_crypto::{DekEpoch, NonceManager, log_decrypt, log_encrypt};
+use openstack_keystone_storage_crypto::{
+    CryptoError, DekEpoch, NonceManager, log_decrypt, log_encrypt,
+};
 
 use crate::StoreError;
 use crate::types::FjallNoncePersistence;
@@ -32,11 +35,13 @@ use crate::types::FjallNoncePersistence;
 const KEY_VOTE: &[u8] = b"vote";
 const KEY_PURGED: &[u8] = b"purged";
 
-/// On-disk prefix length for a log entry: 8 bytes for term (BE u64).
-/// Full layout: [term_u64_BE (8)] ++ log_encrypt output [nonce_12 ++ ciphertext ++ tag_16].
+/// Log entry on-disk layout (all fields big-endian):
+/// `[dek_version_u32; 4] ++ [term_u64; 8] ++ log_encrypt([nonce_12 ++
+/// ciphertext ++ tag_16])`.
+const DEK_VERSION_PREFIX_LEN: usize = 4;
 const TERM_PREFIX_LEN: usize = 8;
-/// Minimum stored log entry size: term(8) + nonce(12) + tag(16) = 36.
-const LOG_ENTRY_MIN_LEN: usize = 36;
+/// Minimum stored size: dek_version(4) + term(8) + nonce(12) + tag(16) = 40.
+const LOG_ENTRY_MIN_LEN: usize = DEK_VERSION_PREFIX_LEN + TERM_PREFIX_LEN + 12 + 16;
 
 #[derive(Clone)]
 pub struct FjallLogStore<C>
@@ -46,7 +51,14 @@ where
     pub db: Arc<Database>,
     pub logs: Keyspace,
     pub meta: Keyspace,
-    dek: Arc<DekEpoch>,
+    /// Current active DEK epoch (shared with FjallStateMachine for live
+    /// rotation).
+    dek: Arc<RwLock<Arc<DekEpoch>>>,
+    /// Retired DEK epochs keyed by version — kept for decrypting old log
+    /// entries until those entries are compacted into a snapshot.
+    old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>>,
+    /// Revoked DEK versions — immediately rejected on decrypt (ADR §6.2).
+    revoked_deks: Arc<Mutex<HashSet<u32>>>,
     nonce_mgr: Arc<Mutex<NonceManager>>,
     _p: PhantomData<C>,
 }
@@ -61,11 +73,18 @@ where
     /// # Parameters
     /// - `db`: Database instance.
     /// - `node_id`: Raft node ID used as the high 8 bytes of each log nonce.
-    /// - `dek`: Data Encryption Key epoch for log entry encryption.
+    /// - `dek`: Shared current DEK epoch (also held by `FjallStateMachine`).
+    /// - `old_deks`: Shared map of retired DEK epochs for reading old entries.
     ///
     /// # Returns
     /// A `Result` containing the `FjallLogStore`, or a `StoreError`.
-    pub fn new(db: Arc<Database>, node_id: u64, dek: Arc<DekEpoch>) -> Result<Self, StoreError> {
+    pub fn new(
+        db: Arc<Database>,
+        node_id: u64,
+        dek: Arc<RwLock<Arc<DekEpoch>>>,
+        old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>>,
+        revoked_deks: Arc<Mutex<HashSet<u32>>>,
+    ) -> Result<Self, StoreError> {
         let logs = db.keyspace("logs", KeyspaceCreateOptions::default)?;
         let meta = db.keyspace("meta", KeyspaceCreateOptions::default)?;
 
@@ -80,6 +99,8 @@ where
             logs,
             meta,
             dek,
+            old_deks,
+            revoked_deks,
             nonce_mgr: Arc::new(Mutex::new(nonce_mgr)),
             _p: Default::default(),
         })
@@ -111,7 +132,8 @@ where
 
     /// Encrypt a serialized Raft entry for storage.
     ///
-    /// Layout: `[term_u64_BE; 8] ++ [nonce_12] ++ [ciphertext] ++ [tag_16]`
+    /// Layout: `[dek_version_u32_BE; 4] ++ [term_u64_BE; 8] ++ [nonce_12] ++
+    /// [ciphertext] ++ [tag_16]`.
     fn encrypt_entry(
         &self,
         term: u64,
@@ -123,14 +145,24 @@ where
             .lock()
             .map_err(|_| StoreError::Other(eyre::eyre!("nonce manager lock poisoned")))?
             .next_nonce()?;
-        let encrypted = log_encrypt(self.dek.log_dek(), plaintext, term, index, &nonce)?;
-        let mut out = Vec::with_capacity(TERM_PREFIX_LEN + encrypted.len());
+        let (dek_version, encrypted) = {
+            let guard = self
+                .dek
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let version = guard.version;
+            let enc = log_encrypt(guard.log_dek(), plaintext, term, index, &nonce)?;
+            (version, enc)
+        };
+        let mut out =
+            Vec::with_capacity(DEK_VERSION_PREFIX_LEN + TERM_PREFIX_LEN + encrypted.len());
+        out.extend_from_slice(&dek_version.to_be_bytes());
         out.extend_from_slice(&term.to_be_bytes());
         out.extend_from_slice(&encrypted);
         Ok(out)
     }
 
-    /// Decrypt a stored log entry.
+    /// Decrypt a stored log entry, selecting the correct DEK epoch by version.
     fn decrypt_entry(&self, index: u64, stored: &[u8]) -> Result<Vec<u8>, StoreError> {
         if stored.len() < LOG_ENTRY_MIN_LEN {
             return Err(StoreError::Other(eyre::eyre!(
@@ -138,13 +170,62 @@ where
                 stored.len()
             )));
         }
+        let dek_version = u32::from_be_bytes(
+            stored[..DEK_VERSION_PREFIX_LEN]
+                .try_into()
+                .map_err(|_| StoreError::Other(eyre::eyre!("could not read dek version")))?,
+        );
+        let rest = &stored[DEK_VERSION_PREFIX_LEN..];
         let term = u64::from_be_bytes(
-            stored[..TERM_PREFIX_LEN]
+            rest[..TERM_PREFIX_LEN]
                 .try_into()
                 .map_err(|_| StoreError::Other(eyre::eyre!("could not read term prefix")))?,
         );
-        let plaintext = log_decrypt(self.dek.log_dek(), &stored[TERM_PREFIX_LEN..], term, index)?;
-        Ok(plaintext.to_vec())
+        let payload = &rest[TERM_PREFIX_LEN..];
+
+        // Use active DEK if versions match, otherwise look up retired DEK map.
+        let current_version = self.dek.read().unwrap_or_else(|p| p.into_inner()).version;
+        if dek_version == current_version {
+            let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
+            let plaintext = log_decrypt(guard.log_dek(), payload, term, index)?;
+            Ok(plaintext.to_vec())
+        } else {
+            // Check if this DEK version has been revoked (emergency rotation).
+            {
+                let revoked = self.revoked_deks.lock().unwrap_or_else(|p| p.into_inner());
+                if revoked.contains(&dek_version) {
+                    return Err(CryptoError::RevokedDek {
+                        version: dek_version,
+                    }
+                    .into());
+                }
+            }
+            let old_map = self.old_deks.lock().unwrap_or_else(|p| p.into_inner());
+            let old = old_map.get(&dek_version).ok_or_else(|| {
+                StoreError::Other(eyre::eyre!(
+                    "no DEK epoch for version {dek_version} — log entry unreadable"
+                ))
+            })?;
+            let plaintext = log_decrypt(old.log_dek(), payload, term, index)?;
+            Ok(plaintext.to_vec())
+        }
+    }
+
+    /// Register a retired DEK epoch so old log entries can still be decrypted.
+    pub fn register_old_dek(&self, epoch: Arc<DekEpoch>) {
+        self.old_deks
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(epoch.version, epoch);
+    }
+
+    /// Remove a retired DEK epoch once all log entries for that version are
+    /// compacted into a snapshot.
+    pub fn evict_old_dek(&self, version: u32) {
+        self.old_deks
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(&version);
     }
 }
 

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -13,11 +13,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # Fjall DB based `openraft` state machine implementation.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fs;
 use std::io;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
@@ -36,7 +36,9 @@ use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::type_config::TypeConfigExt;
-use openstack_keystone_storage_crypto::{DekEpoch, state_decrypt, state_encrypt};
+use openstack_keystone_storage_crypto::{
+    DekEpoch, KekProvider, LockedKey, backup_decrypt, backup_encrypt, state_decrypt, state_encrypt,
+};
 use rand::RngExt;
 use serde::Deserialize;
 use serde::Serialize;
@@ -51,6 +53,12 @@ use crate::types::Metadata;
 
 const KEY_LAST_APPLIED_LOG: &[u8] = b"last_applied_log";
 const KEY_LAST_MEMBERSHIP: &[u8] = b"last_membership";
+
+/// Maximum per-key write version before a DEK rotation is required (ADR 0016-v2
+/// §10).
+const WRITE_RATE_THRESHOLD: u32 = 1u32 << 30;
+/// Warn when per-key write count reaches 90% of the threshold.
+const WRITE_RATE_WARN_THRESHOLD: u32 = WRITE_RATE_THRESHOLD / 10 * 9;
 
 /// Fjall meta key prefix for persisted quarantine markers.
 const QUARANTINE_META_PREFIX: &str = "_meta:quarantine:";
@@ -67,7 +75,8 @@ const QUARANTINE_THRESHOLD: usize = 3;
 /// At three failures the partition is marked quarantined and the marker is
 /// persisted to Fjall `meta` so it survives restarts.
 ///
-/// Quarantine can be cleared by an operator via `FjallStateMachine::clear_quarantine`.
+/// Quarantine can be cleared by an operator via
+/// `FjallStateMachine::clear_quarantine`.
 #[derive(Default)]
 struct QuarantineTracker {
     failures: Mutex<HashMap<String, VecDeque<Instant>>>,
@@ -80,14 +89,14 @@ impl QuarantineTracker {
         let mut quarantined = HashSet::new();
         for item in meta.prefix(QUARANTINE_META_PREFIX.as_bytes()) {
             let (key_bytes, _) = item.into_inner()?;
-            if let Ok(key_str) = String::from_utf8(key_bytes.to_vec()) {
-                if let Some(partition) = key_str.strip_prefix(QUARANTINE_META_PREFIX) {
-                    quarantined.insert(partition.to_string());
-                    tracing::error!(
-                        partition,
-                        "SECURITY: partition is quarantined (loaded from persistent state)"
-                    );
-                }
+            if let Ok(key_str) = String::from_utf8(key_bytes.to_vec())
+                && let Some(partition) = key_str.strip_prefix(QUARANTINE_META_PREFIX)
+            {
+                quarantined.insert(partition.to_string());
+                tracing::error!(
+                    partition,
+                    "SECURITY: partition is quarantined (loaded from persistent state)"
+                );
             }
         }
         Ok(Self {
@@ -103,7 +112,8 @@ impl QuarantineTracker {
             .contains(partition)
     }
 
-    /// Records a GCM failure for a partition; returns `true` if newly quarantined.
+    /// Records a GCM failure for a partition; returns `true` if newly
+    /// quarantined.
     fn record_failure(&self, partition: &str) -> bool {
         if self.is_quarantined(partition) {
             return false;
@@ -170,11 +180,65 @@ struct SnapshotFile {
     data: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
+/// Fjall meta key prefix for retired DEK epochs.
+const DEK_RETIRED_PREFIX: &str = "_meta:dek:retired:";
+/// Fjall meta key for the current wrapped DEK.
+const META_DEK_CURRENT: &[u8] = b"_meta:dek:current";
+/// Fjall meta key prefix for pending emergency rotations.
+const PENDING_ROTATION_PREFIX: &str = "_meta:rotation:pending:";
+/// Dual-control confirmation window in seconds (5 minutes).
+pub const PENDING_ROTATION_TTL_SECS: u64 = 300;
+
+/// Maximum number of revoked DEK versions tracked in memory.
+///
+/// Revoked versions accumulate only on emergency rotations.  Exceeding this
+/// cap is operationally impossible under normal conditions (it would require
+/// more than 1024 security incidents), but the cap prevents unbounded growth
+/// and triggers an ERROR log so operators can investigate.
+const MAX_REVOKED_DEKS: usize = 1024;
+
+/// Load any pending emergency rotations from Fjall meta on startup.
+///
+/// Entries that are already expired are logged and skipped — they cannot be
+/// confirmed and will be cleaned up on the next `CreatePendingRotation`.
+pub fn load_pending_rotations(
+    meta: &Keyspace,
+) -> Result<HashMap<String, PendingRotation>, crate::StoreError> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let mut map = HashMap::new();
+    for item in meta.prefix(PENDING_ROTATION_PREFIX.as_bytes()) {
+        let (_, value_bytes) = item.into_inner()?;
+        match rmp_serde::from_slice::<PendingRotation>(&value_bytes) {
+            Ok(entry) => {
+                if entry.expires_at <= now {
+                    tracing::info!(
+                        rotation_id = %entry.rotation_id,
+                        "skipping expired pending rotation on startup"
+                    );
+                    continue;
+                }
+                map.insert(entry.rotation_id.clone(), entry);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to deserialise pending rotation entry");
+            }
+        }
+    }
+    Ok(map)
+}
+
 /// State machine backed by FjallDB for full persistence.
 ///
 /// All application data is AES-256-GCM encrypted at rest via `state_encrypt`
 /// before writing to the `data` keyspace.  The `dek` field holds the current
 /// DEK epoch; encryption uses the `StateDek` sub-key derived from it.
+///
+/// `old_dek` is set during a DEK rotation transition.  Reads that fail with the
+/// current DEK automatically fall back to `old_dek` so data written before the
+/// rotation completes remains readable until background re-encryption finishes.
 #[derive(Clone)]
 pub struct FjallStateMachine {
     db: Arc<Database>,
@@ -182,8 +246,23 @@ pub struct FjallStateMachine {
     data: Keyspace,
     index: Keyspace,
     snapshot_dir: PathBuf,
-    dek: Arc<DekEpoch>,
+    /// Current active DEK epoch (shared with FjallLogStore via Arc).
+    dek: Arc<RwLock<Arc<DekEpoch>>>,
+    /// Retired DEK epochs held during re-encryption transition (shared with
+    /// FjallLogStore).
+    old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>>,
+    /// Revoked DEK versions — shared with FjallLogStore for immediate rejection
+    /// (H3).
+    revoked_deks: Arc<Mutex<HashSet<u32>>>,
+    /// Key Encryption Key used to unwrap new DEKs on InstallDek apply.
+    kek: Arc<dyn KekProvider>,
+    /// Channel to trigger background re-encryption after DEK rotation.
+    reencrypt_tx: tokio::sync::mpsc::Sender<Arc<DekEpoch>>,
     quarantine: Arc<QuarantineTracker>,
+    /// Pending emergency DEK rotations awaiting dual-control confirmation.
+    /// Shared with `ClusterAdminServiceImpl` so the gRPC handler can inspect
+    /// the map without going through Raft.
+    pub pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
 }
 
 impl FjallStateMachine {
@@ -193,14 +272,22 @@ impl FjallStateMachine {
     /// # Parameters
     /// - `db`: Database instance.
     /// - `snapshot_dir`: Directory to store snapshots.
-    /// - `dek`: Data Encryption Key epoch for state encryption.
+    /// - `dek`: Shared current DEK epoch (also held by `FjallLogStore`).
+    /// - `kek`: Key Encryption Key used to unwrap new DEKs on `InstallDek`.
+    /// - `reencrypt_tx`: Channel for signalling the background re-encryption
+    ///   task with the old DEK epoch that needs re-encryption.
     ///
     /// # Returns
     /// A `Result` containing the `FjallStateMachine`, or a `StoreError`.
     pub fn new(
         db: Arc<Database>,
         snapshot_dir: PathBuf,
-        dek: Arc<DekEpoch>,
+        dek: Arc<RwLock<Arc<DekEpoch>>>,
+        old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>>,
+        revoked_deks: Arc<Mutex<HashSet<u32>>>,
+        kek: Arc<dyn KekProvider>,
+        reencrypt_tx: tokio::sync::mpsc::Sender<Arc<DekEpoch>>,
+        pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
     ) -> Result<Self, StoreError> {
         let meta = db.keyspace("meta", KeyspaceCreateOptions::default)?;
         let data = db.keyspace("data", KeyspaceCreateOptions::default)?;
@@ -217,7 +304,12 @@ impl FjallStateMachine {
             data,
             index,
             dek,
+            old_deks,
+            revoked_deks,
+            kek,
+            reencrypt_tx,
             quarantine,
+            pending_rotations,
         })
     }
 
@@ -258,9 +350,14 @@ impl FjallStateMachine {
     /// `tier`, `keyspace`, and `pk` must match the values used at write time;
     /// any mismatch causes GCM tag verification to fail and returns an error.
     ///
-    /// Returns `StoreError::Quarantined` if the keyspace partition is quarantined.
-    /// GCM tag failures are tracked; three failures within 60 s quarantine the
-    /// partition and persist the marker to Fjall meta for restart durability.
+    /// Returns `StoreError::Quarantined` if the keyspace partition is
+    /// quarantined. GCM tag failures are tracked; three failures within 60
+    /// s quarantine the partition and persist the marker to Fjall meta for
+    /// restart durability.
+    ///
+    /// During DEK rotation, if decryption with the current DEK fails the method
+    /// transparently retries with the previous epoch (`old_dek`) to serve reads
+    /// of keys not yet re-encrypted.
     pub fn decrypt_state(
         &self,
         stored: &[u8],
@@ -274,22 +371,45 @@ impl FjallStateMachine {
             return Err(StoreError::Quarantined(partition));
         }
 
-        match state_decrypt(self.dek.state_dek(), stored, tier, keyspace, pk) {
+        let result = {
+            let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
+            state_decrypt(guard.state_dek(), stored, tier, keyspace, pk)
+        };
+
+        match result {
             Ok((plaintext, _next_version)) => Ok(plaintext.to_vec()),
-            Err(e) => {
-                if matches!(
-                    e,
-                    openstack_keystone_storage_crypto::CryptoError::AesDecrypt
-                ) {
-                    if self.quarantine.record_failure(&partition) {
-                        // Newly quarantined — persist so the marker survives restarts.
-                        let key = format!("{QUARANTINE_META_PREFIX}{partition}");
-                        // Best-effort: non-fatal if Fjall write fails here.
-                        let _ = self.meta.insert(key, b"1");
+            Err(openstack_keystone_storage_crypto::CryptoError::AesDecrypt) => {
+                // ALWAYS record failure first, even if retired DEK succeeds (M6 fix).
+                // The retired DEK fallback is only for reading pre-rotation data,
+                // but the GCM failure with the current DEK still counts toward
+                // quarantine threshold.
+                let failed = self.quarantine.record_failure(&partition);
+
+                // Try retired DEK epochs if in a rotation transition.
+                let old_map = self.old_deks.lock().unwrap_or_else(|p| p.into_inner());
+                for (_, old) in old_map.iter() {
+                    if let Ok((pt, _)) = state_decrypt(old.state_dek(), stored, tier, keyspace, pk)
+                    {
+                        tracing::warn!(
+                            partition,
+                            epoch_version = old.version,
+                            "record decrypted with retired DEK epoch — re-encryption required"
+                        );
+                        return Ok(pt.to_vec());
                     }
                 }
-                Err(StoreError::Crypto { source: e })
+                drop(old_map);
+
+                // Persist quarantine marker if threshold was reached.
+                if failed {
+                    let key = format!("{QUARANTINE_META_PREFIX}{partition}");
+                    let _ = self.meta.insert(key, b"1");
+                }
+                Err(StoreError::Crypto {
+                    source: openstack_keystone_storage_crypto::CryptoError::AesDecrypt,
+                })
             }
+            Err(e) => Err(StoreError::Crypto { source: e }),
         }
     }
 
@@ -314,7 +434,8 @@ impl FjallStateMachine {
     /// Reads the current encrypted record (if present) to extract the stored
     /// version, increments it, then calls `state_encrypt` with the new version.
     ///
-    /// Returns `StoreError::Quarantined` if the keyspace partition is quarantined.
+    /// Returns `StoreError::Quarantined` if the keyspace partition is
+    /// quarantined.
     fn encrypt_and_store(
         &self,
         ks: &Keyspace,
@@ -330,21 +451,44 @@ impl FjallStateMachine {
 
         // Read existing version (0 for new keys).
         let next_version = if let Some(existing) = ks.get(key)? {
-            state_decrypt(self.dek.state_dek(), existing.as_ref(), tier, keyspace, key)
+            let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
+            state_decrypt(guard.state_dek(), existing.as_ref(), tier, keyspace, key)
                 .map(|(_, v)| v)
                 .unwrap_or(0)
         } else {
             0
         };
 
-        let encrypted = state_encrypt(
-            self.dek.state_dek(),
-            plaintext,
-            tier,
-            keyspace,
-            key,
-            next_version,
-        )?;
+        // Enforce per-record write rate limit (ADR 0016-v2 §10 / invariant 9).
+        if next_version >= WRITE_RATE_THRESHOLD {
+            let key_str = String::from_utf8_lossy(key).into_owned();
+            tracing::error!(
+                key = %key_str,
+                version = next_version,
+                threshold = WRITE_RATE_THRESHOLD,
+                "CRITICAL: per-record write rate threshold reached; DEK rotation required",
+            );
+            return Err(StoreError::WriteRateExceeded(key_str, next_version));
+        } else if next_version >= WRITE_RATE_WARN_THRESHOLD {
+            tracing::warn!(
+                key = %String::from_utf8_lossy(key),
+                version = next_version,
+                threshold = WRITE_RATE_THRESHOLD,
+                "per-record write count at 90% of threshold; schedule DEK rotation",
+            );
+        }
+
+        let encrypted = {
+            let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
+            state_encrypt(
+                guard.state_dek(),
+                plaintext,
+                tier,
+                keyspace,
+                key,
+                next_version,
+            )?
+        };
         Ok(encrypted)
     }
 
@@ -374,6 +518,67 @@ fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, StorageError<TypeConfig
 
 fn deserialize<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, StorageError<TypeConfig>> {
     rmp_serde::from_slice(bytes).map_err(|e| StorageError::read(TypeConfig::err_from_error(&e)))
+}
+
+/// Decrypt and deserialize a snapshot file from disk.
+///
+/// On-disk format:
+/// `[dek_version_u32_BE; 4] ++ [utc_epoch_u64_BE; 8] ++
+/// backup_encrypt(rmp_serde(SnapshotFile))`.
+fn decrypt_snapshot_file(
+    disk_bytes: &[u8],
+    current_dek: &std::sync::Arc<std::sync::RwLock<std::sync::Arc<DekEpoch>>>,
+    old_deks: &std::sync::Arc<std::sync::Mutex<BTreeMap<u32, std::sync::Arc<DekEpoch>>>>,
+) -> Result<SnapshotFile, crate::StoreError> {
+    use openstack_keystone_storage_crypto::dek::BackupDek;
+
+    const HEADER_LEN: usize = 4 + 8; // version + epoch
+    if disk_bytes.len() < HEADER_LEN {
+        return Err(crate::StoreError::Other(eyre::eyre!(
+            "snapshot file too short: {} bytes",
+            disk_bytes.len()
+        )));
+    }
+    let dek_version = u32::from_be_bytes(
+        disk_bytes[..4]
+            .try_into()
+            .map_err(|_| crate::StoreError::Other(eyre::eyre!("invalid snapshot version")))?,
+    );
+    let utc_epoch = u64::from_be_bytes(
+        disk_bytes[4..12]
+            .try_into()
+            .map_err(|_| crate::StoreError::Other(eyre::eyre!("invalid snapshot epoch")))?,
+    );
+    let encrypted = &disk_bytes[HEADER_LEN..];
+
+    let try_decrypt = |epoch: &DekEpoch, counter: u64| -> Option<Vec<u8>> {
+        if epoch.version != dek_version {
+            return None;
+        }
+        let bdek = BackupDek::from_raw(*epoch.backup_dek().as_bytes());
+        backup_decrypt(&bdek, encrypted, dek_version, utc_epoch, counter)
+            .ok()
+            .map(|z| z.to_vec())
+    };
+
+    let file_bytes = {
+        let guard = current_dek.read().unwrap_or_else(|p| p.into_inner());
+        (0u64..1024).find_map(|c| try_decrypt(&guard, c))
+    }
+    .or_else(|| {
+        let old = old_deks.lock().unwrap_or_else(|p| p.into_inner());
+        old.values()
+            .flat_map(|epoch| (0u64..1024).filter_map(move |c| try_decrypt(epoch, c)))
+            .next()
+    })
+    .ok_or_else(|| {
+        crate::StoreError::Other(eyre::eyre!(
+            "no DEK epoch matching snapshot version {dek_version}"
+        ))
+    })?;
+
+    rmp_serde::from_slice(&file_bytes)
+        .map_err(|e| crate::StoreError::Other(eyre::eyre!("snapshot deserialize: {e}")))
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<FjallStateMachine> {
@@ -424,8 +629,36 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<FjallStateMachine> {
             )
         })?;
 
+        // Encrypt snapshot file at rest with BackupDek (ADR §7).
+        let (dek_version, backup_dek_ref, counter) = {
+            let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
+            (
+                guard.version,
+                guard.backup_dek().as_bytes().to_owned(),
+                guard.next_backup_counter(),
+            )
+        };
+        use openstack_keystone_storage_crypto::dek::BackupDek;
+        let bdek = BackupDek::from_raw(backup_dek_ref);
+        let utc_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let encrypted = backup_encrypt(&bdek, &file_bytes, dek_version, utc_epoch, counter)
+            .map_err(|e| {
+                StorageError::<TypeConfig>::write_snapshot(
+                    Some(meta.signature()),
+                    TypeConfig::err_from_error(&e),
+                )
+            })?;
+        // On-disk: [dek_version_u32_BE; 4] ++ [utc_epoch_u64_BE; 8] ++ encrypted_blob
+        let mut disk_bytes = Vec::with_capacity(12 + encrypted.len());
+        disk_bytes.extend_from_slice(&dek_version.to_be_bytes());
+        disk_bytes.extend_from_slice(&utc_epoch.to_be_bytes());
+        disk_bytes.extend_from_slice(&encrypted);
+
         let snapshot_path = self.snapshot_dir.join(&snapshot_id);
-        fs::write(&snapshot_path, &file_bytes).map_err(|e| {
+        fs::write(&snapshot_path, &disk_bytes).map_err(|e| {
             StorageError::<TypeConfig>::write_snapshot(
                 Some(meta.signature()),
                 TypeConfig::err_from_error(&e),
@@ -527,8 +760,30 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
         let file_bytes = serialize(&snapshot_file)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
+        // Encrypt the snapshot file at rest with the current BackupDek.
+        let (dek_version, backup_dek_ref, counter) = {
+            let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
+            (
+                guard.version,
+                guard.backup_dek().as_bytes().to_owned(),
+                guard.next_backup_counter(),
+            )
+        };
+        use openstack_keystone_storage_crypto::dek::BackupDek;
+        let bdek = BackupDek::from_raw(backup_dek_ref);
+        let utc_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let encrypted = backup_encrypt(&bdek, &file_bytes, dek_version, utc_epoch, counter)
+            .map_err(|e| io::Error::other(e.to_string()))?;
+        let mut disk_bytes = Vec::with_capacity(12 + encrypted.len());
+        disk_bytes.extend_from_slice(&dek_version.to_be_bytes());
+        disk_bytes.extend_from_slice(&utc_epoch.to_be_bytes());
+        disk_bytes.extend_from_slice(&encrypted);
+
         let snapshot_path = self.snapshot_dir.join(&meta.snapshot_id);
-        fs::write(&snapshot_path, &file_bytes)?;
+        fs::write(&snapshot_path, &disk_bytes)?;
 
         Ok(())
     }
@@ -563,8 +818,8 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
 
         let snapshot_path = self.snapshot_dir.join(&snapshot_id);
 
-        let file_bytes = fs::read(&snapshot_path)?;
-        let snapshot_file: SnapshotFile = rmp_serde::from_slice(&file_bytes)
+        let disk_bytes = fs::read(&snapshot_path)?;
+        let snapshot_file = decrypt_snapshot_file(&disk_bytes, &self.dek, &self.old_deks)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         let data_bytes = rmp_serde::to_vec(&snapshot_file.data)
@@ -577,16 +832,18 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
     }
 
     #[tracing::instrument(skip(self, entries))]
-    async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
+    async fn apply<Strm>(&mut self, entries: Strm) -> Result<(), io::Error>
     where
         Strm: Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>> + Unpin + OptionalSend,
     {
         let mut last_membership = None;
+        let mut entries = entries;
 
         while let Some((entry, responder)) = entries.try_next().await? {
             let last_applied_log = entry.log_id();
             let mut batch = self.db.batch();
             let mut has_violations = false;
+            let mut pending_dek_swap: Option<(Arc<DekEpoch>, bool)> = None;
 
             let response = if let Some(store_req) = entry.app_data {
                 match StoreCommand::unpack(&store_req)? {
@@ -709,6 +966,16 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                                 ),
                                             });
                                         }
+                                        Err(StoreError::WriteRateExceeded(k, v)) => {
+                                            violations.push(Violation {
+                                                r#type: "WRITE_RATE_EXCEEDED".to_string(),
+                                                subject: k,
+                                                description: format!(
+                                                    "write version {v} reached threshold \
+                                                     {WRITE_RATE_THRESHOLD}; DEK rotation required"
+                                                ),
+                                            });
+                                        }
                                         Err(e) => {
                                             return Err(io::Error::other(e.to_string()));
                                         }
@@ -766,6 +1033,16 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                                 ),
                                             });
                                         }
+                                        Err(StoreError::WriteRateExceeded(k, v)) => {
+                                            violations.push(Violation {
+                                                r#type: "WRITE_RATE_EXCEEDED".to_string(),
+                                                subject: k,
+                                                description: format!(
+                                                    "write version {v} reached threshold \
+                                                     {WRITE_RATE_THRESHOLD}; DEK rotation required"
+                                                ),
+                                            });
+                                        }
                                         Err(e) => {
                                             return Err(io::Error::other(e.to_string()));
                                         }
@@ -781,6 +1058,201 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                     let key = format!("{QUARANTINE_META_PREFIX}{partition}");
                                     batch.remove(&self.meta, key.as_bytes());
                                     tracing::info!(partition, "quarantine cleared by operator");
+                                }
+                                MutationInner::InstallDek {
+                                    wrapped_dek,
+                                    dek_version,
+                                    is_emergency,
+                                } => {
+                                    let raw_dek = self
+                                        .kek
+                                        .unwrap_dek(&wrapped_dek)
+                                        .map_err(|e| io::Error::other(e.to_string()))?;
+                                    let locked_dek = LockedKey::from_raw(*raw_dek);
+                                    let new_epoch = Arc::new(
+                                        DekEpoch::from_raw(locked_dek, dek_version)
+                                            .map_err(|e| io::Error::other(e.to_string()))?,
+                                    );
+                                    // Persist new DEK: [version_u32_BE; 4] ++ wrapped_bytes.
+                                    let mut persisted = dek_version.to_be_bytes().to_vec();
+                                    persisted.extend_from_slice(&wrapped_dek);
+                                    batch.insert(&self.meta, META_DEK_CURRENT, persisted);
+                                    let old_version = {
+                                        let g = self.dek.read().unwrap_or_else(|p| p.into_inner());
+                                        g.version
+                                    };
+                                    // Only persist retired DEK if not emergency (emergency
+                                    // revokes).
+                                    if !is_emergency {
+                                        let retired_key =
+                                            format!("{DEK_RETIRED_PREFIX}{old_version}");
+                                        match self.meta.get(META_DEK_CURRENT) {
+                                            Ok(Some(cur)) if cur.len() > 4 => {
+                                                batch.insert(
+                                                    &self.meta,
+                                                    retired_key.as_bytes(),
+                                                    &cur[4..],
+                                                );
+                                            }
+                                            _ => {
+                                                tracing::warn!(
+                                                    old_version,
+                                                    "could not read current DEK bytes for \
+                                                     retirement record; pre-rotation ciphertext \
+                                                     may be unreadable after restart"
+                                                );
+                                            }
+                                        }
+                                    }
+                                    pending_dek_swap = Some((new_epoch, is_emergency));
+                                    tracing::info!(
+                                        old_version,
+                                        new_version = dek_version,
+                                        is_emergency,
+                                        "DEK rotation: epoch swap queued"
+                                    );
+                                }
+                                MutationInner::CreatePendingRotation {
+                                    rotation_id,
+                                    wrapped_dek,
+                                    dek_version,
+                                    expires_at,
+                                    initiator,
+                                } => {
+                                    let now = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap_or_default()
+                                        .as_secs();
+                                    // Remove any pre-existing expired entries first.
+                                    let mut pending = self
+                                        .pending_rotations
+                                        .lock()
+                                        .unwrap_or_else(|p| p.into_inner());
+                                    pending.retain(|_, v| v.expires_at > now);
+
+                                    if !pending.is_empty() {
+                                        violations.push(Violation {
+                                            r#type: "CONFLICT".to_string(),
+                                            subject: rotation_id.clone(),
+                                            description: "another emergency rotation is already \
+                                                          pending; confirm or wait for it to expire"
+                                                .to_string(),
+                                        });
+                                    } else {
+                                        let entry = PendingRotation {
+                                            rotation_id: rotation_id.clone(),
+                                            wrapped_dek: wrapped_dek.clone(),
+                                            dek_version,
+                                            expires_at,
+                                            initiator: initiator.clone(),
+                                        };
+                                        let serialised = rmp_serde::to_vec(&entry)
+                                            .map_err(|e| io::Error::other(e.to_string()))?;
+                                        let meta_key =
+                                            format!("{PENDING_ROTATION_PREFIX}{rotation_id}");
+                                        batch.insert(&self.meta, meta_key.as_bytes(), serialised);
+                                        pending.insert(rotation_id.clone(), entry);
+                                        tracing::info!(
+                                            rotation_id,
+                                            dek_version,
+                                            initiator,
+                                            expires_at,
+                                            "emergency DEK rotation staged; awaiting confirmation"
+                                        );
+                                    }
+                                }
+                                MutationInner::ConfirmPendingRotation {
+                                    rotation_id,
+                                    confirmer,
+                                } => {
+                                    let now = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap_or_default()
+                                        .as_secs();
+                                    let entry = {
+                                        let mut pending = self
+                                            .pending_rotations
+                                            .lock()
+                                            .unwrap_or_else(|p| p.into_inner());
+                                        pending.remove(&rotation_id)
+                                    };
+                                    match entry {
+                                        None => {
+                                            violations.push(Violation {
+                                                r#type: "NOT_FOUND".to_string(),
+                                                subject: rotation_id.clone(),
+                                                description: format!(
+                                                    "no pending emergency rotation with id \
+                                                     {rotation_id}"
+                                                ),
+                                            });
+                                        }
+                                        Some(ref e) if e.expires_at <= now => {
+                                            violations.push(Violation {
+                                                r#type: "EXPIRED".to_string(),
+                                                subject: rotation_id.clone(),
+                                                description: format!(
+                                                    "pending rotation {rotation_id} expired at \
+                                                     {} ({}s ago)",
+                                                    e.expires_at,
+                                                    now.saturating_sub(e.expires_at)
+                                                ),
+                                            });
+                                        }
+                                        Some(ref e) if e.initiator == confirmer => {
+                                            // Re-insert so it can still be confirmed by someone
+                                            // else within the window.
+                                            self.pending_rotations
+                                                .lock()
+                                                .unwrap_or_else(|p| p.into_inner())
+                                                .insert(rotation_id.clone(), e.clone());
+                                            violations.push(Violation {
+                                                r#type: "UNAUTHORIZED".to_string(),
+                                                subject: rotation_id.clone(),
+                                                description: "the confirming operator must be \
+                                                              different from the initiator \
+                                                              (dual-control requirement)"
+                                                    .to_string(),
+                                            });
+                                        }
+                                        Some(entry) => {
+                                            // Dual-control satisfied — execute DEK install.
+                                            let meta_key =
+                                                format!("{PENDING_ROTATION_PREFIX}{rotation_id}");
+                                            batch.remove(&self.meta, meta_key.as_bytes());
+
+                                            let raw_dek =
+                                                self.kek
+                                                    .unwrap_dek(&entry.wrapped_dek)
+                                                    .map_err(|e| io::Error::other(e.to_string()))?;
+                                            let locked_dek = LockedKey::from_raw(*raw_dek);
+                                            let new_epoch = Arc::new(
+                                                DekEpoch::from_raw(locked_dek, entry.dek_version)
+                                                    .map_err(|e| io::Error::other(e.to_string()))?,
+                                            );
+                                            let mut persisted =
+                                                entry.dek_version.to_be_bytes().to_vec();
+                                            persisted.extend_from_slice(&entry.wrapped_dek);
+                                            batch.insert(&self.meta, META_DEK_CURRENT, persisted);
+                                            let old_version = {
+                                                let g = self
+                                                    .dek
+                                                    .read()
+                                                    .unwrap_or_else(|p| p.into_inner());
+                                                g.version
+                                            };
+                                            pending_dek_swap = Some((new_epoch, true));
+                                            tracing::warn!(
+                                                rotation_id,
+                                                old_version,
+                                                new_version = entry.dek_version,
+                                                initiator = entry.initiator,
+                                                confirmer,
+                                                "SECURITY: emergency DEK rotation confirmed \
+                                                 (dual-control); epoch swap queued"
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -802,6 +1274,41 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                 batch
                     .commit()
                     .map_err(|e| io::Error::other(e.to_string()))?;
+
+                // Swap the active DEK epoch after a successful InstallDek commit.
+                if let Some((new_epoch, is_emergency_rotation)) = pending_dek_swap {
+                    let old_epoch = {
+                        let mut guard = self.dek.write().unwrap_or_else(|p| p.into_inner());
+                        std::mem::replace(&mut *guard, new_epoch)
+                    };
+                    if is_emergency_rotation {
+                        // Emergency: old DEK is revoked, not retired
+                        let mut revoked =
+                            self.revoked_deks.lock().unwrap_or_else(|p| p.into_inner());
+                        if revoked.len() >= MAX_REVOKED_DEKS {
+                            tracing::error!(
+                                capacity = MAX_REVOKED_DEKS,
+                                "revoked_deks set is full; this node has had an extraordinary \
+                                 number of emergency rotations — operator review required"
+                            );
+                        }
+                        revoked.insert(old_epoch.version);
+                        drop(revoked);
+                        tracing::warn!(
+                            version = old_epoch.version,
+                            "SECURITY: emergency DEK rotation — old DEK version revoked"
+                        );
+                    } else {
+                        // Register old epoch for state/log read fallback during re-encryption.
+                        self.old_deks
+                            .lock()
+                            .unwrap_or_else(|p| p.into_inner())
+                            .insert(old_epoch.version, old_epoch.clone());
+                    }
+                    // Signal background re-encryption task (non-fatal on channel full).
+                    let _ = self.reencrypt_tx.try_send(old_epoch);
+                    tracing::info!("DEK epoch swapped");
+                }
             }
 
             self.meta

--- a/crates/storage/src/store_command.rs
+++ b/crates/storage/src/store_command.rs
@@ -32,6 +32,25 @@ pub enum StoreCommand {
     Transaction(Vec<MutationInner>),
 }
 
+/// A pending emergency DEK rotation waiting for dual-control confirmation.
+///
+/// Persisted to Fjall meta under `_meta:rotation:pending:<rotation_id>` so
+/// that it survives node restarts within the 5-minute confirmation window.
+#[derive(Debug, Deserialize, PartialEq, Serialize, Clone)]
+pub struct PendingRotation {
+    /// UUID v4 identifier returned to the initiating operator.
+    pub rotation_id: String,
+    /// New DEK wrapped under the active KEK.
+    #[serde(with = "serde_bytes")]
+    pub wrapped_dek: Vec<u8>,
+    /// New monotonically increasing epoch version.
+    pub dek_version: u32,
+    /// Unix epoch seconds after which this entry is considered expired.
+    pub expires_at: u64,
+    /// Peer TLS identity (SPIFFE URI or CN) of the operator who initiated.
+    pub initiator: String,
+}
+
 /// Inner representation of a store modification operation.
 ///
 /// Carries plaintext value bytes for Set/CreateIfAbsent mutations; the state
@@ -60,7 +79,8 @@ pub enum MutationInner {
 
     /// Set the value for the key in the store.
     Set {
-        /// Plaintext serialized value bytes (encrypted by state machine on apply).
+        /// Plaintext serialized value bytes (encrypted by state machine on
+        /// apply).
         #[serde(with = "serde_bytes")]
         cipher: Vec<u8>,
 
@@ -83,7 +103,8 @@ pub enum MutationInner {
     /// Set the value for the key only if the key does not already exist.
     /// If the key exists, a CONFLICT violation is emitted and no write occurs.
     CreateIfAbsent {
-        /// Plaintext serialized value bytes (encrypted by state machine on apply).
+        /// Plaintext serialized value bytes (encrypted by state machine on
+        /// apply).
         #[serde(with = "serde_bytes")]
         cipher: Vec<u8>,
 
@@ -114,6 +135,60 @@ pub enum MutationInner {
     ClearQuarantine {
         /// The keyspace partition to un-quarantine (e.g. `"data"`).
         partition: String,
+    },
+
+    /// Install a new DEK epoch on all cluster members.
+    ///
+    /// Carries the new DEK wrapped under the KEK.  On apply each node unwraps
+    /// the DEK, derives the new epoch sub-keys, persists the wrapped DEK to
+    /// `_meta:dek:current`, retires the previous epoch to
+    /// `_meta:dek:retired:<old_version>`, and swaps the in-memory DEK epoch.
+    ///
+    /// Background re-encryption of state entries from the old epoch to the new
+    /// one begins immediately after the swap completes.
+    InstallDek {
+        /// New DEK wrapped under the active KEK.
+        ///
+        /// Format: `[version_u32_BE; 4] ++ wrap_dek(raw_dek_bytes)`.
+        #[serde(with = "serde_bytes")]
+        wrapped_dek: Vec<u8>,
+        /// New monotonically increasing epoch version.
+        dek_version: u32,
+        /// If `true`, the old DEK is revoked (not retired).  Retired DEKs
+        /// remain available for decrypting pre-rotation data; revoked DEKs
+        /// are immediately rejected.  ADR §6.2 emergency rotation.
+        is_emergency: bool,
+    },
+
+    /// Stage 1 of dual-control emergency DEK rotation (ADR §6.2).
+    ///
+    /// Stores a pending rotation entry in Fjall meta and in the in-memory map.
+    /// The rotation is not yet applied; the new DEK is not yet active.  A
+    /// second operator must call `ConfirmRotateDek` within 5 minutes.
+    CreatePendingRotation {
+        /// UUID v4 identifier returned to the initiating operator.
+        rotation_id: String,
+        /// New DEK wrapped under the active KEK.
+        #[serde(with = "serde_bytes")]
+        wrapped_dek: Vec<u8>,
+        /// New monotonically increasing epoch version.
+        dek_version: u32,
+        /// Unix epoch seconds after which this entry expires.
+        expires_at: u64,
+        /// Peer TLS identity of the initiating operator.
+        initiator: String,
+    },
+
+    /// Stage 2 of dual-control emergency DEK rotation (ADR §6.2).
+    ///
+    /// On apply: verifies the pending entry exists and has not expired, that
+    /// the confirming operator differs from the initiator, then executes the
+    /// same DEK-install logic as `InstallDek { is_emergency: true }`.
+    ConfirmPendingRotation {
+        /// UUID v4 identifier from `CreatePendingRotation`.
+        rotation_id: String,
+        /// Peer TLS identity of the confirming operator.
+        confirmer: String,
     },
 }
 

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -27,7 +27,9 @@ use rcgen::{
     BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
     Issuer, KeyPair, KeyUsagePurpose, SanType,
 };
+use temp_env;
 use tempfile::TempDir;
+
 use tonic::transport::{Channel, ClientTlsConfig, Uri};
 
 use openstack_keystone_config::{
@@ -58,7 +60,9 @@ fn make_env<T: serde::Serialize + ?Sized>(
 #[tracing_test::traced_test]
 #[test]
 fn test_cluster() {
-    TypeConfig::run(test_cluster_inner()).unwrap();
+    temp_env::with_var("KEYSTONE_DEV_KEK", Some(&"00".repeat(32)), || {
+        TypeConfig::run(test_cluster_inner()).unwrap();
+    });
 }
 
 #[allow(dead_code)]
@@ -86,6 +90,7 @@ impl InstanceHolder {
 }
 
 async fn test_cluster_inner() -> Result<()> {
+    // Existing test body
     let provider = rustls::crypto::aws_lc_rs::default_provider();
     rustls::crypto::CryptoProvider::install_default(provider).unwrap();
 
@@ -147,6 +152,9 @@ async fn test_cluster_inner() -> Result<()> {
 
         let metrics = admin_client1.metrics(()).await?.into_inner();
         println!("=== metrics after init: {:?}", metrics);
+        // Wait until node 1 has committed the init membership and elected itself
+        // leader.
+        wait_for_leader(&mut admin_client1, 1).await;
     }
 
     println!(
@@ -401,6 +409,18 @@ fn get_addr(node_id: u64) -> SocketAddr {
             unreachable!("node_id must be 1, 2, or 3");
         }
     }
+}
+
+async fn wait_for_leader(client: &mut ClusterAdminServiceClient<Channel>, expected_leader: u64) {
+    for _ in 0..50 {
+        if let Ok(resp) = client.metrics(()).await {
+            if resp.into_inner().current_leader == Some(expected_leader) {
+                return;
+            }
+        }
+        TypeConfig::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("leader {expected_leader} not elected within 5 seconds");
 }
 
 pub async fn start_raft_app(

--- a/deny.toml
+++ b/deny.toml
@@ -188,8 +188,22 @@ external-default-features = "allow"
 allow = [
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
-]
+ ]
 # List of crates to deny
+#
+# ADR 0016-v2 §11: crates that store cryptographic key material must implement
+# ZeroizeOnDrop. Our own crypto code (storage-crypto) uses aes-gcm / hkdf / sha2
+# which integrate with the zeroize ecosystem. The `mem_forget` clippy lint
+# enforced in storage-crypto and storage crates prevents accidental bypass of
+# drop-based zeroization.
+#
+# NOTE: `ring` crate is not banned here because it's unavoidable as a transitive
+# dependency via openidconnect -> oauth2 -> reqwest 0.12 (no aws-lc-rs feature).
+# Ring key types are NOT used directly by our code — storage-crypto uses
+# aes-gcm/hkdf/sha2 with zeroize. `ring` is only in the dependency tree
+# due to Cargo feature unification (reqwest 0.12 enables __rustls-ring).
+# When openidconnect or its deps update to reqwest 0.13 with aws-lc-rs support,
+# this exception can be reconsidered.
 deny = [
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -33,6 +33,7 @@
     - [Mapping Engine](adr/0020-mapping-engine.md)
     - [Api Key authentication for SCIM](adr/0021-api-key-scim.md)
     - [Rate limiting](adr/0022-rate-limiting.md)
+  - [Distributed Encrypted Storage](raft_storage.md)
 - [Policy enforcement](policy.md)
 - [Fernet token]()
   - [Token payloads]()

--- a/doc/src/raft_storage.md
+++ b/doc/src/raft_storage.md
@@ -1,0 +1,697 @@
+# Distributed Encrypted Storage
+
+This guide covers the architecture, cryptographic design, and operational
+procedures for the Keystone-RS distributed storage engine. The design is
+specified in [ADR 0016-v2](adr/0016-v2-raft-storage.md) and implemented across
+two crates: `openstack-keystone-distributed-storage` (consensus, state machine,
+gRPC) and `openstack-keystone-storage-crypto` (all cryptographic primitives).
+
+## Table of Contents
+
+1. [Architecture Overview](#architecture-overview)
+2. [Crate Layout](#crate-layout)
+3. [Key Hierarchy](#key-hierarchy)
+4. [Encryption Details](#encryption-details)
+   - [Raft Log Encryption](#raft-log-encryption)
+   - [State Machine Encryption](#state-machine-encryption)
+   - [Backup Encryption](#backup-encryption)
+   - [Nonce Management](#nonce-management)
+5. [Data Tiers and Read Consistency](#data-tiers-and-read-consistency)
+6. [Intra-Cluster Transport (mTLS)](#intra-cluster-transport-mtls)
+7. [Audit Log](#audit-log)
+8. [Quarantine and GCM Failure Handling](#quarantine-and-gcm-failure-handling)
+9. [DEK Rotation](#dek-rotation)
+10. [Deployment Guide](#deployment-guide)
+    - [Configuration Reference](#configuration-reference)
+    - [First-Time Cluster Bootstrap](#first-time-cluster-bootstrap)
+    - [Adding Nodes](#adding-nodes)
+    - [TLS Certificate Management](#tls-certificate-management)
+11. [Operational Runbook](#operational-runbook)
+    - [Scheduled DEK Rotation](#scheduled-dek-rotation)
+    - [Emergency DEK Rotation](#emergency-dek-rotation)
+    - [Clearing a Quarantined Partition](#clearing-a-quarantined-partition)
+    - [Backup and Restore](#backup-and-restore)
+12. [Security Invariants](#security-invariants)
+
+---
+
+## Architecture Overview
+
+The storage engine combines three components:
+
+| Layer                     | Component          | Purpose                                           |
+| ------------------------- | ------------------ | ------------------------------------------------- |
+| **Consensus**                 | `openraft`         | Log replication, leader election, linearizability |
+| **State machine / log store** | `fjall` (LSM-tree) | Durable on-disk persistence, SSD-optimized        |
+| **Transport**                 | gRPC over mTLS     | Intra-cluster Raft RPC (SPIFFE or custom PKI)     |
+
+All data is encrypted before it touches the Raft log or the Fjall on-disk
+storage. A full disk compromise or log exfiltration reveals only AES-256-GCM
+ciphertext — no plaintext, no key material.
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  Keystone API layer                                             │
+└───────────────────────────────┬─────────────────────────────────┘
+                                │  StorageApi trait
+┌───────────────────────────────▼─────────────────────────────────┐
+│  Storage struct (app.rs)                                        │
+│  • Raft client  • DEK epoch  • Audit forwarder                  │
+└───────┬───────────────────────┬─────────────────────────────────┘
+        │ Raft proposals        │ Local reads (Tier 0/1)
+┌───────▼───────────────────────▼─────────────────────────────────┐
+│  OpenRaft (consensus)                                           │
+│  ┌──────────────────┐         ┌────────────────────────────┐    │
+│  │  FjallLogStore   │         │  FjallStateMachine         │    │
+│  │  (log_store.rs)  │         │  (state_machine.rs)        │    │
+│  │  Log DEK encrypt │         │  State DEK encrypt/decrypt │    │
+│  └──────────────────┘         └────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+        │                                       │
+        ▼                                       ▼
+  Fjall (log keyspace)                Fjall (state keyspace)
+  [nonce][ciphertext][tag]            [nonce][ciphertext][tag][version]
+```
+
+### Write Path
+
+1. The API serializes the mutation to MessagePack.
+2. The Log DEK encrypts the payload (nonce: `node_id_BE ++ counter_BE`, AD:
+   `term_BE ++ index_BE`).
+3. OpenRaft proposes the encrypted blob and replicates it over mTLS to a quorum.
+4. On apply, the state machine decrypts the log entry using the Log DEK.
+5. The current per-record `version` is read from Fjall (0 for new records).
+6. The State DEK re-encrypts the value for at-rest storage (HKDF-derived nonce,
+   AD: `tier ++ domain ++ primary_key`), then writes
+   `[nonce_12b][ciphertext][tag_16b][version_u32_BE]` to Fjall.
+
+### Read Path
+
+- **Tier 0 / 1 (PUBLIC / INTERNAL):** The local state machine decrypts and
+  returns the value directly.
+- **Tier 2 / 3 (SENSITIVE / SECRET):** A `ReadIndex` (linearizable read) is
+  issued to OpenRaft first, ensuring no stale follower can return a value that
+  has since been revoked.
+
+---
+
+## Crate Layout
+
+```
+crates/
+├── storage-crypto/            # All cryptographic primitives
+│   └── src/
+│       ├── lib.rs             # Public re-exports
+│       ├── kek.rs             # KekProvider trait, EnvKek, Pkcs11KekStub
+│       ├── dek.rs             # DekEpoch, LogDek, StateDek, BackupDek, generate_dek
+│       ├── cipher.rs          # log_encrypt/decrypt, state_encrypt/decrypt,
+│       │                      #   backup_encrypt/decrypt
+│       ├── nonce.rs           # NonceManager — durable monotonic counter
+│       └── audit.rs           # AuditHmacKey
+│
+└── storage/                   # Consensus, gRPC, state machine
+    └── src/
+        ├── lib.rs             # StorageApi impl, DEK bootstrap
+        ├── app.rs             # init_storage, Storage struct, StorageApi impl
+        ├── preflight.rs       # OS-level memory protection checks
+        ├── audit.rs           # AuditForwarder, AuditRecord
+        ├── network.rs         # NetworkManager, SpiffeTlsProvider,
+        │                      #   CertExpiryWatchdog, validate_svid_ttl
+        ├── store/
+        │   ├── log_store.rs   # FjallLogStore (OpenRaft LogStorage impl)
+        │   └── state_machine.rs # FjallStateMachine (OpenRaft StateMachine impl)
+        ├── grpc/
+        │   ├── cluster_admin_service.rs  # init, add_learner, rotate_dek, …
+        │   ├── raft_service.rs           # Raft RPC forwarding
+        │   └── storage_service.rs        # Data read/write RPCs
+        └── store_command.rs   # StoreCommand, MutationInner, DataTier
+```
+
+---
+
+## Key Hierarchy
+
+```text
+ HSM / Cloud KMS  (production)
+  │  or
+  KEYSTONE_DEV_KEK env var  (dev mode only)
+  │
+  ▼
+Key Encryption Key (KEK)                — never enters RAM as plaintext (prod)
+  │
+  │  AES-256-GCM unwrap
+  ▼
+Data Encryption Key (DEK)              — 256-bit random, mlock'd allocation
+  │
+  ├── Log DEK     HKDF-Expand(DEK, "keystone-raft-log-v1",    L=32)
+  ├── State DEK   HKDF-Expand(DEK, "keystone-fjall-state-v1", L=32)
+  └── Backup DEK  HKDF-Expand(DEK, "keystone-backup-v1"
+                               ++ dek_version_u32_BE,          L=32)
+
+Audit HMAC key  HKDF-Expand(KEK, "keystone-audit-hmac-v1"
+                              ++ node_id_u64_BE,               L=32)
+```
+
+HKDF-Expand-only is used because the DEK is already uniformly random;
+HKDF-Extract would add no entropy. Each sub-key is domain-separated by a
+distinct info string, ensuring ciphertexts from different contexts are never
+encrypted under the same key material.
+
+The Audit HMAC key is derived from the **KEK** (not the DEK) so it survives DEK
+rotation without needing re-derivation, while remaining per-node to prevent
+cross-node forgery.
+
+### DEK Persistence
+
+The wrapped DEK is stored in Fjall under the key `_meta:dek:current` as
+`[version_u32_BE; 4] ++ wrapped_bytes`. On startup, `init_storage` reads this
+key, unwraps the DEK under the KEK, derives sub-keys, and stores an
+`Arc<RwLock<Arc<DekEpoch>>>` that all state machine operations share.
+
+---
+
+## Encryption Details
+
+### Raft Log Encryption
+
+**Function:** `log_encrypt(log_dek, plaintext, term, index) → Vec<u8>`
+
+**On-disk layout:** `[nonce_12b][ciphertext][tag_16b]`
+
+| Field            | Value                                          |
+| ---------------- | ---------------------------------------------- |
+| Nonce (12 bytes) | `[node_id_u64_BE; 8] ++ [counter_u32_BE; 4]`   |
+| Associated data  | `term_u64_BE ++ index_u64_BE`                  |
+| Tag              | 16 bytes (full GCM tag, truncation prohibited) |
+
+The AD binding of `term ++ index` prevents an attacker from replaying a log
+entry from a different Raft position.
+
+### State Machine Encryption
+
+**Function:**
+`state_encrypt(state_dek, plaintext, tier, domain_id, pk, version) → Vec<u8>`
+
+**On-disk layout:** `[nonce_12b][ciphertext][tag_16b][version_u32_BE]`
+
+| Field            | Value                                                            |
+| ---------------- | ---------------------------------------------------------------- |
+| Nonce (12 bytes) | `HKDF-Expand(StateDek, pk ++ version_u32_BE, L=12)`              |
+| Associated data  | `[tier_u8] ++ domain_id ++ pk`                                   |
+| Tag              | 16 bytes                                                         |
+| Version suffix   | `version_u32_BE` (read back on next write to compute next nonce) |
+
+The HKDF-derived nonce guarantees uniqueness across record updates: each
+`(pk, version)` pair produces a distinct nonce even if the same plaintext is
+re-written. The version starts at 0 for new records and increments on every
+write, stored as a 4-byte suffix alongside the ciphertext.
+
+The `tier` byte in the AD cryptographically binds the sensitivity classification
+to the ciphertext — altering the stored tier makes the GCM tag invalid.
+
+**Write rate guard:** If `version >= 2^30` (approximately 1 billion writes per
+record per DEK epoch), further writes to that key are blocked with a
+`WRITE_RATE_EXCEEDED` violation and a CRITICAL log entry is emitted. This
+prevents nonce-space exhaustion within a DEK epoch for pathologically hot keys.
+
+### Backup Encryption
+
+**Function:**
+`backup_encrypt(bdek, snapshot_bytes, dek_version, utc_epoch) → Vec<u8>`
+
+**On-disk layout:**
+`[dek_version_u32_BE; 4] ++ [utc_epoch_u64_BE; 8] ++ [nonce_12b][ciphertext][tag_16b]`
+
+| Field           | Value                                                          |
+| --------------- | -------------------------------------------------------------- |
+| Associated data | `b"keystone-backup-v1" ++ utc_epoch_u64_BE ++ dek_version_u32` |
+
+The `dek_version` and `utc_epoch` in the AD bind the snapshot to a specific
+point in time and DEK epoch, preventing time-travel and replay attacks across
+backup archives. A separate DEK manifest (itself AES-256-GCM encrypted with AD
+bound to the manifest label, epoch, and DEK version) is included in the backup
+bundle alongside the encrypted snapshot.
+
+### Nonce Management
+
+The `NonceManager` (`storage-crypto/src/nonce.rs`) maintains a durable monotonic
+counter for Raft log nonces:
+
+- Persists the counter in Fjall under `_meta:nonce_hwm:<node_id>`.
+- Reserves blocks of 1024 counts on each flush to absorb node crashes without
+  nonce reuse.
+- On startup, validates the recovered counter against the persisted high-water
+  mark; **refuses to start** if the counter ≤ HWM (operator intervention
+  required).
+- Emits a WARN when fewer than 10% of the `2^31` rotation threshold remain.
+
+---
+
+## Data Tiers and Read Consistency
+
+Each record carries a `DataTier` marker (0–3) that is part of the AES-GCM
+associated data and stored in the record metadata.
+
+| Tier | Label       | Read path                | Examples                                    |
+| ---- | ----------- | ------------------------ | ------------------------------------------- |
+| 0    | `PUBLIC`    | Local read               | Feature flags, role display names           |
+| 1    | `INTERNAL`  | Local read               | Display attributes, config markers          |
+| 2    | `SENSITIVE` | Linearizable (ReadIndex) | Group memberships, session tokens, API keys |
+| 3    | `SECRET`    | Linearizable (ReadIndex) | Credential plaintext, TOTP seeds            |
+
+Tier 2 and 3 always issue a `ReadIndex` RPC to the current Raft leader before
+reading from the local state machine, ensuring a revoked credential or removed
+group member can never be observed as still-valid on a lagging follower.
+
+Configure local reads for Tier 0/1 data:
+
+```toml
+[distributed_storage]
+local_reads_mode = "local_for_public"   # default
+# local_reads_mode = "linearizable_all" # force ReadIndex for everything
+```
+
+---
+
+## Intra-Cluster Transport (mTLS)
+
+All cluster communication uses TLS 1.3 with AEAD cipher suites only
+(`TLS_AES_256_GCM_SHA384` or `TLS_CHACHA20_POLY1305_SHA256`). Manual joining is
+permanently disabled; every peer must present a valid mTLS identity.
+
+### SPIFFE Mode (Default)
+
+```toml
+[distributed_storage]
+trust_domains = "example.org"
+```
+
+- SVIDs issued by SPIRE are rotated automatically. TTL must not exceed 1 hour.
+- Nodes reject SVIDs with less than 5 minutes remaining (force-renewal window).
+- If SPIRE is unavailable before the renewal window, the node drains proposals
+  and halts — it does **not** fall back to an expired SVID (fail-closed).
+- Incoming SVIDs must match `spiffe://<trust-domain>/keystone/storage/<role>`;
+  mismatches are rejected with `PERMISSION_DENIED` at the gRPC interceptor.
+
+### TLS Fallback Mode
+
+```toml
+[distributed_storage]
+tls_cert_file    = "/etc/keystone/storage/node.pem"
+tls_key_file     = "/etc/keystone/storage/node.key"
+tls_client_ca_file = "/etc/keystone/storage/ca.pem"
+```
+
+- Certificates must be signed by a dedicated Keystone Intermediate CA.
+- Leaf certificate validity must not exceed 30 days.
+- `CertExpiryWatchdog` checks remaining validity hourly: WARN at 7 days, ERROR
+  at 2 days, configurable shutdown at expiry.
+
+### NodeId Uniqueness
+
+Each node has a manually configured `node_id: u64`. At startup and on every
+`add_learner` gRPC call, the cluster membership is checked for a
+`(node_id, rpc_addr)` collision. A detected collision is fatal — the node or the
+operation is aborted with a clear error message. If membership cannot be queried
+(no quorum), startup fails closed.
+
+---
+
+## Audit Log
+
+Every security-relevant operation is signed and forwarded to an external SIEM.
+
+**Record structure:**
+
+```json
+{
+  "timestamp": 1750000000,
+  "event_type": "DEK_ROTATION",
+  "actor": "operator@example.org",
+  "node_id": 1,
+  "dek_version": 3,
+  "details": { ... }
+}
+```
+
+**Signature:** `HMAC-SHA256(AuditHmacKey, canonical_json_of_record)`
+
+The 32-byte MAC is transmitted alongside the record as a hex string. The SIEM
+retains each epoch's key for audit retention purposes. The `node_id` in the HKDF
+derivation ensures different nodes hold distinct signing keys, preventing a
+compromised node from forging records attributed to other nodes.
+
+**Availability:** If the SIEM is unreachable, records are buffered locally
+(encrypted under the Log DEK). At 90% buffer capacity a CRITICAL alert is
+emitted. Buffer exhaustion does **not** block writes to the identity store.
+
+Audited events include: `DEK_ROTATION`, `DEK_ROTATION_EMERGENCY`,
+`QUARANTINE_CLEARED`, and any operator access to gRPC management RPCs.
+
+---
+
+## Quarantine and GCM Failure Handling
+
+GCM tag verification failures indicate tampered or corrupted ciphertext.
+
+| Failure count (within 60 s) | Action                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| 1                           | WARN log, metric increment                                                                 |
+| 2                           | ERROR log, alert                                                                           |
+| 3                           | Drain in-flight Raft proposals, commit quarantine marker via Raft, set partition read-only |
+
+Quarantine state is **Raft-committed** (stored in
+`_meta:quarantine:<node_id>:<partition>`) and therefore persists across restarts
+and is visible to all cluster members. A restarted node reads this key at
+startup and re-enters quarantine if the marker is set.
+
+Clearing quarantine requires a `storage-operator` identity:
+
+```sh
+keystone-manage storage clear-quarantine --partition <partition>
+```
+
+The clear operation is committed via Raft (so it takes effect cluster-wide) and
+is recorded in the audit log.
+
+---
+
+## DEK Rotation
+
+DEK rotation is triggered by time (`dek_rotation_days`, default 90 days) or
+volume (log-encrypt counter reaches 2^31). The rotation is a live background
+process with no downtime.
+
+**Normal rotation:**
+
+```sh
+keystone-manage storage rotate-dek
+```
+
+**Emergency rotation** (suspected DEK compromise — requires dual-control):
+
+```sh
+# Operator A initiates:
+keystone-manage storage rotate-dek --emergency
+# returns rotation_id=<uuid>
+
+# Operator B confirms within 5 minutes:
+keystone-manage storage confirm-rotate-dek --rotation-id <uuid>
+```
+
+If the 5-minute confirmation window expires without confirmation, the pending
+rotation is automatically aborted and an audit entry is written. Emergency
+rotations mark the old DEK as `revoked` (not `retired`) — it is never reused for
+any decryption, even for backup archives from that epoch.
+
+**Re-encryption:** A background task re-encrypts all Fjall records under the new
+DEK using optimistic CAS-on-version: it reads the on-disk version, encrypts
+under the new DEK with `version + 1`, and writes only if the on-disk version is
+unchanged. After 3 failed CAS attempts, the key is skipped (it was already
+updated by a concurrent Raft write) and flagged in the post-rotation
+verification report.
+
+**Progress:** Progress is checkpointed to `_meta:dek:rotation_progress`. If the
+node restarts mid-rotation, it resumes from the last checkpoint.
+
+---
+
+## Deployment Guide
+
+### Prerequisites
+
+- Rust toolchain (see `rust-toolchain.toml`)
+- A SPIRE deployment, or TLS certificates from a dedicated Intermediate CA
+- For production: HSM or Cloud KMS for KEK storage
+- For development: set `KEYSTONE_DEV_KEK` and `KEYSTONE_ALLOW_ENV_KEK=1`
+
+### Configuration Reference
+
+```toml
+[distributed_storage]
+# Unique identifier for this node within the cluster. Must be a u64.
+# Collision with an existing node at a different address is fatal.
+node_id = 1
+
+# Advertised cluster-internal address (used by peers for Raft RPC).
+node_cluster_addr = "https://10.0.0.1:8310"
+
+# Local listener address for inbound cluster connections.
+node_listener_addr = "0.0.0.0:8310"
+
+# Directory where Fjall database files are stored.
+path = "/var/lib/keystone/storage"
+
+# Read consistency mode for Tier 0/1 data.
+# "local_for_public" (default): serve Tier 0/1 locally, ReadIndex for Tier 2/3.
+# "linearizable_all": require ReadIndex for all tiers.
+local_reads_mode = "local_for_public"
+
+# DEK rotation interval in days (default: 90).
+dek_rotation_days = 90
+
+# Per-record write version threshold before blocking further writes (default: 2^30).
+write_rate_threshold = 1073741824
+
+# --- Transport: SPIFFE (default) ---
+trust_domains = "example.org"
+
+# --- Transport: TLS fallback ---
+# tls_cert_file    = "/etc/keystone/storage/node.pem"
+# tls_key_file     = "/etc/keystone/storage/node.key"
+# tls_client_ca_file = "/etc/keystone/storage/ca.pem"
+# # Or embed content directly (base64 or PEM):
+# tls_cert_content = "..."
+# tls_key_content  = "..."
+# tls_client_ca_content = "..."
+```
+
+**Environment variables (development only):**
+
+| Variable                 | Description                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `KEYSTONE_DEV_KEK`       | Hex-encoded 256-bit KEK. Requires `--dev-mode` and `KEYSTONE_ALLOW_ENV_KEK=1`. |
+| `KEYSTONE_ALLOW_ENV_KEK` | Must be set to `1` when using `KEYSTONE_DEV_KEK`.                              |
+
+> **Warning:** `KEYSTONE_DEV_KEK` and `KEYSTONE_ALLOW_ENV_KEK` must never appear
+> in production Dockerfiles, Kubernetes manifests, or systemd units. The CI gate
+> `tools/check_no_dev_mode.sh` enforces this.
+
+### First-Time Cluster Bootstrap
+
+**Step 1 — Start each node** (do not initialize yet):
+
+```sh
+keystone --config /etc/keystone/keystone.conf
+```
+
+Each node starts and waits; Raft is not yet initialized.
+
+**Step 2 — Initialize the first node** as a single-node cluster:
+
+```sh
+keystone-manage storage init \
+  --node-addr https://10.0.0.1:8310 \
+  --node-id 1
+```
+
+Node 1 becomes the leader of a 1-node cluster. Wait for it to report a leader
+(check `keystone-manage storage metrics --node-addr https://10.0.0.1:8310`).
+
+**Step 3 — Add learners:**
+
+```sh
+keystone-manage storage join \
+  --leader-addr https://10.0.0.1:8310 \
+  --node-addr   https://10.0.0.2:8310 \
+  --node-id 2
+
+keystone-manage storage join \
+  --leader-addr https://10.0.0.1:8310 \
+  --node-addr   https://10.0.0.3:8310 \
+  --node-id 3
+```
+
+**Step 4 — Promote learners to voting members:**
+
+```sh
+keystone-manage storage promote \
+  --leader-addr https://10.0.0.1:8310 \
+  --members 1,2,3
+```
+
+### Adding Nodes
+
+To add a new node to a running cluster:
+
+```sh
+# 1. Start the new node process (it will wait for a join instruction).
+
+# 2. From any existing cluster member:
+keystone-manage storage join \
+  --leader-addr https://10.0.0.1:8310 \
+  --node-addr   https://10.0.0.4:8310 \
+  --node-id 4
+
+# 3. Optionally promote to voting member:
+keystone-manage storage promote \
+  --leader-addr https://10.0.0.1:8310 \
+  --members 1,2,3,4
+```
+
+### TLS Certificate Management
+
+**SPIFFE mode:** No operator action required. SPIRE rotates SVIDs automatically.
+The node refuses connections from SVIDs with < 5 minutes remaining validity.
+
+**TLS fallback mode:**
+
+1. Generate a new certificate from your Intermediate CA (max 30-day validity).
+2. Deploy the new certificate and key to the node.
+3. Restart the node, or use a runtime reload mechanism if available.
+4. The `CertExpiryWatchdog` logs WARN at 7 days remaining and ERROR at 2 days.
+
+---
+
+## Operational Runbook
+
+### Scheduled DEK Rotation
+
+Automatic rotation fires after `dek_rotation_days` (default: 90) or when the
+log-encrypt counter approaches 2^31. Manual rotation:
+
+```sh
+keystone-manage storage rotate-dek \
+  --leader-addr https://10.0.0.1:8310
+```
+
+Monitor the audit log (`event_type = "DEK_ROTATION"`) and the post-rotation
+verification report for any skipped keys.
+
+### Emergency DEK Rotation
+
+Use when a DEK is suspected compromised.
+
+```sh
+# Operator A — initiates rotation, receives rotation_id:
+keystone-manage storage rotate-dek \
+  --leader-addr https://10.0.0.1:8310 \
+  --emergency
+# Output: rotation_id=550e8400-e29b-41d4-a716-446655440000
+
+# Operator B — confirms within 5 minutes:
+keystone-manage storage confirm-rotate-dek \
+  --leader-addr https://10.0.0.1:8310 \
+  --rotation-id 550e8400-e29b-41d4-a716-446655440000
+```
+
+If no confirmation is received within 5 minutes, the rotation aborts
+automatically and is recorded in the audit log. The `dek_rotation_days` timer
+resets after successful completion.
+
+### Clearing a Quarantined Partition
+
+A partition enters quarantine after 3 GCM verification failures within 60
+seconds. In quarantine, the partition is read-only and all writes to affected
+keys are rejected with a `QUARANTINED` violation.
+
+**Diagnosis:**
+
+```sh
+# Check node metrics for quarantine state:
+keystone-manage storage metrics --node-addr https://10.0.0.1:8310
+```
+
+Root-cause the GCM failures (hardware fault, storage corruption, or unauthorized
+modification) before clearing quarantine.
+
+**Clear:**
+
+```sh
+keystone-manage storage clear-quarantine \
+  --node-addr https://10.0.0.1:8310 \
+  --partition <partition-name>
+```
+
+This commits a Raft proposal (visible cluster-wide) and emits an audit entry.
+
+### Backup and Restore
+
+**Create a backup** (Fjall snapshot):
+
+```sh
+keystone-manage storage backup \
+  --node-addr https://10.0.0.1:8310 \
+  --output /mnt/backups/keystone-$(date +%Y%m%d).snap
+```
+
+The snapshot is wrapped in a backup-specific AES-256-GCM envelope with the
+Backup DEK and a DEK manifest. Both are bound to the snapshot timestamp and
+current DEK epoch.
+
+**Restore:**
+
+```sh
+# 1. Bootstrap fresh cluster nodes (Step 1 from bootstrap guide).
+# 2. Restore the snapshot to the leader:
+keystone-manage storage restore \
+  --leader-addr https://10.0.0.1:8310 \
+  --snapshot /mnt/backups/keystone-20260101.snap
+# 3. Add remaining nodes as learners (Steps 3–4 from bootstrap guide).
+```
+
+**Retired DEK retention:** Retired DEKs must be retained in the KMS for at least
+365 days to allow offline decryption of archived backups. Use a separate
+`backup_dek_offline` KMS role (distinct from the runtime role) with dual-control
+access controls.
+
+---
+
+## Security Invariants
+
+The following invariants are enforced by the implementation and verified at code
+review. Any change that violates them must be explicitly justified and approved
+by the security team.
+
+1. **No plaintext on disk.** Every byte is AES-256-GCM encrypted before the
+   write call returns. GCM tags are always 16 bytes.
+
+2. **No DEK in plaintext outside mlock'd RAM.** The DEK is stored wrapped under
+   the KEK on disk. In memory it lives only inside mlock'd `Zeroizing` buffers.
+
+3. **Strict mTLS.** Auto-join is permanently disabled. Every inbound connection
+   must present a valid SPIFFE SVID or an operator-managed certificate signed by
+   the cluster Intermediate CA.
+
+4. **No stale reads for sensitive data.** Tier 2 and Tier 3 reads always execute
+   the ReadIndex protocol before returning data.
+
+5. **GCM failure quarantine is durable.** Quarantine state is committed via Raft
+   and persists across node restarts.
+
+6. **No environment-variable KEK in production.** Starting with
+   `KEYSTONE_DEV_KEK` requires both `--dev-mode` and `KEYSTONE_ALLOW_ENV_KEK=1`.
+   CI rejects deployment artifacts that contain these flags.
+
+7. **NodeId collision detection is fail-closed.** A collision detected at
+   startup or on `add_learner` is fatal. Inability to query membership (no
+   quorum) is treated as a detected collision.
+
+8. **DEK generation targets mlock'd memory.** The DEK must not be generated into
+   an unlocked buffer and subsequently copied.
+
+9. **Per-record write rate guard.** Writes beyond the version threshold (`2^30`
+   by default) are blocked with a CRITICAL log. This prevents nonce-space
+   exhaustion for pathologically hot keys within a DEK epoch.
+
+10. **Nonce sources are deterministic and audited.** Random nonces are
+    prohibited. All nonce strategies are documented in the ADR and reviewed by
+    the security team before any new encrypted context is added.
+
+11. **Deployment validation.** `tools/check_no_dev_mode.sh` runs in CI and
+    rejects production service definitions containing `--dev-mode` or
+    `KEYSTONE_ALLOW_ENV_KEK`.
+
+12. **Startup pre-flight.** Before loading any key material, the node verifies
+    `RLIMIT_CORE == 0` and `PR_SET_DUMPABLE == 0`. Failures emit CRITICAL log
+    entries and (when `--dev-mode` is not set) prevent startup.

--- a/tools/check_no_dev_mode.sh
+++ b/tools/check_no_dev_mode.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# check_no_dev_mode.sh — CI safety gate for ADR 0016-v2 §11
+#
+# Scans Dockerfiles, Kubernetes manifests, and systemd unit files for flags
+# that must never appear in production deployments:
+#   --dev-mode
+#   KEYSTONE_ALLOW_ENV_KEK
+#
+# Exit 0 = clean; exit 1 = violations found.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PATTERNS=(
+    '--dev-mode'
+    'KEYSTONE_ALLOW_ENV_KEK'
+)
+
+FILE_GLOBS=(
+    'Dockerfile*'
+    '*.yaml'
+    '*.yml'
+    '*.service'
+    '*.conf'
+)
+
+violations=0
+
+for glob in "${FILE_GLOBS[@]}"; do
+    while IFS= read -r -d '' file; do
+        for pattern in "${PATTERNS[@]}"; do
+            if grep -q "${pattern}" "${file}" 2>/dev/null; then
+                echo "VIOLATION: '${pattern}' found in ${file}" >&2
+                violations=$((violations + 1))
+            fi
+        done
+    done < <(find "${REPO_ROOT}" -name "${glob}" -not -path "*/target/*" -print0 2>/dev/null)
+done
+
+if [ "${violations}" -gt 0 ]; then
+    echo "ERROR: ${violations} dev-mode violation(s) detected. Remove --dev-mode and" >&2
+    echo "       KEYSTONE_ALLOW_ENV_KEK from all deployment artifacts before shipping." >&2
+    exit 1
+fi
+
+echo "OK: no dev-mode flags found in deployment files."


### PR DESCRIPTION
## Summary

This PR implements the remaining phases of ADR 0016-v2 for distributed encrypted storage, adding support for Data Encryption Key (DEK) rotation, audit logging with HMAC signing, snapshot backup encryption, and operational safeguards including write-rate limiting and certificate expiry monitoring.

## Key Changes

### Core Cryptographic Additions
- **Backup encryption** (`storage-crypto/src/cipher.rs`): New `backup_encrypt`/`backup_decrypt` functions for encrypting Raft snapshots with a per-epoch `BackupDek` sub-key, binding ciphertext to DEK version and UTC timestamp via associated data
- **Audit HMAC key** (`storage-crypto/src/audit.rs`): Per-node `AuditHmacKey` derived from KEK (not DEK) so audit keys survive rotation; enables HMAC-SHA256 signing of audit records
- **Backup DEK derivation** (`storage-crypto/src/dek.rs`): New `BackupDek` sub-key type derived with DEK version in the info string to prevent cross-epoch backup reuse

### State Machine & Log Store Enhancements
- **Live DEK rotation support** (`storage/src/store/state_machine.rs`, `storage/src/store/log_store.rs`):
  - Changed `dek` field from `Arc<DekEpoch>` to `Arc<RwLock<Arc<DekEpoch>>>` to allow atomic rotation
  - Added `old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>>` to hold retired epochs during re-encryption transition
  - Decryption now transparently falls back to old DEK epochs if current DEK fails, enabling reads of not-yet-re-encrypted data
  - Log entries now include 4-byte DEK version prefix to support decryption with correct epoch
  - Added `WRITE_RATE_THRESHOLD` (2^30 writes per record per epoch) enforcement with `WriteRateExceeded` error

### Audit Infrastructure
- **Audit forwarder** (`storage/src/audit.rs`): Background task that signs and forwards audit records via HMAC-SHA256; non-blocking emission into async channel; buffering with 90% capacity warning
- **Audit record structure**: Timestamp, event type, actor identity, node ID, DEK version, and structured details; all signed with per-node HMAC key

### Network & TLS Enhancements
- **SPIFFE mode** (`storage/src/network.rs`): `SpiffeTlsProvider` stub for SPIFFE Workload API integration with SVID TTL validation (max 1 hour, 5-minute renewal window)
- **Certificate expiry watchdog** (`storage/src/network.rs`): `CertExpiryWatchdog` background task for manual TLS mode; hourly checks with WARN at 7 days, ERROR at 2 days, optional shutdown on expiry
- **SVID validation**: Enforces `spiffe://<trust-domain>/keystone/storage/<role>` pattern matching

### Cluster Admin Service Updates
- **DEK rotation RPC handlers** (`storage/src/grpc/cluster_admin_service.rs`): `rotate_dek` and `confirm_rotate_dek` endpoints with dual-control for emergency rotation
- **Node ID uniqueness check** (`storage/src/app.rs`): Validates no `(node_id, rpc_addr)` collision exists in committed membership at startup and on `add_learner`; fails closed if membership cannot be queried
- **Audit integration**: All admin operations emit signed audit records

### Storage Initialization
- **DEK bootstrap refactoring** (`storage/src/lib.rs`): Returns shared `Arc<RwLock<Arc<DekEpoch>>>` handle for use by rotation handlers and admin operations
- **Nonce manager integration**: Durable monotonic counter for log entry nonces with high-water mark persistence and block reservation

### Operational Safeguards
- **Write-rate limiting**: Blocks writes to keys exceeding 2^30