### PR TITLE
refactor(federation): Drop openidconnect dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,15 +677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
 dependencies = [
  "rust_decimal",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "utf8-width",
 ]
@@ -2310,7 +2301,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2598,7 +2589,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2787,17 +2777,6 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2906,15 +2885,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3085,7 +3055,7 @@ checksum = "209cc18fddbe7caf18c1cacf692ecc60b7cb8b17423644abd5e9ca0283a27ecc"
 dependencies = [
  "async-trait",
  "percent-encoding",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",
@@ -3582,26 +3552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oauth2"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "getrandom 0.2.17",
- "http",
- "rand 0.8.6",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,37 +3611,6 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
-]
-
-[[package]]
-name = "openidconnect"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
-dependencies = [
- "base64 0.21.7",
- "chrono",
- "dyn-clone",
- "ed25519-dalek",
- "hmac 0.12.1",
- "http",
- "itertools 0.10.5",
- "log",
- "oauth2",
- "p256",
- "p384",
- "rand 0.8.6",
- "rsa",
- "serde",
- "serde-value",
- "serde_json",
- "serde_path_to_error",
- "serde_plain",
- "serde_with",
- "sha2 0.10.9",
- "subtle",
- "thiserror 1.0.69",
- "url",
 ]
 
 [[package]]
@@ -3825,7 +3744,6 @@ dependencies = [
  "inventory",
  "jsonwebtoken",
  "nix 0.31.3",
- "openidconnect",
  "openstack-keystone-api-types",
  "openstack-keystone-appcred-driver-sql",
  "openstack-keystone-assignment-driver-sql",
@@ -3848,7 +3766,8 @@ dependencies = [
  "openstack-keystone-token-restriction-driver-sql",
  "openstack-keystone-trust-driver-sql",
  "openstack-keystone-webauthn",
- "reqwest 0.13.4",
+ "rand 0.10.1",
+ "reqwest",
  "rstest",
  "rustls",
  "sea-orm",
@@ -3856,6 +3775,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha2 0.11.0",
  "spiffe",
  "spiffe-rustls",
  "spiffe-rustls-tokio",
@@ -3969,7 +3889,7 @@ dependencies = [
  "openstack-keystone-k8s-auth-driver-sql",
  "openstack-keystone-token-restriction-driver-sql",
  "openstack-keystone-webauthn",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "sea-orm",
  "sea-orm-migration",
@@ -4365,7 +4285,7 @@ dependencies = [
  "openstack-keystone-distributed-storage",
  "openstack-keystone-token-driver-fernet",
  "rcgen",
- "reqwest 0.13.4",
+ "reqwest",
  "reserve-port",
  "rmp-serde",
  "sea-orm",
@@ -4400,7 +4320,7 @@ dependencies = [
  "bytes",
  "inventory",
  "openstack-sdk-auth-core",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4424,7 +4344,7 @@ dependencies = [
  "dyn-clone",
  "http",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4443,7 +4363,7 @@ dependencies = [
  "async-trait",
  "inventory",
  "openstack-sdk-auth-core",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4464,7 +4384,7 @@ dependencies = [
  "bytes",
  "inventory",
  "openstack-sdk-auth-core",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4489,7 +4409,7 @@ dependencies = [
  "openstack-sdk-auth-password",
  "openstack-sdk-auth-token",
  "openstack-sdk-auth-totp",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4510,7 +4430,7 @@ dependencies = [
  "bytes",
  "inventory",
  "openstack-sdk-auth-core",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4531,7 +4451,7 @@ dependencies = [
  "bytes",
  "inventory",
  "openstack-sdk-auth-core",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4561,7 +4481,7 @@ dependencies = [
  "inventory",
  "open",
  "openstack-sdk-auth-core",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4750,7 +4670,7 @@ dependencies = [
  "openstack-sdk-object-store",
  "openstack-sdk-placement",
  "openstack_sdk_core",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4783,7 +4703,7 @@ dependencies = [
  "openstack-sdk-auth-core",
  "postcard",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4800,15 +4720,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ordered-float"
@@ -5046,7 +4957,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -5720,44 +5631,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http 0.6.11",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -6059,7 +5932,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -6155,18 +6027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -6285,7 +6145,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "inherent",
- "ordered-float 4.6.0",
+ "ordered-float",
  "rust_decimal",
  "sea-query-derive",
  "serde_json",
@@ -6436,16 +6296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float 2.10.1",
- "serde",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6491,7 +6341,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -6505,7 +6355,7 @@ version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -6521,15 +6371,6 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_plain"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -6580,18 +6421,8 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64 0.22.1",
- "bs58",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
  "serde_core",
- "serde_json",
  "serde_with_macros",
- "time",
 ]
 
 [[package]]
@@ -6872,7 +6703,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink 0.10.0",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "native-tls",
@@ -7238,7 +7069,7 @@ dependencies = [
  "http",
  "openstack-keystone-api-types",
  "openstack_sdk",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -7263,7 +7094,7 @@ dependencies = [
  "keycloak",
  "local-ip-address",
  "openstack-keystone-api-types",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -7324,9 +7155,9 @@ dependencies = [
  "fs4",
  "futures-util",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "pastey 0.2.3",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -7567,7 +7398,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -7659,7 +7490,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7995,7 +7826,7 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_json",
  "serde_norway",
@@ -8250,7 +8081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -8276,7 +8107,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -8406,15 +8237,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8795,7 +8617,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -8826,7 +8648,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -8845,7 +8667,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -9074,7 +8896,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "zopfli",
 ]
@@ -9087,7 +8909,7 @@ checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "typed-path",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ itertools = { version = "0.15" }
 mockall = { version = "0.14" }
 mockall_double = { version = "0.3" }
 nix = { version = "0.31", default-features = false }
-openidconnect = { version = "4.0" }
 openraft = { version = "=0.10.0-alpha.21" }
 openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "crates/api-types" }
 openstack-keystone-appcred-driver-sql = { version = "0.1", path = "crates/appcred-driver-sql/" }

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -54,8 +54,9 @@ openstack-keystone-token-driver-fernet.workspace = true
 openstack-keystone-token-restriction-driver-sql.workspace = true
 openstack-keystone-trust-driver-sql.workspace = true
 openstack-keystone-webauthn.workspace = true
-openidconnect.workspace = true
-reqwest = { workspace = true, features = ["json", "http2", "gzip", "deflate"] }
+rand.workspace = true
+reqwest = { workspace = true, features = ["json", "form", "http2", "gzip", "deflate"] }
+sha2.workspace = true
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 sea-orm = { workspace = true, features = ["sqlx-mysql", "sqlx-postgres", "sqlx-sqlite", "runtime-tokio", "runtime-tokio-native-tls"] }
 secrecy = { workspace = true, features = ["serde"] }

--- a/crates/keystone/src/federation/api.rs
+++ b/crates/keystone/src/federation/api.rs
@@ -32,6 +32,7 @@ pub mod error;
 pub mod identity_provider;
 pub mod jwt;
 pub mod oidc;
+mod oidc_utils;
 pub mod types;
 
 /// OpenApi specification for the federation.

--- a/crates/keystone/src/federation/api/auth.rs
+++ b/crates/keystone/src/federation/api/auth.rs
@@ -24,16 +24,14 @@ use tracing::debug;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use validator::Validate;
 
-use openidconnect::core::{CoreAuthenticationFlow, CoreClient, CoreProviderMetadata};
-use openidconnect::reqwest;
-use openidconnect::{
-    ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce, PkceCodeChallenge, RedirectUrl, Scope,
-};
-
 use crate::api::error::KeystoneApiError;
 use crate::federation::{api::error::OidcError, api::types::*};
 use crate::keystone::ServiceState;
 use openstack_keystone_core_types::federation::AuthState;
+
+use super::oidc_utils::{
+    build_auth_url, build_http_client, discover, generate_pkce, generate_random_token,
+};
 
 pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new().routes(routes!(post))
@@ -113,59 +111,50 @@ pub async fn post(
         return Err(OidcError::IdentityProviderDisabled.into());
     }
 
-    let client = if let Some(discovery_url) = &idp.oidc_discovery_url {
-        let http_client = reqwest::ClientBuilder::new()
-            // Following redirects opens the client up to SSRF vulnerabilities.
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .map_err(OidcError::from)?;
+    let discovery_url = idp
+        .oidc_discovery_url
+        .as_deref()
+        .ok_or(OidcError::ClientWithoutDiscoveryNotSupported)?;
 
-        let provider_metadata = CoreProviderMetadata::discover_async(
-            IssuerUrl::new(discovery_url.to_string()).map_err(OidcError::from)?,
-            &http_client,
-        )
+    let http_client = build_http_client()?;
+    let metadata = discover(discovery_url, &http_client)
         .await
         .map_err(|err| OidcError::discovery(discovery_url, &err))?;
 
-        // Validate redirect URI against the IDP's allowed_redirect_uris list.
-        if let Some(allowed) = &idp.allowed_redirect_uris
-            && !allowed.is_empty()
-            && !allowed.contains(&req.redirect_uri)
-        {
-            return Err(OidcError::RedirectUriNotAllowed.into());
-        }
+    // Validate redirect URI against the IDP's allowed_redirect_uris list.
+    if let Some(allowed) = &idp.allowed_redirect_uris
+        && !allowed.is_empty()
+        && !allowed.contains(&req.redirect_uri)
+    {
+        return Err(OidcError::RedirectUriNotAllowed.into());
+    }
 
-        CoreClient::from_provider_metadata(
-            provider_metadata,
-            ClientId::new(idp.oidc_client_id.ok_or(OidcError::ClientIdRequired)?),
-            idp.oidc_client_secret.map(ClientSecret::new),
-        )
-        // Set the URL the user will be redirected to after the authorization process.
-        .set_redirect_uri(RedirectUrl::new(req.redirect_uri.clone()).map_err(OidcError::from)?)
-    } else {
-        return Err(OidcError::ClientWithoutDiscoveryNotSupported.into());
-    };
+    let client_id = idp
+        .oidc_client_id
+        .as_deref()
+        .ok_or(OidcError::ClientIdRequired)?;
 
-    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+    let pkce = generate_pkce();
+    let csrf_token = generate_random_token();
+    let nonce = generate_random_token();
 
-    // `oidc` scope is the default in the openidconnect crate and do not need to be
-    // added explicitly.
-    let oidc_scopes: HashSet<Scope> = idp
+    let oidc_scopes: Vec<String> = idp
         .oidc_scopes
-        .map(|scopes| HashSet::from_iter(scopes.into_iter().map(Scope::new)))
+        .map(|scopes| {
+            let unique: HashSet<String> = scopes.into_iter().collect();
+            unique.into_iter().filter(|s| s != "openid").collect()
+        })
         .unwrap_or_default();
 
-    // Generate the full authorization URL.
-    let (auth_url, csrf_token, nonce) = client
-        .authorize_url(
-            CoreAuthenticationFlow::AuthorizationCode,
-            CsrfToken::new_random,
-            Nonce::new_random,
-        )
-        .add_scopes(oidc_scopes)
-        // Set the PKCE code challenge.
-        .set_pkce_challenge(pkce_challenge)
-        .url();
+    let auth_url = build_auth_url(
+        &metadata.authorization_endpoint,
+        client_id,
+        &req.redirect_uri,
+        &oidc_scopes,
+        &csrf_token,
+        &nonce,
+        &pkce.challenge,
+    )?;
 
     state
         .provider
@@ -173,11 +162,11 @@ pub async fn post(
         .create_auth_state(
             &state,
             AuthState {
-                state: csrf_token.secret().clone(),
-                nonce: nonce.secret().clone(),
+                state: csrf_token.clone(),
+                nonce: nonce.clone(),
                 idp_id: idp.id.clone(),
                 redirect_uri: req.redirect_uri.clone(),
-                pkce_verifier: pkce_verifier.into_secret(),
+                pkce_verifier: pkce.verifier,
                 expires_at: (Local::now() + TimeDelta::seconds(180)).into(),
                 // TODO: Make this configurable
                 scope: req.scope.map(Into::into),
@@ -185,12 +174,7 @@ pub async fn post(
         )
         .await?;
 
-    debug!(
-        "url: {:?}, csrf: {:?}, nonce: {:?}",
-        auth_url,
-        csrf_token.secret(),
-        nonce.secret()
-    );
+    debug!("Initiated OIDC auth, auth_url: {:?}", auth_url,);
     Ok((
         StatusCode::OK,
         Json(IdentityProviderAuthResponse {

--- a/crates/keystone/src/federation/api/common.rs
+++ b/crates/keystone/src/federation/api/common.rs
@@ -11,13 +11,20 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Shared helpers for federation claim flattening.
+//! Shared helpers for federation claim flattening and token issuance.
 
 use std::collections::HashMap;
 
 use serde_json::Value;
 
 use openstack_keystone_core_types::mapping::error::MappingProviderError;
+use openstack_keystone_core_types::scope::Scope;
+
+use crate::api::error::KeystoneApiError;
+use crate::api::types::{Catalog, CatalogService};
+use crate::api::v4::auth::token::types::TokenResponse as KeystoneTokenResponse;
+use crate::auth::SecurityContext;
+use crate::keystone::ServiceState;
 
 /// Maximum bytes allowed per individual claim value.
 const CLAIM_VALUE_LIMIT: usize = 4096;
@@ -25,12 +32,14 @@ const CLAIM_VALUE_LIMIT: usize = 4096;
 /// Maximum total serialized bytes for the flattened claims map.
 const CLAIMS_MAP_LIMIT: usize = 64 * 1024;
 
-/// Flatten a JSON claims object into the dotted-key claims map.
+/// Flatten a JSON claims object into a dotted-key claims map.
 ///
 /// Walks the JSON value recursively, accumulating dotted key paths
 /// (e.g., `user.profile.id`). Normalizes `String`, `Number`, and `Bool`
-/// values to their string representation. Nested objects are traversed;
-/// arrays are dropped (claim condition evaluation expects scalar values).
+/// values to their string representation. Nested objects are traversed.
+/// Arrays of scalars (string, number, bool, null) are collected into a
+/// `Vec<String>` under the current key. Arrays containing nested objects
+/// are flattened with indexed keys (e.g. `user.roles.0`, `user.roles.1`).
 ///
 /// Enforces per-claim (4096 bytes) and total map (64 KiB) size caps per
 /// ADR-0020 §9. Excess per-claim values are silently dropped; total map
@@ -59,6 +68,25 @@ pub(super) fn flatten_federation_claims(
     Ok(claims)
 }
 
+/// Check if all items in the array are scalar types (no nested objects/arrays).
+fn is_scalar(item: &Value) -> bool {
+    matches!(
+        item,
+        Value::String(_) | Value::Number(_) | Value::Bool(_) | Value::Null
+    )
+}
+
+/// Convert a scalar JSON value to its string representation.
+fn scalar_as_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Null => String::new(),
+        Value::Array(_) | Value::Object(_) => unreachable!(),
+    }
+}
+
 /// Recursively flatten a JSON value into the claims map.
 ///
 /// # Arguments
@@ -70,35 +98,290 @@ fn flatten_value(
     prefix: Option<&str>,
     claims: &mut HashMap<String, Vec<String>>,
 ) -> Result<(), MappingProviderError> {
+    let key = prefix.unwrap_or("*").to_string();
+
     match value {
         Value::Object(map) => {
-            for (key, val) in map {
-                let next = match prefix {
-                    Some(p) => Some(format!("{p}.{key}")),
-                    None => Some(key.clone()),
+            for (sub_key, sub_val) in map {
+                let next_key = if prefix.is_some() {
+                    format!("{key}.{sub_key}")
+                } else {
+                    sub_key.to_string()
                 };
-                flatten_value(val, next.as_deref(), claims)?;
+                flatten_value(sub_val, Some(&next_key), claims)?;
+            }
+        }
+        Value::Array(arr) => {
+            if arr.iter().all(is_scalar) {
+                // Flat scalar array: collect directly into claims[key].
+                for item in arr {
+                    let s = scalar_as_string(item);
+                    // Silently drop oversized values per ADR-0020 §9
+                    if s.len() <= CLAIM_VALUE_LIMIT {
+                        claims.entry(key.clone()).or_default().push(s);
+                    }
+                }
+            } else {
+                // Array of nested objects: flatten with indexed keys.
+                for (i, item) in arr.iter().enumerate() {
+                    let next_key = format!("{key}.{i}");
+                    flatten_value(item, Some(&next_key), claims)?;
+                }
             }
         }
         Value::String(s) => {
-            let key = prefix.unwrap_or("*").to_string();
             // Silently drop oversized values per ADR-0020 §9
             if s.len() <= CLAIM_VALUE_LIMIT {
                 claims.entry(key).or_default().push(s.clone());
             }
         }
         Value::Number(n) => {
-            let key = prefix.unwrap_or("*").to_string();
             let s = n.to_string();
             if s.len() <= CLAIM_VALUE_LIMIT {
                 claims.entry(key).or_default().push(s);
             }
         }
         Value::Bool(b) => {
-            let key = prefix.unwrap_or("*").to_string();
             claims.entry(key).or_default().push(b.to_string());
         }
-        Value::Null | Value::Array(_) => {}
+        Value::Null => {}
     }
     Ok(())
+}
+
+/// Build the Keystone token response from the mapping engine auth result.
+///
+/// Common boilerplate shared between OIDC callback and JWT login handlers:
+/// resolves scope authorization, issues the token, attaches the service
+/// catalog, and encodes the token.
+///
+/// # Arguments
+/// * `state` - The service state.
+/// * `auth_result` - AuthenticationResult from `authenticate_by_mapping`.
+/// * `scope` - Scope requested during OIDC auth init (None for JWT flow).
+///
+/// # Returns
+/// Tuple of (token_string, api_token_response_body).
+/// The caller is responsible for attaching the response body to the HTTP
+/// response and including the token string in the `x-subject-token` header.
+pub(super) async fn build_token_response(
+    state: &ServiceState,
+    auth_result: &openstack_keystone_core_types::auth::AuthenticationResult,
+    scope: Option<&Scope>,
+) -> Result<(String, KeystoneTokenResponse), KeystoneApiError> {
+    use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
+    use openstack_keystone_core::api::common::get_authz_info;
+
+    let authz_info = get_authz_info(state, scope).await?;
+    tracing::trace!("Granting the scope: {:?}", authz_info);
+
+    let vsc = state
+        .provider
+        .get_token_provider()
+        .issue_token_context(
+            state,
+            &SecurityContext::try_from(auth_result.clone())?,
+            &authz_info,
+        )
+        .await?;
+
+    let token_string = state
+        .provider
+        .get_token_provider()
+        .encode_token(vsc.token()?)?;
+
+    let mut api_token = KeystoneTokenResponse {
+        token: TokenBuilder::try_from(&vsc)?.build()?,
+    };
+    let catalog = Catalog(
+        state
+            .provider
+            .get_catalog_provider()
+            .get_catalog(state, true)
+            .await?
+            .into_iter()
+            .map(|(s, es)| CatalogService {
+                id: s.id.clone(),
+                name: s.name(),
+                r#type: s.r#type,
+                endpoints: es.into_iter().map(Into::into).collect(),
+            })
+            .collect::<Vec<_>>(),
+    );
+    api_token.token.catalog = Some(catalog);
+
+    Ok((token_string, api_token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flatten_string_claim() {
+        let json = serde_json::json!({"name": "Alice"});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("name").unwrap(), vec!["Alice"]);
+    }
+
+    #[test]
+    fn flatten_bool_claim() {
+        let json = serde_json::json!({"active": true, "disabled": false});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("active").unwrap(), vec!["true"]);
+        assert_eq!(*claims.get("disabled").unwrap(), vec!["false"]);
+    }
+
+    #[test]
+    fn flatten_number_claim() {
+        let json = serde_json::json!({"age": 42, "score": 3.14});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("age").unwrap(), vec!["42"]);
+        assert_eq!(*claims.get("score").unwrap(), vec!["3.14"]);
+    }
+
+    #[test]
+    fn flatten_null_is_dropped() {
+        let json = serde_json::json!({"name": "A", "nothing": null});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert!(!claims.contains_key("nothing"));
+    }
+
+    #[test]
+    fn flatten_nested_object() {
+        let json = serde_json::json!({"user": {"profile": {"name": "Alice"}}});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("user.profile.name").unwrap(), vec!["Alice"]);
+    }
+
+    #[test]
+    fn flatten_scalar_array() {
+        let json = serde_json::json!({"groups": ["admin", "users", "readers"]});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(
+            *claims.get("groups").unwrap(),
+            vec!["admin", "users", "readers"]
+        );
+    }
+
+    #[test]
+    fn flatten_mixed_scalar_array() {
+        let json = serde_json::json!({"values": ["text", 42, true, null]});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(
+            *claims.get("values").unwrap(),
+            vec!["text", "42", "true", ""]
+        );
+    }
+
+    #[test]
+    fn flatten_array_of_objects() {
+        let json = serde_json::json!({ "roles": [{"id": "r1", "name": "admin"}, {"id": "r2", "name": "editor"}] });
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("roles.0.id").unwrap(), vec!["r1"]);
+        assert_eq!(*claims.get("roles.0.name").unwrap(), vec!["admin"]);
+        assert_eq!(*claims.get("roles.1.id").unwrap(), vec!["r2"]);
+        assert_eq!(*claims.get("roles.1.name").unwrap(), vec!["editor"]);
+    }
+
+    #[test]
+    fn flatten_deeply_nested() {
+        let json = serde_json::json!({"a": {"b": {"c": {"d": "deep"}}}});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("a.b.c.d").unwrap(), vec!["deep"]);
+    }
+
+    #[test]
+    fn flatten_empty_object() {
+        let json = serde_json::json!({});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert!(claims.is_empty());
+    }
+
+    #[test]
+    fn flatten_overlarge_value_dropped() {
+        let large = "x".repeat(CLAIM_VALUE_LIMIT + 1);
+        let json = serde_json::json!({"ok": "short", "huge": large});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("ok").unwrap(), vec!["short"]);
+        assert!(
+            !claims.contains_key("huge"),
+            "oversized value must be dropped"
+        );
+    }
+
+    #[test]
+    fn flatten_overlarge_map_returns_error() {
+        let vals: Vec<String> = (0..1000).map(|i| format!("key{i}").repeat(70)).collect();
+        let mut map = serde_json::Map::new();
+        for v in vals {
+            map.insert(v.clone(), serde_json::Value::String(("v".to_string() + &v)));
+        }
+        let claims = flatten_federation_claims(&Value::Object(map));
+        assert!(
+            matches!(claims, Err(MappingProviderError::ClaimsMapTooLarge)),
+            "over 64 KiB map must return error"
+        );
+    }
+
+    #[test]
+    fn flatten_oversized_array_item_dropped() {
+        let large = "x".repeat(CLAIM_VALUE_LIMIT + 1);
+        let json = serde_json::json!({"groups": ["admin", large]});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("groups").unwrap(), vec!["admin"]);
+    }
+
+    #[test]
+    fn flatten_empty_key_default() {
+        // Top-level value with no prefix should use "*" key.
+        let claims = flatten_federation_claims(&serde_json::json!("orphan"));
+        assert!(claims.is_ok() && claims.unwrap().get("*").is_some());
+    }
+
+    #[test]
+    fn flatten_complex_oidc_like_claims() {
+        let json = serde_json::json!({
+            "sub": "user123",
+            "iss": "https://idp.example.com",
+            "aud": ["my-client", "other-client"],
+            "groups": ["admin", "readers"],
+            "email": "alice@example.com",
+            "email_verified": true,
+            "user": {
+                "profile": {
+                    "name": "Alice",
+                    "roles": [
+                        {"id": "r1", "display_name": "Admin"},
+                        {"id": "r2", "display_name": "Editor"}
+                    ]
+                }
+            }
+        });
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert_eq!(*claims.get("sub").unwrap(), vec!["user123"]);
+        assert_eq!(
+            *claims.get("aud").unwrap(),
+            vec!["my-client", "other-client"]
+        );
+        assert_eq!(*claims.get("groups").unwrap(), vec!["admin", "readers"]);
+        assert_eq!(*claims.get("email_verified").unwrap(), vec!["true"]);
+        assert_eq!(*claims.get("user.profile.name").unwrap(), vec!["Alice"]);
+        assert_eq!(*claims.get("user.profile.roles.0.id").unwrap(), vec!["r1"]);
+        assert_eq!(
+            *claims.get("user.profile.roles.0.display_name").unwrap(),
+            vec!["Admin"]
+        );
+        assert_eq!(
+            *claims.get("user.profile.roles.1.display_name").unwrap(),
+            vec!["Editor"]
+        );
+    }
+
+    #[test]
+    fn flatten_empty_array_is_noop() {
+        let json = serde_json::json!({"groups": []});
+        let claims = flatten_federation_claims(&json).unwrap();
+        assert!(!claims.contains_key("groups"));
+    }
 }

--- a/crates/keystone/src/federation/api/error.rs
+++ b/crates/keystone/src/federation/api/error.rs
@@ -15,82 +15,115 @@
 use thiserror::Error;
 use tracing::{Level, error, instrument};
 
-use openstack_keystone_core_types::mapping::error::MappingProviderError;
-
 use crate::api::error::KeystoneApiError;
 
 #[derive(Error, Debug)]
 pub enum OidcError {
+    /// OIDC Discovery error.
     #[error("discovery error for {url}: {msg}")]
-    Discovery { url: String, msg: String },
+    Discovery {
+        /// IdP URL.
+        url: String,
+        /// Error message.
+        msg: String,
+    },
 
     #[error("client without discovery is not supported")]
     ClientWithoutDiscoveryNotSupported,
-
-    #[error("mapping id or mapping name with idp id must be specified")]
-    MappingIdOrNameWithIdp,
 
     #[error(
         "federated authentication requires mapping being specified in the payload or default set on the identity provider"
     )]
     MappingRequired,
 
-    #[error("JWT login requires `openstack-mapping` header to be present.")]
-    MappingRequiredJwt,
-
     #[error("`bearer` authorization token is missing.")]
     BearerJwtTokenMissing,
 
+    /// IdP is disabled.
     #[error("identity provider is disabled")]
     IdentityProviderDisabled,
 
-    #[error("mapping is disabled")]
-    MappingDisabled,
+    /// Redirect URI is not in the allowed list for the identity provider.
+    #[error("redirect URI not allowed by identity provider")]
+    RedirectUriNotAllowed,
 
     #[error("request token error")]
     RequestToken { msg: String },
 
-    #[error("claim verification error")]
-    ClaimVerification {
+    /// JWT decode or signature verification failed.
+    #[error("JWT decode/verification error")]
+    JwtDecode {
         #[from]
-        source: openidconnect::ClaimsVerificationError,
+        source: jsonwebtoken::errors::Error,
     },
 
-    #[error(transparent)]
-    OpenIdConnectReqwest {
+    /// HTTP request to IdP failed.
+    #[error("HTTP request error")]
+    HttpRequest {
         #[from]
-        source: openidconnect::reqwest::Error,
+        source: reqwest::Error,
     },
 
-    #[error(transparent)]
-    OpenIdConnectConfiguration {
-        #[from]
-        source: openidconnect::ConfigurationError,
-    },
-
-    #[error(transparent)]
+    #[error("transparent")]
     UrlParse {
         #[from]
         source: url::ParseError,
     },
 
-    #[error("server did not return an ID token")]
+    /// No JWK matched the key ID from the JWT header.
+    #[error("no matching JWK found for kid `{0}`")]
+    JwkNotFound(String),
+
+    /// JWT nonce claim does not match the expected value.
+    #[error("nonce mismatch in ID token")]
+    NonceMismatch,
+
+    /// JWKS is empty or all keys failed to load.
+    #[error("JWKS contains no usable keys")]
+    NoJwksKeys,
+
+    /// The JWT was signed with an algorithm that is not permitted (e.g.
+    /// symmetric HS256).
+    #[error("unsupported JWT signing algorithm: {0}")]
+    UnsupportedAlgorithm(String),
+
+    #[error("server did not returned an ID token")]
     NoToken,
 
     #[error("identity Provider client_id is missing")]
     ClientIdRequired,
 
+    /// Authentication expired.
     #[error("authentication expired")]
     AuthStateExpired,
 
+    /// No JWT issuer can be identified for the mapping.
     #[error("no jwt issuer can be determined")]
     NoJwtIssuer,
 
-    #[error("mapping engine error: {0}")]
-    MappingEngine(String),
+    /// Issuer in discovery document does not match the requested issuer URL
+    /// (RFC 8414 §3).
+    #[error("issuer mismatch: expected `{expected}`, got `{actual}`")]
+    IssuerMismatch {
+        /// Issuer URL the caller expected.
+        expected: String,
+        /// Issuer URL returned by the discovery document.
+        actual: String,
+    },
 
-    #[error("redirect URI is not allowed")]
-    RedirectUriNotAllowed,
+    /// Flattened claims map exceeds 64 KiB limit (ADR-0020 §9).
+    #[error("claims map size exceeds 64 KiB limit")]
+    ClaimsMapTooLarge,
+
+    /// The `iat` claim is too far in the future, indicating clock skew or a
+    /// forged token.
+    #[error("iat {iat} is in the future (current time: {now})")]
+    IatInFuture {
+        /// The `iat` claim value (Unix timestamp).
+        iat: u64,
+        /// Current time (Unix timestamp).
+        now: u64,
+    },
 }
 
 impl OidcError {
@@ -107,68 +140,81 @@ impl OidcError {
     }
 }
 
+/// Convert OIDC error into the [HTTP](KeystoneApiError) with the expected
+/// message.
 impl From<OidcError> for KeystoneApiError {
     #[instrument(level = Level::ERROR)]
     fn from(value: OidcError) -> Self {
         error!("Federation error: {:#?}", value);
         match value {
-            e @ OidcError::Discovery { .. } => KeystoneApiError::InternalError(e.to_string()),
+            e @ OidcError::Discovery { .. } => {
+                KeystoneApiError::InternalError(e.to_string())
+            }
             e @ OidcError::ClientWithoutDiscoveryNotSupported => {
                 KeystoneApiError::InternalError(e.to_string())
             }
             OidcError::IdentityProviderDisabled => {
                 KeystoneApiError::BadRequest("Federated Identity Provider is disabled.".to_string())
             }
-            OidcError::MappingDisabled => {
-                KeystoneApiError::BadRequest("Federated Identity Provider mapping is disabled.".to_string())
-            }
             OidcError::MappingRequired => {
                 KeystoneApiError::BadRequest("Federated authentication requires mapping being specified in the payload or default set on the identity provider.".to_string())
             }
-            OidcError::MappingIdOrNameWithIdp => KeystoneApiError::BadRequest(
-                "Federated authentication requires mapping being specified in the payload either with ID or name with identity provider id.".to_string(),
-            ),
-            OidcError::MappingRequiredJwt => KeystoneApiError::BadRequest(
-                "JWT authentication requires `openstack-mapping` header to be provided.".to_string(),
-            ),
-            OidcError::BearerJwtTokenMissing => KeystoneApiError::BadRequest(
-                "`bearer` token is missing in the `Authorization` header.".to_string(),
-            ),
-            OidcError::RequestToken { msg } => KeystoneApiError::BadRequest(format!(
-                "Error exchanging authorization code for the authorization token: {msg}"
-            )),
-            OidcError::ClaimVerification { source } => {
-                KeystoneApiError::BadRequest(format!("Error in claims verification: {source}"))
+            OidcError::BearerJwtTokenMissing => {
+                KeystoneApiError::BadRequest("`bearer` token is missing in the `Authorization` header.".to_string())
             }
-            OidcError::OpenIdConnectReqwest { source } => {
-                KeystoneApiError::InternalError(format!("Error in OpenIDConnect logic: {source}"))
+            OidcError::RequestToken { msg } => {
+                KeystoneApiError::BadRequest(format!("Error exchanging authorization code for the authorization token: {msg}"))
             }
-            OidcError::OpenIdConnectConfiguration { source } => {
-                KeystoneApiError::InternalError(format!("Error in OpenIDConnect logic: {source}"))
+            OidcError::JwtDecode { source } => {
+                KeystoneApiError::BadRequest(format!("JWT verification error: {source}"))
+            }
+            OidcError::HttpRequest { source } => {
+                KeystoneApiError::InternalError(format!("HTTP request error: {source}"))
             }
             OidcError::UrlParse { source } => {
-                KeystoneApiError::BadRequest(format!("Error in OpenIDConnect logic: {source}"))
+                KeystoneApiError::BadRequest(format!("URL parse error: {source}"))
+            }
+            OidcError::NonceMismatch => {
+                KeystoneApiError::BadRequest("Nonce mismatch in ID token.".to_string())
+            }
+            OidcError::JwkNotFound(kid) => {
+                KeystoneApiError::BadRequest(format!("No matching JWK for kid `{kid}`"))
+            }
+            OidcError::NoJwksKeys => {
+                KeystoneApiError::InternalError("JWKS contains no usable keys.".to_string())
+            }
+            OidcError::UnsupportedAlgorithm(alg) => {
+                KeystoneApiError::BadRequest(format!("Unsupported JWT algorithm: {alg}"))
             }
             e @ OidcError::NoToken => {
-                KeystoneApiError::InternalError(format!("Error in OpenIDConnect logic: {e}"))
+                KeystoneApiError::InternalError(format!("Error in OIDC logic: {e}"))
             }
             OidcError::ClientIdRequired => {
                 KeystoneApiError::BadRequest("Identity Provider must set `client_id`.".to_string())
             }
-            OidcError::AuthStateExpired => KeystoneApiError::BadRequest(
-                "Authentication has expired. Please start again.".to_string(),
-            ),
-            OidcError::RedirectUriNotAllowed => KeystoneApiError::BadRequest(
-                "redirect_uri is not allowed for this identity provider.".to_string(),
-            ),
-            OidcError::NoJwtIssuer => KeystoneApiError::unauthorized(value, Some("no jwt issuer")),
-            OidcError::MappingEngine(_msg) => KeystoneApiError::UnauthorizedNoContext,
+            OidcError::ClaimsMapTooLarge => {
+                KeystoneApiError::BadRequest("Federated claims map is too large.".to_string())
+            }
+            OidcError::RedirectUriNotAllowed => {
+                KeystoneApiError::BadRequest("Redirect URI not allowed.".to_string())
+            }
+            OidcError::AuthStateExpired => {
+                KeystoneApiError::BadRequest("Authentication has expired. Please start again.".to_string())
+            }
+            OidcError::IssuerMismatch { expected, actual } => {
+                KeystoneApiError::BadRequest(format!(
+                    "OIDC issuer mismatch: expected `{expected}`, got `{actual}`"
+                ))
+            }
+            OidcError::NoJwtIssuer => {
+                // Not exposing info about mapping and idp existence.
+                KeystoneApiError::unauthorized(value, Some("mapping error"))
+            }
+            OidcError::IatInFuture { iat, now } => {
+                KeystoneApiError::BadRequest(format!(
+                    "ID token iat ({iat}) is in the future (current: {now})"
+                ))
+            }
         }
-    }
-}
-
-impl From<MappingProviderError> for OidcError {
-    fn from(value: MappingProviderError) -> Self {
-        Self::MappingEngine(value.to_string())
     }
 }

--- a/crates/keystone/src/federation/api/jwt.rs
+++ b/crates/keystone/src/federation/api/jwt.rs
@@ -14,49 +14,28 @@
 //! JWT based authentication API.
 
 use axum::{
-    Json, debug_handler,
+    debug_handler,
     extract::{Path, State},
     http::{HeaderMap, StatusCode, header::AUTHORIZATION},
     response::IntoResponse,
 };
-use std::str::FromStr;
-use tracing::{trace, warn};
+use tracing::warn;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
-use openidconnect::core::{
-    CoreClient, CoreGenderClaim, CoreJsonWebKey, CoreJweContentEncryptionAlgorithm,
-    CoreJwsSigningAlgorithm, CoreProviderMetadata,
-};
-use openidconnect::reqwest;
-use openidconnect::{Client, ClientId, IdToken, IssuerUrl, JsonWebKeySet, JsonWebKeySetUrl, Nonce};
-
+use crate::api::error::KeystoneApiError;
 use crate::api::v4::auth::token::types::TokenResponse as KeystoneTokenResponse;
-use crate::api::{
-    KeystoneApiError,
-    types::{Catalog, CatalogService},
-};
-use crate::auth::*;
 use crate::federation::api::error::OidcError;
 use crate::keystone::ServiceState;
-use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
-use openstack_keystone_core::api::common::get_authz_info;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
 
 use super::common;
-use super::types::*;
+use super::oidc_utils::{build_http_client, discover, fetch_jwks, verify_jwt};
 
 pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new().routes(routes!(login))
 }
-
-type FullIdToken = IdToken<
-    AllOtherClaims,
-    CoreGenderClaim,
-    CoreJweContentEncryptionAlgorithm,
-    CoreJwsSigningAlgorithm,
->;
 
 #[utoipa::path(
     post,
@@ -109,7 +88,7 @@ pub async fn login(
         .map_err(|_| KeystoneApiError::InvalidHeader)?
         .split_once(' ')
     {
-        Some(("bearer", token)) => token.to_string(),
+        Some((scheme, token)) if scheme.eq_ignore_ascii_case("bearer") => token.to_string(),
         _ => return Err(OidcError::BearerJwtTokenMissing.into()),
     };
 
@@ -134,7 +113,7 @@ pub async fn login(
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {
                 resource: "identity provider".into(),
-                identifier: idp_id.clone(),
+                identifier: idp_id,
             })
         })??;
 
@@ -143,77 +122,65 @@ pub async fn login(
     }
 
     // Build the HTTP client with strict redirect policy.
-    let http_client = reqwest::ClientBuilder::new()
-        // Following redirects opens the client up to SSRF vulnerabilities.
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .map_err(OidcError::from)?;
+    let http_client = build_http_client()?;
 
     // Discover metadata when issuer or jwks_url is not known.
-    let provider_metadata: Option<CoreProviderMetadata> = if let Some(discovery_url) =
-        &idp.oidc_discovery_url
+    let metadata = if let Some(discovery_url) = &idp.oidc_discovery_url
         && (idp.bound_issuer.is_none() || idp.jwks_url.is_none())
     {
         Some(
-            CoreProviderMetadata::discover_async(
-                IssuerUrl::new(discovery_url.to_string()).map_err(OidcError::from)?,
-                &http_client,
-            )
-            .await
-            .map_err(|err| OidcError::discovery(discovery_url, &err))?,
+            discover(discovery_url, &http_client)
+                .await
+                .map_err(|err| OidcError::discovery(discovery_url, &err))?,
         )
     } else {
         None
     };
 
-    let issuer_url = if let Some(bound_issuer) = &idp.bound_issuer {
-        IssuerUrl::new(bound_issuer.clone()).map_err(OidcError::from)?
-    } else if let Some(metadata) = &provider_metadata {
-        metadata.issuer().clone()
-    } else {
+    let issuer_url = idp
+        .bound_issuer
+        .as_deref()
+        .map(|s| s.to_string())
+        .or_else(|| metadata.as_ref().map(|m| m.issuer.to_string()));
+
+    if issuer_url.is_none() {
         warn!("No issuer_url can be determined for {:?}", idp);
         return Err(OidcError::NoJwtIssuer.into());
-    };
+    }
 
     let jwks_url = if let Some(jwks_url) = &idp.jwks_url {
-        JsonWebKeySetUrl::new(jwks_url.clone()).map_err(OidcError::from)?
-    } else if let Some(metadata) = &provider_metadata {
-        metadata.jwks_uri().clone()
+        jwks_url.clone()
+    } else if let Some(ref md) = metadata {
+        md.jwks_uri.clone()
     } else {
         warn!("No jwks_url can be determined for {:?}", idp);
         return Err(OidcError::NoJwtIssuer.into());
     };
 
-    let jwks: JsonWebKeySet<CoreJsonWebKey> = JsonWebKeySet::fetch_async(&jwks_url, &http_client)
+    let jwks = fetch_jwks(&jwks_url, &http_client)
         .await
-        .map_err(|err| OidcError::discovery(jwks_url.as_str(), &err))?;
+        .map_err(|err| OidcError::discovery(&jwks_url, &err))?;
 
-    let audience = "keystone";
-    let client: CoreClient = Client::new(
-        ClientId::new(audience.to_string()),
-        issuer_url.clone(),
-        jwks,
-    );
-
-    let id_token = FullIdToken::from_str(&jwt)?;
-
-    // We disable audience matching because the JWT Bearer token is not necessarily
-    // issued to the keystone audience. The identity provider handles audience
-    // validation through its configured bound_issuer.
-    let id_token_verifier = client.id_token_verifier().require_audience_match(false);
-    // The nonce is not used in the JWT flow, so we can ignore it.
-    let nonce_verifier = |_nonce: Option<&Nonce>| Ok(());
-    let claims = id_token
-        .into_claims(&id_token_verifier, &nonce_verifier)
-        .map_err(OidcError::from)?;
+    // Verify the JWT and extract claims. In the JWT flow we don't enforce audience
+    // matching because the JWT Bearer token is not necessarily issued to the
+    // keystone audience. The identity provider handles audience validation through
+    // its configured bound_issuer.
+    let claims_value: serde_json::Value =
+        verify_jwt(&jwt, &jwks, issuer_url.as_deref(), None, &[])?;
 
     // Flatten claims for the mapping engine. The `sub` claim provides a stable
     // unique identifier for the federated user.
-    let claims_json = serde_json::to_value(&claims)?;
-    let flattened = common::flatten_federation_claims(&claims_json).map_err(OidcError::from)?;
+    let flattened = common::flatten_federation_claims(&claims_value)
+        .map_err(|_| OidcError::ClaimsMapTooLarge)?;
 
-    // Extract the unique workload identifier from the `sub` claim.
-    let unique_workload_id = claims.subject().as_str().to_string();
+    // Extract the unique workload identifier from the required `sub` claim.
+    // OIDC Core §3.1.2: "REQUIRED subject identifier"
+    let unique_workload_id = claims_value["sub"]
+        .as_str()
+        .ok_or_else(|| {
+            KeystoneApiError::BadRequest("`sub` claim is missing from ID token".to_string())
+        })?
+        .to_string();
 
     // Delegate to the mapping engine for identity resolution. The rule_name
     // hint from the `openstack-mapping` header allows targeted rule matching.
@@ -234,50 +201,13 @@ pub async fn login(
         .await?;
 
     // No scope is requested in JWT flow, so we resolve unscoped token.
-    let authz_info = get_authz_info(&state, None).await?;
-    trace!("Granting the scope: {:?}", authz_info);
+    let (token_str, api_token) = common::build_token_response(&state, &auth_result, None).await?;
 
-    // Issue token with validated security context.
-    let vsc = state
-        .provider
-        .get_token_provider()
-        .issue_token_context(
-            &state,
-            &SecurityContext::try_from(auth_result)?,
-            &authz_info,
-        )
-        .await?;
-
-    let mut api_token = KeystoneTokenResponse {
-        token: TokenBuilder::try_from(&vsc)?.build()?,
-    };
-    let catalog: Catalog = Catalog(
-        state
-            .provider
-            .get_catalog_provider()
-            .get_catalog(&state, true)
-            .await?
-            .into_iter()
-            .map(|(s, es)| CatalogService {
-                id: s.id.clone(),
-                name: s.name(),
-                r#type: s.r#type,
-                endpoints: es.into_iter().map(Into::into).collect(),
-            })
-            .collect::<Vec<_>>(),
-    );
-    api_token.token.catalog = Some(catalog);
-
+    tracing::trace!("Token response is {:?}", api_token);
     Ok((
         StatusCode::OK,
-        [(
-            "X-Subject-Token",
-            state
-                .provider
-                .get_token_provider()
-                .encode_token(vsc.token()?)?,
-        )],
-        Json(api_token),
+        [("x-subject-token", token_str)],
+        axum::Json(api_token),
     )
         .into_response())
 }

--- a/crates/keystone/src/federation/api/oidc.rs
+++ b/crates/keystone/src/federation/api/oidc.rs
@@ -15,34 +15,20 @@
 
 use axum::{Json, debug_handler, extract::State, http::StatusCode, response::IntoResponse};
 use chrono::Utc;
-use eyre::WrapErr;
-use tracing::{debug, trace};
 use url::Url;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
-use openidconnect::core::CoreProviderMetadata;
-use openidconnect::reqwest;
-use openidconnect::{
-    AuthorizationCode, ClientId, ClientSecret, IssuerUrl, Nonce, PkceCodeVerifier, RedirectUrl,
-    TokenResponse,
-};
-
+use crate::api::error::KeystoneApiError;
 use crate::api::v4::auth::token::types::TokenResponse as KeystoneTokenResponse;
-use crate::api::{
-    KeystoneApiError,
-    types::{Catalog, CatalogService},
-};
-use crate::auth::*;
 use crate::federation::api::error::OidcError;
+use crate::federation::api::types::*;
 use crate::keystone::ServiceState;
-use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
-use openstack_keystone_core::api::common::get_authz_info;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
 
 use super::common;
-use super::types::*;
+use super::oidc_utils::{build_http_client, discover, exchange_code, fetch_jwks, verify_jwt};
 
 pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new().routes(routes!(callback))
@@ -51,7 +37,8 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
 #[utoipa::path(
     post,
     path = "/oidc/callback",
-    operation_id = "/federation/oidc:callback",
+    operation_id = "federation/oidc/callback",
+    request_body = AuthCallbackParameters,
     responses(
         (
             status = OK,
@@ -108,69 +95,88 @@ pub async fn callback(
     }
 
     // Build the HTTP client with strict redirect policy.
-    let http_client = reqwest::ClientBuilder::new()
-        // Following redirects opens the client up to SSRF vulnerabilities.
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .map_err(OidcError::from)?;
+    let http_client = build_http_client()?;
 
-    let client = if let Some(discovery_url) = &idp.oidc_discovery_url {
-        let provider_metadata = CoreProviderMetadata::discover_async(
-            IssuerUrl::new(discovery_url.to_string()).map_err(OidcError::from)?,
-            &http_client,
-        )
+    let discovery_url = idp
+        .oidc_discovery_url
+        .as_deref()
+        .ok_or(OidcError::ClientWithoutDiscoveryNotSupported)?;
+
+    let metadata = discover(discovery_url, &http_client)
         .await
         .map_err(|err| OidcError::discovery(discovery_url, &err))?;
-        OidcClient::from_provider_metadata(
-            provider_metadata,
-            ClientId::new(
-                idp.oidc_client_id
-                    .clone()
-                    .ok_or(OidcError::ClientIdRequired)?,
-            ),
-            idp.oidc_client_secret.clone().map(ClientSecret::new),
-        )
-        // Set the redirect_uri to protect the authorization code from being stolen.
-        .set_redirect_uri(RedirectUrl::new(auth_state.redirect_uri).map_err(OidcError::from)?)
-    } else {
-        return Err(OidcError::ClientWithoutDiscoveryNotSupported.into());
-    };
 
-    // Exchange the authorization code for the token.
-    let token_response = client
-        .exchange_code(AuthorizationCode::new(query.code))
-        .map_err(OidcError::from)?
-        // Set the PKCE code verifier to prevent authorization code injection.
-        .set_pkce_verifier(PkceCodeVerifier::new(auth_state.pkce_verifier))
-        .request_async(&http_client)
+    let jwks = fetch_jwks(metadata.jwks_uri.as_str(), &http_client)
         .await
-        .map_err(|err| OidcError::request_token(&err))?;
+        .map_err(|err| OidcError::discovery(&metadata.jwks_uri, &err))?;
 
-    // Extract the ID token claims after verifying its authenticity and nonce.
-    let id_token = token_response.id_token().ok_or(OidcError::NoToken)?;
-    let claims = id_token
-        .claims(&client.id_token_verifier(), &Nonce::new(auth_state.nonce))
-        .map_err(OidcError::from)?;
+    let client_id = idp
+        .oidc_client_id
+        .as_deref()
+        .ok_or(OidcError::ClientIdRequired)?;
+
+    // Exchange the authorization code for tokens.
+    let token_response = exchange_code(
+        &metadata.token_endpoint,
+        client_id,
+        idp.oidc_client_secret.as_deref(),
+        &query.code,
+        &auth_state.redirect_uri,
+        &auth_state.pkce_verifier,
+        &http_client,
+    )
+    .await?;
+
+    let id_token = token_response.id_token.ok_or(OidcError::NoToken)?;
+
+    // Verify OIDC ID token and extract claims. OIDC Core §3.1.3.7: the `aud`
+    // claim MUST contain the RP's client ID.  Validate issuer, nonce, and
+    // audience in a single verification pass.
+    let claims_value: serde_json::Value = verify_jwt(
+        &id_token,
+        &jwks,
+        Some(metadata.issuer.as_str()),
+        Some(&auth_state.nonce),
+        &[client_id],
+    )?;
 
     // Validate the bound_issuer against the claims issuer URL to prevent token
     // reuse across different IdPs.
-    if let Some(bound_issuer) = &idp.bound_issuer
-        && Url::parse(bound_issuer)
-            .map_err(OidcError::from)
-            .wrap_err_with(|| {
-                format!("while parsing the mapping bound_issuer url: {bound_issuer}")
-            })?
-            == *claims.issuer().url()
-    {}
+    if let Some(bound_issuer) = &idp.bound_issuer {
+        let claims_issuer = claims_value["iss"].as_str().ok_or_else(|| {
+            KeystoneApiError::BadRequest("ID token does not contain issuer claim".to_string())
+        })?;
 
-    let claims_json = serde_json::to_value(claims)?;
-    debug!("Claims data {claims_json}");
+        let bound = Url::parse(bound_issuer).map_err(OidcError::from)?;
+        let issuer = Url::parse(claims_issuer).map_err(OidcError::from)?;
+        if bound != issuer {
+            return Err(OidcError::IssuerMismatch {
+                expected: bound_issuer.clone(),
+                actual: claims_issuer.to_string(),
+            }
+            .into());
+        }
+    }
+
+    tracing::trace!(
+        "Claims count: {}",
+        claims_value.as_object().map(|m| m.len()).unwrap_or(0)
+    );
 
     // Delegate to the mapping engine for identity resolution. The
     // `default_mapping_name` from the IdP, when set, is used as a rule name
     // hint for targeted rule matching.
-    let flattened = common::flatten_federation_claims(&claims_json).map_err(OidcError::from)?;
-    let unique_workload_id = claims.subject().as_str().to_string();
+    let flattened = common::flatten_federation_claims(&claims_value)
+        .map_err(|_| OidcError::ClaimsMapTooLarge)?;
+
+    // Extract the unique workload identifier from the required `sub` claim.
+    // OIDC Core §3.1.2: "REQUIRED subject identifier"
+    let unique_workload_id = claims_value["sub"]
+        .as_str()
+        .ok_or_else(|| {
+            KeystoneApiError::BadRequest("`sub` claim is missing from ID token".to_string())
+        })?
+        .to_string();
 
     let domain_id = idp.domain_id.clone().ok_or_else(|| {
         KeystoneApiError::BadRequest("Cannot identify domain_id of the user.".to_string())
@@ -195,51 +201,14 @@ pub async fn callback(
     // Resolve scope from the original auth request. The scope may be None
     // (unscoped) or a specific project/domain scope that was requested during
     // OIDC auth init.
-    let authz_info = get_authz_info(&state, auth_state.scope.as_ref()).await?;
-    trace!("Granting the scope: {:?}", authz_info);
+    let (token_str, api_token) =
+        common::build_token_response(&state, &auth_result, auth_state.scope.as_ref()).await?;
 
-    // Issue token with validated security context.
-    let vsc = state
-        .provider
-        .get_token_provider()
-        .issue_token_context(
-            &state,
-            &SecurityContext::try_from(auth_result)?,
-            &authz_info,
-        )
-        .await?;
-
-    let mut api_token = KeystoneTokenResponse {
-        token: TokenBuilder::try_from(&vsc)?.build()?,
-    };
-    let catalog: Catalog = Catalog(
-        state
-            .provider
-            .get_catalog_provider()
-            .get_catalog(&state, true)
-            .await?
-            .into_iter()
-            .map(|(s, es)| CatalogService {
-                id: s.id.clone(),
-                name: s.name(),
-                r#type: s.r#type,
-                endpoints: es.into_iter().map(Into::into).collect(),
-            })
-            .collect::<Vec<_>>(),
-    );
-    api_token.token.catalog = Some(catalog);
-
-    trace!("Token response is {:?}", api_token);
+    tracing::trace!("Token response is {:?}", api_token);
     Ok((
         StatusCode::OK,
-        [(
-            "X-Subject-Token",
-            state
-                .provider
-                .get_token_provider()
-                .encode_token(vsc.token()?)?,
-        )],
-        Json(api_token),
+        [("x-subject-token", token_str)],
+        axum::Json(api_token),
     )
         .into_response())
 }

--- a/crates/keystone/src/federation/api/oidc_utils.rs
+++ b/crates/keystone/src/federation/api/oidc_utils.rs
@@ -1,0 +1,1250 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! OIDC utilities replacing the openidconnect crate.
+//!
+//! Covers discovery, PKCE, authorization URL building, token exchange, and JWT
+//! verification using reqwest + jsonwebtoken directly.
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use jsonwebtoken::{
+    Algorithm, DecodingKey, Header, TokenData, Validation, decode, decode_header, jwk::JwkSet,
+};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use super::error::OidcError;
+
+/// Subset of the OIDC Provider Metadata we actually use.
+#[derive(Debug, Deserialize)]
+pub(super) struct OidcProviderMetadata {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub jwks_uri: String,
+}
+
+/// Fetch and parse OIDC discovery metadata from
+/// `{issuer_url}/.well-known/openid-configuration`.
+///
+/// Validates per RFC 8414 §3 that the returned `issuer` matches the URL used
+/// for discovery.
+pub(super) async fn discover(
+    issuer_url: &str,
+    client: &reqwest::Client,
+) -> Result<OidcProviderMetadata, OidcError> {
+    let base = issuer_url.trim_end_matches('/');
+    let url = format!("{base}/.well-known/openid-configuration");
+    let metadata = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(OidcError::from)?
+        .error_for_status()
+        .map_err(OidcError::from)?
+        .json::<OidcProviderMetadata>()
+        .await
+        .map_err(OidcError::from)?;
+
+    // RFC 8414 §3: issuer in the document MUST match the URL used for discovery.
+    let returned_issuer = metadata.issuer.trim_end_matches('/');
+    if returned_issuer != base {
+        return Err(OidcError::IssuerMismatch {
+            expected: base.to_string(),
+            actual: returned_issuer.to_string(),
+        });
+    }
+
+    Ok(metadata)
+}
+
+/// PKCE S256 challenge/verifier pair.
+pub(super) struct PkceChallenge {
+    /// Random verifier sent at token exchange time.
+    pub verifier: String,
+    /// SHA-256 hash of the verifier, sent at authorization time.
+    pub challenge: String,
+}
+
+/// Generate a fresh PKCE S256 challenge/verifier pair.
+pub(super) fn generate_pkce() -> PkceChallenge {
+    let verifier = generate_random_token();
+    let hash = Sha256::digest(verifier.as_bytes());
+    let challenge = URL_SAFE_NO_PAD.encode(hash);
+    PkceChallenge {
+        verifier,
+        challenge,
+    }
+}
+
+/// Generate a cryptographically random base64url-encoded token (32 bytes).
+pub(super) fn generate_random_token() -> String {
+    let bytes: [u8; 32] = rand::random();
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Build an OIDC authorization URL.
+///
+/// Adds `openid` scope automatically; caller provides any additional scopes.
+pub(super) fn build_auth_url(
+    authorization_endpoint: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    extra_scopes: &[String],
+    state: &str,
+    nonce: &str,
+    pkce_challenge: &str,
+) -> Result<String, OidcError> {
+    let mut url = Url::parse(authorization_endpoint)?;
+    {
+        let mut q = url.query_pairs_mut();
+        q.append_pair("response_type", "code");
+        q.append_pair("client_id", client_id);
+        q.append_pair("redirect_uri", redirect_uri);
+
+        let mut scopes: Vec<&str> = vec!["openid"];
+        for s in extra_scopes {
+            scopes.push(s.as_str());
+        }
+        q.append_pair("scope", &scopes.join(" "));
+
+        q.append_pair("state", state);
+        q.append_pair("nonce", nonce);
+        q.append_pair("code_challenge", pkce_challenge);
+        q.append_pair("code_challenge_method", "S256");
+    }
+    Ok(url.to_string())
+}
+
+/// Response body from the token endpoint.
+#[derive(Debug, Deserialize)]
+pub(super) struct TokenExchangeResponse {
+    pub id_token: Option<String>,
+    #[allow(dead_code)]
+    pub access_token: Option<String>,
+    #[allow(dead_code)]
+    pub token_type: String,
+    #[allow(dead_code)]
+    pub expires_in: Option<u64>,
+}
+
+/// Exchange an authorization code for tokens at the token endpoint.
+pub(super) async fn exchange_code(
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: Option<&str>,
+    code: &str,
+    redirect_uri: &str,
+    code_verifier: &str,
+    http_client: &reqwest::Client,
+) -> Result<TokenExchangeResponse, OidcError> {
+    let mut params: Vec<(&str, &str)> = vec![
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("client_id", client_id),
+        ("code_verifier", code_verifier),
+    ];
+    if let Some(secret) = client_secret {
+        params.push(("client_secret", secret));
+    }
+
+    let response = http_client
+        .post(token_endpoint)
+        .form(&params)
+        .send()
+        .await
+        .map_err(OidcError::from)?
+        .error_for_status()
+        .map_err(OidcError::from)?
+        .json::<TokenExchangeResponse>()
+        .await
+        .map_err(OidcError::from)?;
+    Ok(response)
+}
+
+/// Fetch a JWKS from the given URI.
+pub(super) async fn fetch_jwks(
+    jwks_uri: &str,
+    client: &reqwest::Client,
+) -> Result<JwkSet, OidcError> {
+    let jwks = client
+        .get(jwks_uri)
+        .send()
+        .await
+        .map_err(OidcError::from)?
+        .error_for_status()
+        .map_err(OidcError::from)?
+        .json::<JwkSet>()
+        .await
+        .map_err(OidcError::from)?;
+    Ok(jwks)
+}
+
+/// Algorithms that are safe to use with JWKS (asymmetric only).
+fn is_asymmetric(alg: Algorithm) -> bool {
+    matches!(
+        alg,
+        Algorithm::RS256
+            | Algorithm::RS384
+            | Algorithm::RS512
+            | Algorithm::ES256
+            | Algorithm::ES384
+            | Algorithm::PS256
+            | Algorithm::PS384
+            | Algorithm::PS512
+            | Algorithm::EdDSA
+    )
+}
+
+/// Decode and verify a JWT using JWKS.
+///
+/// - `issuer`: validates the `iss` claim when `Some`.
+/// - `expected_nonce`: validates the `nonce` claim when `Some` (OIDC flows).
+/// - `audiences`: validates the `aud` claim when non-empty.
+///
+/// Returns the decoded claims as a `serde_json::Value`.
+pub(super) fn verify_jwt(
+    token: &str,
+    jwks: &JwkSet,
+    issuer: Option<&str>,
+    expected_nonce: Option<&str>,
+    audiences: &[&str],
+) -> Result<serde_json::Value, OidcError> {
+    let header: Header = decode_header(token)?;
+
+    if !is_asymmetric(header.alg) {
+        return Err(OidcError::UnsupportedAlgorithm(format!("{:?}", header.alg)));
+    }
+
+    // Find the right JWK: by kid if present, otherwise try all keys.
+    let decoding_key = if let Some(kid) = &header.kid {
+        let jwk = jwks
+            .find(kid)
+            .ok_or_else(|| OidcError::JwkNotFound(kid.clone()))?;
+        DecodingKey::from_jwk(jwk)?
+    } else {
+        // No kid — try all keys, return first that verifies.
+        let mut last_err: Option<jsonwebtoken::errors::Error> = None;
+        for jwk in &jwks.keys {
+            match DecodingKey::from_jwk(jwk) {
+                Ok(key) => {
+                    let val = build_validation(header.alg, issuer, audiences);
+                    match decode::<serde_json::Value>(token, &key, &val) {
+                        Ok(data) => {
+                            check_nonce(&data, expected_nonce)?;
+                            check_iat(&data)?;
+                            return Ok(data.claims);
+                        }
+                        Err(e) => last_err = Some(e),
+                    }
+                }
+                Err(e) => last_err = Some(e),
+            }
+        }
+        return Err(last_err
+            .map(OidcError::from)
+            .unwrap_or(OidcError::NoJwksKeys));
+    };
+
+    let validation = build_validation(header.alg, issuer, audiences);
+    let data: TokenData<serde_json::Value> = decode(token, &decoding_key, &validation)?;
+    check_nonce(&data, expected_nonce)?;
+    check_iat(&data)?;
+    Ok(data.claims)
+}
+
+/// Validate the `iat` (issued-at) claim is not suspiciously far in the future.
+///
+/// jsonwebtoken does not check `iat` freshness. OIDC Core §3.2.1.1 requires
+/// the RP to reject tokens whose `iat` is more than a reasonable window in the
+/// future (we use 1 hour + leeway).
+fn check_iat(data: &TokenData<serde_json::Value>) -> Result<(), OidcError> {
+    let iat = data.claims.get("iat").and_then(|v| v.as_u64()).unwrap_or(0);
+    let now = chrono::Utc::now().timestamp() as u64;
+    if iat > now + IAT_FUTURE_MAX_SECS {
+        return Err(OidcError::IatInFuture { iat, now });
+    }
+    Ok(())
+}
+
+/// Maximum allowed `iat` skew (seconds). OIDC Core §3.2.1.1 requires
+/// rejecting tokens whose `iat` is more than 1 hour in the future.
+const IAT_FUTURE_MAX_SECS: u64 = 3600;
+
+fn build_validation(alg: Algorithm, issuer: Option<&str>, audiences: &[&str]) -> Validation {
+    let mut val = Validation::new(alg);
+    // Enforce not-before claim per RFC 7519 §4.1.5 (not enabled by default in
+    // jsonwebtoken).
+    val.validate_nbf = true;
+    // OIDC spec recommends 60s clock skew tolerance for exp/nbf/iat validation.
+    val.leeway = 60;
+    // OIDC Core §3.1.3.7 and §3.1.2: `sub` and `aud` are REQUIRED ID token
+    // claims. `exp` is added by default by `Validation::new(alg)`.
+    val.required_spec_claims
+        .extend(["sub", "aud"].map(String::from));
+    if let Some(iss) = issuer {
+        val.set_issuer(&[iss]);
+    }
+    if audiences.is_empty() {
+        val.validate_aud = false;
+    } else {
+        val.set_audience(audiences);
+    }
+    val
+}
+
+fn check_nonce(
+    data: &TokenData<serde_json::Value>,
+    expected_nonce: Option<&str>,
+) -> Result<(), OidcError> {
+    if let Some(expected) = expected_nonce {
+        let actual = data
+            .claims
+            .get("nonce")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if actual != expected {
+            return Err(OidcError::NonceMismatch);
+        }
+    }
+    Ok(())
+}
+
+/// Build a `reqwest::Client` with redirect following disabled (SSRF guard)
+/// and a reasonable default timeout to prevent resource exhaustion.
+pub(super) fn build_http_client() -> Result<reqwest::Client, OidcError> {
+    reqwest::ClientBuilder::new()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(OidcError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeDelta, Utc};
+    use httpmock::prelude::*;
+    use jsonwebtoken::{Algorithm, EncodingKey, Header as JwtHeader, encode, jwk::JwkSet};
+    use serde_json::json;
+
+    // RSA-2048 test key pair (PKCS#8 PEM + corresponding JWK n/e).
+    // Generated offline with openssl and verified against jsonwebtoken.
+    const TEST_RSA_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\n\
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCV6tfl03xepqw6\n\
+7fphuiONQC1PI1r3po83jDOoX3fhdp7zUQa6m8pueK5tJK+y/iwwK0ok9bRQl5OF\n\
+R08myyW6fPbz9sw2JUNyLfSmAht4dzj+m0FOITMbURCu0mpgDI8ciqcQVuKK4EDT\n\
+FBa8p+/9pf5ROQKgewbJnTjAJcDcOOkLjmPyUfEknbCsRuTLesVRb++PLV/vCz7u\n\
+3nvMG1/9NYPH2BxM7oBxcdX3tQRNtcjcdAkks5zZUQjLLny4UgicIKw8Jxn+bf16\n\
+FZEPkS4vfKtAYTscmjZrsT0nZtvTEFATNd39TMEj6U47Dae/AibVSU4/zbNFO3G8\n\
+hr1ySf1PAgMBAAECgf8qnnxQS7K6UjX5pzwVNvIA4JMdXiiasKKxC3/c7CqaQ3QJ\n\
+DVUxt8MNpM9/xe4tEPibY7MiJA0Caoa+ldx41YCrZxQi8bEcXiZAMwk9fc2mxuil\n\
+6tKJgAMj3Vmn57fkQQMY/acrjDJpSKyzVR8hn0co8UCUSGfojNgoP/vFwLz2wXIL\n\
+mcy5banAlgUwJOAcgTfR/dI7wtSKaHqqt12lCkpyV4LVBIppn+/lAbiTU0eqzCoz\n\
+DxA2HlSWmvpZp6rNRFlk3086VTes+TX+TnPn/nemJTeJnxJ1mFRa2m97Vp60BiOR\n\
+XU8+B/H/y09TVPELfh2Drbp5xbRDoult/x7zxGkCgYEA0nXoELcW09K5BOi0rKBl\n\
+qip2c8JQKOz/GLCM6fe8ZrOODcS9M5GwsM5EFl4Z2rKT+d0Cj959MrxaFBvs7oT8\n\
+UyuVMavNgbXQFohHMWbexrcMf61EbfQC9TWPMJw405HqjyUjNo/amfPrCDX6U1S8\n\
+AxcJ5hj8zxIUKYkbl25eth0CgYEAtltAeGPbjzNQK5Tfxe0qOaq7bbhySqlFJGqT\n\
+5cNPLR7IDKe+JDBNYxyJYnyFZKYxpGgu42nrz/sv+xgetaHIeak4GayTb5sxpcp3\n\
+Nd9oAMNHNnX6N5LlxkXnxQOSgtT3BGrvIMxk/HrHQCCFsBwkWtOv5XWRVWo8jMGd\n\
+lZW0dVsCgYAVwBO0rodQauWuKTKK6KS5GlxViE5qfFu8vHpDr9OrtYDH0X5QNw1Q\n\
+qHCG80CuxmfemcWrAq5jsO2KSHyLBflhyw5HLN83OYgA3CKna184oDBNfaWly2MG\n\
+3nsm5e5Fhz37fzYNbH6GDJxMo+9z7zzjAN2IBysRZ2foBwBv/PsSzQKBgQCvY5rh\n\
+b+HHnGnaUOjdHBtFtaFpiUJb7uwyd1NiZHQtiHKOQXPOqKp1zgeRMwS1ZmdOomme\n\
+jsygkA546Zz3wu/nm8r6XpK7gD/DHrWDmikUur0uc1BCzUW0ap3dTm9G6H/gvtzZ\n\
+5dynPYuQcPdEB/0rYnjGMEqlJXWxR7NCIOedCwKBgQCemeC5iU+EdVONhRj5XRMK\n\
+1kMeZZVAywqI9sOJXFIC7FWbMw796lCD62SNYeER6dDGj3+2pkMHgZrncOzRSX2G\n\
+aAmc9ACPh/hdBmHlSF++nRg+5t+4okyZHe3dgCYUM7n5tq5OFvyrfZ1lmGQlHcyD\n\
+w61t8gqclj1jTxn4LURp0Q==\n\
+-----END PRIVATE KEY-----\n";
+
+    // Base64urlUInt-encoded RSA modulus (n) for the key above — 256 raw bytes, no
+    // leading zero.
+    const TEST_JWK_N: &str = "lerX5dN8XqasOu36YbojjUAtTyNa96aPN4wzqF934Xae81EGupvKbniubSSvsv4s\
+MCtKJPW0UJeThUdPJsslunz28_bMNiVDci30pgIbeHc4_ptBTiEzG1EQrtJqYAyP\
+HIqnEFbiiuBA0xQWvKfv_aX-UTkCoHsGyZ04wCXA3DjpC45j8lHxJJ2wrEbky3rF\
+UW_vjy1f7ws-7t57zBtf_TWDx9gcTO6AcXHV97UETbXI3HQJJLOc2VEIyy58uFII\
+nCCsPCcZ_m39ehWRD5EuL3yrQGE7HJo2a7E9J2bb0xBQEzXd_UzBI-lOOw2nvwIm\
+1UlOP82zRTtxvIa9ckn9Tw";
+
+    const TEST_JWK_E: &str = "AQAB";
+    const TEST_KID: &str = "test-kid";
+
+    fn rsa_encoding_key() -> EncodingKey {
+        EncodingKey::from_rsa_pem(TEST_RSA_PRIVATE_KEY.as_bytes())
+            .expect("hard-coded test RSA private key must parse")
+    }
+
+    fn rsa_jwk(kid: &str) -> jsonwebtoken::jwk::Jwk {
+        serde_json::from_value(json!({
+            "kty": "RSA",
+            "use": "sig",
+            "alg": "RS256",
+            "kid": kid,
+            "n": TEST_JWK_N,
+            "e": TEST_JWK_E,
+        }))
+        .expect("hard-coded test JWK must deserialize")
+    }
+
+    fn make_jwt(claims: &serde_json::Value, kid: Option<&str>) -> String {
+        let mut header = JwtHeader::new(Algorithm::RS256);
+        header.kid = kid.map(str::to_owned);
+        encode(&header, claims, &rsa_encoding_key()).expect("test JWT must encode")
+    }
+
+    fn valid_claims(iss: &str, aud: &str, nonce: Option<&str>) -> serde_json::Value {
+        let exp = (Utc::now() + TimeDelta::hours(1)).timestamp();
+        let mut c = json!({
+            "sub": "user123",
+            "iss": iss,
+            "aud": aud,
+            "exp": exp,
+            "iat": Utc::now().timestamp(),
+        });
+        if let Some(n) = nonce {
+            c["nonce"] = json!(n);
+        }
+        c
+    }
+
+    // ── PKCE ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn pkce_challenge_is_sha256_of_verifier() {
+        let pkce = generate_pkce();
+        let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(pkce.verifier.as_bytes()));
+        assert_eq!(pkce.challenge, expected);
+    }
+
+    #[test]
+    fn pkce_verifier_is_base64url_no_padding() {
+        let pkce = generate_pkce();
+        assert!(
+            !pkce.verifier.contains('+'),
+            "must not use + (standard base64)"
+        );
+        assert!(
+            !pkce.verifier.contains('/'),
+            "must not use / (standard base64)"
+        );
+        assert!(!pkce.verifier.contains('='), "must not have padding");
+        // 32 raw bytes → 43 base64url chars; RFC 7636 requires 43–128 chars.
+        assert!(
+            (43..=128).contains(&pkce.verifier.len()),
+            "verifier length {} out of RFC 7636 range",
+            pkce.verifier.len()
+        );
+    }
+
+    #[test]
+    fn pkce_pairs_are_unique() {
+        let p1 = generate_pkce();
+        let p2 = generate_pkce();
+        assert_ne!(p1.verifier, p2.verifier);
+        assert_ne!(p1.challenge, p2.challenge);
+    }
+
+    // ── Random token ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn random_token_is_base64url_no_padding() {
+        let t = generate_random_token();
+        assert!(!t.contains('+'));
+        assert!(!t.contains('/'));
+        assert!(!t.contains('='));
+    }
+
+    #[test]
+    fn random_tokens_are_unique() {
+        let t1 = generate_random_token();
+        let t2 = generate_random_token();
+        assert_ne!(t1, t2);
+    }
+
+    // ── build_auth_url ────────────────────────────────────────────────────────
+
+    #[test]
+    fn auth_url_contains_required_params() {
+        let url = build_auth_url(
+            "https://idp.example.com/authorize",
+            "my-client",
+            "https://app.example.com/callback",
+            &[],
+            "state123",
+            "nonce456",
+            "challenge789",
+        )
+        .unwrap();
+
+        assert!(url.contains("response_type=code"), "missing response_type");
+        assert!(url.contains("client_id=my-client"), "missing client_id");
+        assert!(url.contains("state=state123"), "missing state");
+        assert!(url.contains("nonce=nonce456"), "missing nonce");
+        assert!(
+            url.contains("code_challenge=challenge789"),
+            "missing code_challenge"
+        );
+        assert!(
+            url.contains("code_challenge_method=S256"),
+            "missing code_challenge_method"
+        );
+    }
+
+    #[test]
+    fn auth_url_always_includes_openid_scope() {
+        let url = build_auth_url(
+            "https://idp.example.com/auth",
+            "cid",
+            "https://app.example.com/cb",
+            &[],
+            "s",
+            "n",
+            "c",
+        )
+        .unwrap();
+
+        let parsed = Url::parse(&url).unwrap();
+        let scope: String = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "scope")
+            .map(|(_, v)| v.into_owned())
+            .unwrap_or_default();
+        assert!(
+            scope.split_whitespace().any(|s| s == "openid"),
+            "openid scope missing from '{scope}'"
+        );
+    }
+
+    #[test]
+    fn auth_url_includes_extra_scopes() {
+        let extra = vec!["profile".to_string(), "email".to_string()];
+        let url = build_auth_url(
+            "https://idp.example.com/auth",
+            "cid",
+            "https://app.example.com/cb",
+            &extra,
+            "s",
+            "n",
+            "c",
+        )
+        .unwrap();
+
+        let parsed = Url::parse(&url).unwrap();
+        let scope: String = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "scope")
+            .map(|(_, v)| v.into_owned())
+            .unwrap_or_default();
+        let scopes: Vec<&str> = scope.split_whitespace().collect();
+        assert!(scopes.contains(&"openid"));
+        assert!(scopes.contains(&"profile"));
+        assert!(scopes.contains(&"email"));
+    }
+
+    #[test]
+    fn auth_url_rejects_invalid_endpoint() {
+        let result = build_auth_url("not-a-url", "cid", "https://cb", &[], "s", "n", "c");
+        assert!(matches!(result, Err(OidcError::UrlParse { .. })));
+    }
+
+    // ── discover ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn discover_success() {
+        let server = MockServer::start();
+        let base_url = server.base_url();
+        server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "issuer": base_url,
+                "authorization_endpoint": format!("{base_url}/auth"),
+                "token_endpoint": format!("{base_url}/token"),
+                "jwks_uri": format!("{base_url}/jwks"),
+            }));
+        });
+
+        let client = reqwest::Client::new();
+        let metadata = discover(&base_url, &client).await.unwrap();
+        assert_eq!(metadata.issuer, base_url);
+        assert!(metadata.authorization_endpoint.ends_with("/auth"));
+    }
+
+    #[tokio::test]
+    async fn discover_strips_trailing_slash() {
+        let server = MockServer::start();
+        let base_url = server.base_url();
+        server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "issuer": base_url,
+                "authorization_endpoint": format!("{base_url}/auth"),
+                "token_endpoint": format!("{base_url}/token"),
+                "jwks_uri": format!("{base_url}/jwks"),
+            }));
+        });
+
+        let client = reqwest::Client::new();
+        let url_with_slash = format!("{base_url}/");
+        // Should succeed even though trailing slash was appended by caller.
+        discover(&url_with_slash, &client).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn discover_returns_error_on_http_failure() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(404);
+        });
+
+        let client = reqwest::Client::new();
+        let result = discover(&server.base_url(), &client).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn discover_rejects_issuer_mismatch() {
+        // RFC 8414 §3: returned issuer must equal the URL used for discovery.
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "issuer": "https://attacker.example.com",
+                "authorization_endpoint": "https://attacker.example.com/auth",
+                "token_endpoint": "https://attacker.example.com/token",
+                "jwks_uri": "https://attacker.example.com/jwks",
+            }));
+        });
+
+        let client = reqwest::Client::new();
+        let result = discover(&server.base_url(), &client).await;
+        assert!(
+            matches!(result, Err(OidcError::IssuerMismatch { .. })),
+            "expected IssuerMismatch, got {result:?}"
+        );
+    }
+
+    // ── fetch_jwks ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn fetch_jwks_parses_key_set() {
+        let server = MockServer::start();
+        let jwk_val = json!({
+            "kty": "RSA", "use": "sig", "alg": "RS256", "kid": "k1",
+            "n": TEST_JWK_N, "e": TEST_JWK_E,
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/jwks.json");
+            then.status(200).json_body(json!({"keys": [jwk_val]}));
+        });
+
+        let client = reqwest::Client::new();
+        let jwks = fetch_jwks(&format!("{}/jwks.json", server.base_url()), &client)
+            .await
+            .unwrap();
+        assert_eq!(jwks.keys.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_jwks_returns_error_on_http_failure() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/jwks.json");
+            then.status(500);
+        });
+
+        let client = reqwest::Client::new();
+        let result = fetch_jwks(&format!("{}/jwks.json", server.base_url()), &client).await;
+        assert!(result.is_err());
+    }
+
+    // ── exchange_code ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn exchange_code_success() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200).json_body(json!({
+                "access_token": "at-value",
+                "token_type": "Bearer",
+                "id_token": "id.token.value",
+                "expires_in": 3600,
+            }));
+        });
+
+        let client = reqwest::Client::new();
+        let resp = exchange_code(
+            &format!("{}/token", server.base_url()),
+            "client-id",
+            None,
+            "auth-code",
+            "https://app.example.com/cb",
+            "pkce-verifier",
+            &client,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.access_token, Some("at-value".to_string()));
+        assert_eq!(resp.id_token, Some("id.token.value".to_string()));
+    }
+
+    #[tokio::test]
+    async fn exchange_code_passes_client_secret() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .body_includes("client_secret=s3cr3t");
+            then.status(200).json_body(json!({
+                "access_token": "at",
+                "token_type": "Bearer",
+            }));
+        });
+
+        let client = reqwest::Client::new();
+        exchange_code(
+            &format!("{}/token", server.base_url()),
+            "cid",
+            Some("s3cr3t"),
+            "code",
+            "https://cb",
+            "verifier",
+            &client,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn exchange_code_returns_error_on_http_failure() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(400);
+        });
+
+        let client = reqwest::Client::new();
+        let result = exchange_code(
+            &format!("{}/token", server.base_url()),
+            "cid",
+            None,
+            "code",
+            "https://cb",
+            "v",
+            &client,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    // ── verify_jwt ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn verify_jwt_rejects_symmetric_hs256() {
+        let key = EncodingKey::from_secret(b"symmetric-secret");
+        let exp = (Utc::now() + TimeDelta::hours(1)).timestamp();
+        let claims = json!({"sub": "user", "exp": exp});
+        let token = encode(&JwtHeader::default(), &claims, &key).unwrap();
+
+        let jwks: JwkSet = serde_json::from_value(json!({"keys": []})).unwrap();
+        let result = verify_jwt(&token, &jwks, None, None, &[]);
+        assert!(
+            matches!(result, Err(OidcError::UnsupportedAlgorithm(_))),
+            "expected UnsupportedAlgorithm, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_valid_rs256_with_kid() {
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let claims = valid_claims("https://iss.example.com", "my-client", None);
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(result.is_ok(), "{result:?}");
+        assert_eq!(result.unwrap()["sub"], "user123");
+    }
+
+    #[test]
+    fn verify_jwt_rejects_wrong_issuer() {
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let claims = valid_claims("https://iss.example.com", "my-client", None);
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://other-issuer.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(matches!(result, Err(OidcError::JwtDecode { .. })));
+    }
+
+    #[test]
+    fn verify_jwt_rejects_nonce_mismatch() {
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let claims = valid_claims(
+            "https://iss.example.com",
+            "my-client",
+            Some("correct-nonce"),
+        );
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            Some("wrong-nonce"),
+            &["my-client"],
+        );
+        assert!(matches!(result, Err(OidcError::NonceMismatch)));
+    }
+
+    #[test]
+    fn verify_jwt_accepts_correct_nonce() {
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let claims = valid_claims("https://iss.example.com", "my-client", Some("my-nonce"));
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            Some("my-nonce"),
+            &["my-client"],
+        );
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn verify_jwt_rejects_unknown_kid() {
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk("other-kid")],
+        };
+        let claims = valid_claims("https://iss.example.com", "my-client", None);
+        let token = make_jwt(&claims, Some(TEST_KID)); // signed with TEST_KID
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            matches!(result, Err(OidcError::JwkNotFound(_))),
+            "expected JwkNotFound, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_falls_back_to_kidless_key_scan() {
+        // Token has no kid in header; verify_jwt should try all JWKS keys.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let claims = valid_claims("https://iss.example.com", "my-client", None);
+        let token = make_jwt(&claims, None); // no kid in header
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn verify_jwt_empty_jwks_returns_no_keys_error() {
+        // No kid in header, empty JWKS → NoJwksKeys.
+        let jwks: JwkSet = serde_json::from_value(json!({"keys": []})).unwrap();
+        let claims = valid_claims("https://iss.example.com", "my-client", None);
+        let token = make_jwt(&claims, None);
+
+        let result = verify_jwt(&token, &jwks, None, None, &[]);
+        assert!(
+            matches!(result, Err(OidcError::NoJwksKeys)),
+            "expected NoJwksKeys, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_rejects_expired_token() {
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let exp = (Utc::now() - TimeDelta::hours(1)).timestamp();
+        let claims = json!({
+            "sub": "user",
+            "iss": "https://iss.example.com",
+            "aud": "my-client",
+            "exp": exp,
+            "iat": exp - 3600,
+        });
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(matches!(result, Err(OidcError::JwtDecode { .. })));
+    }
+
+    #[test]
+    fn verify_jwt_accepts_aud_as_json_array() {
+        // OIDC Core §3.1.3.7: real IdPs (Keycloak, Auth0) emit `aud` as a JSON array.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let exp = (Utc::now() + TimeDelta::hours(1)).timestamp();
+        let claims = json!({
+            "sub": "user123",
+            "iss": "https://iss.example.com",
+            "aud": ["my-client", "other-client"],
+            "exp": exp,
+            "iat": Utc::now().timestamp(),
+        });
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            result.is_ok(),
+            "aud array containing my-client must validate, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_rejects_aud_when_none_match() {
+        // RFC 7519 §4.1.3: when audience is validated, at least one value must match.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let exp = (Utc::now() + TimeDelta::hours(1)).timestamp();
+        let claims = json!({
+            "sub": "user123",
+            "iss": "https://iss.example.com",
+            "aud": "some-other-client",
+            "exp": exp,
+            "iat": Utc::now().timestamp(),
+        });
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            matches!(result, Err(OidcError::JwtDecode { .. })),
+            "aud not in expected audiences must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_selects_correct_kid_from_multi_key_jwks() {
+        // RFC 7517 §3: key rotation — JWKS contains multiple keys, verify_jwt must
+        // select the one matching the token's kid.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk("old-key"), rsa_jwk(TEST_KID), rsa_jwk("unused-key")],
+        };
+        let claims = valid_claims("https://iss.example.com", "my-client", None);
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            result.is_ok(),
+            "must find and verify using the key matching kid from multi-key JWKS, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_rejects_alg_none() {
+        // CVE-2015-9235: algorithm confusion — alg none tokens must be rejected.
+        // jsonwebtoken's decode_header fails on `alg: "none"` with a JSON parse error
+        // since it doesn't support the `none` variant, producing `JwtDecode`.
+        let exp = (Utc::now() + TimeDelta::hours(1)).timestamp();
+        let header_b64 = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\",\"typ\":\"JWT\"}");
+        let claims_b64 =
+            URL_SAFE_NO_PAD.encode(json!({"sub": "attack", "exp": exp}).to_string().as_bytes());
+        let token = format!("{header_b64}.{claims_b64}.");
+
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let result = verify_jwt(&token, &jwks, None, None, &[]);
+        assert!(
+            matches!(result, Err(OidcError::JwtDecode { .. })),
+            "alg none must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_rejects_missing_nonce_when_expected() {
+        // OIDC Core §3.1.3.6: nonce is REQUIRED in ID tokens for authorization code
+        // flows. When caller expects a nonce but token lacks the claim,
+        // verification must fail.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let claims = valid_claims("https://iss.example.com", "my-client", None);
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            Some("expected-nonce"),
+            &["my-client"],
+        );
+        assert!(
+            matches!(result, Err(OidcError::NonceMismatch)),
+            "missing nonce claim with expected nonce must fail, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_rejects_future_nbf() {
+        // RFC 7519 §4.1.5: nbf (not-before) — token with nbf in the future must be
+        // rejected.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let nbf_future = (Utc::now() + TimeDelta::hours(1)).timestamp();
+        let claims = json!({
+            "sub": "user",
+            "iss": "https://iss.example.com",
+            "aud": "my-client",
+            "exp": nbf_future + 3600,
+            "iat": Utc::now().timestamp(),
+            "nbf": nbf_future,
+        });
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            matches!(result, Err(OidcError::JwtDecode { .. })),
+            "nbf in the future must cause rejection, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_does_not_panic_on_malformed_token() {
+        // Malformed JWT (bad base64, wrong segments) must produce JwtDecode, not a
+        // panic.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let result = verify_jwt("not-a-jwt-at-all", &jwks, None, None, &[]);
+        assert!(
+            matches!(result, Err(OidcError::JwtDecode { .. })),
+            "malformed JWT must produce JwtDecode, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn token_exchange_response_id_token_only() {
+        // TokenExchangeResponse with only id_token verifies access_token optionality.
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200).json_body(json!({
+                "id_token": "id.token.value",
+                "token_type": "Bearer",
+            }));
+        });
+
+        let client = reqwest::Client::new();
+        let resp = exchange_code(
+            &format!("{}/token", server.base_url()),
+            "cid",
+            None,
+            "code",
+            "https://cb",
+            "verifier",
+            &client,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resp.access_token, None,
+            "access_token must be absent in id-token-only response"
+        );
+        assert_eq!(resp.id_token, Some("id.token.value".to_string()));
+    }
+
+    // ── iat validation ────────────────────────────────────────────────────────
+
+    #[test]
+    fn verify_jwt_rejects_iat_too_far_in_future() {
+        // OIDC Core §3.2.1.1: iat MUST NOT be more than 1 hour in the future.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let iat_future = (Utc::now() + TimeDelta::hours(2)).timestamp() as u64;
+        let claims = json!({
+            "sub": "user",
+            "iss": "https://iss.example.com",
+            "aud": "my-client",
+            "exp": iat_future + 3600,
+            "iat": iat_future,
+        });
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            matches!(result, Err(OidcError::IatInFuture { .. })),
+            "iat more than 1 hour in future must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_accepts_iat_within_future_window() {
+        // iat within 1 hour of now must be accepted.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let iat_slightly_future = (Utc::now() + TimeDelta::minutes(30)).timestamp() as u64;
+        let claims = json!({
+            "sub": "user",
+            "iss": "https://iss.example.com",
+            "aud": "my-client",
+            "exp": iat_slightly_future + 3600,
+            "iat": iat_slightly_future,
+        });
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            result.is_ok(),
+            "iat within 1 hour must be accepted, got {result:?}"
+        );
+    }
+
+    // ── required claims ───────────────────────────────────────────────────────
+
+    #[test]
+    fn verify_jwt_rejects_missing_sub() {
+        // OIDC Core §3.1.2: sub is REQUIRED.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let exp = (Utc::now() + TimeDelta::hours(1)).timestamp();
+        let claims = json!({
+            "iss": "https://iss.example.com",
+            "aud": "my-client",
+            "exp": exp,
+            "iat": Utc::now().timestamp(),
+        });
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            matches!(result, Err(OidcError::JwtDecode { .. })),
+            "missing sub must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_jwt_rejects_missing_aud() {
+        // OIDC Core §3.1.3.7: aud is REQUIRED.
+        let jwks = JwkSet {
+            keys: vec![rsa_jwk(TEST_KID)],
+        };
+        let exp = (Utc::now() + TimeDelta::hours(1)).timestamp();
+        let claims = json!({
+            "sub": "user",
+            "iss": "https://iss.example.com",
+            "exp": exp,
+            "iat": Utc::now().timestamp(),
+        });
+        let token = make_jwt(&claims, Some(TEST_KID));
+
+        let result = verify_jwt(
+            &token,
+            &jwks,
+            Some("https://iss.example.com"),
+            None,
+            &["my-client"],
+        );
+        assert!(
+            matches!(result, Err(OidcError::JwtDecode { .. })),
+            "missing aud must be rejected, got {result:?}"
+        );
+    }
+}

--- a/crates/keystone/src/federation/api/types.rs
+++ b/crates/keystone/src/federation/api/types.rs
@@ -11,66 +11,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Federation API types and federation types.
-
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-
-use openidconnect::core::{
-    CoreAuthDisplay, CoreAuthPrompt, CoreErrorResponseType, CoreGenderClaim, CoreJsonWebKey,
-    CoreJweContentEncryptionAlgorithm, CoreJwsSigningAlgorithm, CoreRevocableToken,
-    CoreRevocationErrorResponse, CoreTokenIntrospectionResponse, CoreTokenType,
-};
-use openidconnect::{
-    AdditionalClaims, EndpointMaybeSet, EndpointNotSet, EndpointSet, ExtraTokenFields,
-    IdTokenFields, StandardErrorResponse, StandardTokenResponse,
-};
+//! Federation API types.
 
 pub use openstack_keystone_api_types::federation::*;
 
 mod identity_provider;
-
-pub(super) type OidcIdTokenFields = IdTokenFields<
-    AllOtherClaims,
-    ExtraFields,
-    CoreGenderClaim,
-    CoreJweContentEncryptionAlgorithm,
-    CoreJwsSigningAlgorithm,
->;
-
-pub(super) type OidcTokenResponse = StandardTokenResponse<OidcIdTokenFields, CoreTokenType>;
-
-pub(super) type OidcClient<
-    HasAuthUrl = EndpointSet,
-    HasDeviceAuthUrl = EndpointNotSet,
-    HasIntrospectionUrl = EndpointNotSet,
-    HasRevocationUrl = EndpointNotSet,
-    HasTokenUrl = EndpointMaybeSet,
-    HasUserInfoUrl = EndpointMaybeSet,
-> = openidconnect::Client<
-    AllOtherClaims,
-    CoreAuthDisplay,
-    CoreGenderClaim,
-    CoreJweContentEncryptionAlgorithm,
-    CoreJsonWebKey,
-    CoreAuthPrompt,
-    StandardErrorResponse<CoreErrorResponseType>,
-    OidcTokenResponse,
-    CoreTokenIntrospectionResponse,
-    CoreRevocableToken,
-    CoreRevocationErrorResponse,
-    HasAuthUrl,
-    HasDeviceAuthUrl,
-    HasIntrospectionUrl,
-    HasRevocationUrl,
-    HasTokenUrl,
-    HasUserInfoUrl,
->;
-
-#[derive(Debug, Deserialize, Serialize)]
-pub(super) struct AllOtherClaims(HashMap<String, serde_json::Value>);
-impl AdditionalClaims for AllOtherClaims {}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub(super) struct ExtraFields(HashMap<String, serde_json::Value>);
-impl ExtraTokenFields for ExtraFields {}

--- a/crates/keystone/src/k8s_auth_client.rs
+++ b/crates/keystone/src/k8s_auth_client.rs
@@ -20,7 +20,6 @@ use chrono::Utc;
 use dashmap::DashMap;
 use jsonwebtoken::dangerous::insecure_decode;
 use reqwest::{Client, StatusCode};
-use serde_json::Value;
 use tokio::fs;
 use tracing::debug;
 

--- a/tests/api/src/auth/project.rs
+++ b/tests/api/src/auth/project.rs
@@ -18,11 +18,8 @@ use eyre::Result;
 
 use openstack_keystone_api_types::v3::project::ProjectShort;
 use openstack_sdk::api::rest_endpoint_prelude::*;
-use openstack_sdk::config::CloudConfig;
 use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
-use crate::common::get_session_by_user_password;
-use crate::guard::ResourceGuard;
 use tracing_test::traced_test;
 
 #[derive(Clone, Debug)]

--- a/typos.toml
+++ b/typos.toml
@@ -31,7 +31,8 @@ extend-glob = []
 extend-ignore-identifiers-re = ["INSERT"]
 extend-ignore-words-re = ["udid", "typ"]
 extend-ignore-re = [
-  "gAA.*\\b"
+  "gAA.*\\b",
+  "TEST_JWK_N.*[A-Za-z0-9+/=_-]{20,}",
 ]
 
 [type.rust.extend-identifiers]
@@ -43,6 +44,8 @@ rule_ba = "rule_ba"
 ro = "ro"
 ser = "ser"
 COSE = "COSE"
+BA = "BA"
+UE = "UE"
 
 [type.lock]
 extend-glob = []


### PR DESCRIPTION
`openidconnect` v4.0 pins reqwest 0.12 internally while the workspace is
on reqwest 0.13, causing a duplicate reqwest dependency. It is also not
updated for quite a long time signaling the project is not healty.

Replace with a custom oidc_utils module that implements OIDC discovery,
PKCE S256 generation, authorization URL building, token exchange, JWKS
fetching, and JWT verification using the workspace's reqwest (0.13) and
the already-present jsonwebtoken (10.4) crates.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-Off-By: Artem Goncharov <artem.goncharov@gmail.com>
