### PR TITLE
feat(cli): Add cli storage subcommands per ADR 0016-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,7 @@ dependencies = [
  "color-eyre",
  "comfy-table",
  "eyre",
+ "futures",
  "httpmock",
  "inventory",
  "openstack-keystone",

--- a/crates/cli-manage/Cargo.toml
+++ b/crates/cli-manage/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
 comfy-table = "7.2"
 eyre.workspace = true
+futures.workspace = true
 inventory.workspace = true
 openstack-keystone-api-types.workspace = true
 openstack-keystone = { version = "0.1", path = "../keystone" }

--- a/crates/cli-manage/src/storage.rs
+++ b/crates/cli-manage/src/storage.rs
@@ -24,22 +24,32 @@ use openstack_keystone_distributed_storage::{
     protobuf::raft::cluster_admin_service_client::ClusterAdminServiceClient,
 };
 
+mod backup;
 mod clear_quarantine;
+mod confirm_rotate_dek;
 mod demote;
 mod init;
 mod join;
 mod list_peers;
+mod metrics;
 mod promote;
 mod remove_peer;
+mod restore;
+mod rotate_dek;
 
 use crate::PerformAction;
+use crate::storage::backup::BackupCommand;
 use crate::storage::clear_quarantine::ClearQuarantineCommand;
+use crate::storage::confirm_rotate_dek::ConfirmRotateDekCommand;
 use crate::storage::demote::DemoteCommand;
 use crate::storage::init::InitCommand;
 use crate::storage::join::JoinCommand;
 use crate::storage::list_peers::ListPeersCommand;
+use crate::storage::metrics::MetricsCommand;
 use crate::storage::promote::PromoteCommand;
 use crate::storage::remove_peer::RemovePeerCommand;
+use crate::storage::restore::RestoreCommand;
+use crate::storage::rotate_dek::RotateDekCommand;
 
 /// Distributed storage.
 ///
@@ -55,26 +65,36 @@ pub struct StorageCommand {
 impl PerformAction for StorageCommand {
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         match self.command {
+            StorageCommands::Backup(e) => e.take_action(config).await,
             StorageCommands::ClearQuarantine(e) => e.take_action(config).await,
+            StorageCommands::ConfirmRotateDek(e) => e.take_action(config).await,
             StorageCommands::Demote(e) => e.take_action(config).await,
             StorageCommands::Init(e) => e.take_action(config).await,
             StorageCommands::Join(e) => e.take_action(config).await,
             StorageCommands::ListPeers(e) => e.take_action(config).await,
+            StorageCommands::Metrics(e) => e.take_action(config).await,
             StorageCommands::Promote(e) => e.take_action(config).await,
             StorageCommands::RemovePeer(e) => e.take_action(config).await,
+            StorageCommands::Restore(e) => e.take_action(config).await,
+            StorageCommands::RotateDek(e) => e.take_action(config).await,
         }
     }
 }
 
 #[derive(Subcommand)]
 enum StorageCommands {
+    Backup(BackupCommand),
     ClearQuarantine(ClearQuarantineCommand),
+    ConfirmRotateDek(ConfirmRotateDekCommand),
     Demote(DemoteCommand),
     Init(InitCommand),
     Join(JoinCommand),
     ListPeers(ListPeersCommand),
+    Metrics(MetricsCommand),
     Promote(PromoteCommand),
     RemovePeer(RemovePeerCommand),
+    Restore(RestoreCommand),
+    RotateDek(RotateDekCommand),
 }
 
 async fn get_grpc_client(

--- a/crates/cli-manage/src/storage/backup.rs
+++ b/crates/cli-manage/src/storage/backup.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::Report;
+use color_eyre::eyre::eyre;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tonic::transport::Uri;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_distributed_storage::protobuf as pb;
+
+use super::get_grpc_client;
+use crate::PerformAction;
+
+/// Create an encrypted operator backup (Fjall snapshot).
+///
+/// Triggers a fresh snapshot on the target node, then streams the AES-256-GCM
+/// encrypted bytes to `--output`. The backup is bound to the current DEK epoch
+/// via the Backup DEK (BDEK) and the snapshot timestamp — it cannot be replayed
+/// against a different cluster or epoch without the corresponding KMS key.
+///
+/// The final output includes a DEK manifest covering any retired DEKs required
+/// for offline decryption. Retain this file and the KMS keys for at least 365
+/// days per ADR 0016-v2 §7.
+#[derive(Parser)]
+pub(super) struct BackupCommand {
+    /// Address of the target cluster (e.g. `https://127.0.0.1:50051`).
+    #[arg(long)]
+    pub cluster_addr: Option<Uri>,
+
+    /// Output file path for the encrypted snapshot.
+    #[arg(long)]
+    pub output: PathBuf,
+}
+
+#[async_trait]
+impl PerformAction for BackupCommand {
+    #[allow(clippy::print_stdout)]
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        if config.distributed_storage.is_none() {
+            return Err(eyre!("no distributed_storage configuration"));
+        }
+
+        let mut client = get_grpc_client(config, self.cluster_addr).await?;
+
+        let mut stream = client
+            .backup(pb::raft::BackupRequest {})
+            .await?
+            .into_inner();
+
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&self.output)
+            .await
+            .map_err(|e| eyre!("cannot create output file {:?}: {e}", self.output))?;
+
+        let mut total_bytes = 0usize;
+        let mut snapshot_utc_epoch: Option<u64> = None;
+        let mut dek_version: Option<u32> = None;
+
+        while let Some(chunk) = stream.message().await? {
+            total_bytes += chunk.data.len();
+            file.write_all(&chunk.data).await?;
+            if chunk.snapshot_utc_epoch.is_some() {
+                snapshot_utc_epoch = chunk.snapshot_utc_epoch;
+                dek_version = chunk.dek_version;
+            }
+        }
+
+        file.flush().await?;
+
+        println!(
+            "Backup written to {:?} ({} bytes)",
+            self.output, total_bytes
+        );
+        if let (Some(epoch), Some(ver)) = (snapshot_utc_epoch, dek_version) {
+            println!("  snapshot_utc_epoch={epoch}  dek_version={ver}");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cli-manage/src/storage/confirm_rotate_dek.rs
+++ b/crates/cli-manage/src/storage/confirm_rotate_dek.rs
@@ -23,42 +23,40 @@ use openstack_keystone_distributed_storage::protobuf as pb;
 use super::get_grpc_client;
 use crate::PerformAction;
 
-/// Clear a quarantined keyspace partition.
+/// Confirm a pending emergency DEK rotation (dual-control second factor).
 ///
-/// A partition is automatically quarantined after three AES-256-GCM tag
-/// verification failures within 60 seconds. This command issues a Raft
-/// proposal that propagates the clearance to all cluster members and removes
-/// the persistent quarantine marker.
+/// Must be invoked by a *different* `storage-operator` than the one who ran
+/// `rotate-dek --emergency`, within 5 minutes of that command. Both operator
+/// identities are recorded in the audit log.
 ///
-/// Only use this command after investigating the root cause of the GCM
-/// failures — quarantine protects against data corruption or active tampering.
+/// If the 5-minute window has already expired, the pending rotation has been
+/// automatically aborted and this command will return an error.
 #[derive(Parser)]
-pub(super) struct ClearQuarantineCommand {
-    /// Cluster member to contact (e.g. `https://127.0.0.1:50051`).
+pub(super) struct ConfirmRotateDekCommand {
+    /// Address of the target cluster (e.g. `https://127.0.0.1:50051`).
     #[arg(long)]
     pub cluster_addr: Option<Uri>,
 
-    /// The keyspace partition to un-quarantine.
-    ///
-    /// Common values: "data" (default application data), "meta", "index".
-    #[arg(default_value = "data")]
-    pub partition: String,
+    /// The rotation_id printed by `rotate-dek --emergency`.
+    #[arg(long)]
+    pub rotation_id: String,
 }
 
 #[async_trait]
-impl PerformAction for ClearQuarantineCommand {
+impl PerformAction for ConfirmRotateDekCommand {
+    #[allow(clippy::print_stdout)]
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         let mut client = get_grpc_client(config, self.cluster_addr).await?;
 
         client
-            .clear_quarantine(pb::raft::ClearQuarantineRequest {
-                partition: self.partition.clone(),
+            .confirm_rotate_dek(pb::raft::ConfirmRotateDekRequest {
+                rotation_id: self.rotation_id.clone(),
             })
             .await?;
 
         println!(
-            "Quarantine cleared for partition '{}'. The partition is now writable on all nodes.",
-            self.partition
+            "Emergency DEK rotation {} confirmed. The compromised DEK is now revoked.",
+            self.rotation_id
         );
         Ok(())
     }

--- a/crates/cli-manage/src/storage/metrics.rs
+++ b/crates/cli-manage/src/storage/metrics.rs
@@ -1,0 +1,77 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::Report;
+use color_eyre::eyre::eyre;
+use tonic::transport::Uri;
+
+use openstack_keystone_config::Config;
+
+use super::get_grpc_client;
+use crate::PerformAction;
+
+/// Show raw cluster metrics from a Raft node.
+///
+/// Displays the current leader, membership configuration, and the full
+/// OpenRaft metrics string. Useful for a quick health check or when
+/// diagnosing replication lag, leader elections, or quarantine state.
+///
+/// For a tabular view of cluster peers use `list-peers` instead.
+#[derive(Parser)]
+pub(super) struct MetricsCommand {
+    /// Address of the target cluster node (e.g. `https://127.0.0.1:50051`).
+    #[arg(long)]
+    pub cluster_addr: Option<Uri>,
+}
+
+#[async_trait]
+impl PerformAction for MetricsCommand {
+    #[allow(clippy::print_stdout)]
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        if config.distributed_storage.is_none() {
+            return Err(eyre!("no distributed_storage configuration"));
+        }
+
+        let mut client = get_grpc_client(config, self.cluster_addr).await?;
+        let metrics = client.metrics(()).await?.into_inner();
+
+        let leader = match metrics.current_leader {
+            Some(id) => format!("node {id}"),
+            None => "none (election in progress?)".to_string(),
+        };
+        println!("Current leader : {leader}");
+
+        if let Some(membership) = &metrics.membership {
+            let voters: Vec<String> = membership
+                .configs
+                .iter()
+                .flat_map(|s| s.node_ids.keys())
+                .map(|id| id.to_string())
+                .collect();
+            println!("Voters         : [{}]", voters.join(", "));
+
+            let all_nodes: Vec<String> = membership
+                .nodes
+                .values()
+                .map(|n| format!("{}={}", n.node_id, n.rpc_addr))
+                .collect();
+            println!("All nodes      : [{}]", all_nodes.join(", "));
+        }
+
+        println!("\nRaw metrics:\n{}", metrics.other_metrics);
+        Ok(())
+    }
+}

--- a/crates/cli-manage/src/storage/restore.rs
+++ b/crates/cli-manage/src/storage/restore.rs
@@ -1,0 +1,97 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::Report;
+use color_eyre::eyre::eyre;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+use tonic::transport::Uri;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_distributed_storage::protobuf as pb;
+
+use super::get_grpc_client;
+use crate::PerformAction;
+
+const CHUNK_SIZE: usize = 256 * 1024;
+
+fn file_chunk_stream(file: File) -> impl futures::Stream<Item = pb::raft::RestoreChunk> {
+    futures::stream::unfold(file, |mut f| async move {
+        let mut buf = vec![0u8; CHUNK_SIZE];
+        let n = f.read(&mut buf).await.unwrap_or(0);
+        if n == 0 {
+            return None;
+        }
+        buf.truncate(n);
+        Some((pb::raft::RestoreChunk { data: buf }, f))
+    })
+}
+
+/// Restore an encrypted operator backup to a freshly-bootstrapped cluster.
+///
+/// Streams the backup file produced by `backup` to the leader, which validates
+/// the AES-256-GCM envelope (Backup DEK + AD binding), decrypts it, and
+/// installs the snapshot into the Raft state machine.
+///
+/// **Prerequisites (see ADR 0016-v2 §7):**
+/// 1. Bootstrap a fresh single-node cluster (`storage init`).
+/// 2. Run this command against the leader.
+/// 3. Add remaining nodes as learners (`storage join`) and promote them.
+///
+/// The KMS must hold the Backup DEK (`backup_dek` role) for the DEK epoch
+/// indicated by the snapshot's `dek_version` field.
+#[derive(Parser)]
+pub(super) struct RestoreCommand {
+    /// Address of the target cluster (e.g. `https://127.0.0.1:50051`).
+    #[arg(long)]
+    pub cluster_addr: Option<Uri>,
+
+    /// Path to the encrypted snapshot file produced by `backup`.
+    #[arg(long)]
+    pub snapshot: PathBuf,
+}
+
+#[async_trait]
+impl PerformAction for RestoreCommand {
+    #[allow(clippy::print_stdout)]
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let file = File::open(&self.snapshot)
+            .await
+            .map_err(|e| eyre!("cannot open snapshot file {:?}: {e}", self.snapshot))?;
+        let file_size = file.metadata().await.map(|m| m.len()).unwrap_or(0) as usize;
+
+        // Stream in 256 KiB chunks; at most one chunk is resident in memory at a time.
+        let stream = file_chunk_stream(file);
+
+        let mut client = get_grpc_client(config, self.cluster_addr).await?;
+
+        client.restore(stream).await?;
+
+        println!(
+            "Restore complete ({} bytes from {:?}).",
+            file_size, self.snapshot
+        );
+        println!(
+            "Next steps:\n  \
+             1. Add remaining nodes as learners:  keystone-manage storage join ...\n  \
+             2. Promote learners to voters:        keystone-manage storage promote ..."
+        );
+
+        Ok(())
+    }
+}

--- a/crates/cli-manage/src/storage/rotate_dek.rs
+++ b/crates/cli-manage/src/storage/rotate_dek.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::Report;
+use tonic::transport::Uri;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_distributed_storage::protobuf as pb;
+
+use super::get_grpc_client;
+use crate::PerformAction;
+
+/// Rotate the Data Encryption Key (DEK).
+///
+/// Triggers a live background DEK rotation with no cluster downtime. All new
+/// Raft log writes use the fresh DEK immediately; a background task re-encrypts
+/// existing Fjall state entries using optimistic CAS-on-version.
+///
+/// Use `--emergency` when the current DEK is suspected or confirmed
+/// compromised. Emergency rotation requires dual-control: a second
+/// `storage-operator` must run `confirm-rotate-dek` with the returned
+/// rotation-id within 5 minutes, or the rotation is automatically aborted.
+#[derive(Parser)]
+pub(super) struct RotateDekCommand {
+    /// Address of the target cluster node (e.g. `https://127.0.0.1:50051`).
+    #[arg(long)]
+    pub cluster_addr: Option<Uri>,
+
+    /// Initiate an emergency rotation (dual-control required).
+    ///
+    /// The current DEK will be marked revoked (not retired) once a second
+    /// operator confirms via `confirm-rotate-dek`. If no confirmation arrives
+    /// within 5 minutes the rotation is automatically aborted.
+    #[arg(long, default_value_t = false)]
+    pub emergency: bool,
+}
+
+#[async_trait]
+impl PerformAction for RotateDekCommand {
+    #[allow(clippy::print_stdout)]
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let mut client = get_grpc_client(config, self.cluster_addr).await?;
+
+        let resp = client
+            .rotate_dek(pb::raft::RotateDekRequest {
+                emergency: self.emergency,
+            })
+            .await?
+            .into_inner();
+
+        if self.emergency {
+            if resp.pending_rotation_id.is_empty() {
+                println!("Emergency DEK rotation staged but no rotation_id returned.");
+            } else {
+                println!(
+                    "Emergency DEK rotation staged.\n\
+                     rotation_id={}\n\n\
+                     A second storage-operator must confirm within 5 minutes:\n\
+                     \n  keystone-manage storage confirm-rotate-dek \\\n\
+                       \t--rotation-id {}",
+                    resp.pending_rotation_id, resp.pending_rotation_id,
+                );
+            }
+        } else {
+            println!("DEK rotation committed. Monitor the audit log for DEK_ROTATION events.");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/storage/proto/raft.proto
+++ b/crates/storage/proto/raft.proto
@@ -243,6 +243,19 @@ service ClusterAdminService {
   // DEK rotation. Must be invoked within 5 minutes of the initial
   // RotateDekRequest{emergency: true} by a second storage-operator.
   rpc ConfirmRotateDek(ConfirmRotateDekRequest) returns (AdminResponse) {}
+
+  // Backup builds a fresh Fjall snapshot, encrypts it with the Backup DEK, and
+  // streams the encrypted bytes to the operator. The final chunk carries the
+  // snapshot_utc_epoch and dek_version from the backup envelope header for
+  // client-side verification. Requires operator access over the internal
+  // management network.
+  rpc Backup(BackupRequest) returns (stream BackupChunk) {}
+
+  // Restore accepts a client-streamed encrypted snapshot (produced by Backup),
+  // validates the backup envelope, decrypts it, and installs it into the Raft
+  // state machine. Only invoke against a freshly-bootstrapped single-node
+  // cluster before adding learners (see ADR 0016-v2 §7).
+  rpc Restore(stream RestoreChunk) returns (AdminResponse) {}
 }
 
 message ClearQuarantineRequest {
@@ -260,5 +273,24 @@ message RotateDekRequest {
 message ConfirmRotateDekRequest {
   // The rotation_id of the pending emergency rotation that requires confirmation.
   string rotation_id = 1;
+}
+
+// BackupRequest initiates a server-side operator snapshot export.
+message BackupRequest {}
+
+// BackupChunk is one chunk of the streaming encrypted snapshot response.
+// The final chunk carries snapshot_utc_epoch and dek_version so the client
+// can verify the backup envelope without decrypting it.
+message BackupChunk {
+  bytes data = 1;
+  // Only set in the final chunk.
+  optional uint64 snapshot_utc_epoch = 2;
+  // Only set in the final chunk.
+  optional uint32 dek_version = 3;
+}
+
+// RestoreChunk is one chunk of the client-to-server encrypted snapshot upload.
+message RestoreChunk {
+  bytes data = 1;
 }
 

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -217,6 +217,7 @@ pub async fn get_app_server(storage: &Storage) -> Result<Routes, StoreError> {
         storage.current_dek.clone(),
         storage.audit_forwarder.clone(),
         storage.pending_rotations.clone(),
+        storage.state_machine_store.clone(),
     );
     let storage_svc_impl = StorageServiceImpl::new(storage.raft.clone());
 

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -14,11 +14,13 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex, RwLock};
 
+use openraft::RaftSnapshotBuilder;
 use openraft::async_runtime::WatchReceiver;
 use openstack_keystone_storage_crypto::{DekEpoch, KekProvider, generate_dek};
 use tonic::Request;
 use tonic::Response;
 use tonic::Status;
+use tonic::Streaming;
 use tracing::trace;
 
 use crate::StoreError;
@@ -84,6 +86,8 @@ pub struct ClusterAdminServiceImpl {
     audit: AuditForwarder,
     /// Pending emergency DEK rotations (shared with FjallStateMachine).
     pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
+    /// State machine store — used for backup snapshot building and restore.
+    sm: Arc<StateMachineStore>,
 }
 
 impl ClusterAdminServiceImpl {
@@ -105,6 +109,7 @@ impl ClusterAdminServiceImpl {
         current_dek: Arc<RwLock<Arc<DekEpoch>>>,
         audit: AuditForwarder,
         pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
+        sm: Arc<StateMachineStore>,
     ) -> Self {
         Self {
             raft_node,
@@ -113,6 +118,7 @@ impl ClusterAdminServiceImpl {
             current_dek,
             audit,
             pending_rotations,
+            sm,
         }
     }
 
@@ -556,6 +562,213 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
             confirmer = actor,
             "SECURITY: emergency DEK rotation confirmed via dual-control"
         );
+        Ok(Response::new(pb::raft::AdminResponse::default()))
+    }
+
+    type BackupStream = std::pin::Pin<
+        Box<dyn futures::Stream<Item = Result<pb::raft::BackupChunk, Status>> + Send>,
+    >;
+
+    /// Build a fresh Fjall snapshot and stream the encrypted bytes to the
+    /// operator.
+    ///
+    /// Encryption is performed by `build_snapshot` using the Backup DEK (see
+    /// ADR 0016-v2 §7).  Chunks are 256 KiB; the final chunk carries the
+    /// snapshot_utc_epoch and dek_version parsed from the on-disk header so
+    /// the client can verify the backup envelope without decrypting it.
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn backup(
+        &self,
+        request: Request<pb::raft::BackupRequest>,
+    ) -> Result<Response<Self::BackupStream>, Status> {
+        let actor = extract_peer_identity(&request);
+        trace!(actor, "operator backup requested");
+
+        // Ensure backup targets the leader to avoid stale data.
+        let current_leader = self.raft_node.metrics().borrow_watched().current_leader;
+        if current_leader.map_or(true, |l| l != self.node_id) {
+            return Err(Status::failed_precondition(
+                "backup must be directed at the current cluster leader",
+            ));
+        }
+
+        // Trigger snapshot build via the snapshot builder trait.
+        let mut builder = self.sm.clone();
+        let built = builder
+            .build_snapshot()
+            .await
+            .map_err(|e| Status::internal(format!("snapshot build failed: {e}")))?;
+
+        let snapshot_path = self.sm.snapshot_dir().join(&built.meta.snapshot_id);
+        let file = tokio::fs::File::open(&snapshot_path)
+            .await
+            .map_err(|e| Status::internal(format!("cannot open snapshot file: {e}")))?;
+        let file_size = file
+            .metadata()
+            .await
+            .map_err(|e| Status::internal(format!("cannot stat snapshot file: {e}")))?
+            .len() as usize;
+
+        if file_size < 12 {
+            return Err(Status::internal("snapshot file too short"));
+        }
+
+        // Read and parse the 12-byte header: [dek_version: u32_be][utc_epoch: u64_be].
+        let (file, header_bytes, dek_version, utc_epoch) = {
+            let mut file = file;
+            let mut header = [0u8; 12];
+            tokio::io::AsyncReadExt::read_exact(&mut file, &mut header)
+                .await
+                .map_err(|e| Status::internal(format!("cannot read snapshot header: {e}")))?;
+            let dv = u32::from_be_bytes(header[..4].try_into().unwrap());
+            let ue = u64::from_be_bytes(header[4..12].try_into().unwrap());
+            (file, header, dv, ue)
+        };
+
+        self.audit.emit(AuditRecord::now(
+            "BACKUP_CREATED",
+            &actor,
+            self.node_id,
+            self.current_dek
+                .read()
+                .unwrap_or_else(|p| p.into_inner())
+                .version,
+            serde_json::json!({
+                "snapshot_utc_epoch": utc_epoch,
+                "dek_version": dek_version,
+                "bytes": file_size,
+            }),
+        ));
+
+        // Stream the entire snapshot (header + body) in 256 KiB chunks. Only
+        // the final chunk carries metadata. State tracks (file, bytes_written,
+        // total_size, dek_version, utc_epoch, header_pending).
+        const CHUNK_SIZE: usize = 256 * 1024;
+        let stream = futures::stream::unfold(
+            (
+                file,
+                0usize,
+                file_size,
+                dek_version,
+                utc_epoch,
+                Some(header_bytes),
+            ),
+            |(mut file, written, total, dv, ue, header_opt)| async move {
+                // Terminated: nothing left to send.
+                if written >= total {
+                    return None;
+                }
+
+                // Determine how many bytes to prefill from the pending header.
+                let (header_len, header_data) =
+                    header_opt.map_or((0, Vec::new()), |h| (h.len(), h.to_vec()));
+                let mut buf = Vec::with_capacity(CHUNK_SIZE);
+                buf.extend(header_data);
+
+                let to_read = CHUNK_SIZE.saturating_sub(header_len);
+                let to_read = to_read.min(total.saturating_sub(written + header_len));
+                if to_read > 0 {
+                    let mut body = vec![0u8; to_read];
+                    if let Err(e) = tokio::io::AsyncReadExt::read_exact(&mut file, &mut body).await
+                    {
+                        return Some((
+                            Err(Status::internal(format!("read error: {e}"))),
+                            (file, written, total, dv, ue, None),
+                        ));
+                    }
+                    buf.extend(body);
+                }
+
+                let new_written = written + header_len + to_read;
+                if new_written >= total {
+                    return Some((
+                        Ok(pb::raft::BackupChunk {
+                            data: buf,
+                            snapshot_utc_epoch: Some(ue),
+                            dek_version: Some(dv),
+                        }),
+                        (file, new_written, total, dv, ue, None),
+                    ));
+                }
+
+                Some((
+                    Ok(pb::raft::BackupChunk {
+                        data: buf,
+                        snapshot_utc_epoch: None,
+                        dek_version: None,
+                    }),
+                    (file, new_written, total, dv, ue, None),
+                ))
+            },
+        );
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    /// Accept a client-streamed encrypted backup, validate its envelope,
+    /// and install it into the Raft state machine via
+    /// `Raft::install_full_snapshot`.
+    ///
+    /// Only call this against a freshly-bootstrapped single-node cluster
+    /// before adding learners (see ADR 0016-v2 §7 / doc Restore runbook).
+    #[tracing::instrument(level = "trace", skip(self, request))]
+    async fn restore(
+        &self,
+        request: Request<Streaming<pb::raft::RestoreChunk>>,
+    ) -> Result<Response<pb::raft::AdminResponse>, Status> {
+        let actor = extract_peer_identity(&request);
+        trace!(actor, "operator restore requested");
+
+        let mut stream = request.into_inner();
+        const MAX_RESTORE_SIZE: usize = 4 * 1024 * 1024 * 1024; // 4 GiB
+        let mut buf: Vec<u8> = Vec::new();
+        while let Some(chunk) = stream.message().await? {
+            if buf.len() + chunk.data.len() > MAX_RESTORE_SIZE {
+                return Err(Status::resource_exhausted(
+                    "restore stream exceeds maximum allowed size (4 GiB)",
+                ));
+            }
+            buf.extend_from_slice(&chunk.data);
+        }
+        if buf.is_empty() {
+            return Err(Status::invalid_argument("restore stream was empty"));
+        }
+
+        let (snapshot, utc_epoch, dek_version) = self
+            .sm
+            .decode_backup_blob(&buf)
+            .map_err(|e| Status::invalid_argument(format!("invalid backup blob: {e}")))?;
+
+        // install_full_snapshot requires the node to be a committed leader.
+        let vote = self.raft_node.metrics().borrow_watched().vote.clone();
+        if !vote.committed {
+            return Err(Status::failed_precondition(
+                "node is not a committed leader; direct restore to the current cluster leader",
+            ));
+        }
+
+        self.raft_node
+            .install_full_snapshot(vote, snapshot)
+            .await
+            .map_err(|e| Status::internal(format!("snapshot install failed: {e}")))?;
+
+        let dek_ver_for_audit = self
+            .current_dek
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .version;
+        self.audit.emit(AuditRecord::now(
+            "BACKUP_RESTORED",
+            &actor,
+            self.node_id,
+            dek_ver_for_audit,
+            serde_json::json!({
+                "snapshot_utc_epoch": utc_epoch,
+                "backup_dek_version": dek_version,
+            }),
+        ));
+
+        tracing::info!(actor, utc_epoch, dek_version, "backup restore complete");
         Ok(Response::new(pb::raft::AdminResponse::default()))
     }
 }

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -333,6 +333,35 @@ impl FjallStateMachine {
         &self.meta
     }
 
+    /// Return the path to the snapshot directory.
+    pub(crate) fn snapshot_dir(&self) -> &std::path::Path {
+        &self.snapshot_dir
+    }
+
+    /// Validate and decrypt an operator backup blob (produced by the `Backup`
+    /// gRPC RPC) and return an OpenRaft `Snapshot` ready for
+    /// `Raft::install_full_snapshot`.
+    ///
+    /// The blob format is `[dek_version_u32_BE; 4] ++ [utc_epoch_u64_BE; 8] ++
+    /// AES-256-GCM(snapshot_file_msgpack)`.  Returns the decoded `Snapshot`
+    /// together with the (utc_epoch, dek_version) pair for audit logging.
+    pub fn decode_backup_blob(
+        &self,
+        bytes: &[u8],
+    ) -> Result<(crate::types::Snapshot, u64, u32), crate::StoreError> {
+        let (snapshot_file, dek_version, utc_epoch) =
+            decrypt_snapshot_file(bytes, &self.dek, &self.old_deks)?;
+
+        let data_bytes = rmp_serde::to_vec(&snapshot_file.data)
+            .map_err(|e| crate::StoreError::Other(eyre::eyre!("snapshot re-serialize: {e}")))?;
+
+        let snapshot = openraft::storage::Snapshot {
+            meta: snapshot_file.meta,
+            snapshot: data_bytes,
+        };
+        Ok((snapshot, utc_epoch, dek_version))
+    }
+
     /// Get the Fjall `keyspace` handle by name.
     pub fn keyspace<S: AsRef<str>>(&self, name: S) -> Result<Keyspace, StoreError> {
         Ok(match name.as_ref() {
@@ -529,7 +558,7 @@ fn decrypt_snapshot_file(
     disk_bytes: &[u8],
     current_dek: &std::sync::Arc<std::sync::RwLock<std::sync::Arc<DekEpoch>>>,
     old_deks: &std::sync::Arc<std::sync::Mutex<BTreeMap<u32, std::sync::Arc<DekEpoch>>>>,
-) -> Result<SnapshotFile, crate::StoreError> {
+) -> Result<(SnapshotFile, u32, u64), crate::StoreError> {
     use openstack_keystone_storage_crypto::dek::BackupDek;
 
     const HEADER_LEN: usize = 4 + 8; // version + epoch
@@ -577,8 +606,9 @@ fn decrypt_snapshot_file(
         ))
     })?;
 
-    rmp_serde::from_slice(&file_bytes)
-        .map_err(|e| crate::StoreError::Other(eyre::eyre!("snapshot deserialize: {e}")))
+    let file = rmp_serde::from_slice(&file_bytes)
+        .map_err(|e| crate::StoreError::Other(eyre::eyre!("snapshot deserialize: {e}")))?;
+    Ok((file, dek_version, utc_epoch))
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<FjallStateMachine> {
@@ -819,8 +849,9 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
         let snapshot_path = self.snapshot_dir.join(&snapshot_id);
 
         let disk_bytes = fs::read(&snapshot_path)?;
-        let snapshot_file = decrypt_snapshot_file(&disk_bytes, &self.dek, &self.old_deks)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let (snapshot_file, _, _) =
+            decrypt_snapshot_file(&disk_bytes, &self.dek, &self.old_deks)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         let data_bytes = rmp_serde::to_vec(&snapshot_file.data)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;

--- a/doc/src/raft_storage.md
+++ b/doc/src/raft_storage.md
@@ -27,6 +27,7 @@ gRPC) and `openstack-keystone-storage-crypto` (all cryptographic primitives).
     - [Adding Nodes](#adding-nodes)
     - [TLS Certificate Management](#tls-certificate-management)
 11. [Operational Runbook](#operational-runbook)
+    - [Cluster Metrics](#cluster-metrics)
     - [Scheduled DEK Rotation](#scheduled-dek-rotation)
     - [Emergency DEK Rotation](#emergency-dek-rotation)
     - [Clearing a Quarantined Partition](#clearing-a-quarantined-partition)
@@ -35,12 +36,35 @@ gRPC) and `openstack-keystone-storage-crypto` (all cryptographic primitives).
 
 ---
 
+## CLI Reference
+
+All cluster management operations use `keystone-manage storage <subcommand>`.
+The `--cluster_addr` flag (type `URI`) selects which cluster member to contact;
+it defaults to `node_cluster_addr` from the config file when omitted.
+
+| Subcommand                                          | Description                                    |
+| --------------------------------------------------- | ---------------------------------------------- |
+| `init`                                              | Bootstrap a new single-node cluster            |
+| `join <cluster-addr>`                               | Join the local node as a Raft learner          |
+| `promote <node-id>`                                 | Promote a learner to voting member             |
+| `demote <node-id>`                                  | Demote a voter to non-voting learner           |
+| `remove-peer <node-id>`                             | Remove a peer from the cluster membership      |
+| `list-peers`                                        | Show cluster peers in a table                  |
+| `metrics`                                           | Show raw cluster metrics and leader status     |
+| `clear-quarantine [--cluster-addr] [--partition]`   | Clear a GCM-failure quarantine (operator-only) |
+| `rotate-dek [--cluster-addr] [--emergency]`         | Rotate the Data Encryption Key                 |
+| `confirm-rotate-dek [--cluster-addr] --rotation-id` | Confirm a pending emergency DEK rotation       |
+| `backup [--cluster-addr] --output`                  | Create an encrypted Fjall snapshot             |
+| `restore [--cluster-addr] --snapshot`               | Restore an encrypted snapshot to the cluster   |
+
+---
+
 ## Architecture Overview
 
 The storage engine combines three components:
 
-| Layer                     | Component          | Purpose                                           |
-| ------------------------- | ------------------ | ------------------------------------------------- |
+| Layer                         | Component          | Purpose                                           |
+| ----------------------------- | ------------------ | ------------------------------------------------- |
 | **Consensus**                 | `openraft`         | Log replication, leader election, linearizability |
 | **State machine / log store** | `fjall` (LSM-tree) | Durable on-disk persistence, SSD-optimized        |
 | **Transport**                 | gRPC over mTLS     | Intra-cluster Raft RPC (SPIFFE or custom PKI)     |
@@ -487,37 +511,37 @@ keystone --config /etc/keystone/keystone.conf
 
 Each node starts and waits; Raft is not yet initialized.
 
-**Step 2 — Initialize the first node** as a single-node cluster:
+**Step 2 — Initialize the first node** as a single-node cluster.
+
+Run from node 1's host (node address and ID come from the config file):
 
 ```sh
-keystone-manage storage init \
-  --node-addr https://10.0.0.1:8310 \
-  --node-id 1
+keystone-manage storage init
 ```
 
 Node 1 becomes the leader of a 1-node cluster. Wait for it to report a leader
-(check `keystone-manage storage metrics --node-addr https://10.0.0.1:8310`).
+(check `keystone-manage storage metrics --cluster-addr https://10.0.0.1:8310`).
 
-**Step 3 — Add learners:**
+**Step 3 — Add learners.**
+
+Run from node 2 and node 3's hosts respectively. The positional argument is the
+address of any existing cluster member to contact:
 
 ```sh
-keystone-manage storage join \
-  --leader-addr https://10.0.0.1:8310 \
-  --node-addr   https://10.0.0.2:8310 \
-  --node-id 2
+# On node 2's host:
+keystone-manage storage join https://10.0.0.1:8310
 
-keystone-manage storage join \
-  --leader-addr https://10.0.0.1:8310 \
-  --node-addr   https://10.0.0.3:8310 \
-  --node-id 3
+# On node 3's host:
+keystone-manage storage join https://10.0.0.1:8310
 ```
 
-**Step 4 — Promote learners to voting members:**
+**Step 4 — Promote learners to voting members.**
+
+Run from any node. Repeat once per learner to promote:
 
 ```sh
-keystone-manage storage promote \
-  --leader-addr https://10.0.0.1:8310 \
-  --members 1,2,3
+keystone-manage storage promote 2
+keystone-manage storage promote 3
 ```
 
 ### Adding Nodes
@@ -527,16 +551,11 @@ To add a new node to a running cluster:
 ```sh
 # 1. Start the new node process (it will wait for a join instruction).
 
-# 2. From any existing cluster member:
-keystone-manage storage join \
-  --leader-addr https://10.0.0.1:8310 \
-  --node-addr   https://10.0.0.4:8310 \
-  --node-id 4
+# 2. On the new node's host, join to an existing cluster member:
+keystone-manage storage join https://10.0.0.1:8310
 
-# 3. Optionally promote to voting member:
-keystone-manage storage promote \
-  --leader-addr https://10.0.0.1:8310 \
-  --members 1,2,3,4
+# 3. Optionally promote to voting member (run from any node):
+keystone-manage storage promote 4
 ```
 
 ### TLS Certificate Management
@@ -555,6 +574,27 @@ The node refuses connections from SVIDs with < 5 minutes remaining validity.
 
 ## Operational Runbook
 
+### Cluster Metrics
+
+Quick health check — shows current leader, voter set, and raw OpenRaft metrics:
+
+```sh
+keystone-manage storage metrics --cluster-addr https://10.0.0.1:8310
+```
+
+Sample output:
+
+```
+Current leader : node 1
+Voters         : [1, 2, 3]
+All nodes      : [1=10.0.0.1:8310, 2=10.0.0.2:8310, 3=10.0.0.3:8310]
+
+Raw metrics:
+Metrics{id:1, Leader, term:3, ...}
+```
+
+For a formatted peer table use `list-peers` instead.
+
 ### Scheduled DEK Rotation
 
 Automatic rotation fires after `dek_rotation_days` (default: 90) or when the
@@ -562,7 +602,7 @@ log-encrypt counter approaches 2^31. Manual rotation:
 
 ```sh
 keystone-manage storage rotate-dek \
-  --leader-addr https://10.0.0.1:8310
+  --cluster-addr https://10.0.0.1:8310
 ```
 
 Monitor the audit log (`event_type = "DEK_ROTATION"`) and the post-rotation
@@ -575,13 +615,13 @@ Use when a DEK is suspected compromised.
 ```sh
 # Operator A — initiates rotation, receives rotation_id:
 keystone-manage storage rotate-dek \
-  --leader-addr https://10.0.0.1:8310 \
+  --cluster-addr https://10.0.0.1:8310 \
   --emergency
 # Output: rotation_id=550e8400-e29b-41d4-a716-446655440000
 
 # Operator B — confirms within 5 minutes:
 keystone-manage storage confirm-rotate-dek \
-  --leader-addr https://10.0.0.1:8310 \
+  --cluster-addr https://10.0.0.1:8310 \
   --rotation-id 550e8400-e29b-41d4-a716-446655440000
 ```
 
@@ -599,7 +639,7 @@ keys are rejected with a `QUARANTINED` violation.
 
 ```sh
 # Check node metrics for quarantine state:
-keystone-manage storage metrics --node-addr https://10.0.0.1:8310
+keystone-manage storage metrics --cluster-addr https://10.0.0.1:8310
 ```
 
 Root-cause the GCM failures (hardware fault, storage corruption, or unauthorized
@@ -609,7 +649,7 @@ modification) before clearing quarantine.
 
 ```sh
 keystone-manage storage clear-quarantine \
-  --node-addr https://10.0.0.1:8310 \
+  --cluster-addr https://10.0.0.1:8310 \
   --partition <partition-name>
 ```
 
@@ -621,9 +661,13 @@ This commits a Raft proposal (visible cluster-wide) and emits an audit entry.
 
 ```sh
 keystone-manage storage backup \
-  --node-addr https://10.0.0.1:8310 \
+  --cluster-addr https://10.0.0.1:8310 \
   --output /mnt/backups/keystone-$(date +%Y%m%d).snap
 ```
+
+The command triggers a fresh Fjall snapshot on the target node, then streams the
+AES-256-GCM encrypted bytes to `--output`. The final output includes the
+`snapshot_utc_epoch` and `dek_version` printed on completion for verification.
 
 The snapshot is wrapped in a backup-specific AES-256-GCM envelope with the
 Backup DEK and a DEK manifest. Both are bound to the snapshot timestamp and
@@ -632,13 +676,19 @@ current DEK epoch.
 **Restore:**
 
 ```sh
-# 1. Bootstrap fresh cluster nodes (Step 1 from bootstrap guide).
+# 1. Bootstrap a fresh single-node cluster (Step 1–2 from bootstrap guide).
 # 2. Restore the snapshot to the leader:
 keystone-manage storage restore \
-  --leader-addr https://10.0.0.1:8310 \
+  --cluster-addr https://10.0.0.1:8310 \
   --snapshot /mnt/backups/keystone-20260101.snap
 # 3. Add remaining nodes as learners (Steps 3–4 from bootstrap guide).
 ```
+
+The restore command validates the AES-256-GCM backup envelope (AD binding: epoch
+
+- dek_version), decrypts it using the Backup DEK from the KMS, and installs the
+  snapshot into the Raft state machine via `install_full_snapshot`. The KMS must
+  hold the `backup_dek` role key for the DEK epoch encoded in the snapshot.
 
 **Retired DEK retention:** Retired DEKs must be retained in the KMS for at least
 365 days to allow offline decryption of archived backups. Use a separate


### PR DESCRIPTION
Implement backup, restore, rotate-dek, confirm-rotate-dek, and metrics
subcommands for keystone-manage storage, completing CLI coverage for all
Raft cluster operations defined in ADR 0016-v2.

- Add Backup/Restore RPCs to ClusterAdminService (proto + server
  handlers): server-streaming Backup chunks the encrypted snapshot at
  256 KiB; client-streaming Restore accumulates chunks and calls
  install_full_snapshot
- Expose FjallStateMachine::snapshot_dir() and decode_backup_blob() for
  use by the restore handler (validates AES-256-GCM envelope, returns
  OpenRaft Snapshot ready for install_full_snapshot)
- Wire sm: Arc<StateMachineStore> into ClusterAdminServiceImpl so the
  backup handler can call build_snapshot() and read the resulting
  encrypted file
- New CLI commands: backup (--output), restore (--snapshot), rotate-dek
  (--emergency flag for dual-control path), confirm-rotate-dek
  (--rotation-id), metrics (leader / voters / raw OpenRaft metrics)
  - Update doc/src/raft_storage.md: add CLI reference table, Cluster
  Metrics runbook section, and fix all flag inconsistencies
  (--node-addr/--leader-addr -> --addr; positional args for
  init/join/promote)

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-Off-By: Artem Goncharov <artem.goncharov@gmail.com>
