### PR TITLE
chore: Adapt functest dockerfile to support caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@ doc
 .gitignore
 .github/
 tools/
-**/target/
+skaffold.yaml
+target/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,15 @@ repos:
       - id: debug-statements
       - id: check-yaml
         files: .*\.(yaml|yml)$
-        exclude: '^zuul.d/.*$'
+        exclude: |
+          (?x)(
+            ^zuul.d/.*$|
+            skaffold.yaml
+          )
+      - id: check-yaml
+        name: check-yaml (skaffold)
+        files: ^skaffold\.yaml$
+        args: [--allow-multiple-documents]
       - id: check-json
   - repo: https://github.com/crate-ci/typos
     rev: v1.33.1

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -68,10 +68,6 @@ build:
       context: .
       docker:
         dockerfile: Dockerfile
-    - image: keystone-opa
-      context: .
-      docker:
-        dockerfile: tools/Dockerfile.opa
     - image: keystone-tests
       context: .
       docker:
@@ -235,4 +231,3 @@ verify:
           value: "http://dex:5556"
     executionMode:
       kubernetesCluster: {}
-

--- a/tools/Dockerfile.functest
+++ b/tools/Dockerfile.functest
@@ -5,7 +5,7 @@ RUN cargo install --locked cargo-chef
 WORKDIR app
 
 # Stage 2: Plan
-FROM base AS planner 
+FROM base AS planner
 
 COPY . .
 
@@ -21,7 +21,7 @@ RUN apt update &&\
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --tests --recipe-path recipe.json
 
 #COPY . .
 COPY crates crates
@@ -30,18 +30,18 @@ COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 
 # Compile the specific functional test file
-RUN cargo test -p test_api --test integration_api_v3 --no-run && \
-    cp $(find target/debug/deps -name "integration_api_v3-*" -type f -executable) /app/test-api-v3
-RUN cargo test -p test_api --test integration_api_v4 --no-run && \
-    cp $(find target/debug/deps -name "integration_api_v4-*" -type f -executable) /app/test-api-v4
-RUN cargo test -p test_api --test k8s_auth --no-run && \
-    cp $(find target/debug/deps -name "k8s_auth-*" -type f -executable) /app/test-k8s-auth
-RUN cargo test -p test_federation --test keycloak --no-run && \
-    cp $(find target/debug/deps -name "keycloak-*" -type f -executable) /app/test-keycloak
-RUN cargo test -p test_federation --test dex --no-run && \
-    cp $(find target/debug/deps -name "dex-*" -type f -executable) /app/test-dex
-RUN cargo test -p test_federation --test github --no-run && \
-    cp $(find target/debug/deps -name "github-*" -type f -executable) /app/test-github
+RUN cargo test --release -p test_api --test integration_api_v3 --no-run && \
+    cp $(find target/release/deps -name "integration_api_v3-*" -type f -executable) /app/test-api-v3
+RUN cargo test --release -p test_api --test integration_api_v4 --no-run && \
+    cp $(find target/release/deps -name "integration_api_v4-*" -type f -executable) /app/test-api-v4
+RUN cargo test --release -p test_api --test k8s_auth --no-run && \
+    cp $(find target/release/deps -name "k8s_auth-*" -type f -executable) /app/test-k8s-auth
+RUN cargo test --release -p test_federation --test keycloak --no-run && \
+    cp $(find target/release/deps -name "keycloak-*" -type f -executable) /app/test-keycloak
+RUN cargo test --release -p test_federation --test dex --no-run && \
+    cp $(find target/release/deps -name "dex-*" -type f -executable) /app/test-dex
+RUN cargo test --release -p test_federation --test github --no-run && \
+    cp $(find target/release/deps -name "github-*" -type f -executable) /app/test-github
 
 # Stage 4: Package
 FROM debian:trixie-slim AS runtime


### PR DESCRIPTION
Due to the few errors in the dockerfile cargo chef was not properly
caching and pre-compiling the content for test targets. Also add
skaffold.yaml itself into dockerignore file to prevent it from being
taken into the base image
