### PR TITLE
chore: Reduce number of Keycloak pods in k8

### DIFF
--- a/tools/k8s/tests/keycloak/keycloak-replica-patch.yaml
+++ b/tools/k8s/tests/keycloak/keycloak-replica-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+spec:
+  replicas: 1

--- a/tools/k8s/tests/keycloak/kustomization.yaml
+++ b/tools/k8s/tests/keycloak/kustomization.yaml
@@ -5,3 +5,6 @@
 resources:
   #- deployment.yaml
   - https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/refs/heads/main/kubernetes/keycloak.yaml
+
+patchesStrategicMerge:
+  - keycloak-replica-patch.yaml


### PR DESCRIPTION
Patch kustomization for the Keycloak deployment to only start 1 instance
of the statefulset.
