### PR TITLE
fix: Restore building of the opa image

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -68,6 +68,10 @@ build:
       context: .
       docker:
         dockerfile: Dockerfile
+    - image: keystone-opa
+      context: .
+      docker:
+        dockerfile: tools/Dockerfile.opa
     - image: keystone-tests
       context: .
       docker:


### PR DESCRIPTION
It was a mistake to delete it and the test was not started hiding the
error.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
