### PR TITLE
refactor: Wrap ServiceState under ExecutionContext

### DIFF
--- a/crates/assignment-driver-sql/src/lib.rs
+++ b/crates/assignment-driver-sql/src/lib.rs
@@ -25,6 +25,8 @@ use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::{SqlDriver, SqlDriverRegistration};
 use openstack_keystone_core_types::assignment::*;
 
+use openstack_keystone_core::auth::ExecutionContext;
+
 mod assignment;
 pub mod entity;
 
@@ -58,10 +60,11 @@ impl SqlBackend {
         state: &ServiceState,
         assignments: Vec<Assignment>,
     ) -> Result<Vec<Assignment>, AssignmentProviderError> {
+        let exec = ExecutionContext::internal(state);
         let rules = state
             .provider
             .get_role_provider()
-            .list_role_imply_rules(state)
+            .list_role_imply_rules(&exec)
             .await?;
         let mut imply_rules: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
         for rule in &rules {
@@ -252,7 +255,7 @@ impl AssignmentBackend for SqlBackend {
             let users = state
                 .provider
                 .get_identity_provider()
-                .list_groups_of_user(state, uid)
+                .list_groups_of_user(&ExecutionContext::internal(state), uid)
                 .await?;
             actors.extend(users.into_iter().map(|x| x.id));
         };
@@ -265,7 +268,7 @@ impl AssignmentBackend for SqlBackend {
             if let Some(parents) = state
                 .provider
                 .get_resource_provider()
-                .get_project_parents(state, val)
+                .get_project_parents(&ExecutionContext::internal(state), val)
                 .await?
             {
                 // All assignments for parent projects having `inherited=true` must be included.
@@ -354,7 +357,7 @@ mod tests {
             .into_connection();
 
         let mut role_mock = MockRoleProvider::default();
-        role_mock.expect_list_role_imply_rules().returning(|_| {
+        role_mock.expect_list_role_imply_rules().returning(|_e| {
             Ok(vec![
                 RoleImplyBuilder::default()
                     .prior_role(RoleRef {
@@ -477,7 +480,7 @@ mod tests {
             .into_connection();
 
         let mut role_mock = MockRoleProvider::default();
-        role_mock.expect_list_role_imply_rules().returning(|_| {
+        role_mock.expect_list_role_imply_rules().returning(|_e| {
             Ok(vec![
                 RoleImplyBuilder::default()
                     .prior_role(RoleRef {

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -29,7 +29,7 @@ use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
 
 use crate::api::KeystoneApiError;
-use crate::auth::ValidatedSecurityContext;
+use crate::auth::{ExecutionContext, ValidatedSecurityContext};
 use crate::keystone::ServiceState;
 
 #[derive(Debug, Clone)]
@@ -135,7 +135,10 @@ where
             let result = state
                 .provider
                 .get_mapping_provider()
-                .authenticate_by_mapping(&state, &flat_spiffe_claims(svid))
+                .authenticate_by_mapping(
+                    &ExecutionContext::internal(&state),
+                    &flat_spiffe_claims(svid),
+                )
                 .await?;
             let ctx = SecurityContext::try_from(result)?;
             let vsc =
@@ -153,7 +156,12 @@ where
             let vsc = state
                 .provider
                 .get_token_provider()
-                .authorize_by_token(&state, auth_header, Some(false), None)
+                .authorize_by_token(
+                    &ExecutionContext::internal(&state),
+                    auth_header,
+                    Some(false),
+                    None,
+                )
                 .await
                 .inspect_err(|e| error!("{:#?}", e))
                 .map_err(|_| KeystoneApiError::UnauthorizedNoContext)?;
@@ -298,7 +306,7 @@ mod tests {
         let config_manager = ConfigManager::not_watched(config);
 
         let mut role_mock = MockRoleProvider::new();
-        role_mock.expect_list_roles().returning(|_, params| {
+        role_mock.expect_list_roles().returning(|_e, params| {
             let name = params
                 .name
                 .clone()
@@ -456,7 +464,7 @@ mod tests {
         let config_manager = ConfigManager::not_watched(config);
 
         let mut role_mock = MockRoleProvider::new();
-        role_mock.expect_list_roles().returning(|_, params| {
+        role_mock.expect_list_roles().returning(|_e, params| {
             let name = params
                 .name
                 .clone()
@@ -507,7 +515,7 @@ mod tests {
 
         let mut token_mock = MockTokenProvider::new();
         token_mock.expect_authorize_by_token().once().returning(
-            move |_state, _token, _allow_rescope, _restrict_to| {
+            move |_exec, _token, _allow_rescope, _restrict_to| {
                 let mut security_context = SecurityContextTestingBuilder::default()
                     .authentication_context(AuthenticationContext::Password)
                     .principal(

--- a/crates/core/src/api/common.rs
+++ b/crates/core/src/api/common.rs
@@ -23,6 +23,7 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::resource::{Domain, Project};
 use openstack_keystone_core_types::scope::Scope as ProviderScope;
 
+use crate::auth::ExecutionContext;
 use crate::keystone::ServiceState;
 
 /// Get the scope [ProjectBuilder] for the given Project.
@@ -67,20 +68,22 @@ pub async fn get_domain<I: AsRef<str>, N: AsRef<str>>(
     name: Option<N>,
 ) -> Result<Domain, KeystoneApiError> {
     if let Some(did) = &id {
+        let exec = ExecutionContext::internal(state);
         state
             .provider
             .get_resource_provider()
-            .get_domain(state, did.as_ref())
+            .get_domain(&exec, did.as_ref())
             .await?
             .ok_or_else(|| KeystoneApiError::NotFound {
                 resource: "domain".into(),
                 identifier: did.as_ref().to_string(),
             })
     } else if let Some(name) = &name {
+        let exec = ExecutionContext::internal(state);
         state
             .provider
             .get_resource_provider()
-            .find_domain_by_name(state, name.as_ref())
+            .find_domain_by_name(&exec, name.as_ref())
             .await?
             .ok_or_else(|| KeystoneApiError::NotFound {
                 resource: "domain".into(),
@@ -105,13 +108,15 @@ pub async fn find_project_from_scope(
     scope: &ScopeProject,
 ) -> Result<Option<Project>, KeystoneApiError> {
     let project = if let Some(pid) = &scope.id {
+        let exec = ExecutionContext::internal(state);
         state
             .provider
             .get_resource_provider()
-            .get_project(state, pid)
+            .get_project(&exec, pid)
             .await?
     } else if let Some(name) = &scope.name {
         if let Some(domain) = &scope.domain {
+            let exec = ExecutionContext::internal(state);
             let domain_id = match &domain.id {
                 Some(id) => id.clone(),
                 None => {
@@ -119,7 +124,7 @@ pub async fn find_project_from_scope(
                         .provider
                         .get_resource_provider()
                         .find_domain_by_name(
-                            state,
+                            &exec,
                             &domain
                                 .name
                                 .clone()
@@ -139,7 +144,7 @@ pub async fn find_project_from_scope(
             state
                 .provider
                 .get_resource_provider()
-                .get_project_by_name(state, name, &domain_id)
+                .get_project_by_name(&exec, name, &domain_id)
                 .await?
         } else {
             return Err(KeystoneApiError::ProjectDomain);

--- a/crates/core/src/application_credential/provider_api.rs
+++ b/crates/core/src/application_credential/provider_api.rs
@@ -15,7 +15,7 @@
 use async_trait::async_trait;
 
 use crate::application_credential::error::ApplicationCredentialProviderError;
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use openstack_keystone_core_types::application_credential::*;
 
 /// Application credentials API.
@@ -31,9 +31,9 @@ pub trait ApplicationCredentialApi: Send + Sync {
     /// # Returns
     /// - `Result<AccessRule, ApplicationCredentialProviderError>` - The created
     ///   access rule or an error.
-    async fn create_access_rule(
+    async fn create_access_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         rule: AccessRuleCreate,
     ) -> Result<AccessRule, ApplicationCredentialProviderError>;
 
@@ -47,9 +47,9 @@ pub trait ApplicationCredentialApi: Send + Sync {
     /// - `Result<ApplicationCredentialCreateResponse,
     ///   ApplicationCredentialProviderError>` - The creation response or an
     ///   error.
-    async fn create_application_credential(
+    async fn create_application_credential<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         rec: ApplicationCredentialCreate,
     ) -> Result<ApplicationCredentialCreateResponse, ApplicationCredentialProviderError>;
 
@@ -65,7 +65,7 @@ pub trait ApplicationCredentialApi: Send + Sync {
     ///   an error.
     async fn delete_access_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         id: &'a str,
     ) -> Result<(), ApplicationCredentialProviderError>;
@@ -82,7 +82,7 @@ pub trait ApplicationCredentialApi: Send + Sync {
     ///   access rule if found, or an error.
     async fn get_access_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         id: &'a str,
     ) -> Result<Option<AccessRule>, ApplicationCredentialProviderError>;
@@ -99,7 +99,7 @@ pub trait ApplicationCredentialApi: Send + Sync {
     ///   error.
     async fn get_application_credential<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<ApplicationCredential>, ApplicationCredentialProviderError>;
 
@@ -114,7 +114,7 @@ pub trait ApplicationCredentialApi: Send + Sync {
     ///   of access rules or an error.
     async fn list_access_rules<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Vec<AccessRule>, ApplicationCredentialProviderError>;
 
@@ -128,9 +128,9 @@ pub trait ApplicationCredentialApi: Send + Sync {
     /// - `Result<Vec<ApplicationCredential>,
     ///   ApplicationCredentialProviderError>` - A list of application
     ///   credentials or an error.
-    async fn list_application_credentials(
+    async fn list_application_credentials<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &ApplicationCredentialListParameters,
     ) -> Result<Vec<ApplicationCredential>, ApplicationCredentialProviderError>;
 }

--- a/crates/core/src/application_credential/service.rs
+++ b/crates/core/src/application_credential/service.rs
@@ -31,7 +31,7 @@ use crate::application_credential::{
     ApplicationCredentialApi, ApplicationCredentialProviderError,
     backend::ApplicationCredentialBackend,
 };
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::plugin_manager::PluginManagerApi;
 
 /// Application Credential Provider.
@@ -72,9 +72,9 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
     /// # Returns
     /// - `Result<AccessRule, ApplicationCredentialProviderError>` - The created
     ///   access rule or an error.
-    async fn create_access_rule(
+    async fn create_access_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         rule: AccessRuleCreate,
     ) -> Result<AccessRule, ApplicationCredentialProviderError> {
         let mut rule = rule;
@@ -84,9 +84,12 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
             rule.id = Some(Uuid::new_v4().simple().to_string());
         }
         let user_id = rule.user_id.clone();
-        let access_rule = self.backend_driver.create_access_rule(state, rule).await?;
+        let access_rule = self
+            .backend_driver
+            .create_access_rule(ctx.state(), rule)
+            .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -110,17 +113,18 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
     /// - `Result<ApplicationCredentialCreateResponse,
     ///   ApplicationCredentialProviderError>` - The creation response or an
     ///   error.
-    async fn create_application_credential(
+    async fn create_application_credential<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         rec: ApplicationCredentialCreate,
     ) -> Result<ApplicationCredentialCreateResponse, ApplicationCredentialProviderError> {
         rec.validate()?;
         // TODO: implement some filters.
-        let roles: HashSet<String> = state
+        let roles: HashSet<String> = ctx
+            .state()
             .provider
             .get_role_provider()
-            .list_roles(state, &RoleListParameters::default())
+            .list_roles(ctx, &RoleListParameters::default())
             .await?
             .iter()
             .map(|role| role.id.clone())
@@ -150,10 +154,10 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
         }
         let response = self
             .backend_driver
-            .create_application_credential(state, new_rec.clone())
+            .create_application_credential(ctx.state(), new_rec.clone())
             .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -179,15 +183,15 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
     ///   an error.
     async fn delete_access_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         id: &'a str,
     ) -> Result<(), ApplicationCredentialProviderError> {
         self.backend_driver
-            .delete_access_rule(state, user_id, id)
+            .delete_access_rule(ctx.state(), user_id, id)
             .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -213,12 +217,12 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
     ///   access rule if found, or an error.
     async fn get_access_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         id: &'a str,
     ) -> Result<Option<AccessRule>, ApplicationCredentialProviderError> {
         self.backend_driver
-            .get_access_rule(state, user_id, id)
+            .get_access_rule(ctx.state(), user_id, id)
             .await
     }
 
@@ -234,18 +238,19 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
     ///   error.
     async fn get_application_credential<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<ApplicationCredential>, ApplicationCredentialProviderError> {
         if let Some(mut app_cred) = self
             .backend_driver
-            .get_application_credential(state, id)
+            .get_application_credential(ctx.state(), id)
             .await?
         {
-            let roles: BTreeMap<String, Role> = state
+            let roles: BTreeMap<String, Role> = ctx
+                .state()
                 .provider
                 .get_role_provider()
-                .list_roles(state, &RoleListParameters::default())
+                .list_roles(ctx, &RoleListParameters::default())
                 .await?
                 .into_iter()
                 .map(|x| (x.id.clone(), x))
@@ -273,10 +278,12 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
     ///   of access rules or an error.
     async fn list_access_rules<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Vec<AccessRule>, ApplicationCredentialProviderError> {
-        self.backend_driver.list_access_rules(state, user_id).await
+        self.backend_driver
+            .list_access_rules(ctx.state(), user_id)
+            .await
     }
 
     /// List application credentials.
@@ -289,21 +296,22 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
     /// - `Result<Vec<ApplicationCredential>,
     ///   ApplicationCredentialProviderError>` - A list of application
     ///   credentials or an error.
-    async fn list_application_credentials(
+    async fn list_application_credentials<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &ApplicationCredentialListParameters,
     ) -> Result<Vec<ApplicationCredential>, ApplicationCredentialProviderError> {
         params.validate()?;
         let mut creds = self
             .backend_driver
-            .list_application_credentials(state, params)
+            .list_application_credentials(ctx.state(), params)
             .await?;
 
-        let roles: BTreeMap<String, Role> = state
+        let roles: BTreeMap<String, Role> = ctx
+            .state()
             .provider
             .get_role_provider()
-            .list_roles(state, &RoleListParameters::default())
+            .list_roles(ctx, &RoleListParameters::default())
             .await?
             .into_iter()
             .map(|x| (x.id.clone(), x))

--- a/crates/core/src/assignment/provider_api.rs
+++ b/crates/core/src/assignment/provider_api.rs
@@ -15,7 +15,7 @@
 use async_trait::async_trait;
 
 use crate::assignment::AssignmentProviderError;
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use openstack_keystone_core_types::assignment::*;
 
 /// The trait covering [`Role`](crate::role::types::Role) assignments between
@@ -31,9 +31,9 @@ pub trait AssignmentApi: Send + Sync {
     /// # Returns
     /// - `Result<Assignment, AssignmentProviderError>` - The created assignment
     ///   or an error.
-    async fn create_grant(
+    async fn create_grant<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: AssignmentCreate,
     ) -> Result<Assignment, AssignmentProviderError>;
 
@@ -53,9 +53,9 @@ pub trait AssignmentApi: Send + Sync {
     /// # Returns
     /// - `Result<Vec<Assignment>, AssignmentProviderError>` - A list of
     ///   assignments or an error.
-    async fn list_role_assignments(
+    async fn list_role_assignments<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &RoleAssignmentListParameters,
     ) -> Result<Vec<Assignment>, AssignmentProviderError>;
 
@@ -67,9 +67,9 @@ pub trait AssignmentApi: Send + Sync {
     ///
     /// # Returns
     /// - `Result<(), AssignmentProviderError>` - Ok on success, or an error.
-    async fn revoke_grant(
+    async fn revoke_grant<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: Assignment,
     ) -> Result<(), AssignmentProviderError>;
 }

--- a/crates/core/src/assignment/service.rs
+++ b/crates/core/src/assignment/service.rs
@@ -22,7 +22,7 @@ use openstack_keystone_core_types::revoke::RevocationEventCreate;
 use openstack_keystone_core_types::role::{Role, RoleListParameters};
 
 use crate::assignment::{AssignmentApi, AssignmentProviderError, backend::AssignmentBackend};
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::plugin_manager::PluginManagerApi;
 
 pub struct AssignmentService {
@@ -62,14 +62,14 @@ impl AssignmentApi for AssignmentService {
     /// # Returns
     /// - `Result<Assignment, AssignmentProviderError>` - The created assignment
     ///   or an error.
-    async fn create_grant(
+    async fn create_grant<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         grant: AssignmentCreate,
     ) -> Result<Assignment, AssignmentProviderError> {
-        let assignment = self.backend_driver.create_grant(state, grant).await?;
+        let assignment = self.backend_driver.create_grant(ctx.state(), grant).await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -121,17 +121,21 @@ impl AssignmentApi for AssignmentService {
     /// # Returns
     /// - `Result<Vec<Assignment>, AssignmentProviderError>` - A list of
     ///   assignments or an error.
-    async fn list_role_assignments(
+    async fn list_role_assignments<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &RoleAssignmentListParameters,
     ) -> Result<Vec<Assignment>, AssignmentProviderError> {
-        let mut assignments = self.backend_driver.list_assignments(state, params).await?;
+        let mut assignments = self
+            .backend_driver
+            .list_assignments(ctx.state(), params)
+            .await?;
         if !assignments.is_empty() && params.include_names.is_some_and(|x| x) {
-            let roles: BTreeMap<String, Role> = state
+            let roles: BTreeMap<String, Role> = ctx
+                .state()
                 .provider
                 .get_role_provider()
-                .list_roles(state, &RoleListParameters::default())
+                .list_roles(ctx, &RoleListParameters::default())
                 .await?
                 .into_iter()
                 .map(|x| (x.id.clone(), x))
@@ -152,13 +156,15 @@ impl AssignmentApi for AssignmentService {
     ///
     /// # Returns
     /// - `Result<(), AssignmentProviderError>` - Ok on success, or an error.
-    async fn revoke_grant(
+    async fn revoke_grant<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         grant: Assignment,
     ) -> Result<(), AssignmentProviderError> {
         // Call backend with reference (no move)
-        self.backend_driver.revoke_grant(state, &grant).await?;
+        self.backend_driver
+            .revoke_grant(ctx.state(), &grant)
+            .await?;
 
         // Determine user_id or group_id
         let user_id = match &grant.r#type {
@@ -197,13 +203,13 @@ impl AssignmentApi for AssignmentService {
             revoked_at: chrono::Utc::now(),
         };
 
-        state
+        ctx.state()
             .provider
             .get_revoke_provider()
-            .create_revocation_event(state, revocation_event)
+            .create_revocation_event(ctx, revocation_event)
             .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -280,7 +286,7 @@ mod tests {
         assert!(
             provider
                 .create_grant(
-                    &state,
+                    &ExecutionContext::internal(&state),
                     AssignmentCreate::user_project("actor_id", "target_id", "role_id", false)
                 )
                 .await
@@ -303,7 +309,7 @@ mod tests {
         assert!(
             provider
                 .list_role_assignments(
-                    &state,
+                    &ExecutionContext::internal(&state),
                     &RoleAssignmentListParameters {
                         role_id: Some("rid".into()),
                         resolve_implied_roles: false,
@@ -358,7 +364,7 @@ mod tests {
 
         let res = provider
             .list_role_assignments(
-                &state,
+                &ExecutionContext::internal(&state),
                 &RoleAssignmentListParameters {
                     role_id: Some("rid".into()),
                     include_names: Some(true),
@@ -409,6 +415,11 @@ mod tests {
             backend_driver: Arc::new(backend),
         };
 
-        assert!(provider.revoke_grant(&state, assignment).await.is_ok());
+        assert!(
+            provider
+                .revoke_grant(&ExecutionContext::internal(&state), assignment)
+                .await
+                .is_ok()
+        );
     }
 }

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -101,7 +101,7 @@ impl ValidatedSecurityContext {
             let user_domain = state
                 .provider
                 .get_resource_provider()
-                .get_domain(state, domain_id)
+                .get_domain(&ExecutionContext::internal(state), domain_id)
                 .await
                 .auth_context("fetching user domain")?
                 .ok_or(ResourceProviderError::DomainNotFound(domain_id.clone()))
@@ -140,7 +140,7 @@ impl ValidatedSecurityContext {
                 state
                     .provider
                     .get_trust_provider()
-                    .validate_trust_delegation_chain(state, trust)
+                    .validate_trust_delegation_chain(&ExecutionContext::internal(state), trust)
                     .await
                     .auth_context("validating trust delegation chain")?;
 
@@ -153,7 +153,7 @@ impl ValidatedSecurityContext {
                 let trustor = state
                     .provider
                     .get_identity_provider()
-                    .get_user(state, &trust.trustor_user_id)
+                    .get_user(&ExecutionContext::internal(state), &trust.trustor_user_id)
                     .await
                     .auth_context("fetching trustor user")?
                     .ok_or(IdentityProviderError::UserNotFound(
@@ -175,7 +175,10 @@ impl ValidatedSecurityContext {
                         let trustor_domain_enabled = state
                             .provider
                             .get_resource_provider()
-                            .get_domain_enabled(state, &trustor.domain_id)
+                            .get_domain_enabled(
+                                &ExecutionContext::internal(state),
+                                &trustor.domain_id,
+                            )
                             .await
                             .auth_context("get_trustor_domain_enabled")?;
                         if !trustor_domain_enabled {
@@ -193,7 +196,7 @@ impl ValidatedSecurityContext {
                 let vu = state
                     .provider
                     .get_mapping_provider()
-                    .get_virtual_user(state, &mc.virtual_user_id)
+                    .get_virtual_user(&ExecutionContext::internal(state), &mc.virtual_user_id)
                     .await
                     .auth_context("fetching virtual user for scope resolution")?
                     .ok_or(AuthenticationError::ActorHasNoRolesOnTarget)
@@ -313,6 +316,73 @@ impl Deref for ValidatedSecurityContext {
     }
 }
 
+/// ExecutionContext bundles service state and optional security context.
+///
+/// Passed to all provider methods instead of separate `state` and `ctx`
+/// parameters. For authenticated HTTP requests, constructed with
+/// `from_auth(state, user_auth)`. For internal auth-flow code (e.g.
+/// fernet token validation) where no security context exists yet,
+/// constructed with `internal(state)`.
+///
+/// This eliminates the need for `stub()` patterns and makes the distinction
+/// between authenticated and internal calls explicit.
+#[derive(Clone)]
+pub struct ExecutionContext<'a> {
+    /// The current service state, providing access to providers, configuration,
+    /// and other shared resources.
+    state: &'a ServiceState,
+
+    /// Optional validated security context from the authenticated request.
+    /// `None` when called from internal code paths that have no auth context
+    /// yet (e.g., token validation, internal provider delegation).
+    ctx: Option<&'a ValidatedSecurityContext>,
+}
+
+impl<'a> ExecutionContext<'a> {
+    /// Construct from an authenticated request context.
+    #[must_use]
+    pub fn from_auth(state: &'a ServiceState, ctx: &'a ValidatedSecurityContext) -> Self {
+        Self {
+            state,
+            ctx: Some(ctx),
+        }
+    }
+
+    /// Construct for internal calls where no security context exists yet
+    /// (e.g. token validation, trust chain resolution).
+    #[must_use]
+    pub fn internal(state: &'a ServiceState) -> Self {
+        Self { state, ctx: None }
+    }
+
+    /// The service state.
+    #[must_use]
+    pub fn state(&self) -> &ServiceState {
+        self.state
+    }
+
+    /// The security context, if available.
+    #[must_use]
+    pub fn ctx(&self) -> Option<&ValidatedSecurityContext> {
+        self.ctx
+    }
+
+    /// Returns whether a security context is present (i.e., not an internal
+    /// call).
+    #[must_use]
+    pub fn has_auth(&self) -> bool {
+        self.ctx.is_some()
+    }
+}
+
+impl<'a> Deref for ExecutionContext<'a> {
+    type Target = ServiceState;
+
+    fn deref(&self) -> &Self::Target {
+        self.state
+    }
+}
+
 // Expand scope role information.
 //
 // Compute the effective roles that the principal has on the scope taking into
@@ -378,7 +448,7 @@ async fn resolve_domain_roles(
         .provider
         .get_assignment_provider()
         .list_role_assignments(
-            state,
+            &ExecutionContext::internal(state),
             &RoleAssignmentListParametersBuilder::default()
                 .user_id(&user_id)
                 .domain_id(domain_id)
@@ -429,7 +499,7 @@ async fn resolve_project_token_restriction_roles(
     state
         .provider
         .get_role_provider()
-        .expand_implied_roles(state, &mut roles)
+        .expand_implied_roles(&ExecutionContext::internal(state), &mut roles)
         .await
         .auth_context("expanding token restriction roles")?;
     Ok(roles)
@@ -446,7 +516,7 @@ async fn resolve_project_default_roles(
         .provider
         .get_assignment_provider()
         .list_role_assignments(
-            state,
+            &ExecutionContext::internal(state),
             &RoleAssignmentListParametersBuilder::default()
                 .user_id(&user_id)
                 .project_id(project_id)
@@ -489,7 +559,7 @@ async fn resolve_system_roles(
             .provider
             .get_role_provider()
             .list_roles(
-                state,
+                &ExecutionContext::internal(state),
                 &RoleListParameters {
                     name: Some("reader".into()),
                     ..Default::default()
@@ -508,7 +578,7 @@ async fn resolve_system_roles(
         .provider
         .get_assignment_provider()
         .list_role_assignments(
-            state,
+            &ExecutionContext::internal(state),
             &RoleAssignmentListParametersBuilder::default()
                 .user_id(&user_id)
                 .system_id(system_id)
@@ -532,7 +602,7 @@ async fn resolve_trust_roles(
         .provider
         .get_assignment_provider()
         .list_role_assignments(
-            state,
+            &ExecutionContext::internal(state),
             &RoleAssignmentListParametersBuilder::default()
                 .user_id(tpi.trust.trustor_user_id.clone())
                 .project_id(tpi.project.id.clone())
@@ -554,7 +624,7 @@ async fn resolve_trust_roles(
         state
             .provider
             .get_role_provider()
-            .expand_implied_roles(state, &mut trust_roles)
+            .expand_implied_roles(&ExecutionContext::internal(state), &mut trust_roles)
             .await
             .auth_context("expanding implied roles for trust")?;
 
@@ -907,7 +977,7 @@ mod tests {
                     && q.domain_id.is_none()
                     && q.system_id.is_none()
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role(rid1)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(rid1)]));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -941,7 +1011,7 @@ mod tests {
                     && q.project_id.is_none()
                     && q.system_id.is_none()
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role(rid1)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(rid1)]));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -975,7 +1045,7 @@ mod tests {
                     && q.domain_id.is_none()
                     && q.project_id.is_none()
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role(rid1)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(rid1)]));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1007,11 +1077,11 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role(rid1)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(rid1)]));
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
-            .returning(|_state, _roles| Ok(()));
+            .returning(|_e, _roles| Ok(()));
         let state = get_mocked_state(
             None,
             Some(
@@ -1046,7 +1116,7 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role("rid1")]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role("rid1")]));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1108,7 +1178,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role(admin_rid)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(admin_rid)]));
         let ac = openstack_keystone_core_types::application_credential::ApplicationCredential {
             id: "ac1".to_string(),
             user_id: uid.to_string(),
@@ -1162,8 +1232,8 @@ mod tests {
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
-            .withf(move |_state, roles| roles.len() == 2 && roles.iter().any(|r| r.id == rid1))
-            .returning(move |_state, roles| {
+            .withf(move |_e, roles| roles.len() == 2 && roles.iter().any(|r| r.id == rid1))
+            .returning(move |_e, roles| {
                 for role in roles.iter_mut() {
                     if role.id == rid1 {
                         role.name = Some("admin".to_string());
@@ -1198,11 +1268,11 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role(trustor_rid)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(trustor_rid)]));
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
-            .returning(|_state, _roles| Ok(()));
+            .returning(|_e, _roles| Ok(()));
         let state = get_mocked_state(
             None,
             Some(
@@ -1242,13 +1312,13 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| {
+            .returning(move |_e, _q| {
                 Ok(vec![assignment_with_role(rid1), assignment_with_role(rid2)])
             });
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
-            .returning(|_state, _roles| Ok(()));
+            .returning(|_e, _roles| Ok(()));
         let state = get_mocked_state(
             None,
             Some(
@@ -1282,7 +1352,7 @@ mod tests {
                     && q.domain_id.as_deref() == Some(did)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+            .returning(move |_e, _q| Ok(Vec::<Assignment>::new()));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1402,7 +1472,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+            .returning(move |_e, _q| Ok(Vec::<Assignment>::new()));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1434,7 +1504,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+            .returning(move |_e, _q| Ok(Vec::<Assignment>::new()));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1469,7 +1539,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| {
+            .returning(move |_e, _q| {
                 Ok(vec![
                     assignment_with_role(admin_rid),
                     assignment_with_role(viewer_rid),
@@ -1547,7 +1617,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![]));
+            .returning(move |_e, _q| Ok(vec![]));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1588,7 +1658,7 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| {
+            .returning(move |_e, _q| {
                 Ok(vec![
                     assignment_with_role_actor(base_rid, trustor),
                     assignment_with_role_actor(implied_rid, trustor),
@@ -1597,7 +1667,7 @@ mod tests {
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
-            .returning(move |_state, roles| {
+            .returning(move |_e, roles| {
                 roles.push(role_ref(implied_rid, "implied"));
                 Ok(())
             });
@@ -1636,7 +1706,7 @@ mod tests {
                     && q.domain_id.as_deref() == Some(did)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Err(AssignmentProviderError::Driver("db down".into())));
+            .returning(move |_e, _q| Err(AssignmentProviderError::Driver("db down".into())));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1665,7 +1735,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Err(AssignmentProviderError::Driver("db down".into())));
+            .returning(move |_e, _q| Err(AssignmentProviderError::Driver("db down".into())));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1694,7 +1764,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Err(AssignmentProviderError::Driver("db down".into())));
+            .returning(move |_e, _q| Err(AssignmentProviderError::Driver("db down".into())));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1722,7 +1792,7 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Err(AssignmentProviderError::Driver("db down".into())));
+            .returning(move |_e, _q| Err(AssignmentProviderError::Driver("db down".into())));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -1752,11 +1822,11 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role(trust_rid)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(trust_rid)]));
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
-            .returning(move |_state, _roles| Err(RoleProviderError::Driver("db down".into())));
+            .returning(move |_e, _roles| Err(RoleProviderError::Driver("db down".into())));
         let state = get_mocked_state(
             None,
             Some(
@@ -1797,7 +1867,7 @@ mod tests {
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
-            .returning(move |_state, _roles| Err(RoleProviderError::Driver("db".into())));
+            .returning(move |_e, _roles| Err(RoleProviderError::Driver("db".into())));
         let state =
             get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
         let scope = make_project_scope("pid");
@@ -1819,7 +1889,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role("admin")]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role("admin")]));
         let ac = openstack_keystone_core_types::application_credential::ApplicationCredential {
             id: "ac1".to_string(),
             user_id: uid.to_string(),
@@ -1865,7 +1935,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role("admin")]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role("admin")]));
         let ac = openstack_keystone_core_types::application_credential::ApplicationCredential {
             id: "ac1".to_string(),
             user_id: uid.to_string(),
@@ -1914,11 +1984,11 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role_actor(base_rid, trustor)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role_actor(base_rid, trustor)]));
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
-            .returning(move |_state, roles| {
+            .returning(move |_e, roles| {
                 roles.push(role_ref(extra_rid, "extra"));
                 Ok(())
             });
@@ -1958,7 +2028,7 @@ mod tests {
                     && q.project_id.as_deref() == Some(pid)
                     && q.effective == Some(true)
             })
-            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+            .returning(move |_e, _q| Ok(Vec::<Assignment>::new()));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -2008,7 +2078,7 @@ mod tests {
                     && q.effective == Some(true)
                     && q.include_names == Some(true)
             })
-            .returning(move |_state, _q| Ok(Vec::<Assignment>::new()));
+            .returning(move |_e, _q| Ok(Vec::<Assignment>::new()));
         let state = get_mocked_state(
             None,
             Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
@@ -2074,7 +2144,7 @@ mod tests {
                     && q.domain_id.is_none()
                     && q.system_id.is_none()
             })
-            .returning(move |_state, _q| Ok(vec![assignment_with_role(rid)]));
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(rid)]));
 
         let state = get_mocked_state(
             None,
@@ -2192,7 +2262,7 @@ mod tests {
         let mut mapping_mock = MockMappingProvider::new();
         mapping_mock
             .expect_get_virtual_user()
-            .returning(move |_state, id: &str| {
+            .returning(move |_e, id: &str| {
                 if id == vir_id {
                     Ok(Some(vu.clone()))
                 } else {
@@ -2262,7 +2332,7 @@ mod tests {
         let mut mapping_mock = MockMappingProvider::new();
         mapping_mock
             .expect_get_virtual_user()
-            .returning(move |_state, id: &str| {
+            .returning(move |_e, id: &str| {
                 if id == vir_id {
                     Ok(Some(vu.clone()))
                 } else {
@@ -2331,7 +2401,7 @@ mod tests {
         let mut mapping_mock = MockMappingProvider::new();
         mapping_mock
             .expect_get_virtual_user()
-            .returning(move |_state, id: &str| {
+            .returning(move |_e, id: &str| {
                 if id == vir_id {
                     Ok(Some(vu.clone()))
                 } else {
@@ -2403,7 +2473,7 @@ mod tests {
         let mut mapping_mock = MockMappingProvider::new();
         mapping_mock
             .expect_get_virtual_user()
-            .returning(move |_state, id: &str| {
+            .returning(move |_e, id: &str| {
                 if id == vir_id {
                     Ok(Some(vu.clone()))
                 } else {
@@ -2459,7 +2529,7 @@ mod tests {
         let mut mapping_mock = MockMappingProvider::new();
         mapping_mock
             .expect_get_virtual_user()
-            .returning(move |_state, _| Ok(None::<VirtualUser>));
+            .returning(move |_e, _| Ok(None::<VirtualUser>));
 
         let state = get_mocked_state(
             None,
@@ -2508,7 +2578,7 @@ mod tests {
         let mut mapping_mock = MockMappingProvider::new();
         mapping_mock
             .expect_get_virtual_user()
-            .returning(move |_state, id: &str| {
+            .returning(move |_e, id: &str| {
                 if id == vir_id {
                     Ok(Some(vu.clone()))
                 } else {
@@ -2581,7 +2651,7 @@ mod tests {
         let mut mapping_mock = MockMappingProvider::new();
         mapping_mock
             .expect_get_virtual_user()
-            .returning(move |_state, id: &str| {
+            .returning(move |_e, id: &str| {
                 if id == vir_id {
                     Ok(Some(vu.clone()))
                 } else {
@@ -2655,7 +2725,7 @@ mod tests {
         let mut mapping_mock = MockMappingProvider::new();
         mapping_mock
             .expect_get_virtual_user()
-            .returning(move |_state, id: &str| {
+            .returning(move |_e, id: &str| {
                 if id == vir_id {
                     Ok(Some(vu.clone()))
                 } else {

--- a/crates/core/src/catalog/provider_api.rs
+++ b/crates/core/src/catalog/provider_api.rs
@@ -16,8 +16,8 @@ use async_trait::async_trait;
 
 use openstack_keystone_core_types::catalog::*;
 
+use crate::auth::ExecutionContext;
 use crate::catalog::CatalogProviderError;
-use crate::keystone::ServiceState;
 
 #[async_trait]
 pub trait CatalogApi: Send + Sync {
@@ -30,9 +30,9 @@ pub trait CatalogApi: Send + Sync {
     /// # Returns
     /// A `Result` containing the created `Endpoint`, or a
     /// `CatalogProviderError`.
-    async fn create_endpoint(
+    async fn create_endpoint<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         endpoint: EndpointCreate,
     ) -> Result<Endpoint, CatalogProviderError>;
 
@@ -44,9 +44,9 @@ pub trait CatalogApi: Send + Sync {
     ///
     /// # Returns
     /// A `Result` containing the created `Region`, or a `CatalogProviderError`.
-    async fn create_region(
+    async fn create_region<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         region: RegionCreate,
     ) -> Result<Region, CatalogProviderError>;
 
@@ -59,9 +59,9 @@ pub trait CatalogApi: Send + Sync {
     /// # Returns
     /// A `Result` containing the created `Service`, or a
     /// `CatalogProviderError`.
-    async fn create_service(
+    async fn create_service<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         service: ServiceCreate,
     ) -> Result<Service, CatalogProviderError>;
 
@@ -75,7 +75,7 @@ pub trait CatalogApi: Send + Sync {
     /// A `Result` indicating success or a `CatalogProviderError`.
     async fn delete_endpoint<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError>;
 
@@ -89,7 +89,7 @@ pub trait CatalogApi: Send + Sync {
     /// A `Result` indicating success or a `CatalogProviderError`.
     async fn delete_region<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError>;
 
@@ -103,7 +103,7 @@ pub trait CatalogApi: Send + Sync {
     /// A `Result` indicating success or a `CatalogProviderError`.
     async fn delete_service<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError>;
 
@@ -116,9 +116,9 @@ pub trait CatalogApi: Send + Sync {
     /// # Returns
     /// A `Result` containing a vector of tuples of `Service` and its associated
     /// `Endpoint`s, or a `CatalogProviderError`.
-    async fn get_catalog(
+    async fn get_catalog<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         enabled: bool,
     ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError>;
 
@@ -133,7 +133,7 @@ pub trait CatalogApi: Send + Sync {
     /// `CatalogProviderError`.
     async fn get_endpoint<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Endpoint>, CatalogProviderError>;
 
@@ -148,7 +148,7 @@ pub trait CatalogApi: Send + Sync {
     /// `CatalogProviderError`.
     async fn get_region<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Region>, CatalogProviderError>;
 
@@ -163,7 +163,7 @@ pub trait CatalogApi: Send + Sync {
     /// `CatalogProviderError`.
     async fn get_service<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Service>, CatalogProviderError>;
 
@@ -176,9 +176,9 @@ pub trait CatalogApi: Send + Sync {
     /// # Returns
     /// A `Result` containing a vector of `Endpoint` objects or a
     /// `CatalogProviderError`.
-    async fn list_endpoints(
+    async fn list_endpoints<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         params: &EndpointListParameters,
     ) -> Result<Vec<Endpoint>, CatalogProviderError>;
 
@@ -191,9 +191,9 @@ pub trait CatalogApi: Send + Sync {
     /// # Returns
     /// A `Result` containing a vector of `Region` objects or a
     /// `CatalogProviderError`.
-    async fn list_regions(
+    async fn list_regions<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         params: &RegionListParameters,
     ) -> Result<Vec<Region>, CatalogProviderError>;
 
@@ -206,9 +206,9 @@ pub trait CatalogApi: Send + Sync {
     /// # Returns
     /// A `Result` containing a vector of `Service` objects or a
     /// `CatalogProviderError`.
-    async fn list_services(
+    async fn list_services<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         params: &ServiceListParameters,
     ) -> Result<Vec<Service>, CatalogProviderError>;
 
@@ -224,7 +224,7 @@ pub trait CatalogApi: Send + Sync {
     /// `CatalogProviderError`.
     async fn update_endpoint<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
         endpoint: EndpointUpdate,
     ) -> Result<Endpoint, CatalogProviderError>;
@@ -240,7 +240,7 @@ pub trait CatalogApi: Send + Sync {
     /// A `Result` containing the updated `Region`, or a `CatalogProviderError`.
     async fn update_region<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
         region: RegionUpdate,
     ) -> Result<Region, CatalogProviderError>;
@@ -257,7 +257,7 @@ pub trait CatalogApi: Send + Sync {
     /// `CatalogProviderError`.
     async fn update_service<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
         service: ServiceUpdate,
     ) -> Result<Service, CatalogProviderError>;

--- a/crates/core/src/catalog/service.rs
+++ b/crates/core/src/catalog/service.rs
@@ -20,8 +20,8 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::catalog::*;
 use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 
+use crate::auth::ExecutionContext;
 use crate::catalog::{CatalogApi, CatalogProviderError, backend::CatalogBackend};
-use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 
 pub struct CatalogService {
@@ -60,15 +60,18 @@ impl CatalogApi for CatalogService {
     /// # Returns
     /// A `Result` containing the created `Endpoint`, or a
     /// `CatalogProviderError`.
-    async fn create_endpoint(
+    async fn create_endpoint<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         endpoint: EndpointCreate,
     ) -> Result<Endpoint, CatalogProviderError> {
         endpoint.validate()?;
-        let endpoint = self.backend_driver.create_endpoint(state, endpoint).await?;
+        let endpoint = self
+            .backend_driver
+            .create_endpoint(exec.state(), endpoint)
+            .await?;
 
-        state
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -89,15 +92,18 @@ impl CatalogApi for CatalogService {
     ///
     /// # Returns
     /// A `Result` containing the created `Region`, or a `CatalogProviderError`.
-    async fn create_region(
+    async fn create_region<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         region: RegionCreate,
     ) -> Result<Region, CatalogProviderError> {
         region.validate()?;
-        let region = self.backend_driver.create_region(state, region).await?;
+        let region = self
+            .backend_driver
+            .create_region(exec.state(), region)
+            .await?;
 
-        state
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -119,15 +125,18 @@ impl CatalogApi for CatalogService {
     /// # Returns
     /// A `Result` containing the created `Service`, or a
     /// `CatalogProviderError`.
-    async fn create_service(
+    async fn create_service<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         service: ServiceCreate,
     ) -> Result<Service, CatalogProviderError> {
         service.validate()?;
-        let service = self.backend_driver.create_service(state, service).await?;
+        let service = self
+            .backend_driver
+            .create_service(exec.state(), service)
+            .await?;
 
-        state
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -150,12 +159,14 @@ impl CatalogApi for CatalogService {
     /// A `Result` indicating success or a `CatalogProviderError`.
     async fn delete_endpoint<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError> {
-        self.backend_driver.delete_endpoint(state, id).await?;
+        self.backend_driver
+            .delete_endpoint(exec.state(), id)
+            .await?;
 
-        state
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -176,12 +187,12 @@ impl CatalogApi for CatalogService {
     /// A `Result` indicating success or a `CatalogProviderError`.
     async fn delete_region<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError> {
-        self.backend_driver.delete_region(state, id).await?;
+        self.backend_driver.delete_region(exec.state(), id).await?;
 
-        state
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -202,12 +213,12 @@ impl CatalogApi for CatalogService {
     /// A `Result` indicating success or a `CatalogProviderError`.
     async fn delete_service<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError> {
-        self.backend_driver.delete_service(state, id).await?;
+        self.backend_driver.delete_service(exec.state(), id).await?;
 
-        state
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -227,12 +238,12 @@ impl CatalogApi for CatalogService {
     /// # Returns
     /// A `Result` containing a vector of tuples of `Service` and its associated
     /// `Endpoint`s, or a `CatalogProviderError`.
-    async fn get_catalog(
+    async fn get_catalog<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         enabled: bool,
     ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError> {
-        self.backend_driver.get_catalog(state, enabled).await
+        self.backend_driver.get_catalog(exec.state(), enabled).await
     }
 
     /// Get single endpoint by ID.
@@ -246,10 +257,10 @@ impl CatalogApi for CatalogService {
     /// `Error`.
     async fn get_endpoint<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Endpoint>, CatalogProviderError> {
-        self.backend_driver.get_endpoint(state, id).await
+        self.backend_driver.get_endpoint(exec.state(), id).await
     }
 
     /// Get single region by ID.
@@ -263,10 +274,10 @@ impl CatalogApi for CatalogService {
     /// `Error`.
     async fn get_region<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Region>, CatalogProviderError> {
-        self.backend_driver.get_region(state, id).await
+        self.backend_driver.get_region(exec.state(), id).await
     }
 
     /// Get single service by ID.
@@ -280,10 +291,10 @@ impl CatalogApi for CatalogService {
     /// `Error`.
     async fn get_service<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Service>, CatalogProviderError> {
-        self.backend_driver.get_service(state, id).await
+        self.backend_driver.get_service(exec.state(), id).await
     }
 
     /// List Endpoints.
@@ -295,13 +306,15 @@ impl CatalogApi for CatalogService {
     /// # Returns
     /// A `Result` containing a vector of `Endpoint` objects or a
     /// `CatalogProviderError`.
-    async fn list_endpoints(
+    async fn list_endpoints<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         params: &EndpointListParameters,
     ) -> Result<Vec<Endpoint>, CatalogProviderError> {
         params.validate()?;
-        self.backend_driver.list_endpoints(state, params).await
+        self.backend_driver
+            .list_endpoints(exec.state(), params)
+            .await
     }
 
     /// List regions.
@@ -313,13 +326,13 @@ impl CatalogApi for CatalogService {
     /// # Returns
     /// A `Result` containing a vector of `Region` objects or a
     /// `CatalogProviderError`.
-    async fn list_regions(
+    async fn list_regions<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         params: &RegionListParameters,
     ) -> Result<Vec<Region>, CatalogProviderError> {
         params.validate()?;
-        self.backend_driver.list_regions(state, params).await
+        self.backend_driver.list_regions(exec.state(), params).await
     }
 
     /// List services.
@@ -331,13 +344,15 @@ impl CatalogApi for CatalogService {
     /// # Returns
     /// A `Result` containing a vector of `Service` objects or a
     /// `CatalogProviderError`.
-    async fn list_services(
+    async fn list_services<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         params: &ServiceListParameters,
     ) -> Result<Vec<Service>, CatalogProviderError> {
         params.validate()?;
-        self.backend_driver.list_services(state, params).await
+        self.backend_driver
+            .list_services(exec.state(), params)
+            .await
     }
 
     /// Update an existing endpoint.
@@ -352,16 +367,16 @@ impl CatalogApi for CatalogService {
     /// `CatalogProviderError`.
     async fn update_endpoint<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
         endpoint: EndpointUpdate,
     ) -> Result<Endpoint, CatalogProviderError> {
         endpoint.validate()?;
         let updated = self
             .backend_driver
-            .update_endpoint(state, id, endpoint)
+            .update_endpoint(exec.state(), id, endpoint)
             .await?;
-        state
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Update,
@@ -382,13 +397,16 @@ impl CatalogApi for CatalogService {
     /// A `Result` containing the updated `Region`, or a `CatalogProviderError`.
     async fn update_region<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
         region: RegionUpdate,
     ) -> Result<Region, CatalogProviderError> {
         region.validate()?;
-        let updated = self.backend_driver.update_region(state, id, region).await?;
-        state
+        let updated = self
+            .backend_driver
+            .update_region(exec.state(), id, region)
+            .await?;
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -410,16 +428,16 @@ impl CatalogApi for CatalogService {
     /// `CatalogProviderError`.
     async fn update_service<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         id: &'a str,
         service: ServiceUpdate,
     ) -> Result<Service, CatalogProviderError> {
         service.validate()?;
         let updated = self
             .backend_driver
-            .update_service(state, id, service)
+            .update_service(exec.state(), id, service)
             .await?;
-        state
+        exec.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,

--- a/crates/core/src/federation/provider_api.rs
+++ b/crates/core/src/federation/provider_api.rs
@@ -19,8 +19,8 @@ use async_trait::async_trait;
 
 use openstack_keystone_core_types::federation::*;
 
+use crate::auth::ExecutionContext;
 use crate::federation::error::FederationProviderError;
-use crate::keystone::ServiceState;
 
 /// Federation provider interface.
 #[async_trait]
@@ -33,7 +33,7 @@ pub trait FederationApi: Send + Sync {
     /// # Returns
     /// - `Result<(), FederationProviderError>` - Ok if successful, or a
     ///   federation provider error.
-    async fn cleanup(&self, state: &ServiceState) -> Result<(), FederationProviderError>;
+    async fn cleanup<'a>(&self, ctx: &ExecutionContext<'a>) -> Result<(), FederationProviderError>;
 
     /// Create identity provider.
     ///
@@ -44,9 +44,9 @@ pub trait FederationApi: Send + Sync {
     /// # Returns
     /// - `Result<IdentityProvider, FederationProviderError>` - The created
     ///   `IdentityProvider` or an error.
-    async fn create_identity_provider(
+    async fn create_identity_provider<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         idp: IdentityProviderCreate,
     ) -> Result<IdentityProvider, FederationProviderError>;
 
@@ -59,9 +59,9 @@ pub trait FederationApi: Send + Sync {
     /// # Returns
     /// - `Result<AuthState, FederationProviderError>` - The created `AuthState`
     ///   or an error.
-    async fn create_auth_state(
+    async fn create_auth_state<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         state: AuthState,
     ) -> Result<AuthState, FederationProviderError>;
 
@@ -75,7 +75,7 @@ pub trait FederationApi: Send + Sync {
     /// - `Result<(), FederationProviderError>` - Ok if successful, or an error.
     async fn delete_auth_state<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), FederationProviderError>;
 
@@ -89,7 +89,7 @@ pub trait FederationApi: Send + Sync {
     /// - `Result<(), FederationProviderError>` - Ok if successful, or an error.
     async fn delete_identity_provider<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), FederationProviderError>;
 
@@ -104,7 +104,7 @@ pub trait FederationApi: Send + Sync {
     ///   containing an `Option` with the AuthState if found, or an `Error`.
     async fn get_auth_state<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<AuthState>, FederationProviderError>;
 
@@ -120,7 +120,7 @@ pub trait FederationApi: Send + Sync {
     ///   an `Error`.
     async fn get_identity_provider<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<IdentityProvider>, FederationProviderError>;
 
@@ -133,9 +133,9 @@ pub trait FederationApi: Send + Sync {
     /// # Returns
     /// - `Result<Vec<IdentityProvider>, FederationProviderError>` - A list of
     ///   identity providers or an error.
-    async fn list_identity_providers(
+    async fn list_identity_providers<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &IdentityProviderListParameters,
     ) -> Result<Vec<IdentityProvider>, FederationProviderError>;
 
@@ -151,7 +151,7 @@ pub trait FederationApi: Send + Sync {
     ///   `IdentityProvider` or an error.
     async fn update_identity_provider<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
         idp: IdentityProviderUpdate,
     ) -> Result<IdentityProvider, FederationProviderError>;

--- a/crates/core/src/federation/service.rs
+++ b/crates/core/src/federation/service.rs
@@ -22,8 +22,8 @@ use uuid::Uuid;
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::federation::*;
 
+use crate::auth::ExecutionContext;
 use crate::federation::{FederationApi, FederationProviderError, backend::FederationBackend};
-use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 
 pub struct FederationService {
@@ -57,13 +57,13 @@ impl FederationApi for FederationService {
     /// Cleanup expired resources.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     ///
     /// # Returns
     /// - `Result<(), FederationProviderError>` - Ok if successful, or a
     ///   federation provider error.
-    async fn cleanup(&self, state: &ServiceState) -> Result<(), FederationProviderError> {
-        self.backend_driver.cleanup(state).await
+    async fn cleanup<'a>(&self, ctx: &ExecutionContext<'a>) -> Result<(), FederationProviderError> {
+        self.backend_driver.cleanup(ctx.state()).await
     }
 
     /// Create new auth state.
@@ -75,13 +75,13 @@ impl FederationApi for FederationService {
     /// # Returns
     /// - `Result<AuthState, FederationProviderError>` - The created `AuthState`
     ///   or an error.
-    async fn create_auth_state(
+    async fn create_auth_state<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         auth_state: AuthState,
     ) -> Result<AuthState, FederationProviderError> {
         self.backend_driver
-            .create_auth_state(state, auth_state)
+            .create_auth_state(ctx.state(), auth_state)
             .await
     }
 
@@ -94,9 +94,9 @@ impl FederationApi for FederationService {
     /// # Returns
     /// - `Result<IdentityProvider, FederationProviderError>` - The created
     ///   `IdentityProvider` or an error.
-    async fn create_identity_provider(
+    async fn create_identity_provider<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         idp: IdentityProviderCreate,
     ) -> Result<IdentityProvider, FederationProviderError> {
         let mut mod_idp = idp;
@@ -105,7 +105,7 @@ impl FederationApi for FederationService {
         }
 
         self.backend_driver
-            .create_identity_provider(state, mod_idp)
+            .create_identity_provider(ctx.state(), mod_idp)
             .await
     }
 
@@ -119,10 +119,10 @@ impl FederationApi for FederationService {
     /// - `Result<(), FederationProviderError>` - Ok if successful, or an error.
     async fn delete_auth_state<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), FederationProviderError> {
-        self.backend_driver.delete_auth_state(state, id).await
+        self.backend_driver.delete_auth_state(ctx.state(), id).await
     }
 
     /// Delete identity provider.
@@ -135,11 +135,11 @@ impl FederationApi for FederationService {
     /// - `Result<(), FederationProviderError>` - Ok if successful, or an error.
     async fn delete_identity_provider<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), FederationProviderError> {
         self.backend_driver
-            .delete_identity_provider(state, id)
+            .delete_identity_provider(ctx.state(), id)
             .await
     }
 
@@ -154,10 +154,10 @@ impl FederationApi for FederationService {
     ///   containing an `Option` with the auth state if found, or an `Error`.
     async fn get_auth_state<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<AuthState>, FederationProviderError> {
-        self.backend_driver.get_auth_state(state, id).await
+        self.backend_driver.get_auth_state(ctx.state(), id).await
     }
 
     /// Get single IDP by ID.
@@ -172,10 +172,12 @@ impl FederationApi for FederationService {
     ///   or an `Error`.
     async fn get_identity_provider<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<IdentityProvider>, FederationProviderError> {
-        self.backend_driver.get_identity_provider(state, id).await
+        self.backend_driver
+            .get_identity_provider(ctx.state(), id)
+            .await
     }
 
     /// List IDP.
@@ -187,13 +189,13 @@ impl FederationApi for FederationService {
     /// # Returns
     /// - `Result<Vec<IdentityProvider>, FederationProviderError>` - A list of
     ///   identity providers or an error.
-    async fn list_identity_providers(
+    async fn list_identity_providers<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &IdentityProviderListParameters,
     ) -> Result<Vec<IdentityProvider>, FederationProviderError> {
         self.backend_driver
-            .list_identity_providers(state, params)
+            .list_identity_providers(ctx.state(), params)
             .await
     }
 
@@ -209,12 +211,12 @@ impl FederationApi for FederationService {
     ///   `IdentityProvider` or an error.
     async fn update_identity_provider<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
         idp: IdentityProviderUpdate,
     ) -> Result<IdentityProvider, FederationProviderError> {
         self.backend_driver
-            .update_identity_provider(state, id, idp)
+            .update_identity_provider(ctx.state(), id, idp)
             .await
     }
 }

--- a/crates/core/src/identity/provider_api.rs
+++ b/crates/core/src/identity/provider_api.rs
@@ -20,8 +20,8 @@ use std::collections::HashSet;
 use openstack_keystone_core_types::identity::*;
 
 use crate::auth::AuthenticationResult;
+use crate::auth::ExecutionContext;
 use crate::identity::IdentityProviderError;
-use crate::keystone::ServiceState;
 
 #[async_trait]
 pub trait IdentityApi: Send + Sync {
@@ -33,7 +33,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `group_id`: The ID of the group.
     async fn add_user_to_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError>;
@@ -47,7 +47,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `idp_id`: The ID of the identity provider.
     async fn add_user_to_group_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_id: &'a str,
         idp_id: &'a str,
@@ -60,7 +60,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `memberships`: A list of (user ID, group ID) tuples.
     async fn add_users_to_groups<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         memberships: Vec<(&'a str, &'a str)>,
     ) -> Result<(), IdentityProviderError>;
 
@@ -72,7 +72,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `idp_id`: The ID of the identity provider.
     async fn add_users_to_groups_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         memberships: Vec<(&'a str, &'a str)>,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError>;
@@ -82,9 +82,9 @@ pub trait IdentityApi: Send + Sync {
     /// # Parameters
     /// - `state`: The service state.
     /// - `auth`: The password authentication request.
-    async fn authenticate_by_password(
+    async fn authenticate_by_password<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         auth: &UserPasswordAuthRequest,
     ) -> Result<AuthenticationResult, IdentityProviderError>;
 
@@ -93,9 +93,9 @@ pub trait IdentityApi: Send + Sync {
     /// # Parameters
     /// - `state`: The service state.
     /// - `group`: The group details to create.
-    async fn create_group(
+    async fn create_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         group: GroupCreate,
     ) -> Result<Group, IdentityProviderError>;
 
@@ -104,9 +104,9 @@ pub trait IdentityApi: Send + Sync {
     /// # Parameters
     /// - `state`: The service state.
     /// - `sa`: The service account details to create.
-    async fn create_service_account(
+    async fn create_service_account<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         sa: ServiceAccountCreate,
     ) -> Result<ServiceAccount, IdentityProviderError>;
 
@@ -115,9 +115,9 @@ pub trait IdentityApi: Send + Sync {
     /// # Parameters
     /// - `state`: The service state.
     /// - `user`: The user details to create.
-    async fn create_user(
+    async fn create_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user: UserCreate,
     ) -> Result<UserResponse, IdentityProviderError>;
 
@@ -128,7 +128,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `user_id`: The ID of the user to delete.
     async fn delete_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<(), IdentityProviderError>;
 
@@ -143,7 +143,7 @@ pub trait IdentityApi: Send + Sync {
     ///   an `Option` with the group if found, or an `Error`.
     async fn get_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         group_id: &'a str,
     ) -> Result<Option<Group>, IdentityProviderError>;
 
@@ -159,7 +159,7 @@ pub trait IdentityApi: Send + Sync {
     ///   `Error`.
     async fn get_service_account<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Option<ServiceAccount>, IdentityProviderError>;
 
@@ -174,7 +174,7 @@ pub trait IdentityApi: Send + Sync {
     ///   containing an `Option` with the user if found, or an `Error`.
     async fn get_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Option<UserResponse>, IdentityProviderError>;
 
@@ -185,7 +185,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `user_id`: The ID of the user.
     async fn get_user_domain_id<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<String, IdentityProviderError>;
 
@@ -201,7 +201,7 @@ pub trait IdentityApi: Send + Sync {
     ///   containing an `Option` with the user if found, or an `Error`.
     async fn find_federated_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         idp_id: &'a str,
         unique_id: &'a str,
     ) -> Result<Option<UserResponse>, IdentityProviderError>;
@@ -211,9 +211,9 @@ pub trait IdentityApi: Send + Sync {
     /// # Parameters
     /// - `state`: The service state.
     /// - `params`: The parameters for listing groups.
-    async fn list_groups(
+    async fn list_groups<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &GroupListParameters,
     ) -> Result<Vec<Group>, IdentityProviderError>;
 
@@ -222,9 +222,9 @@ pub trait IdentityApi: Send + Sync {
     /// # Parameters
     /// - `state`: The service state.
     /// - `params`: The parameters for listing users.
-    async fn list_users(
+    async fn list_users<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &UserListParameters,
     ) -> Result<Vec<UserResponse>, IdentityProviderError>;
 
@@ -235,7 +235,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `group_id`: The ID of the group to delete.
     async fn delete_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError>;
 
@@ -246,7 +246,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `user_id`: The ID of the user.
     async fn list_groups_of_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Vec<Group>, IdentityProviderError>;
 
@@ -258,7 +258,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `group_id`: The ID of the group.
     async fn remove_user_from_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError>;
@@ -272,7 +272,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `idp_id`: The ID of the identity provider.
     async fn remove_user_from_group_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_id: &'a str,
         idp_id: &'a str,
@@ -286,7 +286,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `group_ids`: A set of group IDs.
     async fn remove_user_from_groups<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
     ) -> Result<(), IdentityProviderError>;
@@ -300,7 +300,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `idp_id`: The ID of the identity provider.
     async fn remove_user_from_groups_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
         idp_id: &'a str,
@@ -314,7 +314,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `group_ids`: A set of group IDs.
     async fn set_user_groups<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
     ) -> Result<(), IdentityProviderError>;
@@ -327,7 +327,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `user`: The user details to update.
     async fn update_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         user: UserUpdate,
     ) -> Result<UserResponse, IdentityProviderError>;
@@ -344,7 +344,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `new_password`: The new password to set.
     async fn update_user_password<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         original_password: SecretString,
         new_password: SecretString,
@@ -360,7 +360,7 @@ pub trait IdentityApi: Send + Sync {
     /// - `last_verified`: The last verified date, if any.
     async fn set_user_groups_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
         idp_id: &'a str,

--- a/crates/core/src/identity/service.rs
+++ b/crates/core/src/identity/service.rs
@@ -27,9 +27,8 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::identity::*;
 
-use crate::auth::AuthenticationResult;
+use crate::auth::{AuthenticationResult, ExecutionContext};
 use crate::identity::{IdentityApi, IdentityProviderError, backend::IdentityBackend};
-use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 use crate::resource::error::ResourceProviderError;
 
@@ -88,12 +87,12 @@ impl IdentityApi for IdentityService {
     /// - `group_id`: The ID of the group.
     async fn add_user_to_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .add_user_to_group(state, user_id, group_id)
+            .add_user_to_group(ctx.state(), user_id, group_id)
             .await
     }
 
@@ -106,13 +105,13 @@ impl IdentityApi for IdentityService {
     /// - `idp_id`: The ID of the identity provider.
     async fn add_user_to_group_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_id: &'a str,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .add_user_to_group_expiring(state, user_id, group_id, idp_id)
+            .add_user_to_group_expiring(ctx.state(), user_id, group_id, idp_id)
             .await
     }
 
@@ -123,11 +122,11 @@ impl IdentityApi for IdentityService {
     /// - `memberships`: A list of (user ID, group ID) tuples.
     async fn add_users_to_groups<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         memberships: Vec<(&'a str, &'a str)>,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .add_users_to_groups(state, memberships)
+            .add_users_to_groups(ctx.state(), memberships)
             .await
     }
 
@@ -139,12 +138,12 @@ impl IdentityApi for IdentityService {
     /// - `idp_id`: The ID of the identity provider.
     async fn add_users_to_groups_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         memberships: Vec<(&'a str, &'a str)>,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .add_users_to_groups_expiring(state, memberships, idp_id)
+            .add_users_to_groups_expiring(ctx.state(), memberships, idp_id)
             .await
     }
 
@@ -153,11 +152,12 @@ impl IdentityApi for IdentityService {
     /// # Parameters
     /// - `state`: The service state.
     /// - `auth`: The password authentication request.
-    async fn authenticate_by_password(
+    async fn authenticate_by_password<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         auth: &UserPasswordAuthRequest,
     ) -> Result<AuthenticationResult, IdentityProviderError> {
+        let state = ctx.state();
         let mut auth = auth.clone();
         if auth.id.is_none() {
             if auth.name.is_none() {
@@ -169,7 +169,7 @@ impl IdentityApi for IdentityService {
                     let d = state
                         .provider
                         .get_resource_provider()
-                        .find_domain_by_name(state, dname)
+                        .find_domain_by_name(ctx, dname)
                         .await?
                         .ok_or(ResourceProviderError::DomainNotFound(dname.clone()))?;
                     domain.id = Some(d.id);
@@ -191,18 +191,18 @@ impl IdentityApi for IdentityService {
     /// # Parameters
     /// - `state`: The service state.
     /// - `group`: The group details to create.
-    async fn create_group(
+    async fn create_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         group: GroupCreate,
     ) -> Result<Group, IdentityProviderError> {
         let mut res = group;
         if res.id.is_none() {
             res.id = Some(Uuid::new_v4().simple().to_string());
         }
-        let group = self.backend_driver.create_group(state, res).await?;
+        let group = self.backend_driver.create_group(ctx.state(), res).await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -220,9 +220,9 @@ impl IdentityApi for IdentityService {
     /// # Parameters
     /// - `state`: The service state.
     /// - `sa`: The service account details to create.
-    async fn create_service_account(
+    async fn create_service_account<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         sa: ServiceAccountCreate,
     ) -> Result<ServiceAccount, IdentityProviderError> {
         let mut mod_sa = sa;
@@ -234,7 +234,7 @@ impl IdentityApi for IdentityService {
         }
         mod_sa.validate()?;
         self.backend_driver
-            .create_service_account(state, mod_sa)
+            .create_service_account(ctx.state(), mod_sa)
             .await
     }
 
@@ -243,9 +243,9 @@ impl IdentityApi for IdentityService {
     /// # Parameters
     /// - `state`: The service state.
     /// - `user`: The user details to create.
-    async fn create_user(
+    async fn create_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user: UserCreate,
     ) -> Result<UserResponse, IdentityProviderError> {
         let mut mod_user = user;
@@ -258,13 +258,16 @@ impl IdentityApi for IdentityService {
         mod_user.validate()?;
         // Validate password against configured regex pattern.
         if let Some(ref password) = mod_user.password {
-            let cfg = state.config_manager.config.read().await;
+            let cfg = ctx.state().config_manager.config.read().await;
             cfg.security_compliance
                 .validate_password(&SecretString::from(password.as_str()))?;
         }
-        let user = self.backend_driver.create_user(state, mod_user).await?;
+        let user = self
+            .backend_driver
+            .create_user(ctx.state(), mod_user)
+            .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -284,12 +287,14 @@ impl IdentityApi for IdentityService {
     /// - `group_id`: The ID of the group to delete.
     async fn delete_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver.delete_group(state, group_id).await?;
+        self.backend_driver
+            .delete_group(ctx.state(), group_id)
+            .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -309,15 +314,17 @@ impl IdentityApi for IdentityService {
     /// - `user_id`: The ID of the user to delete.
     async fn delete_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver.delete_user(state, user_id).await?;
+        self.backend_driver
+            .delete_user(ctx.state(), user_id)
+            .await?;
         if self.caching {
             self.user_id_domain_id_cache.write().await.remove(user_id);
         }
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -342,11 +349,11 @@ impl IdentityApi for IdentityService {
     ///   `Error`.
     async fn get_service_account<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Option<ServiceAccount>, IdentityProviderError> {
         self.backend_driver
-            .get_service_account(state, user_id)
+            .get_service_account(ctx.state(), user_id)
             .await
     }
 
@@ -361,10 +368,10 @@ impl IdentityApi for IdentityService {
     ///   containing an `Option` with the user if found, or an `Error`.
     async fn get_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Option<UserResponse>, IdentityProviderError> {
-        let user = self.backend_driver.get_user(state, user_id).await?;
+        let user = self.backend_driver.get_user(ctx.state(), user_id).await?;
         if self.caching
             && let Some(user) = &user
         {
@@ -389,7 +396,7 @@ impl IdentityApi for IdentityService {
     /// from the cache.
     async fn get_user_domain_id<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<String, IdentityProviderError> {
         if self.caching {
@@ -398,7 +405,7 @@ impl IdentityApi for IdentityService {
             } else {
                 let domain_id = self
                     .backend_driver
-                    .get_user_domain_id(state, user_id)
+                    .get_user_domain_id(ctx.state(), user_id)
                     .await?;
                 self.user_id_domain_id_cache
                     .write()
@@ -409,7 +416,7 @@ impl IdentityApi for IdentityService {
         } else {
             Ok(self
                 .backend_driver
-                .get_user_domain_id(state, user_id)
+                .get_user_domain_id(ctx.state(), user_id)
                 .await?)
         }
     }
@@ -426,12 +433,12 @@ impl IdentityApi for IdentityService {
     ///   containing an `Option` with the user if found, or an `Error`.
     async fn find_federated_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         idp_id: &'a str,
         unique_id: &'a str,
     ) -> Result<Option<UserResponse>, IdentityProviderError> {
         self.backend_driver
-            .find_federated_user(state, idp_id, unique_id)
+            .find_federated_user(ctx.state(), idp_id, unique_id)
             .await
     }
 
@@ -440,12 +447,12 @@ impl IdentityApi for IdentityService {
     /// # Parameters
     /// - `state`: The service state.
     /// - `params`: The parameters for listing users.
-    async fn list_users(
+    async fn list_users<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &UserListParameters,
     ) -> Result<Vec<UserResponse>, IdentityProviderError> {
-        self.backend_driver.list_users(state, params).await
+        self.backend_driver.list_users(ctx.state(), params).await
     }
 
     /// List groups.
@@ -453,12 +460,12 @@ impl IdentityApi for IdentityService {
     /// # Parameters
     /// - `state`: The service state.
     /// - `params`: The parameters for listing groups.
-    async fn list_groups(
+    async fn list_groups<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &GroupListParameters,
     ) -> Result<Vec<Group>, IdentityProviderError> {
-        self.backend_driver.list_groups(state, params).await
+        self.backend_driver.list_groups(ctx.state(), params).await
     }
 
     /// Get single group.
@@ -472,10 +479,10 @@ impl IdentityApi for IdentityService {
     ///   an `Option` with the group if found, or an `Error`.
     async fn get_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         group_id: &'a str,
     ) -> Result<Option<Group>, IdentityProviderError> {
-        self.backend_driver.get_group(state, group_id).await
+        self.backend_driver.get_group(ctx.state(), group_id).await
     }
 
     /// List groups a user is a member of.
@@ -485,11 +492,11 @@ impl IdentityApi for IdentityService {
     /// - `user_id`: The ID of the user.
     async fn list_groups_of_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Vec<Group>, IdentityProviderError> {
         self.backend_driver
-            .list_groups_of_user(state, user_id)
+            .list_groups_of_user(ctx.state(), user_id)
             .await
     }
 
@@ -501,12 +508,12 @@ impl IdentityApi for IdentityService {
     /// - `group_id`: The ID of the group.
     async fn remove_user_from_group<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .remove_user_from_group(state, user_id, group_id)
+            .remove_user_from_group(ctx.state(), user_id, group_id)
             .await
     }
 
@@ -519,13 +526,13 @@ impl IdentityApi for IdentityService {
     /// - `idp_id`: The ID of the identity provider.
     async fn remove_user_from_group_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_id: &'a str,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .remove_user_from_group_expiring(state, user_id, group_id, idp_id)
+            .remove_user_from_group_expiring(ctx.state(), user_id, group_id, idp_id)
             .await
     }
 
@@ -537,12 +544,12 @@ impl IdentityApi for IdentityService {
     /// - `group_ids`: A set of group IDs.
     async fn remove_user_from_groups<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .remove_user_from_groups(state, user_id, group_ids)
+            .remove_user_from_groups(ctx.state(), user_id, group_ids)
             .await
     }
 
@@ -555,13 +562,13 @@ impl IdentityApi for IdentityService {
     /// - `idp_id`: The ID of the identity provider.
     async fn remove_user_from_groups_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .remove_user_from_groups_expiring(state, user_id, group_ids, idp_id)
+            .remove_user_from_groups_expiring(ctx.state(), user_id, group_ids, idp_id)
             .await
     }
 
@@ -573,12 +580,12 @@ impl IdentityApi for IdentityService {
     /// - `group_ids`: A set of group IDs.
     async fn set_user_groups<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .set_user_groups(state, user_id, group_ids)
+            .set_user_groups(ctx.state(), user_id, group_ids)
             .await
     }
 
@@ -590,23 +597,23 @@ impl IdentityApi for IdentityService {
     /// - `user`: The user details to update.
     async fn update_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         user: UserUpdate,
     ) -> Result<UserResponse, IdentityProviderError> {
         user.validate()?;
         // Validate password against configured regex pattern.
         if let Some(ref password) = user.password {
-            let cfg = state.config_manager.config.read().await;
+            let cfg = ctx.state().config_manager.config.read().await;
             cfg.security_compliance
                 .validate_password(&SecretString::from(password.as_str()))?;
         }
         let user = self
             .backend_driver
-            .update_user(state, user_id, user)
+            .update_user(ctx.state(), user_id, user)
             .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Update,
@@ -628,15 +635,15 @@ impl IdentityApi for IdentityService {
     /// - `new_password`: The new password to set.
     async fn update_user_password<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         original_password: SecretString,
         new_password: SecretString,
     ) -> Result<(), IdentityProviderError> {
-        let cfg = state.config_manager.config.read().await;
+        let cfg = ctx.state().config_manager.config.read().await;
         cfg.security_compliance.validate_password(&new_password)?;
         self.backend_driver
-            .update_user_password(state, user_id, original_password, new_password)
+            .update_user_password(ctx.state(), user_id, original_password, new_password)
             .await
     }
 
@@ -650,14 +657,14 @@ impl IdentityApi for IdentityService {
     /// - `last_verified`: The last verified date, if any.
     async fn set_user_groups_expiring<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
         idp_id: &'a str,
         last_verified: Option<&'a DateTime<Utc>>,
     ) -> Result<(), IdentityProviderError> {
         self.backend_driver
-            .set_user_groups_expiring(state, user_id, group_ids, idp_id, last_verified)
+            .set_user_groups_expiring(ctx.state(), user_id, group_ids, idp_id, last_verified)
             .await
     }
 }
@@ -699,7 +706,7 @@ mod tests {
         assert_eq!(
             provider
                 .create_user(
-                    &state,
+                    &ExecutionContext::internal(&state),
                     UserCreateBuilder::default()
                         .name("uname")
                         .domain_id("did")
@@ -740,7 +747,7 @@ mod tests {
 
         assert_eq!(
             provider
-                .get_user(&state, "uid")
+                .get_user(&ExecutionContext::internal(&state), "uid")
                 .await
                 .unwrap()
                 .expect("user should be there"),
@@ -771,23 +778,32 @@ mod tests {
         provider.caching = true;
 
         assert_eq!(
-            provider.get_user_domain_id(&state, "uid").await.unwrap(),
+            provider
+                .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
+                .await
+                .unwrap(),
             "did"
         );
         assert_eq!(
-            provider.get_user_domain_id(&state, "uid").await.unwrap(),
+            provider
+                .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
+                .await
+                .unwrap(),
             "did",
             "second time data extracted from cache"
         );
         assert!(
             provider
-                .get_user_domain_id(&state, "missing")
+                .get_user_domain_id(&ExecutionContext::internal(&state), "missing")
                 .await
                 .is_err()
         );
         provider.caching = false;
         assert_eq!(
-            provider.get_user_domain_id(&state, "uid").await.unwrap(),
+            provider
+                .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
+                .await
+                .unwrap(),
             "did",
             "third time backend is again triggered causing total of 2 invocations"
         );
@@ -803,7 +819,12 @@ mod tests {
             .returning(|_, _| Ok(()));
         let provider = IdentityService::from_driver(backend);
 
-        assert!(provider.delete_user(&state, "uid").await.is_ok());
+        assert!(
+            provider
+                .delete_user(&ExecutionContext::internal(&state), "uid")
+                .await
+                .is_ok()
+        );
     }
 
     /// Password regex rejects invalid password on user creation.
@@ -815,7 +836,7 @@ mod tests {
 
         let result = provider
             .create_user(
-                &state,
+                &ExecutionContext::internal(&state),
                 UserCreateBuilder::default()
                     .name("uname")
                     .domain_id("did")
@@ -852,7 +873,7 @@ mod tests {
         assert!(
             provider
                 .create_user(
-                    &state,
+                    &ExecutionContext::internal(&state),
                     UserCreateBuilder::default()
                         .name("uname")
                         .domain_id("did")
@@ -886,7 +907,7 @@ mod tests {
         assert!(
             provider
                 .create_user(
-                    &state,
+                    &ExecutionContext::internal(&state),
                     UserCreateBuilder::default()
                         .name("uname")
                         .domain_id("did")
@@ -908,7 +929,7 @@ mod tests {
 
         let result = provider
             .update_user(
-                &state,
+                &ExecutionContext::internal(&state),
                 "uid",
                 UserUpdateBuilder::default()
                     .password("short")
@@ -946,7 +967,7 @@ mod tests {
         assert!(
             provider
                 .update_user(
-                    &state,
+                    &ExecutionContext::internal(&state),
                     "uid",
                     UserUpdateBuilder::default()
                         .password("Abc1")
@@ -981,7 +1002,7 @@ mod tests {
         assert!(
             provider
                 .update_user(
-                    &state,
+                    &ExecutionContext::internal(&state),
                     "uid",
                     UserUpdateBuilder::default()
                         .name("new_name")

--- a/crates/core/src/idmapping/provider_api.rs
+++ b/crates/core/src/idmapping/provider_api.rs
@@ -16,8 +16,8 @@ use async_trait::async_trait;
 
 use openstack_keystone_core_types::idmapping::*;
 
+use crate::auth::ExecutionContext;
 use crate::idmapping::IdMappingProviderError;
-use crate::keystone::ServiceState;
 
 /// IdMapping provider API.
 #[async_trait]
@@ -35,7 +35,7 @@ pub trait IdMappingApi: Send + Sync {
     ///   containing an `Option` with the `IdMapping` if found, or an `Error`.
     async fn get_by_local_id<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         local_id: &'a str,
         domain_id: &'a str,
         entity_type: IdMappingEntityType,
@@ -52,7 +52,7 @@ pub trait IdMappingApi: Send + Sync {
     ///   containing an `Option` with the `IdMapping` if found, or an `Error`.
     async fn get_by_public_id<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         public_id: &'a str,
     ) -> Result<Option<IdMapping>, IdMappingProviderError>;
 }

--- a/crates/core/src/idmapping/service.rs
+++ b/crates/core/src/idmapping/service.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::idmapping::*;
 
+use crate::auth::ExecutionContext;
 use crate::idmapping::{IdMappingApi, IdMappingProviderError, backend::IdMappingBackend};
-use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 
 pub struct IdMappingService {
@@ -64,13 +64,13 @@ impl IdMappingApi for IdMappingService {
     ///   containing an `Option` with the `IdMapping` if found, or an `Error`.
     async fn get_by_local_id<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         local_id: &'a str,
         domain_id: &'a str,
         entity_type: IdMappingEntityType,
     ) -> Result<Option<IdMapping>, IdMappingProviderError> {
         self.backend_driver
-            .get_by_local_id(state, local_id, domain_id, entity_type)
+            .get_by_local_id(ctx.state(), local_id, domain_id, entity_type)
             .await
     }
 
@@ -85,10 +85,12 @@ impl IdMappingApi for IdMappingService {
     ///   containing an `Option` with the `IdMapping` if found, or an `Error`.
     async fn get_by_public_id<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         public_id: &'a str,
     ) -> Result<Option<IdMapping>, IdMappingProviderError> {
-        self.backend_driver.get_by_public_id(state, public_id).await
+        self.backend_driver
+            .get_by_public_id(ctx.state(), public_id)
+            .await
     }
 }
 
@@ -126,7 +128,12 @@ mod tests {
         let provider = create_provider(backend);
 
         let res: IdMapping = provider
-            .get_by_local_id(&state, "lid", "did", IdMappingEntityType::User)
+            .get_by_local_id(
+                &ExecutionContext::internal(&state),
+                "lid",
+                "did",
+                IdMappingEntityType::User,
+            )
             .await
             .unwrap()
             .expect("id mapping should be there");
@@ -151,7 +158,7 @@ mod tests {
         let provider = create_provider(backend);
 
         let res: IdMapping = provider
-            .get_by_public_id(&state, "pid")
+            .get_by_public_id(&ExecutionContext::internal(&state), "pid")
             .await
             .unwrap()
             .expect("id mapping should be there");

--- a/crates/core/src/k8s_auth/auth.rs
+++ b/crates/core/src/k8s_auth/auth.rs
@@ -26,8 +26,8 @@ use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
 
 use super::K8sAuthApi;
+use crate::auth::ExecutionContext;
 use crate::k8s_auth::{K8sAuthProviderError, service::K8sAuthService};
-use crate::keystone::ServiceState;
 
 impl K8sAuthService {
     /// Authenticate via K8s TokenReview + mapping engine.
@@ -45,12 +45,12 @@ impl K8sAuthService {
     /// * `K8sAuthProviderError` if authentication fails.
     pub(super) async fn authenticate_by_mapping(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'_>,
         req: &K8sAuthRequest,
     ) -> Result<AuthenticationResult, K8sAuthProviderError> {
         // Fetch k8s auth instance.
         let instance = self
-            .get_auth_instance(state, &req.auth_instance_id)
+            .get_auth_instance(exec, &req.auth_instance_id)
             .await?
             .ok_or(K8sAuthProviderError::AuthInstanceNotFound(
                 req.auth_instance_id.clone(),
@@ -83,10 +83,10 @@ impl K8sAuthService {
             rule_name: req.rule_name.clone(),
         };
 
-        let auth_result = state
+        let auth_result = exec
             .provider
             .get_mapping_provider()
-            .authenticate_by_mapping(state, &mapping_req)
+            .authenticate_by_mapping(exec, &mapping_req)
             .await
             .map_err(|e| K8sAuthProviderError::MappingEngine(e.to_string()))?;
 
@@ -307,7 +307,7 @@ mod tests {
         let service = make_service(backend);
         let result = service
             .authenticate_by_mapping(
-                &state,
+                &ExecutionContext::internal(&state),
                 &K8sAuthRequest {
                     auth_instance_id: "missing".into(),
                     jwt: SecretString::new("jwt".into()),
@@ -340,7 +340,7 @@ mod tests {
         let service = make_service(backend);
         let result = service
             .authenticate_by_mapping(
-                &state,
+                &ExecutionContext::internal(&state),
                 &K8sAuthRequest {
                     auth_instance_id: "cid".into(),
                     jwt: SecretString::new("jwt".into()),

--- a/crates/core/src/k8s_auth/provider_api.rs
+++ b/crates/core/src/k8s_auth/provider_api.rs
@@ -18,8 +18,8 @@ use async_trait::async_trait;
 use openstack_keystone_core_types::k8s_auth::*;
 
 use crate::auth::AuthenticationResult;
+use crate::auth::ExecutionContext;
 use crate::k8s_auth::K8sAuthProviderError;
-use crate::keystone::ServiceState;
 
 /// The trait for managing the K8s_auth functionality.
 #[async_trait]
@@ -37,9 +37,9 @@ pub trait K8sAuthApi: Send + Sync {
     /// # Returns
     /// * Success with [`AuthenticationResult`] via mapping engine.
     /// * `K8sAuthProviderError` if authentication fails.
-    async fn authenticate_by_k8s_mapping(
+    async fn authenticate_by_k8s_mapping<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         req: &K8sAuthRequest,
     ) -> Result<AuthenticationResult, K8sAuthProviderError>;
 
@@ -52,9 +52,9 @@ pub trait K8sAuthApi: Send + Sync {
     /// # Returns
     /// * Success with the created [`K8sAuthInstance`].
     /// * Error if the instance could not be created.
-    async fn create_auth_instance(
+    async fn create_auth_instance<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         config: K8sAuthInstanceCreate,
     ) -> Result<K8sAuthInstance, K8sAuthProviderError>;
 
@@ -69,7 +69,7 @@ pub trait K8sAuthApi: Send + Sync {
     /// * Error if the deletion failed.
     async fn delete_auth_instance<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), K8sAuthProviderError>;
 
@@ -84,7 +84,7 @@ pub trait K8sAuthApi: Send + Sync {
     /// or an `Error`.
     async fn get_auth_instance<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<K8sAuthInstance>, K8sAuthProviderError>;
 
@@ -97,9 +97,9 @@ pub trait K8sAuthApi: Send + Sync {
     /// # Returns
     /// * Success with a list of [`K8sAuthInstance`].
     /// * Error if the listing failed.
-    async fn list_auth_instances(
+    async fn list_auth_instances<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &K8sAuthInstanceListParameters,
     ) -> Result<Vec<K8sAuthInstance>, K8sAuthProviderError>;
 
@@ -115,7 +115,7 @@ pub trait K8sAuthApi: Send + Sync {
     /// * Error if the update failed.
     async fn update_auth_instance<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
         data: K8sAuthInstanceUpdate,
     ) -> Result<K8sAuthInstance, K8sAuthProviderError>;

--- a/crates/core/src/k8s_auth/service.rs
+++ b/crates/core/src/k8s_auth/service.rs
@@ -20,9 +20,8 @@ use async_trait::async_trait;
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::k8s_auth::*;
 
-use crate::auth::AuthenticationResult;
+use crate::auth::{AuthenticationResult, ExecutionContext};
 use crate::k8s_auth::{K8sAuthApi, K8sAuthProviderError, K8sHttpClient, backend::K8sAuthBackend};
-use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 
 /// K8s Auth provider.
@@ -70,12 +69,12 @@ impl K8sAuthApi for K8sAuthService {
     /// # Returns
     /// * Success with [`AuthenticationResult`] via mapping engine.
     /// * Error if authentication fails.
-    async fn authenticate_by_k8s_mapping(
+    async fn authenticate_by_k8s_mapping<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         req: &K8sAuthRequest,
     ) -> Result<AuthenticationResult, K8sAuthProviderError> {
-        self.authenticate_by_mapping(state, req).await
+        self.authenticate_by_mapping(ctx, req).await
     }
 
     /// Register new K8s auth instance.
@@ -87,16 +86,18 @@ impl K8sAuthApi for K8sAuthService {
     /// # Returns
     /// * Success with the created [`K8sAuthInstance`].
     /// * Error if the instance could not be created.
-    async fn create_auth_instance(
+    async fn create_auth_instance<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         instance: K8sAuthInstanceCreate,
     ) -> Result<K8sAuthInstance, K8sAuthProviderError> {
         let mut new = instance;
         if new.id.is_none() {
             new.id = Some(uuid::Uuid::new_v4().simple().to_string());
         }
-        self.backend_driver.create_auth_instance(state, new).await
+        self.backend_driver
+            .create_auth_instance(ctx.state(), new)
+            .await
     }
 
     /// Delete K8s auth provider.
@@ -110,10 +111,12 @@ impl K8sAuthApi for K8sAuthService {
     /// * Error if the deletion failed.
     async fn delete_auth_instance<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), K8sAuthProviderError> {
-        self.backend_driver.delete_auth_instance(state, id).await
+        self.backend_driver
+            .delete_auth_instance(ctx.state(), id)
+            .await
     }
 
     /// Fetch auth instance.
@@ -127,10 +130,10 @@ impl K8sAuthApi for K8sAuthService {
     /// or an `Error`.
     async fn get_auth_instance<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<K8sAuthInstance>, K8sAuthProviderError> {
-        self.backend_driver.get_auth_instance(state, id).await
+        self.backend_driver.get_auth_instance(ctx.state(), id).await
     }
 
     /// List K8s auth instances.
@@ -142,12 +145,14 @@ impl K8sAuthApi for K8sAuthService {
     /// # Returns
     /// * Success with a list of [`K8sAuthInstance`].
     /// * Error if the listing failed.
-    async fn list_auth_instances(
+    async fn list_auth_instances<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &K8sAuthInstanceListParameters,
     ) -> Result<Vec<K8sAuthInstance>, K8sAuthProviderError> {
-        self.backend_driver.list_auth_instances(state, params).await
+        self.backend_driver
+            .list_auth_instances(ctx.state(), params)
+            .await
     }
 
     /// Update K8s auth instance.
@@ -162,12 +167,12 @@ impl K8sAuthApi for K8sAuthService {
     /// * Error if the update failed.
     async fn update_auth_instance<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
         data: K8sAuthInstanceUpdate,
     ) -> Result<K8sAuthInstance, K8sAuthProviderError> {
         self.backend_driver
-            .update_auth_instance(state, id, data)
+            .update_auth_instance(ctx.state(), id, data)
             .await
     }
 }
@@ -223,7 +228,7 @@ mod tests {
         assert!(
             provider
                 .create_auth_instance(
-                    &state,
+                    &ExecutionContext::internal(&state),
                     K8sAuthInstanceCreate {
                         ca_cert: Some("ca".into()),
                         disable_local_ca_jwt: Some(true),

--- a/crates/core/src/mapping/provider_api.rs
+++ b/crates/core/src/mapping/provider_api.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::*;
 
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::mapping::error::MappingProviderError;
 
 /// Mapping provider interface.
@@ -33,9 +33,9 @@ pub trait MappingApi: Send + Sync {
     /// # Returns
     /// - `Result<MappingRuleSet, MappingProviderError>` - The created
     ///   `MappingRuleSet` or an error.
-    async fn create_ruleset(
+    async fn create_ruleset<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         ruleset: MappingRuleSetCreate,
     ) -> Result<MappingRuleSet, MappingProviderError>;
 
@@ -49,7 +49,7 @@ pub trait MappingApi: Send + Sync {
     /// - `Result<(), MappingProviderError>` - Ok if successful, or an error.
     async fn delete_ruleset<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
     ) -> Result<(), MappingProviderError>;
 
@@ -69,7 +69,7 @@ pub trait MappingApi: Send + Sync {
     /// - `Result<(), MappingProviderError>` - Ok if successful, or an error.
     async fn delete_virtual_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<(), MappingProviderError>;
 
@@ -85,7 +85,7 @@ pub trait MappingApi: Send + Sync {
     ///   error.
     async fn get_ruleset<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
     ) -> Result<Option<MappingRuleSet>, MappingProviderError>;
 
@@ -102,7 +102,7 @@ pub trait MappingApi: Send + Sync {
     ///   error.
     async fn get_ruleset_by_source<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain_id: &'a str,
         source: &'a IdentitySource,
     ) -> Result<Option<MappingRuleSet>, MappingProviderError>;
@@ -118,7 +118,7 @@ pub trait MappingApi: Send + Sync {
     ///   containing an `Option` with the `VirtualUser` if found, or an error.
     async fn get_virtual_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Option<VirtualUser>, MappingProviderError>;
 
@@ -131,9 +131,9 @@ pub trait MappingApi: Send + Sync {
     /// # Returns
     /// - `Result<Vec<MappingRuleSet>, MappingProviderError>` - A list of
     ///   `MappingRuleSet` entries or an error.
-    async fn list_rulesets(
+    async fn list_rulesets<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &MappingRuleSetListParameters,
     ) -> Result<Vec<MappingRuleSet>, MappingProviderError>;
 
@@ -152,7 +152,7 @@ pub trait MappingApi: Send + Sync {
     ///   `MappingRuleSet` with mutations applied, or an error.
     async fn mutate_rules<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
         mutations: RuleMutations,
     ) -> Result<MappingRuleSet, MappingProviderError>;
@@ -169,7 +169,7 @@ pub trait MappingApi: Send + Sync {
     ///   `MappingRuleSet` or an error.
     async fn update_ruleset<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
         data: MappingRuleSetUpdate,
     ) -> Result<MappingRuleSet, MappingProviderError>;
@@ -188,7 +188,7 @@ pub trait MappingApi: Send + Sync {
     ///   `VirtualUser` or an error.
     async fn disable_virtual_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<VirtualUser, MappingProviderError>;
 
@@ -205,7 +205,7 @@ pub trait MappingApi: Send + Sync {
     ///   `VirtualUser` or an error.
     async fn enable_virtual_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<VirtualUser, MappingProviderError>;
 
@@ -224,9 +224,9 @@ pub trait MappingApi: Send + Sync {
     /// # Returns
     /// - `Result<AuthenticationResult, MappingProviderError>` - The
     ///   authentication result on success, or an error.
-    async fn authenticate_by_mapping(
+    async fn authenticate_by_mapping<'a>(
         &self,
-        state: &ServiceState,
-        req: &MappingAuthRequest,
+        ctx: &ExecutionContext<'a>,
+        req: &'a MappingAuthRequest,
     ) -> Result<AuthenticationResult, MappingProviderError>;
 }

--- a/crates/core/src/mapping/service.rs
+++ b/crates/core/src/mapping/service.rs
@@ -33,6 +33,7 @@ use openstack_keystone_core_types::identity::{
 };
 use openstack_keystone_core_types::mapping::*;
 
+use crate::auth::ExecutionContext;
 use crate::keystone::ServiceState;
 use crate::mapping::{
     MappingApi, MappingProviderError, backend::MappingBackend, engine, hmac, validation, version,
@@ -72,12 +73,12 @@ impl MappingService {
     ///
     /// Evaluates claims against the ruleset, performs a shadow registry upsert,
     /// and emits `AuthenticationResult`.
-    pub(super) async fn authenticate_by_mapping_internal(
+    pub(super) async fn authenticate_by_mapping_internal<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         req: &MappingAuthRequest,
     ) -> Result<AuthenticationResult, MappingProviderError> {
-        let cfg = state.config_manager.config.read().await;
+        let cfg = ctx.state().config_manager.config.read().await;
         let salt = cfg
             .mapping
             .cluster_salt
@@ -90,14 +91,14 @@ impl MappingService {
                 )
             })?;
 
-        self.authenticate_by_mapping_with_salt(state, req, &salt)
+        self.authenticate_by_mapping_with_salt(ctx, req, &salt)
             .await
     }
 
     /// Authenticate a principal with an explicit salt.
-    pub(super) async fn authenticate_by_mapping_with_salt(
+    pub(super) async fn authenticate_by_mapping_with_salt<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         req: &MappingAuthRequest,
         salt: &[u8],
     ) -> Result<AuthenticationResult, MappingProviderError> {
@@ -105,7 +106,7 @@ impl MappingService {
         let domain_id = req.domain_id.as_deref().unwrap_or("global");
         let ruleset = self
             .backend_driver
-            .get_ruleset_by_source(state, domain_id, &req.source)
+            .get_ruleset_by_source(ctx.state(), domain_id, &req.source)
             .await?
             .ok_or(MappingProviderError::NoMatchingRule)?;
 
@@ -136,11 +137,11 @@ impl MappingService {
         // 5. Branch on identity mode
         match identity_mode {
             IdentityMode::Local => {
-                self.authenticate_local(state, &match_result, &ruleset, req)
+                self.authenticate_local(ctx.state(), &match_result, &ruleset, req)
                     .await
             }
             IdentityMode::Ephemeral => {
-                self.authenticate_ephemeral(state, &match_result, &ruleset, req, salt)
+                self.authenticate_ephemeral(ctx.state(), &match_result, &ruleset, req, salt)
                     .await
             }
         }
@@ -160,7 +161,7 @@ impl MappingService {
 
         let virtual_user = self
             .upsert_virtual_user_shadow(
-                state,
+                &ExecutionContext::internal(state),
                 &virtual_user_id,
                 match_result,
                 ruleset,
@@ -247,7 +248,7 @@ impl MappingService {
         let user_groups = state
             .provider
             .get_identity_provider()
-            .list_groups_of_user(state, &user.id)
+            .list_groups_of_user(&ExecutionContext::internal(state), &user.id)
             .await
             .map_err(MappingProviderError::driver)?;
 
@@ -289,10 +290,11 @@ impl MappingService {
         user_name: &str,
         unique_workload_id: &str,
     ) -> Result<UserResponse, MappingProviderError> {
+        let ctx = ExecutionContext::internal(state);
         let idp = state
             .provider
             .get_federation_provider()
-            .get_identity_provider(state, idp_id)
+            .get_identity_provider(&ctx, idp_id)
             .await
             .map_err(MappingProviderError::driver)?
             .ok_or_else(|| {
@@ -306,7 +308,7 @@ impl MappingService {
         let identity_provider = state.provider.get_identity_provider();
 
         if let Some(existing) = identity_provider
-            .find_federated_user(state, idp_id, unique_workload_id)
+            .find_federated_user(&ctx, idp_id, unique_workload_id)
             .await
             .map_err(MappingProviderError::driver)?
         {
@@ -335,7 +337,7 @@ impl MappingService {
 
         let user = identity_provider
             .create_user(
-                state,
+                &ctx,
                 user_builder.build().map_err(MappingProviderError::driver)?,
             )
             .await
@@ -352,11 +354,12 @@ impl MappingService {
         match_result: &MatchResult,
         idp_id: &str,
     ) -> Result<(), MappingProviderError> {
+        let ctx = ExecutionContext::internal(state);
         let identity_provider = state.provider.get_identity_provider();
 
         let domain_groups: HashMap<String, String> = identity_provider
             .list_groups(
-                state,
+                &ctx,
                 &GroupListParameters {
                     domain_id: Some(user.domain_id.clone()),
                     ..Default::default()
@@ -382,7 +385,7 @@ impl MappingService {
                         .unwrap_or_default();
                     let created = identity_provider
                         .create_group(
-                            state,
+                            &ctx,
                             GroupCreate {
                                 domain_id,
                                 name: group_name.clone(),
@@ -400,7 +403,7 @@ impl MappingService {
         if !group_ids.is_empty() {
             identity_provider
                 .set_user_groups_expiring(
-                    state,
+                    &ctx,
                     &user.id,
                     HashSet::from_iter(group_ids.iter().map(|s| s.as_str())),
                     idp_id,
@@ -418,9 +421,9 @@ impl MappingService {
     /// If the record exists, refresh fields while preserving `created_at` and
     /// `is_system` (immutable from initial creation). If new, create fresh.
     /// Retries on `CasConflict` with exponential backoff.
-    pub(super) async fn upsert_virtual_user_shadow(
+    pub(super) async fn upsert_virtual_user_shadow<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         virtual_user_id: &str,
         match_result: &MatchResult,
         ruleset: &MappingRuleSet,
@@ -432,7 +435,7 @@ impl MappingService {
         for attempt in 0..max_retries {
             let existing = self
                 .backend_driver
-                .get_virtual_user(state, virtual_user_id)
+                .get_virtual_user(ctx.state(), virtual_user_id)
                 .await?;
 
             let result = if let Some(mut vu) = existing {
@@ -450,7 +453,7 @@ impl MappingService {
 
                 // Persist updated record (CAS-protected at storage layer)
                 self.backend_driver
-                    .update_virtual_user(state, virtual_user_id, vu.clone())
+                    .update_virtual_user(ctx.state(), virtual_user_id, vu.clone())
                     .await
             } else {
                 // Insert path: create fresh record
@@ -471,7 +474,7 @@ impl MappingService {
                 };
 
                 self.backend_driver
-                    .create_virtual_user(state, vu.clone())
+                    .create_virtual_user(ctx.state(), vu.clone())
                     .await
             };
 
@@ -501,9 +504,9 @@ impl MappingApi for MappingService {
     ///
     /// Validates the payload, generates UUID, computes content-aware version,
     /// then delegates to the backend driver.
-    async fn create_ruleset(
+    async fn create_ruleset<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mut ruleset: MappingRuleSetCreate,
     ) -> Result<MappingRuleSet, MappingProviderError> {
         // 1. Write-time validation
@@ -532,7 +535,7 @@ impl MappingApi for MappingService {
         // 5. Delegate to backend
         let created = self
             .backend_driver
-            .create_ruleset(state, ruleset_obj)
+            .create_ruleset(ctx.state(), ruleset_obj)
             .await?;
 
         // 6. Return the created ruleset
@@ -550,13 +553,16 @@ impl MappingApi for MappingService {
     /// Delete a mapping ruleset.
     async fn delete_ruleset<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
     ) -> Result<(), MappingProviderError> {
         let max_retries = 5u64;
         for attempt in 0..max_retries {
             // Check immutability: if ruleset contains `is_system` rules, reject
-            if let Some(existing) = self.backend_driver.get_ruleset(state, mapping_id).await?
+            if let Some(existing) = self
+                .backend_driver
+                .get_ruleset(ctx.state(), mapping_id)
+                .await?
                 && existing.rules.iter().any(|r| r.identity.is_system)
             {
                 return Err(MappingProviderError::RulesetImmutable(
@@ -564,7 +570,11 @@ impl MappingApi for MappingService {
                 ));
             }
 
-            match self.backend_driver.delete_ruleset(state, mapping_id).await {
+            match self
+                .backend_driver
+                .delete_ruleset(ctx.state(), mapping_id)
+                .await
+            {
                 Ok(()) => return Ok(()),
                 Err(MappingProviderError::CasConflict { .. }) if attempt + 1 < max_retries => {
                     let backoff_ms = 50 * (1u64 << attempt);
@@ -585,14 +595,14 @@ impl MappingApi for MappingService {
     /// Delete a virtual user shadow record.
     async fn delete_virtual_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<(), MappingProviderError> {
         let max_retries = 5u64;
         for attempt in 0..max_retries {
             match self
                 .backend_driver
-                .delete_virtual_user(state, user_id)
+                .delete_virtual_user(ctx.state(), user_id)
                 .await
             {
                 Ok(()) => return Ok(()),
@@ -615,40 +625,44 @@ impl MappingApi for MappingService {
     /// Fetch a mapping ruleset by ID.
     async fn get_ruleset<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
     ) -> Result<Option<MappingRuleSet>, MappingProviderError> {
-        self.backend_driver.get_ruleset(state, mapping_id).await
+        self.backend_driver
+            .get_ruleset(ctx.state(), mapping_id)
+            .await
     }
 
     /// Fetch a ruleset by its (domain_id, source) composite index.
     async fn get_ruleset_by_source<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain_id: &'a str,
         source: &'a IdentitySource,
     ) -> Result<Option<MappingRuleSet>, MappingProviderError> {
         self.backend_driver
-            .get_ruleset_by_source(state, domain_id, source)
+            .get_ruleset_by_source(ctx.state(), domain_id, source)
             .await
     }
 
     /// Fetch a virtual user shadow record by user ID.
     async fn get_virtual_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Option<VirtualUser>, MappingProviderError> {
-        self.backend_driver.get_virtual_user(state, user_id).await
+        self.backend_driver
+            .get_virtual_user(ctx.state(), user_id)
+            .await
     }
 
     /// List mapping rulesets.
-    async fn list_rulesets(
+    async fn list_rulesets<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &MappingRuleSetListParameters,
     ) -> Result<Vec<MappingRuleSet>, MappingProviderError> {
-        self.backend_driver.list_rulesets(state, params).await
+        self.backend_driver.list_rulesets(ctx.state(), params).await
     }
 
     /// Mutate rules within a mapping ruleset imperatively.
@@ -657,14 +671,14 @@ impl MappingApi for MappingService {
     /// in memory, re-validates, computes new version, then delegates update.
     async fn mutate_rules<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
         mutations: RuleMutations,
     ) -> Result<MappingRuleSet, MappingProviderError> {
         // 1. Fetch current ruleset
         let existing = self
             .backend_driver
-            .get_ruleset(state, mapping_id)
+            .get_ruleset(ctx.state(), mapping_id)
             .await?
             .ok_or_else(|| MappingProviderError::NotFound(mapping_id.to_string()))?;
 
@@ -761,7 +775,7 @@ impl MappingApi for MappingService {
 
         let updated = self
             .backend_driver
-            .update_ruleset(state, mapping_id, update_payload)
+            .update_ruleset(ctx.state(), mapping_id, update_payload)
             .await?;
 
         // 7. Return with new version
@@ -782,14 +796,14 @@ impl MappingApi for MappingService {
     /// new version, then delegates to the backend driver.
     async fn update_ruleset<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
         data: MappingRuleSetUpdate,
     ) -> Result<MappingRuleSet, MappingProviderError> {
         // 1. Fetch existing ruleset
         let existing = self
             .backend_driver
-            .get_ruleset(state, mapping_id)
+            .get_ruleset(ctx.state(), mapping_id)
             .await?
             .ok_or_else(|| MappingProviderError::NotFound(mapping_id.to_string()))?;
 
@@ -817,7 +831,7 @@ impl MappingApi for MappingService {
         // 5. Delegate to backend
         let updated = self
             .backend_driver
-            .update_ruleset(state, mapping_id, data)
+            .update_ruleset(ctx.state(), mapping_id, data)
             .await?;
 
         // 6. Return with updated version
@@ -835,38 +849,40 @@ impl MappingApi for MappingService {
     /// Disable a virtual user shadow record.
     async fn disable_virtual_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<VirtualUser, MappingProviderError> {
         self.backend_driver
-            .disable_virtual_user(state, user_id)
+            .disable_virtual_user(ctx.state(), user_id)
             .await
     }
 
     /// Enable (reactivate) a virtual user shadow record.
     async fn enable_virtual_user<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<VirtualUser, MappingProviderError> {
         self.backend_driver
-            .enable_virtual_user(state, user_id)
+            .enable_virtual_user(ctx.state(), user_id)
             .await
     }
 
     /// Authenticate a principal through the unified mapping engine.
-    async fn authenticate_by_mapping(
+    async fn authenticate_by_mapping<'a>(
         &self,
-        state: &ServiceState,
-        req: &MappingAuthRequest,
+        exec: &ExecutionContext<'a>,
+        req: &'a MappingAuthRequest,
     ) -> Result<AuthenticationResult, MappingProviderError> {
-        self.authenticate_by_mapping_internal(state, req).await
+        self.authenticate_by_mapping_internal(exec, req).await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::ExecutionContext;
+    use crate::keystone::ServiceState;
     use crate::mapping::backend::MockMappingBackend;
     use crate::tests::get_mocked_state;
     use openstack_keystone_config::Config;
@@ -909,7 +925,10 @@ mod tests {
 
         let service = MappingService::from_driver(mock_backend);
 
-        let result = service.get_ruleset(&state, mapping_id).await.unwrap();
+        let result = service
+            .get_ruleset(&ExecutionContext::internal(&state), mapping_id)
+            .await
+            .unwrap();
 
         assert!(result.is_some());
         assert_eq!(result.unwrap().mapping_id, "test-id");
@@ -949,7 +968,7 @@ mod tests {
         let service = MappingService::from_driver(mock_backend);
 
         let result = service
-            .create_ruleset(&state, ruleset_create)
+            .create_ruleset(&ExecutionContext::internal(&state), ruleset_create)
             .await
             .unwrap();
 
@@ -991,7 +1010,10 @@ mod tests {
 
         let service = MappingService::from_driver(mock_backend);
 
-        service.delete_ruleset(&state, mapping_id).await.unwrap();
+        service
+            .delete_ruleset(&ExecutionContext::internal(&state), mapping_id)
+            .await
+            .unwrap();
     }
 
     fn make_ruleset(mapping_id: &str, is_system: bool) -> MappingRuleSet {
@@ -1052,7 +1074,10 @@ mod tests {
 
         let service = MappingService::from_driver(mock_backend);
 
-        service.delete_virtual_user(&state, user_id).await.unwrap();
+        service
+            .delete_virtual_user(&ExecutionContext::internal(&state), user_id)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -1091,7 +1116,9 @@ mod tests {
             });
 
         let service = MappingService::from_driver(mock_backend);
-        let result = service.delete_ruleset(&state, mapping_id).await;
+        let result = service
+            .delete_ruleset(&ExecutionContext::internal(&state), mapping_id)
+            .await;
 
         assert!(result.is_err());
         assert!(matches!(
@@ -1131,7 +1158,9 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let service = MappingService::from_driver(mock_backend);
-        let result = service.delete_ruleset(&state, mapping_id).await;
+        let result = service
+            .delete_ruleset(&ExecutionContext::internal(&state), mapping_id)
+            .await;
 
         assert!(result.is_ok());
     }
@@ -1154,7 +1183,9 @@ mod tests {
             });
 
         let service = MappingService::from_driver(mock_backend);
-        let result = service.delete_virtual_user(&state, user_id).await;
+        let result = service
+            .delete_virtual_user(&ExecutionContext::internal(&state), user_id)
+            .await;
 
         assert!(result.is_err());
         assert!(matches!(
@@ -1178,7 +1209,10 @@ mod tests {
 
         let service = MappingService::from_driver(mock_backend);
 
-        let result = service.get_virtual_user(&state, user_id).await.unwrap();
+        let result = service
+            .get_virtual_user(&ExecutionContext::internal(&state), user_id)
+            .await
+            .unwrap();
 
         assert!(result.is_some());
         assert_eq!(result.unwrap().user_id, user_id);
@@ -1198,7 +1232,10 @@ mod tests {
         let service = MappingService::from_driver(mock_backend);
 
         let result = service
-            .list_rulesets(&state, &MappingRuleSetListParameters::default())
+            .list_rulesets(
+                &ExecutionContext::internal(&state),
+                &MappingRuleSetListParameters::default(),
+            )
             .await
             .unwrap();
 
@@ -1219,7 +1256,9 @@ mod tests {
 
         let service = MappingService::from_driver(mock_backend);
 
-        let result = service.delete_ruleset(&state, mapping_id).await;
+        let result = service
+            .delete_ruleset(&ExecutionContext::internal(&state), mapping_id)
+            .await;
 
         assert!(result.is_err());
         assert!(matches!(
@@ -1250,7 +1289,7 @@ mod tests {
 
         let result = service
             .update_ruleset(
-                &state,
+                &ExecutionContext::internal(&state),
                 mapping_id,
                 MappingRuleSetUpdate {
                     enabled: Some(true),
@@ -1280,7 +1319,7 @@ mod tests {
 
         let result = service
             .update_ruleset(
-                &state,
+                &ExecutionContext::internal(&state),
                 mapping_id,
                 MappingRuleSetUpdate {
                     enabled: Some(true),
@@ -1430,7 +1469,7 @@ mod tests {
 
         let result = service
             .mutate_rules(
-                &state,
+                &ExecutionContext::internal(&state),
                 mapping_id,
                 RuleMutations {
                     mutations: vec![RuleMutation::Insert {
@@ -1463,7 +1502,7 @@ mod tests {
 
         let result = service
             .mutate_rules(
-                &state,
+                &ExecutionContext::internal(&state),
                 mapping_id,
                 RuleMutations {
                     mutations: vec![RuleMutation::Delete {
@@ -1492,7 +1531,7 @@ mod tests {
 
         let result = service
             .mutate_rules(
-                &state,
+                &ExecutionContext::internal(&state),
                 mapping_id,
                 RuleMutations {
                     mutations: vec![RuleMutation::Delete {
@@ -1540,7 +1579,7 @@ mod tests {
 
         let result = service
             .mutate_rules(
-                &state,
+                &ExecutionContext::internal(&state),
                 mapping_id,
                 RuleMutations {
                     mutations: vec![RuleMutation::Insert {
@@ -1577,7 +1616,7 @@ mod tests {
 
         let result = service
             .authenticate_by_mapping(
-                &state,
+                &ExecutionContext::internal(&state),
                 &MappingAuthRequest {
                     domain_id: Some("default-domain".to_string()),
                     source: source.clone(),
@@ -1620,7 +1659,7 @@ mod tests {
 
         let result = service
             .authenticate_by_mapping(
-                &state,
+                &ExecutionContext::internal(&state),
                 &MappingAuthRequest {
                     domain_id: Some("default-domain".to_string()),
                     source: IdentitySource::Federation {
@@ -1665,7 +1704,7 @@ mod tests {
 
         let result = service
             .authenticate_by_mapping(
-                &state,
+                &ExecutionContext::internal(&state),
                 &MappingAuthRequest {
                     domain_id: Some("default-domain".to_string()),
                     source: IdentitySource::Federation {
@@ -1714,7 +1753,10 @@ mod tests {
 
         let service = MappingService::from_driver(mock_backend);
 
-        let result = service.enable_virtual_user(&state, user_id).await.unwrap();
+        let result = service
+            .enable_virtual_user(&ExecutionContext::internal(&state), user_id)
+            .await
+            .unwrap();
 
         assert_eq!(result.user_id, user_id);
         assert!(result.enabled);
@@ -1750,7 +1792,10 @@ mod tests {
 
         let service = MappingService::from_driver(mock_backend);
 
-        let result = service.disable_virtual_user(&state, user_id).await.unwrap();
+        let result = service
+            .disable_virtual_user(&ExecutionContext::internal(&state), user_id)
+            .await
+            .unwrap();
 
         assert_eq!(result.user_id, user_id);
         assert!(!result.enabled);
@@ -1783,7 +1828,11 @@ mod tests {
         let service = MappingService::from_driver(mock_backend);
 
         let result = service
-            .get_ruleset_by_source(&state, "default-domain", &source)
+            .get_ruleset_by_source(
+                &ExecutionContext::internal(&state),
+                "default-domain",
+                &source,
+            )
             .await
             .unwrap();
 
@@ -1858,7 +1907,7 @@ mod tests {
 
         let result = service
             .authenticate_by_mapping(
-                &state,
+                &ExecutionContext::internal(&state),
                 &MappingAuthRequest {
                     domain_id: Some("default-domain".to_string()),
                     source: source.clone(),

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -23,7 +23,7 @@ use secrecy::SecretString;
 use std::collections::HashSet;
 
 use crate::auth::AuthenticationResult;
-use crate::auth::{ScopeInfo, SecurityContext, ValidatedSecurityContext};
+use crate::auth::{ExecutionContext, ScopeInfo, SecurityContext, ValidatedSecurityContext};
 use crate::keystone::ServiceState;
 
 mod application_credential {
@@ -40,47 +40,47 @@ mod application_credential {
 
         #[async_trait]
         impl ApplicationCredentialApi for ApplicationCredentialProvider {
-            async fn create_access_rule(
+            async fn create_access_rule<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 rule: AccessRuleCreate,
             ) -> Result<AccessRule, ApplicationCredentialProviderError>;
 
-            async fn create_application_credential(
+            async fn create_application_credential<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 rec: ApplicationCredentialCreate,
             ) -> Result<ApplicationCredentialCreateResponse, ApplicationCredentialProviderError>;
 
             async fn delete_access_rule<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 id: &'a str,
             ) -> Result<(), ApplicationCredentialProviderError>;
 
             async fn get_access_rule<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 id: &'a str,
             ) -> Result<Option<AccessRule>, ApplicationCredentialProviderError>;
 
             async fn get_application_credential<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<ApplicationCredential>, ApplicationCredentialProviderError>;
 
             async fn list_access_rules<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<Vec<AccessRule>, ApplicationCredentialProviderError>;
 
-            async fn list_application_credentials(
+            async fn list_application_credentials<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &ApplicationCredentialListParameters,
             ) -> Result<Vec<ApplicationCredential>, ApplicationCredentialProviderError>;
         }
@@ -100,21 +100,21 @@ mod assignment {
 
         #[async_trait]
         impl AssignmentApi for AssignmentProvider {
-            async fn create_grant(
+            async fn create_grant<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: AssignmentCreate,
             ) -> Result<Assignment, AssignmentProviderError>;
 
-            async fn list_role_assignments(
+            async fn list_role_assignments<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &RoleAssignmentListParameters,
             ) -> Result<Vec<Assignment>, AssignmentProviderError>;
 
-            async fn revoke_grant(
+            async fn revoke_grant<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: Assignment,
             ) -> Result<(), AssignmentProviderError>;
         }
@@ -135,101 +135,101 @@ mod catalog {
 
         #[async_trait]
         impl CatalogApi for CatalogProvider {
-            async fn create_endpoint(
+            async fn create_endpoint<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 endpoint: EndpointCreate,
             ) -> Result<Endpoint, CatalogProviderError>;
 
-            async fn create_region(
+            async fn create_region<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 region: RegionCreate,
             ) -> Result<Region, CatalogProviderError>;
 
-            async fn create_service(
+            async fn create_service<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 service: ServiceCreate,
             ) -> Result<Service, CatalogProviderError>;
 
             async fn delete_endpoint<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), CatalogProviderError>;
 
             async fn delete_region<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), CatalogProviderError>;
 
             async fn delete_service<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), CatalogProviderError>;
 
-            async fn get_catalog(
+            async fn get_catalog<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 enabled: bool,
             ) -> Result<Vec<(Service, Vec<Endpoint>)>, CatalogProviderError>;
 
             async fn get_endpoint<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<Endpoint>, CatalogProviderError>;
 
             async fn get_region<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<Region>, CatalogProviderError>;
 
             async fn get_service<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<Service>, CatalogProviderError>;
 
-            async fn list_endpoints(
+            async fn list_endpoints<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &EndpointListParameters,
             ) -> Result<Vec<Endpoint>, CatalogProviderError>;
 
-            async fn list_regions(
+            async fn list_regions<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &RegionListParameters,
             ) -> Result<Vec<Region>, CatalogProviderError>;
 
-            async fn list_services(
+            async fn list_services<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &ServiceListParameters,
             ) -> Result<Vec<Service>, CatalogProviderError>;
 
             async fn update_endpoint<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
                 endpoint: EndpointUpdate,
             ) -> Result<Endpoint, CatalogProviderError>;
 
             async fn update_region<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
                 region: RegionUpdate,
             ) -> Result<Region, CatalogProviderError>;
 
             async fn update_service<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
                 service: ServiceUpdate,
             ) -> Result<Service, CatalogProviderError>;
@@ -250,56 +250,56 @@ mod federation {
 
         #[async_trait]
         impl FederationApi for FederationProvider {
-            async fn cleanup(
+            async fn cleanup<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
             ) -> Result<(), FederationProviderError>;
 
-            async fn create_auth_state(
+            async fn create_auth_state<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 auth_state: AuthState,
             ) -> Result<AuthState, FederationProviderError>;
 
-            async fn create_identity_provider(
+            async fn create_identity_provider<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 idp: IdentityProviderCreate,
             ) -> Result<IdentityProvider, FederationProviderError>;
 
             async fn delete_auth_state<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), FederationProviderError>;
 
             async fn delete_identity_provider<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), FederationProviderError>;
 
             async fn get_auth_state<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<AuthState>, FederationProviderError>;
 
             async fn get_identity_provider<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<IdentityProvider>, FederationProviderError>;
 
-            async fn list_identity_providers(
+            async fn list_identity_providers<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &IdentityProviderListParameters,
             ) -> Result<Vec<IdentityProvider>, FederationProviderError>;
 
             async fn update_identity_provider<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
                 idp: IdentityProviderUpdate,
             ) -> Result<IdentityProvider, FederationProviderError>;
@@ -322,14 +322,14 @@ mod identity {
         impl IdentityApi for IdentityProvider {
             async fn add_user_to_group<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 group_id: &'a str,
             ) -> Result<(), IdentityProviderError>;
 
             async fn add_user_to_group_expiring<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 group_id: &'a str,
                 idp_id: &'a str,
@@ -337,63 +337,63 @@ mod identity {
 
             async fn add_users_to_groups<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 memberships: Vec<(&'a str, &'a str)>,
             ) -> Result<(), IdentityProviderError>;
 
             async fn add_users_to_groups_expiring<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 memberships: Vec<(&'a str, &'a str)>,
                 idp_id: &'a str,
             ) -> Result<(), IdentityProviderError>;
 
-            async fn authenticate_by_password(
+            async fn authenticate_by_password<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 auth: &UserPasswordAuthRequest,
             ) -> Result<AuthenticationResult, IdentityProviderError>;
 
-            async fn create_group(
+            async fn create_group<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 group: GroupCreate,
             ) -> Result<Group, IdentityProviderError>;
 
-            async fn create_service_account(
+            async fn create_service_account<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 sa: ServiceAccountCreate,
             ) -> Result<ServiceAccount, IdentityProviderError>;
 
-            async fn create_user(
+            async fn create_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user: UserCreate,
             ) -> Result<UserResponse, IdentityProviderError>;
 
             async fn delete_group<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 group_id: &'a str,
             ) -> Result<(), IdentityProviderError>;
 
             async fn delete_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<(), IdentityProviderError>;
 
             async fn update_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 user: UserUpdate,
             ) -> Result<UserResponse, IdentityProviderError>;
 
             async fn update_user_password<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 original_password: SecretString,
                 new_password: SecretString,
@@ -401,63 +401,63 @@ mod identity {
 
             async fn get_group<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 group_id: &'a str,
             ) -> Result<Option<Group>, IdentityProviderError>;
 
             async fn get_service_account<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<Option<ServiceAccount>, IdentityProviderError>;
 
             async fn get_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<Option<UserResponse>, IdentityProviderError>;
 
             async fn get_user_domain_id<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<String, IdentityProviderError>;
 
             async fn find_federated_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 idp_id: &'a str,
                 unique_id: &'a str,
             ) -> Result<Option<UserResponse>, IdentityProviderError>;
 
-            async fn list_groups(
+            async fn list_groups<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &GroupListParameters,
             ) -> Result<Vec<Group>, IdentityProviderError>;
 
             async fn list_groups_of_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<Vec<Group>, IdentityProviderError>;
 
-            async fn list_users(
+            async fn list_users<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &UserListParameters,
             ) -> Result<Vec<UserResponse>, IdentityProviderError>;
 
             async fn remove_user_from_group<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 group_id: &'a str,
             ) -> Result<(), IdentityProviderError>;
 
             async fn remove_user_from_group_expiring<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 group_id: &'a str,
                 idp_id: &'a str,
@@ -465,14 +465,14 @@ mod identity {
 
             async fn remove_user_from_groups<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 group_ids: HashSet<&'a str>,
             ) -> Result<(), IdentityProviderError>;
 
             async fn remove_user_from_groups_expiring<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 group_ids: HashSet<&'a str>,
                 idp_id: &'a str,
@@ -480,14 +480,14 @@ mod identity {
 
             async fn set_user_groups<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 group_ids: HashSet<&'a str>,
             ) -> Result<(), IdentityProviderError>;
 
             async fn set_user_groups_expiring<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
                 group_ids: HashSet<&'a str>,
                 idp_id: &'a str,
@@ -512,7 +512,7 @@ mod idmapping {
         impl IdMappingApi for IdMappingProvider {
             async fn get_by_local_id<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 local_id: &'a str,
                 domain_id: &'a str,
                 entity_type: IdMappingEntityType,
@@ -520,7 +520,7 @@ mod idmapping {
 
             async fn get_by_public_id<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 public_id: &'a str,
             ) -> Result<Option<IdMapping>, IdMappingProviderError>;
         }
@@ -540,39 +540,39 @@ mod k8s_auth {
 
         #[async_trait]
         impl K8sAuthApi for K8sAuthProvider {
-            async fn authenticate_by_k8s_mapping(
+            async fn authenticate_by_k8s_mapping<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 req: &K8sAuthRequest,
             ) -> Result<AuthenticationResult, K8sAuthProviderError>;
 
-            async fn create_auth_instance(
+            async fn create_auth_instance<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 config: K8sAuthInstanceCreate,
             ) -> Result<K8sAuthInstance, K8sAuthProviderError>;
 
             async fn delete_auth_instance<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), K8sAuthProviderError>;
 
             async fn get_auth_instance<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<K8sAuthInstance>, K8sAuthProviderError>;
 
-            async fn list_auth_instances(
+            async fn list_auth_instances<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &K8sAuthInstanceListParameters,
             ) -> Result<Vec<K8sAuthInstance>, K8sAuthProviderError>;
 
             async fn update_auth_instance<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
                 data: K8sAuthInstanceUpdate,
             ) -> Result<K8sAuthInstance, K8sAuthProviderError>;
@@ -593,79 +593,79 @@ mod mapping {
 
         #[async_trait]
         impl MappingApi for MappingProvider {
-            async fn create_ruleset(
+            async fn create_ruleset<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 ruleset: MappingRuleSetCreate,
             ) -> Result<MappingRuleSet, MappingProviderError>;
 
             async fn delete_ruleset<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 mapping_id: &'a str,
             ) -> Result<(), MappingProviderError>;
 
             async fn delete_virtual_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<(), MappingProviderError>;
 
             async fn get_ruleset<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 mapping_id: &'a str,
             ) -> Result<Option<MappingRuleSet>, MappingProviderError>;
 
             async fn get_ruleset_by_source<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 domain_id: &'a str,
                 source: &'a IdentitySource,
             ) -> Result<Option<MappingRuleSet>, MappingProviderError>;
 
             async fn get_virtual_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<Option<VirtualUser>, MappingProviderError>;
 
-            async fn list_rulesets(
+            async fn list_rulesets<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &MappingRuleSetListParameters,
             ) -> Result<Vec<MappingRuleSet>, MappingProviderError>;
 
             async fn mutate_rules<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 mapping_id: &'a str,
                 mutations: RuleMutations,
             ) -> Result<MappingRuleSet, MappingProviderError>;
 
             async fn update_ruleset<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 mapping_id: &'a str,
                 data: MappingRuleSetUpdate,
             ) -> Result<MappingRuleSet, MappingProviderError>;
 
             async fn disable_virtual_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<VirtualUser, MappingProviderError>;
 
             async fn enable_virtual_user<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 user_id: &'a str,
             ) -> Result<VirtualUser, MappingProviderError>;
 
-            async fn authenticate_by_mapping(
+            async fn authenticate_by_mapping<'a>(
                 &self,
-                state: &ServiceState,
-                req: &MappingAuthRequest,
+                ctx: &ExecutionContext<'a>,
+                req: &'a MappingAuthRequest,
             ) -> Result<AuthenticationResult, MappingProviderError>;
         }
     }
@@ -686,74 +686,74 @@ mod resource {
         impl ResourceApi for ResourceProvider {
             async fn get_domain_enabled<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 domain_id: &'a str,
             ) -> Result<bool, ResourceProviderError>;
 
-            async fn create_domain(
+            async fn create_domain<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 domain: DomainCreate,
             ) -> Result<Domain, ResourceProviderError>;
 
-            async fn create_project(
+            async fn create_project<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 project: ProjectCreate,
             ) -> Result<Project, ResourceProviderError>;
 
             async fn delete_domain<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), ResourceProviderError>;
 
             async fn delete_project<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), ResourceProviderError>;
 
             async fn get_domain<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 domain_id: &'a str,
             ) -> Result<Option<Domain>, ResourceProviderError>;
 
             async fn find_domain_by_name<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 domain_name: &'a str,
             ) -> Result<Option<Domain>, ResourceProviderError>;
 
             async fn get_project<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 project_id: &'a str,
             ) -> Result<Option<Project>, ResourceProviderError>;
 
             async fn get_project_by_name<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 name: &'a str,
                 domain_id: &'a str,
             ) -> Result<Option<Project>, ResourceProviderError>;
 
             async fn get_project_parents<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 project_id: &'a str,
             ) -> Result<Option<Vec<Project>>, ResourceProviderError>;
 
-            async fn list_domains(
+            async fn list_domains<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &DomainListParameters,
             ) -> Result<Vec<Domain>, ResourceProviderError>;
 
-            async fn list_projects(
+            async fn list_projects<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &ProjectListParameters,
             ) -> Result<Vec<Project>, ResourceProviderError>;
         }
@@ -774,21 +774,21 @@ mod revoke {
 
         #[async_trait]
         impl RevokeApi for RevokeProvider {
-            async fn create_revocation_event(
+            async fn create_revocation_event<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 event: RevocationEventCreate,
             ) -> Result<RevocationEvent, RevokeProviderError>;
 
-            async fn is_token_revoked(
+            async fn is_token_revoked<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 token_security_context: &ValidatedSecurityContext,
             ) -> Result<bool, RevokeProviderError>;
 
-            async fn revoke_token(
+            async fn revoke_token<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 token: &FernetToken,
             ) -> Result<(), RevokeProviderError>;
         }
@@ -808,72 +808,72 @@ mod role {
 
         #[async_trait]
         impl RoleApi for RoleProvider {
-            async fn create_role(
+            async fn create_role<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: RoleCreate,
             ) -> Result<Role, RoleProviderError>;
 
             async fn create_role_imply_rule<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 prior_role_id: &'a str,
                 implied_role_id: &'a str,
             ) -> Result<RoleImply, RoleProviderError>;
 
             async fn check_role_imply_rule<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 prior_role_id: &'a str,
                 implied_role_id: &'a str,
             ) -> Result<bool, RoleProviderError>;
 
             async fn delete_role<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), RoleProviderError>;
 
             async fn delete_role_imply_rule<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 prior_role_id: &'a str,
                 implied_role_id: &'a str,
             ) -> Result<(), RoleProviderError>;
 
-            async fn expand_implied_roles(
+            async fn expand_implied_roles<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 roles: &mut Vec<RoleRef>,
             ) -> Result<(), RoleProviderError>;
 
             async fn get_role<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<Role>, RoleProviderError>;
 
             async fn get_role_imply_rule<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 prior_role_id: &'a str,
                 implied_role_id: &'a str,
             ) -> Result<Option<RoleImply>, RoleProviderError>;
 
-            async fn list_role_imply_rules(
+            async fn list_role_imply_rules<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
             ) -> Result<Vec<RoleImply>, RoleProviderError>;
 
             async fn list_role_imply_rules_by_prior<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 prior_role_id: &'a str,
             ) -> Result<Vec<RoleImply>, RoleProviderError>;
 
-            async fn list_roles(
+            async fn list_roles<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &RoleListParameters,
             ) -> Result<Vec<Role>, RoleProviderError>;
         }
@@ -896,7 +896,7 @@ mod token {
         impl TokenApi for TokenProvider {
             async fn authorize_by_token<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 credential: &'a str,
                 allow_expired: Option<bool>,
                 window_seconds: Option<i64>,
@@ -904,7 +904,7 @@ mod token {
 
             async fn validate_to_context<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 credential: &'a str,
                 allow_expired: Option<bool>,
                 window_seconds: Option<i64>,
@@ -922,33 +922,33 @@ mod token {
 
             async fn get_token_restriction<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
                 expand_roles: bool,
             ) -> Result<Option<TokenRestriction>, TokenProviderError>;
 
             async fn list_token_restrictions<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &TokenRestrictionListParameters,
             ) -> Result<Vec<TokenRestriction>, TokenProviderError>;
 
             async fn create_token_restriction<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 restriction: TokenRestrictionCreate,
             ) -> Result<TokenRestriction, TokenProviderError>;
 
             async fn update_token_restriction<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
                 restriction: TokenRestrictionUpdate,
             ) -> Result<TokenRestriction, TokenProviderError>;
 
             async fn delete_token_restriction<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<(), TokenProviderError>;
         }
@@ -970,25 +970,25 @@ mod trust {
         impl TrustApi for TrustProvider {
             async fn get_trust<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<Trust>, TrustProviderError>;
 
             async fn get_trust_delegation_chain<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 id: &'a str,
             ) -> Result<Option<Vec<Trust>>, TrustProviderError>;
 
-            async fn list_trusts(
+            async fn list_trusts<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 params: &TrustListParameters,
             ) -> Result<Vec<Trust>, TrustProviderError>;
 
-            async fn validate_trust_delegation_chain(
+            async fn validate_trust_delegation_chain<'a>(
                 &self,
-                state: &ServiceState,
+                ctx: &ExecutionContext<'a>,
                 trust: &Trust,
             ) -> Result<bool, TrustProviderError>;
         }

--- a/crates/core/src/resource/provider_api.rs
+++ b/crates/core/src/resource/provider_api.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 
 use openstack_keystone_core_types::resource::*;
 
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::resource::ResourceProviderError;
 
 /// Resource API.
@@ -31,7 +31,7 @@ pub trait ResourceApi: Send + Sync {
     /// or an `Error`.
     async fn get_domain_enabled<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain_id: &'a str,
     ) -> Result<bool, ResourceProviderError>;
 
@@ -41,9 +41,9 @@ pub trait ResourceApi: Send + Sync {
     /// * `domain` - The domain details to create.
     ///
     /// A `Result` containing the created `Domain`, or an `Error`.
-    async fn create_domain(
+    async fn create_domain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain: DomainCreate,
     ) -> Result<Domain, ResourceProviderError>;
 
@@ -53,9 +53,9 @@ pub trait ResourceApi: Send + Sync {
     /// * `project` - The project details to create.
     ///
     /// A `Result` containing the created `Project`, or an `Error`.
-    async fn create_project(
+    async fn create_project<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         project: ProjectCreate,
     ) -> Result<Project, ResourceProviderError>;
 
@@ -67,7 +67,7 @@ pub trait ResourceApi: Send + Sync {
     /// A `Result` containing `()` if successful, or an `Error`.
     async fn delete_domain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), ResourceProviderError>;
 
@@ -79,7 +79,7 @@ pub trait ResourceApi: Send + Sync {
     /// A `Result` containing `()` if successful, or an `Error`.
     async fn delete_project<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), ResourceProviderError>;
 
@@ -92,7 +92,7 @@ pub trait ResourceApi: Send + Sync {
     /// `Error`.
     async fn get_domain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain_id: &'a str,
     ) -> Result<Option<Domain>, ResourceProviderError>;
 
@@ -105,7 +105,7 @@ pub trait ResourceApi: Send + Sync {
     /// `Error`.
     async fn get_project<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         project_id: &'a str,
     ) -> Result<Option<Project>, ResourceProviderError>;
 
@@ -119,7 +119,7 @@ pub trait ResourceApi: Send + Sync {
     /// `Error`.
     async fn get_project_by_name<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         name: &'a str,
         domain_id: &'a str,
     ) -> Result<Option<Project>, ResourceProviderError>;
@@ -133,7 +133,7 @@ pub trait ResourceApi: Send + Sync {
     /// an `Error`.
     async fn get_project_parents<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         project_id: &'a str,
     ) -> Result<Option<Vec<Project>>, ResourceProviderError>;
 
@@ -146,7 +146,7 @@ pub trait ResourceApi: Send + Sync {
     /// `Error`.
     async fn find_domain_by_name<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain_name: &'a str,
     ) -> Result<Option<Domain>, ResourceProviderError>;
 
@@ -156,9 +156,9 @@ pub trait ResourceApi: Send + Sync {
     /// * `params` - The list parameters.
     ///
     /// A `Result` containing a `Vec<Domain>`, or an `Error`.
-    async fn list_domains(
+    async fn list_domains<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &DomainListParameters,
     ) -> Result<Vec<Domain>, ResourceProviderError>;
 
@@ -168,9 +168,9 @@ pub trait ResourceApi: Send + Sync {
     /// * `params` - The list parameters.
     ///
     /// A `Result` containing a `Vec<Project>`, or an `Error`.
-    async fn list_projects(
+    async fn list_projects<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &ProjectListParameters,
     ) -> Result<Vec<Project>, ResourceProviderError>;
 }

--- a/crates/core/src/resource/service.rs
+++ b/crates/core/src/resource/service.rs
@@ -21,7 +21,7 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::resource::*;
 
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::plugin_manager::PluginManagerApi;
 use crate::resource::{ResourceApi, ResourceProviderError, backend::ResourceBackend};
 
@@ -64,11 +64,11 @@ impl ResourceApi for ResourceService {
     ///   or an error.
     async fn get_domain_enabled<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain_id: &'a str,
     ) -> Result<bool, ResourceProviderError> {
         self.backend_driver
-            .get_domain_enabled(state, domain_id)
+            .get_domain_enabled(ctx.state(), domain_id)
             .await
     }
 
@@ -81,9 +81,9 @@ impl ResourceApi for ResourceService {
     /// # Returns
     /// - `Result<Domain, ResourceProviderError>` - The created `Domain` or an
     ///   error.
-    async fn create_domain(
+    async fn create_domain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain: DomainCreate,
     ) -> Result<Domain, ResourceProviderError> {
         let mut new_domain = domain;
@@ -92,9 +92,12 @@ impl ResourceApi for ResourceService {
             new_domain.id = Some(Uuid::new_v4().simple().to_string());
         }
         new_domain.validate()?;
-        let domain = self.backend_driver.create_domain(state, new_domain).await?;
+        let domain = self
+            .backend_driver
+            .create_domain(ctx.state(), new_domain)
+            .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -116,9 +119,9 @@ impl ResourceApi for ResourceService {
     /// # Returns
     /// - `Result<Project, ResourceProviderError>` - The created `Project` or an
     ///   error.
-    async fn create_project(
+    async fn create_project<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         project: ProjectCreate,
     ) -> Result<Project, ResourceProviderError> {
         let mut new_project = project;
@@ -129,10 +132,10 @@ impl ResourceApi for ResourceService {
         new_project.validate()?;
         let project = self
             .backend_driver
-            .create_project(state, new_project)
+            .create_project(ctx.state(), new_project)
             .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -156,12 +159,12 @@ impl ResourceApi for ResourceService {
     ///   error.
     async fn delete_domain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), ResourceProviderError> {
-        self.backend_driver.delete_domain(state, id).await?;
+        self.backend_driver.delete_domain(ctx.state(), id).await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -183,12 +186,12 @@ impl ResourceApi for ResourceService {
     ///   error.
     async fn delete_project<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), ResourceProviderError> {
-        self.backend_driver.delete_project(state, id).await?;
+        self.backend_driver.delete_project(ctx.state(), id).await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -210,10 +213,10 @@ impl ResourceApi for ResourceService {
     ///   `Error`.
     async fn get_domain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain_id: &'a str,
     ) -> Result<Option<Domain>, ResourceProviderError> {
-        self.backend_driver.get_domain(state, domain_id).await
+        self.backend_driver.get_domain(ctx.state(), domain_id).await
     }
 
     /// Get a single project.
@@ -227,10 +230,12 @@ impl ResourceApi for ResourceService {
     ///   `Error`.
     async fn get_project<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         project_id: &'a str,
     ) -> Result<Option<Project>, ResourceProviderError> {
-        self.backend_driver.get_project(state, project_id).await
+        self.backend_driver
+            .get_project(ctx.state(), project_id)
+            .await
     }
 
     /// Get a single project by name and domain ID.
@@ -245,12 +250,12 @@ impl ResourceApi for ResourceService {
     ///   `Error`.
     async fn get_project_by_name<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         name: &'a str,
         domain_id: &'a str,
     ) -> Result<Option<Project>, ResourceProviderError> {
         self.backend_driver
-            .get_project_by_name(state, name, domain_id)
+            .get_project_by_name(ctx.state(), name, domain_id)
             .await
     }
 
@@ -265,11 +270,11 @@ impl ResourceApi for ResourceService {
     ///   an `Error`.
     async fn get_project_parents<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         project_id: &'a str,
     ) -> Result<Option<Vec<Project>>, ResourceProviderError> {
         self.backend_driver
-            .get_project_parents(state, project_id)
+            .get_project_parents(ctx.state(), project_id)
             .await
     }
 
@@ -284,11 +289,11 @@ impl ResourceApi for ResourceService {
     ///   `Error`.
     async fn find_domain_by_name<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         domain_name: &'a str,
     ) -> Result<Option<Domain>, ResourceProviderError> {
         self.backend_driver
-            .get_domain_by_name(state, domain_name)
+            .get_domain_by_name(ctx.state(), domain_name)
             .await
     }
 
@@ -301,12 +306,12 @@ impl ResourceApi for ResourceService {
     /// # Returns
     /// - `Result<Vec<Domain>, ResourceProviderError>` - A list of domains or an
     ///   error.
-    async fn list_domains(
+    async fn list_domains<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &DomainListParameters,
     ) -> Result<Vec<Domain>, ResourceProviderError> {
-        self.backend_driver.list_domains(state, params).await
+        self.backend_driver.list_domains(ctx.state(), params).await
     }
 
     /// List projects.
@@ -318,11 +323,11 @@ impl ResourceApi for ResourceService {
     /// # Returns
     /// - `Result<Vec<Project>, ResourceProviderError>` - A list of projects or
     ///   an error.
-    async fn list_projects(
+    async fn list_projects<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &ProjectListParameters,
     ) -> Result<Vec<Project>, ResourceProviderError> {
-        self.backend_driver.list_projects(state, params).await
+        self.backend_driver.list_projects(ctx.state(), params).await
     }
 }

--- a/crates/core/src/revoke/provider_api.rs
+++ b/crates/core/src/revoke/provider_api.rs
@@ -19,8 +19,7 @@ use async_trait::async_trait;
 use openstack_keystone_core_types::revoke::*;
 use openstack_keystone_core_types::token::FernetToken;
 
-use crate::auth::ValidatedSecurityContext;
-use crate::keystone::ServiceState;
+use crate::auth::{ExecutionContext, ValidatedSecurityContext};
 use crate::revoke::RevokeProviderError;
 
 /// Revocation Provider interface.
@@ -31,9 +30,9 @@ pub trait RevokeApi: Send + Sync {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `event` - The revocation event to create.
-    async fn create_revocation_event(
+    async fn create_revocation_event<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         event: RevocationEventCreate,
     ) -> Result<RevocationEvent, RevokeProviderError>;
 
@@ -46,9 +45,9 @@ pub trait RevokeApi: Send + Sync {
     /// * `state` - The current service state.
     /// * `token_security_context` - A `ValidatedSecurityContext` of the Token.
     /// * `token` - The token to check.
-    async fn is_token_revoked(
+    async fn is_token_revoked<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         token_security_context: &ValidatedSecurityContext,
     ) -> Result<bool, RevokeProviderError>;
 
@@ -60,9 +59,9 @@ pub trait RevokeApi: Send + Sync {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `token` - The token to revoke.
-    async fn revoke_token(
+    async fn revoke_token<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         token: &FernetToken,
     ) -> Result<(), RevokeProviderError>;
 }

--- a/crates/core/src/revoke/service.rs
+++ b/crates/core/src/revoke/service.rs
@@ -20,8 +20,8 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::revoke::*;
 use openstack_keystone_core_types::token::FernetToken;
 
+use crate::auth::ExecutionContext;
 use crate::auth::ValidatedSecurityContext;
-use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 use crate::revoke::{RevokeApi, RevokeProviderError, backend::RevokeBackend};
 
@@ -55,13 +55,13 @@ impl RevokeApi for RevokeService {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `event` - The revocation event to create.
-    async fn create_revocation_event(
+    async fn create_revocation_event<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         event: RevocationEventCreate,
     ) -> Result<RevocationEvent, RevokeProviderError> {
         self.backend_driver
-            .create_revocation_event(state, event)
+            .create_revocation_event(ctx.state(), event)
             .await
     }
 
@@ -74,14 +74,14 @@ impl RevokeApi for RevokeService {
     /// * `state` - The current service state.
     /// * `token_security_context` - A `ValidatedSecurityContext` of the Token.
     /// * `token` - The token to check.
-    async fn is_token_revoked(
+    async fn is_token_revoked<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         token_security_context: &ValidatedSecurityContext,
     ) -> Result<bool, RevokeProviderError> {
         tracing::info!("Checking for the revocation events");
         self.backend_driver
-            .is_token_revoked(state, token_security_context)
+            .is_token_revoked(ctx.state(), token_security_context)
             .await
     }
 
@@ -93,12 +93,12 @@ impl RevokeApi for RevokeService {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `token` - The token to revoke.
-    async fn revoke_token(
+    async fn revoke_token<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         token: &FernetToken,
     ) -> Result<(), RevokeProviderError> {
-        self.backend_driver.revoke_token(state, token).await
+        self.backend_driver.revoke_token(ctx.state(), token).await
     }
 }
 
@@ -127,7 +127,10 @@ mod tests {
 
         assert!(
             provider
-                .create_revocation_event(&state, RevocationEventCreate::default())
+                .create_revocation_event(
+                    &ExecutionContext::internal(&state),
+                    RevocationEventCreate::default()
+                )
                 .await
                 .is_ok()
         );

--- a/crates/core/src/role/provider_api.rs
+++ b/crates/core/src/role/provider_api.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 
 use openstack_keystone_core_types::role::*;
 
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::role::RoleProviderError;
 
 /// A trait defining the role API.
@@ -30,9 +30,9 @@ pub trait RoleApi: Send + Sync {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `params` - The parameters for creating a role.
-    async fn create_role(
+    async fn create_role<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: RoleCreate,
     ) -> Result<Role, RoleProviderError>;
 
@@ -44,7 +44,7 @@ pub trait RoleApi: Send + Sync {
     /// * `implied_role_id` - The ID of the implied role.
     async fn create_role_imply_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<RoleImply, RoleProviderError>;
@@ -57,7 +57,7 @@ pub trait RoleApi: Send + Sync {
     /// * `implied_role_id` - The ID of the implied role.
     async fn check_role_imply_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<bool, RoleProviderError>;
@@ -69,7 +69,7 @@ pub trait RoleApi: Send + Sync {
     /// * `id` - The ID of the role to delete.
     async fn delete_role<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), RoleProviderError>;
 
@@ -81,7 +81,7 @@ pub trait RoleApi: Send + Sync {
     /// * `implied_role_id` - The ID of the implied role.
     async fn delete_role_imply_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<(), RoleProviderError>;
@@ -91,9 +91,9 @@ pub trait RoleApi: Send + Sync {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `roles` - The list of roles to expand.
-    async fn expand_implied_roles(
+    async fn expand_implied_roles<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         roles: &mut Vec<RoleRef>,
     ) -> Result<(), RoleProviderError>;
 
@@ -106,7 +106,7 @@ pub trait RoleApi: Send + Sync {
     /// `Error`.
     async fn get_role<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         role_id: &'a str,
     ) -> Result<Option<Role>, RoleProviderError>;
 
@@ -118,7 +118,7 @@ pub trait RoleApi: Send + Sync {
     /// * `implied_role_id` - The ID of the implied role.
     async fn get_role_imply_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<Option<RoleImply>, RoleProviderError>;
@@ -127,9 +127,9 @@ pub trait RoleApi: Send + Sync {
     ///
     /// # Arguments
     /// * `state` - The current service state.
-    async fn list_role_imply_rules(
+    async fn list_role_imply_rules<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
     ) -> Result<Vec<RoleImply>, RoleProviderError>;
 
     /// List role imply rules for a specific prior role.
@@ -139,7 +139,7 @@ pub trait RoleApi: Send + Sync {
     /// * `prior_role_id` - The ID of the prior role.
     async fn list_role_imply_rules_by_prior<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
     ) -> Result<Vec<RoleImply>, RoleProviderError>;
 
@@ -148,9 +148,9 @@ pub trait RoleApi: Send + Sync {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `params` - The parameters for listing roles.
-    async fn list_roles(
+    async fn list_roles<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &RoleListParameters,
     ) -> Result<Vec<Role>, RoleProviderError>;
 }

--- a/crates/core/src/role/service.rs
+++ b/crates/core/src/role/service.rs
@@ -22,7 +22,7 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::role::*;
 
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::plugin_manager::PluginManagerApi;
 use crate::role::{RoleApi, RoleProviderError, backend::RoleBackend};
 
@@ -54,9 +54,9 @@ impl RoleApi for RoleService {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `params` - The parameters for creating a role.
-    async fn create_role(
+    async fn create_role<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: RoleCreate,
     ) -> Result<Role, RoleProviderError> {
         params.validate()?;
@@ -66,9 +66,12 @@ impl RoleApi for RoleService {
         if new_params.id.is_none() {
             new_params.id = Some(Uuid::new_v4().simple().to_string());
         }
-        let role = self.backend_driver.create_role(state, new_params).await?;
+        let role = self
+            .backend_driver
+            .create_role(ctx.state(), new_params)
+            .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -89,16 +92,16 @@ impl RoleApi for RoleService {
     /// * `implied_role_id` - The ID of the implied role.
     async fn create_role_imply_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<RoleImply, RoleProviderError> {
         let rule = self
             .backend_driver
-            .create_role_imply_rule(state, prior_role_id, implied_role_id)
+            .create_role_imply_rule(ctx.state(), prior_role_id, implied_role_id)
             .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Create,
@@ -120,12 +123,12 @@ impl RoleApi for RoleService {
     /// * `implied_role_id` - The ID of the implied role.
     async fn check_role_imply_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<bool, RoleProviderError> {
         self.backend_driver
-            .check_role_imply_rule(state, prior_role_id, implied_role_id)
+            .check_role_imply_rule(ctx.state(), prior_role_id, implied_role_id)
             .await
     }
 
@@ -136,12 +139,12 @@ impl RoleApi for RoleService {
     /// * `id` - The ID of the role to delete.
     async fn delete_role<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), RoleProviderError> {
-        self.backend_driver.delete_role(state, id).await?;
+        self.backend_driver.delete_role(ctx.state(), id).await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -160,15 +163,15 @@ impl RoleApi for RoleService {
     /// * `implied_role_id` - The ID of the implied role.
     async fn delete_role_imply_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<(), RoleProviderError> {
         self.backend_driver
-            .delete_role_imply_rule(state, prior_role_id, implied_role_id)
+            .delete_role_imply_rule(ctx.state(), prior_role_id, implied_role_id)
             .await?;
 
-        state
+        ctx.state()
             .event_dispatcher
             .emit(Event::new(
                 Operation::Delete,
@@ -189,16 +192,16 @@ impl RoleApi for RoleService {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `roles` - The list of roles to expand.
-    async fn expand_implied_roles(
+    async fn expand_implied_roles<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         roles: &mut Vec<RoleRef>,
     ) -> Result<(), RoleProviderError> {
         // In most of the cases a logic for expanding the roles may be implemented by
         // the provider itself, but some backend drivers may have more efficient
         // methods.
         self.backend_driver
-            .expand_implied_roles(state, roles)
+            .expand_implied_roles(ctx.state(), roles)
             .await?;
         Ok(())
     }
@@ -212,10 +215,10 @@ impl RoleApi for RoleService {
     /// `Error`.
     async fn get_role<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Role>, RoleProviderError> {
-        self.backend_driver.get_role(state, id).await
+        self.backend_driver.get_role(ctx.state(), id).await
     }
 
     /// Get a role imply rule.
@@ -226,12 +229,12 @@ impl RoleApi for RoleService {
     /// * `implied_role_id` - The ID of the implied role.
     async fn get_role_imply_rule<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<Option<RoleImply>, RoleProviderError> {
         self.backend_driver
-            .get_role_imply_rule(state, prior_role_id, implied_role_id)
+            .get_role_imply_rule(ctx.state(), prior_role_id, implied_role_id)
             .await
     }
 
@@ -239,11 +242,11 @@ impl RoleApi for RoleService {
     ///
     /// # Arguments
     /// * `state` - The current service state.
-    async fn list_role_imply_rules(
+    async fn list_role_imply_rules<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
     ) -> Result<Vec<RoleImply>, RoleProviderError> {
-        self.backend_driver.list_role_imply_rules(state).await
+        self.backend_driver.list_role_imply_rules(ctx.state()).await
     }
 
     /// List role imply rules for a specific prior role.
@@ -253,11 +256,11 @@ impl RoleApi for RoleService {
     /// * `prior_role_id` - The ID of the prior role.
     async fn list_role_imply_rules_by_prior<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
     ) -> Result<Vec<RoleImply>, RoleProviderError> {
         self.backend_driver
-            .list_role_imply_rules_by_prior(state, prior_role_id)
+            .list_role_imply_rules_by_prior(ctx.state(), prior_role_id)
             .await
     }
 
@@ -266,12 +269,12 @@ impl RoleApi for RoleService {
     /// # Arguments
     /// * `state` - The current service state.
     /// * `params` - The parameters for listing roles.
-    async fn list_roles(
+    async fn list_roles<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &RoleListParameters,
     ) -> Result<Vec<Role>, RoleProviderError> {
         params.validate()?;
-        self.backend_driver.list_roles(state, params).await
+        self.backend_driver.list_roles(ctx.state(), params).await
     }
 }

--- a/crates/core/src/token/provider_api.rs
+++ b/crates/core/src/token/provider_api.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 
 use openstack_keystone_core_types::token::*;
 
-use crate::auth::{ScopeInfo, SecurityContext, ValidatedSecurityContext};
+use crate::auth::{ExecutionContext, ScopeInfo, SecurityContext, ValidatedSecurityContext};
 use crate::keystone::ServiceState;
 use crate::token::TokenProviderError;
 
@@ -37,7 +37,7 @@ pub trait TokenApi: Send + Sync {
     ///   information or an error.
     async fn authorize_by_token<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         credential: &'a str,
         allow_expired: Option<bool>,
         window_seconds: Option<i64>,
@@ -50,7 +50,7 @@ pub trait TokenApi: Send + Sync {
     /// roles, and returns the locked context.
     ///
     /// # Parameters
-    /// - `state`: The current service state.
+    /// - `exec`: The execution context.
     /// - `credential`: The token credential string.
     /// - `allow_expired`: Whether to allow expired tokens.
     /// - `window_seconds`: Expiration buffer in seconds.
@@ -60,7 +60,7 @@ pub trait TokenApi: Send + Sync {
     ///   and expanded security context or an error.
     async fn validate_to_context<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         credential: &'a str,
         allow_expired: Option<bool>,
         window_seconds: Option<i64>,
@@ -112,7 +112,7 @@ pub trait TokenApi: Send + Sync {
     ///   `Error`.
     async fn get_token_restriction<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
         expand_roles: bool,
     ) -> Result<Option<TokenRestriction>, TokenProviderError>;
@@ -128,7 +128,7 @@ pub trait TokenApi: Send + Sync {
     ///   restriction or an error.
     async fn create_token_restriction<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         restriction: TokenRestrictionCreate,
     ) -> Result<TokenRestriction, TokenProviderError>;
 
@@ -143,7 +143,7 @@ pub trait TokenApi: Send + Sync {
     ///   restrictions or an error.
     async fn list_token_restrictions<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &TokenRestrictionListParameters,
     ) -> Result<Vec<TokenRestriction>, TokenProviderError>;
 
@@ -159,7 +159,7 @@ pub trait TokenApi: Send + Sync {
     ///   restriction or an error.
     async fn update_token_restriction<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
         restriction: TokenRestrictionUpdate,
     ) -> Result<TokenRestriction, TokenProviderError>;
@@ -174,7 +174,7 @@ pub trait TokenApi: Send + Sync {
     /// - `Result<(), TokenProviderError>` - Ok on success, or an error.
     async fn delete_token_restriction<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), TokenProviderError>;
 }

--- a/crates/core/src/token/service.rs
+++ b/crates/core/src/token/service.rs
@@ -40,6 +40,7 @@ use openstack_keystone_core_types::token::{
 };
 use openstack_keystone_core_types::trust::TrustProviderError;
 
+use crate::auth::ExecutionContext;
 use crate::auth::*;
 use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
@@ -108,12 +109,13 @@ impl TokenService {
         state: &ServiceState,
         token: &FernetToken,
     ) -> Result<AuthzInfo, TokenProviderError> {
+        let ctx = ExecutionContext::internal(state);
         let scope = match token {
             FernetToken::ApplicationCredential(data) => {
                 let project = state
                     .provider
                     .get_resource_provider()
-                    .get_project(state, &data.project_id)
+                    .get_project(&ctx, &data.project_id)
                     .await?
                     .ok_or(ResourceProviderError::ProjectNotFound(
                         data.project_id.clone(),
@@ -121,7 +123,7 @@ impl TokenService {
                 let project_domain = state
                     .provider
                     .get_resource_provider()
-                    .get_domain(state, &project.domain_id)
+                    .get_domain(&ctx, &project.domain_id)
                     .await?
                     .ok_or(ResourceProviderError::DomainNotFound(
                         project.domain_id.clone(),
@@ -135,7 +137,7 @@ impl TokenService {
                 state
                     .provider
                     .get_resource_provider()
-                    .get_domain(state, &data.domain_id)
+                    .get_domain(&ctx, &data.domain_id)
                     .await?
                     .ok_or(ResourceProviderError::DomainNotFound(
                         data.domain_id.clone(),
@@ -145,7 +147,7 @@ impl TokenService {
                 let project = state
                     .provider
                     .get_resource_provider()
-                    .get_project(state, &data.project_id)
+                    .get_project(&ctx, &data.project_id)
                     .await?
                     .ok_or(ResourceProviderError::ProjectNotFound(
                         data.project_id.clone(),
@@ -153,7 +155,7 @@ impl TokenService {
                 let project_domain = state
                     .provider
                     .get_resource_provider()
-                    .get_domain(state, &project.domain_id)
+                    .get_domain(&ctx, &project.domain_id)
                     .await?
                     .ok_or(ResourceProviderError::DomainNotFound(
                         project.domain_id.clone(),
@@ -167,7 +169,7 @@ impl TokenService {
                 state
                     .provider
                     .get_resource_provider()
-                    .get_domain(state, &data.domain_id)
+                    .get_domain(&ctx, &data.domain_id)
                     .await?
                     .ok_or(ResourceProviderError::DomainNotFound(
                         data.domain_id.clone(),
@@ -177,7 +179,7 @@ impl TokenService {
                 let project = state
                     .provider
                     .get_resource_provider()
-                    .get_project(state, &data.project_id)
+                    .get_project(&ctx, &data.project_id)
                     .await?
                     .ok_or(ResourceProviderError::ProjectNotFound(
                         data.project_id.clone(),
@@ -185,7 +187,7 @@ impl TokenService {
                 let project_domain = state
                     .provider
                     .get_resource_provider()
-                    .get_domain(state, &project.domain_id)
+                    .get_domain(&ctx, &project.domain_id)
                     .await?
                     .ok_or(ResourceProviderError::DomainNotFound(
                         project.domain_id.clone(),
@@ -200,7 +202,7 @@ impl TokenService {
                 let project = state
                     .provider
                     .get_resource_provider()
-                    .get_project(state, &data.project_id)
+                    .get_project(&ctx, &data.project_id)
                     .await?
                     .ok_or(ResourceProviderError::ProjectNotFound(
                         data.project_id.clone(),
@@ -208,7 +210,7 @@ impl TokenService {
                 let project_domain = state
                     .provider
                     .get_resource_provider()
-                    .get_domain(state, &project.domain_id)
+                    .get_domain(&ctx, &project.domain_id)
                     .await?
                     .ok_or(ResourceProviderError::DomainNotFound(
                         project.domain_id.clone(),
@@ -216,7 +218,7 @@ impl TokenService {
                 let trust = state
                     .provider
                     .get_trust_provider()
-                    .get_trust(state, &data.trust_id)
+                    .get_trust(&ctx, &data.trust_id)
                     .await?
                     .ok_or(TrustProviderError::TrustNotFound(data.trust_id.clone()))?;
                 ScopeInfo::TrustProject(Box::new(TrustProjectInfo {
@@ -229,7 +231,7 @@ impl TokenService {
                 let project = state
                     .provider
                     .get_resource_provider()
-                    .get_project(state, &data.project_id)
+                    .get_project(&ctx, &data.project_id)
                     .await?
                     .ok_or(ResourceProviderError::ProjectNotFound(
                         data.project_id.clone(),
@@ -237,7 +239,7 @@ impl TokenService {
                 let project_domain = state
                     .provider
                     .get_resource_provider()
-                    .get_domain(state, &project.domain_id)
+                    .get_domain(&ctx, &project.domain_id)
                     .await?
                     .ok_or(ResourceProviderError::DomainNotFound(
                         project.domain_id.clone(),
@@ -260,12 +262,13 @@ impl TokenService {
     /// returns the locked context.
     async fn validate_to_context_impl(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'_>,
         credential: &str,
         allow_expired: Option<bool>,
         window_seconds: Option<i64>,
     ) -> Result<ValidatedSecurityContext, TokenProviderError> {
         let token = self.backend_driver.decode(credential)?;
+        let state = ctx.state();
 
         let latest_expiration_cutof = Utc::now()
             .checked_add_signed(TimeDelta::seconds(window_seconds.unwrap_or(0)))
@@ -288,7 +291,7 @@ impl TokenService {
                     application_credential: state
                         .provider
                         .get_application_credential_provider()
-                        .get_application_credential(state, &data.application_credential_id)
+                        .get_application_credential(ctx, &data.application_credential_id)
                         .await?
                         .ok_or_else(|| {
                             ApplicationCredentialProviderError::ApplicationCredentialNotFound(
@@ -302,7 +305,7 @@ impl TokenService {
                 trust: state
                     .provider
                     .get_trust_provider()
-                    .get_trust(state, &data.trust_id)
+                    .get_trust(ctx, &data.trust_id)
                     .await?
                     .ok_or_else(|| TrustProviderError::TrustNotFound(data.trust_id.clone()))?,
                 token: Some(token.clone()),
@@ -313,20 +316,21 @@ impl TokenService {
         let user = state
             .provider
             .get_identity_provider()
-            .get_user(state, token.user_id())
+            .get_user(ctx, token.user_id())
             .await?
             .ok_or(TokenProviderError::UserNotFound(token.user_id().clone()))?;
         let user_domain = state
             .provider
             .get_resource_provider()
-            .get_domain(state, &user.domain_id)
+            .get_domain(ctx, &user.domain_id)
             .await?
             .ok_or(ResourceProviderError::DomainNotFound(
                 user.domain_id.clone(),
             ))?;
-        let mut ctx = AuthenticationResultBuilder::default();
+        let mut auth_result_builder = AuthenticationResultBuilder::default();
 
-        ctx.context(auth_context)
+        auth_result_builder
+            .context(auth_context)
             .principal(PrincipalInfo {
                 identity: IdentityInfo::User(
                     UserIdentityInfoBuilder::default()
@@ -349,15 +353,15 @@ impl TokenService {
             let token_restriction = &state
                 .provider
                 .get_token_provider()
-                .get_token_restriction(state, &restriction.token_restriction_id, false)
+                .get_token_restriction(ctx, &restriction.token_restriction_id, false)
                 .await?
                 .ok_or(TokenProviderError::TokenRestrictionNotFound(
                     restriction.token_restriction_id.clone(),
                 ))?;
-            ctx.token_restriction(token_restriction.to_owned());
+            auth_result_builder.token_restriction(token_restriction.to_owned());
         }
 
-        let auth_result = ctx.build()?;
+        let auth_result = auth_result_builder.build()?;
 
         let mut sc = SecurityContext::try_from(auth_result)?;
         sc.set_token(token.clone());
@@ -371,7 +375,7 @@ impl TokenService {
         if state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(state, &vsc)
+            .is_token_revoked(ctx, &vsc)
             .await?
         {
             return Err(TokenProviderError::TokenRevoked);
@@ -401,13 +405,13 @@ impl TokenApi for TokenService {
     ///   information or an error.
     async fn authorize_by_token<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         credential: &'a str,
         allow_expired: Option<bool>,
         window_seconds: Option<i64>,
     ) -> Result<ValidatedSecurityContext, TokenProviderError> {
         let vsc = self
-            .validate_to_context_impl(state, credential, allow_expired, window_seconds)
+            .validate_to_context_impl(ctx, credential, allow_expired, window_seconds)
             .await?;
 
         if let FernetToken::Restricted(restriction) = vsc.token()?
@@ -421,12 +425,12 @@ impl TokenApi for TokenService {
     /// Validate the token and produce a [`ValidatedSecurityContext`].
     async fn validate_to_context<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         credential: &'a str,
         allow_expired: Option<bool>,
         window_seconds: Option<i64>,
     ) -> Result<ValidatedSecurityContext, TokenProviderError> {
-        self.validate_to_context_impl(state, credential, allow_expired, window_seconds)
+        self.validate_to_context_impl(ctx, credential, allow_expired, window_seconds)
             .await
     }
 
@@ -497,21 +501,22 @@ impl TokenApi for TokenService {
     ///   `Error`.
     async fn get_token_restriction<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
         expand_roles: bool,
     ) -> Result<Option<TokenRestriction>, TokenProviderError> {
         let mut res = self
             .tr_backend_driver
-            .get_token_restriction(state, id)
+            .get_token_restriction(ctx.state(), id)
             .await?;
         if let Some(ref mut tr) = res
             && expand_roles
         {
-            let roles: HashMap<String, Role> = state
+            let roles: HashMap<String, Role> = ctx
+                .state()
                 .provider
                 .get_role_provider()
-                .list_roles(state, &RoleListParameters::default())
+                .list_roles(ctx, &RoleListParameters::default())
                 .await?
                 .into_iter()
                 .map(|role| (role.id.clone(), role))
@@ -522,10 +527,10 @@ impl TokenApi for TokenService {
                 .iter()
                 .filter_map(|rid| roles.get(rid).map(|role| role.into()))
                 .collect();
-            state
+            ctx.state()
                 .provider
                 .get_role_provider()
-                .expand_implied_roles(state, &mut filtered_roles)
+                .expand_implied_roles(ctx, &mut filtered_roles)
                 .await?;
             tr.roles.get_or_insert_default().extend(filtered_roles);
         }
@@ -544,7 +549,7 @@ impl TokenApi for TokenService {
     ///   restriction or an error.
     async fn create_token_restriction<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         restriction: TokenRestrictionCreate,
     ) -> Result<TokenRestriction, TokenProviderError> {
         let mut restriction = restriction;
@@ -552,7 +557,7 @@ impl TokenApi for TokenService {
             restriction.id = Uuid::new_v4().simple().to_string();
         }
         self.tr_backend_driver
-            .create_token_restriction(state, restriction)
+            .create_token_restriction(ctx.state(), restriction)
             .await
     }
 
@@ -567,11 +572,11 @@ impl TokenApi for TokenService {
     ///   restrictions or an error.
     async fn list_token_restrictions<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &TokenRestrictionListParameters,
     ) -> Result<Vec<TokenRestriction>, TokenProviderError> {
         self.tr_backend_driver
-            .list_token_restrictions(state, params)
+            .list_token_restrictions(ctx.state(), params)
             .await
     }
 
@@ -587,12 +592,12 @@ impl TokenApi for TokenService {
     ///   restriction or an error.
     async fn update_token_restriction<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
         restriction: TokenRestrictionUpdate,
     ) -> Result<TokenRestriction, TokenProviderError> {
         self.tr_backend_driver
-            .update_token_restriction(state, id, restriction)
+            .update_token_restriction(ctx.state(), id, restriction)
             .await
     }
 
@@ -606,11 +611,11 @@ impl TokenApi for TokenService {
     /// - `Result<(), TokenProviderError>` - Ok on success, or an error.
     async fn delete_token_restriction<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), TokenProviderError> {
         self.tr_backend_driver
-            .delete_token_restriction(state, id)
+            .delete_token_restriction(ctx.state(), id)
             .await
     }
 }
@@ -754,8 +759,9 @@ mod tests {
         let state = get_mocked_state(Some(config), Some(provider)).await;
 
         let credential = token_provider.encode_token(&token).unwrap();
+        let ctx = ExecutionContext::internal(&state);
         match token_provider
-            .validate_to_context(&state, &credential, Some(false), None)
+            .validate_to_context(&ctx, &credential, Some(false), None)
             .await
         {
             Err(TokenProviderError::TokenRevoked) => {}

--- a/crates/core/src/trust/provider_api.rs
+++ b/crates/core/src/trust/provider_api.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 
 use openstack_keystone_core_types::trust::*;
 
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::trust::TrustProviderError;
 
 /// Trust extension provider interface.
@@ -32,7 +32,7 @@ pub trait TrustApi: Send + Sync {
     /// `Error`.
     async fn get_trust<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Trust>, TrustProviderError>;
 
@@ -45,7 +45,7 @@ pub trait TrustApi: Send + Sync {
     /// `Error`.
     async fn get_trust_delegation_chain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Vec<Trust>>, TrustProviderError>;
 
@@ -58,9 +58,9 @@ pub trait TrustApi: Send + Sync {
     /// # Returns
     /// - `Result<Vec<Trust>, TrustProviderError>` - A list of trusts or an
     ///   error.
-    async fn list_trusts(
+    async fn list_trusts<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &TrustListParameters,
     ) -> Result<Vec<Trust>, TrustProviderError>;
 
@@ -73,9 +73,9 @@ pub trait TrustApi: Send + Sync {
     /// # Returns
     /// - `Result<bool, TrustProviderError>` - Ok(true) if the chain is valid,
     ///   or an error.
-    async fn validate_trust_delegation_chain(
+    async fn validate_trust_delegation_chain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         trust: &Trust,
     ) -> Result<bool, TrustProviderError>;
 }

--- a/crates/core/src/trust/service.rs
+++ b/crates/core/src/trust/service.rs
@@ -25,7 +25,7 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::role::*;
 use openstack_keystone_core_types::trust::*;
 
-use crate::keystone::ServiceState;
+use crate::auth::ExecutionContext;
 use crate::plugin_manager::PluginManagerApi;
 use crate::trust::{TrustApi, TrustProviderError, backend::TrustBackend};
 
@@ -69,16 +69,16 @@ impl TrustApi for TrustService {
     ///   `Option` with the trust if found, or an `Error`.
     async fn get_trust<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Trust>, TrustProviderError> {
-        if let Some(mut trust) = self.backend_driver.get_trust(state, id).await? {
+        if let Some(mut trust) = self.backend_driver.get_trust(ctx.state(), id).await? {
             let all_roles: HashMap<String, Role> = HashMap::from_iter(
-                state
+                ctx.state()
                     .provider
                     .get_role_provider()
                     .list_roles(
-                        state,
+                        ctx,
                         &RoleListParameters {
                             domain_id: Some(None),
                             ..Default::default()
@@ -116,11 +116,11 @@ impl TrustApi for TrustService {
     ///   `Error`.
     async fn get_trust_delegation_chain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Vec<Trust>>, TrustProviderError> {
         self.backend_driver
-            .get_trust_delegation_chain(state, id)
+            .get_trust_delegation_chain(ctx.state(), id)
             .await
     }
 
@@ -133,19 +133,19 @@ impl TrustApi for TrustService {
     /// # Returns
     /// - `Result<Vec<Trust>, TrustProviderError>` - A list of trusts or an
     ///   error.
-    async fn list_trusts(
+    async fn list_trusts<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         params: &TrustListParameters,
     ) -> Result<Vec<Trust>, TrustProviderError> {
-        let mut trusts = self.backend_driver.list_trusts(state, params).await?;
+        let mut trusts = self.backend_driver.list_trusts(ctx.state(), params).await?;
 
         let all_roles: HashMap<String, Role> = HashMap::from_iter(
-            state
+            ctx.state()
                 .provider
                 .get_role_provider()
                 .list_roles(
-                    state,
+                    ctx,
                     &RoleListParameters {
                         domain_id: Some(None),
                         ..Default::default()
@@ -187,15 +187,15 @@ impl TrustApi for TrustService {
     /// # Returns
     /// - `Result<bool, TrustProviderError>` - Ok(true) if the chain is valid,
     ///   or an error.
-    async fn validate_trust_delegation_chain(
+    async fn validate_trust_delegation_chain<'a>(
         &self,
-        state: &ServiceState,
+        ctx: &ExecutionContext<'a>,
         trust: &Trust,
     ) -> Result<bool, TrustProviderError> {
         if trust.redelegated_trust_id.is_some()
-            && let Some(chain) = self.get_trust_delegation_chain(state, &trust.id).await?
+            && let Some(chain) = self.get_trust_delegation_chain(ctx, &trust.id).await?
         {
-            let config = state.config_manager.config.read().await;
+            let config = ctx.state().config_manager.config.read().await;
             if chain.len() > config.trust.max_redelegation_count {
                 return Err(TrustProviderError::RedelegationDeepnessExceed {
                     length: chain.len(),
@@ -321,7 +321,7 @@ mod tests {
         let trust_provider = create_trust_service(backend);
 
         let trust: Trust = trust_provider
-            .get_trust(&state, "fake_trust")
+            .get_trust(&ExecutionContext::internal(&state), "fake_trust")
             .await
             .unwrap()
             .expect("trust found");
@@ -364,7 +364,7 @@ mod tests {
         let trust_provider = create_trust_service(backend);
 
         let chain = trust_provider
-            .get_trust_delegation_chain(&state, "fake_trust")
+            .get_trust_delegation_chain(&ExecutionContext::internal(&state), "fake_trust")
             .await
             .unwrap()
             .expect("chain fetched");
@@ -399,12 +399,12 @@ mod tests {
 
         let trust_provider = create_trust_service(backend);
         let trust = trust_provider
-            .get_trust(&state, "fake_trust")
+            .get_trust(&ExecutionContext::internal(&state), "fake_trust")
             .await
             .unwrap()
             .expect("trust found");
         trust_provider
-            .validate_trust_delegation_chain(&state, &trust)
+            .validate_trust_delegation_chain(&ExecutionContext::internal(&state), &trust)
             .await
             .unwrap();
     }
@@ -453,12 +453,12 @@ mod tests {
 
         let trust_provider = create_trust_service(backend);
         let trust = trust_provider
-            .get_trust(&state, "redelegated_trust")
+            .get_trust(&ExecutionContext::internal(&state), "redelegated_trust")
             .await
             .unwrap()
             .expect("trust found");
         trust_provider
-            .validate_trust_delegation_chain(&state, &trust)
+            .validate_trust_delegation_chain(&ExecutionContext::internal(&state), &trust)
             .await
             .unwrap();
     }
@@ -514,12 +514,12 @@ mod tests {
 
         let trust_provider = create_trust_service(backend);
         let trust = trust_provider
-            .get_trust(&state, "redelegated_trust2")
+            .get_trust(&ExecutionContext::internal(&state), "redelegated_trust2")
             .await
             .unwrap()
             .expect("trust found");
         if let Err(TrustProviderError::ExpirationImpossible) = trust_provider
-            .validate_trust_delegation_chain(&state, &trust)
+            .validate_trust_delegation_chain(&ExecutionContext::internal(&state), &trust)
             .await
         {
         } else {
@@ -588,13 +588,13 @@ mod tests {
 
         let trust_provider = create_trust_service(backend);
         let trust = trust_provider
-            .get_trust(&state, "redelegated_trust")
+            .get_trust(&ExecutionContext::internal(&state), "redelegated_trust")
             .await
             .unwrap()
             .expect("trust found");
 
         if let Err(TrustProviderError::RedelegatedRolesNotAvailable) = trust_provider
-            .validate_trust_delegation_chain(&state, &trust)
+            .validate_trust_delegation_chain(&ExecutionContext::internal(&state), &trust)
             .await
         {
         } else {
@@ -653,12 +653,12 @@ mod tests {
 
         let trust_provider = create_trust_service(backend);
         let trust = trust_provider
-            .get_trust(&state, "redelegated_trust2")
+            .get_trust(&ExecutionContext::internal(&state), "redelegated_trust2")
             .await
             .unwrap()
             .expect("trust found");
         match trust_provider
-            .validate_trust_delegation_chain(&state, &trust)
+            .validate_trust_delegation_chain(&ExecutionContext::internal(&state), &trust)
             .await
         {
             Err(TrustProviderError::RedelegatedImpersonationNotAllowed) => {}
@@ -758,12 +758,12 @@ mod tests {
 
         let trust_provider = create_trust_service(backend);
         let trust = trust_provider
-            .get_trust(&state, "redelegated_trust2")
+            .get_trust(&ExecutionContext::internal(&state), "redelegated_trust2")
             .await
             .unwrap()
             .expect("trust found");
         match trust_provider
-            .validate_trust_delegation_chain(&state, &trust)
+            .validate_trust_delegation_chain(&ExecutionContext::internal(&state), &trust)
             .await
         {
             Err(TrustProviderError::RedelegationDeepnessExceed { .. }) => {}
@@ -776,12 +776,15 @@ mod tests {
         }
 
         let trust = trust_provider
-            .get_trust(&state, "redelegated_trust_long")
+            .get_trust(
+                &ExecutionContext::internal(&state),
+                "redelegated_trust_long",
+            )
             .await
             .unwrap()
             .expect("trust found");
         match trust_provider
-            .validate_trust_delegation_chain(&state, &trust)
+            .validate_trust_delegation_chain(&ExecutionContext::internal(&state), &trust)
             .await
         {
             Err(TrustProviderError::RedelegationDeepnessExceed { .. }) => {}
@@ -827,7 +830,10 @@ mod tests {
         let trust_provider = create_trust_service(backend);
 
         let list = trust_provider
-            .list_trusts(&state, &TrustListParameters::default())
+            .list_trusts(
+                &ExecutionContext::internal(&state),
+                &TrustListParameters::default(),
+            )
             .await
             .unwrap();
         assert_eq!(list.len(), 2);

--- a/crates/k8s-auth-driver-sql/src/instance/create.rs
+++ b/crates/k8s-auth-driver-sql/src/instance/create.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Create K8s auth instance
+//! # Create K8s auth instance
 
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;

--- a/crates/k8s-auth-driver-sql/src/instance/delete.rs
+++ b/crates/k8s-auth-driver-sql/src/instance/delete.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Delete k8s auth provider
+//! # Delete k8s auth provider
 
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;

--- a/crates/k8s-auth-driver-sql/src/instance/get.rs
+++ b/crates/k8s-auth-driver-sql/src/instance/get.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Get existing k8s auth provider.
+//! # Get existing k8s auth provider
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 

--- a/crates/k8s-auth-driver-sql/src/instance/list.rs
+++ b/crates/k8s-auth-driver-sql/src/instance/list.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! List K8s auth instances
+//! # List K8s auth instances
 
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;

--- a/crates/k8s-auth-driver-sql/src/instance/update.rs
+++ b/crates/k8s-auth-driver-sql/src/instance/update.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Update the existing K8s auth instance
+//! # Update the existing K8s auth instance
 
 use sea_orm::DatabaseConnection;
 use sea_orm::TransactionTrait;

--- a/crates/keystone/src/api/common.rs
+++ b/crates/keystone/src/api/common.rs
@@ -20,6 +20,7 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::resource::Domain;
 
 use crate::api::KeystoneApiError;
+use crate::auth::ExecutionContext;
 use crate::keystone::ServiceState;
 
 /// Get the domain by ID or Name.
@@ -36,11 +37,12 @@ pub async fn get_domain<I: AsRef<str>, N: AsRef<str>>(
     id: Option<I>,
     name: Option<N>,
 ) -> Result<Domain, KeystoneApiError> {
+    let exec = ExecutionContext::internal(state);
     if let Some(did) = &id {
         state
             .provider
             .get_resource_provider()
-            .get_domain(state, did.as_ref())
+            .get_domain(&exec, did.as_ref())
             .await?
             .ok_or_else(|| KeystoneApiError::NotFound {
                 resource: "domain".into(),
@@ -50,7 +52,7 @@ pub async fn get_domain<I: AsRef<str>, N: AsRef<str>>(
         state
             .provider
             .get_resource_provider()
-            .find_domain_by_name(state, name.as_ref())
+            .find_domain_by_name(&exec, name.as_ref())
             .await?
             .ok_or_else(|| KeystoneApiError::NotFound {
                 resource: "domain".into(),
@@ -137,7 +139,7 @@ mod tests {
         let mut resource_mock = MockResourceProvider::default();
         resource_mock
             .expect_get_domain()
-            .withf(|_, id: &'_ str| id == "domain_id")
+            .withf(|_exec, id: &'_ str| id == "domain_id")
             .returning(|_, _| {
                 Ok(Some(Domain {
                     id: "domain_id".into(),
@@ -147,7 +149,7 @@ mod tests {
             });
         resource_mock
             .expect_find_domain_by_name()
-            .withf(|_, id: &'_ str| id == "domain_name")
+            .withf(|_exec, id: &'_ str| id == "domain_name")
             .returning(|_, _| {
                 Ok(Some(Domain {
                     id: "domain_id".into(),

--- a/crates/keystone/src/api/v3/auth/project/list.rs
+++ b/crates/keystone/src/api/v3/auth/project/list.rs
@@ -23,6 +23,7 @@ use openstack_keystone_core_types::resource::ProjectListParameters;
 use crate::api::v3::project::types::ProjectShortList;
 use crate::api::{auth::Auth, error::KeystoneApiError};
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get available project scopes.
 ///
@@ -50,11 +51,12 @@ pub(super) async fn list(
         .enforce("identity/auth/project/list", &user_auth, Value::Null, None)
         .await?;
 
+    let exec = ExecutionContext::from_auth(&state, &user_auth);
     let project_ids: HashSet<String> = state
         .provider
         .get_assignment_provider()
         .list_role_assignments(
-            &state,
+            &exec,
             &RoleAssignmentListParameters {
                 user_id: Some(user_auth.principal().get_user_id().clone()),
                 effective: Some(true),
@@ -80,7 +82,7 @@ pub(super) async fn list(
                     .provider
                     .get_resource_provider()
                     .list_projects(
-                        &state,
+                        &exec,
                         &ProjectListParameters {
                             ids: Some(project_ids),
                             ..Default::default()
@@ -128,12 +130,12 @@ mod tests {
         let mut assignment_mock = MockAssignmentProvider::default();
         assignment_mock
             .expect_list_role_assignments()
-            .withf(|_, params: &RoleAssignmentListParameters| {
+            .withf(|_exec, params: &RoleAssignmentListParameters| {
                 params.user_id.as_ref().is_some_and(|x| x == "uid")
                     && params.effective.is_some_and(|x| x)
                     && params.include_names.is_some_and(|x| !x)
             })
-            .returning(|_, _| {
+            .returning(|_exec, _| {
                 Ok(vec![
                     Assignment {
                         role_id: "role_id".into(),
@@ -167,13 +169,13 @@ mod tests {
         let mut resource_mock = MockResourceProvider::default();
         resource_mock
             .expect_list_projects()
-            .withf(|_, params: &ProjectListParameters| {
+            .withf(|_exec, params: &ProjectListParameters| {
                 params
                     .ids
                     .as_ref()
                     .is_some_and(|x| *x == HashSet::from(["p1".to_string(), "p2".to_string()]))
             })
-            .returning(|_, _| {
+            .returning(|_exec, _| {
                 Ok(vec![
                     ProviderProject {
                         description: None,

--- a/crates/keystone/src/api/v3/auth/token/common.rs
+++ b/crates/keystone/src/api/v3/auth/token/common.rs
@@ -12,6 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_keystone_core::auth::ExecutionContext;
+
 use crate::api::error::KeystoneApiError;
 use crate::api::v3::auth::token::types::AuthRequest;
 use crate::auth::*;
@@ -35,7 +37,7 @@ pub(super) async fn authenticate_request(
                     state
                         .provider
                         .get_identity_provider()
-                        .authenticate_by_password(state, &req)
+                        .authenticate_by_password(&ExecutionContext::internal(state), &req)
                         .await?,
                 );
             }
@@ -45,7 +47,12 @@ pub(super) async fn authenticate_request(
             let vsc = state
                 .provider
                 .get_token_provider()
-                .authorize_by_token(state, &token.id, Some(false), None)
+                .authorize_by_token(
+                    &ExecutionContext::internal(state),
+                    &token.id,
+                    Some(false),
+                    None,
+                )
                 .await?;
             let auth_res = AuthenticationResult {
                 audit_id: vsc.inner().audit_ids().first().cloned().unwrap_or_default(),
@@ -178,12 +185,12 @@ mod tests {
                     id == "fake_token" && *allow_expired == Some(false) && window.is_none()
                 },
             )
-            .returning(move |_, _, _, _| Ok(vsc_clone.clone()));
+            .returning(move |_state, _, _, _| Ok(vsc_clone.clone()));
         let mut identity_mock = MockIdentityProvider::default();
         identity_mock
             .expect_get_user()
-            .withf(|_, id: &'_ str| id == "uid")
-            .returning(move |_, _| Ok(Some(user.clone())));
+            .withf(|_exec, id: &'_ str| id == "uid")
+            .returning(move |_exec, _| Ok(Some(user.clone())));
 
         let provider = Provider::mocked_builder()
             .mock_identity(identity_mock)

--- a/crates/keystone/src/api/v3/auth/token/create.rs
+++ b/crates/keystone/src/api/v3/auth/token/create.rs
@@ -25,6 +25,7 @@ use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
 use openstack_keystone_core_types::auth::*;
 
 use openstack_keystone_core::api::common::get_authz_info;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::scope::Scope as ProviderScope;
 
 use crate::api::v3::auth::token::common::authenticate_request;
@@ -75,11 +76,12 @@ pub(super) async fn create(
         token: TokenBuilder::try_from(&vsc)?.build()?,
     };
     if !query.nocatalog.is_some_and(|x| x) {
+        let exec = ExecutionContext::internal(&state);
         let catalog: Catalog = Catalog(
             state
                 .provider
                 .get_catalog_provider()
-                .get_catalog(&state, true)
+                .get_catalog(&exec, true)
                 .await?
                 .into_iter()
                 .map(|(s, es)| CatalogService {

--- a/crates/keystone/src/api/v3/auth/token/delete.rs
+++ b/crates/keystone/src/api/v3/auth/token/delete.rs
@@ -21,6 +21,8 @@ use axum::{
 use serde_json::{json, to_value};
 use tracing::error;
 
+use openstack_keystone_core::auth::ExecutionContext;
+
 use crate::api::{auth::Auth, error::KeystoneApiError};
 use crate::keystone::ServiceState;
 
@@ -61,7 +63,12 @@ pub(super) async fn delete(
     let vsc = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &subject_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &subject_token,
+            None,
+            None,
+        )
         .await
         .inspect_err(|e| error!("{:?}", e.to_string()))
         .map_err(|_| KeystoneApiError::NotFound {
@@ -82,7 +89,10 @@ pub(super) async fn delete(
     state
         .provider
         .get_revoke_provider()
-        .revoke_token(&state, vsc.token()?)
+        .revoke_token(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            vsc.token()?,
+        )
         .await
         .map_err(KeystoneApiError::forbidden)?;
 
@@ -149,7 +159,7 @@ mod tests {
         token_mock
             .expect_validate_to_context()
             .withf(|_, token: &'_ str, _, _| token == "foo")
-            .returning(move |_, _, _, _| Ok(vsc.clone()));
+            .returning(move |_state, _, _, _| Ok(vsc.clone()));
 
         token_mock
     }
@@ -200,14 +210,14 @@ mod tests {
         token_mock
             .expect_validate_to_context()
             .withf(|_, token: &'_ str, _, _| token == "baz")
-            .returning(move |_, _, _, _| Ok(vsc_for_mock.clone()));
+            .returning(move |_state, _, _, _| Ok(vsc_for_mock.clone()));
 
         let mut revoke_mock = MockRevokeProvider::default();
         // subject token revoked
         revoke_mock
             .expect_revoke_token()
             .withf(move |_, token: &ProviderToken| *token == fernet_for_revoke)
-            .returning(|_, _| Ok(()));
+            .returning(|_exec, _| Ok(()));
 
         let provider = Provider::mocked_builder()
             .mock_token(token_mock)
@@ -244,7 +254,7 @@ mod tests {
         token_mock
             .expect_validate_to_context()
             .withf(|_, token: &'_ str, _, _| token == "baz")
-            .returning(move |_, _, _, _| Err(TokenProviderError::Expired));
+            .returning(move |_state, _, _, _| Err(TokenProviderError::Expired));
 
         let provider = Provider::mocked_builder().mock_token(token_mock);
 
@@ -279,7 +289,7 @@ mod tests {
         token_mock
             .expect_validate_to_context()
             .withf(|_, token: &'_ str, _, _| token == "baz")
-            .returning(move |_, _, _, _| Err(TokenProviderError::TokenRevoked));
+            .returning(move |_state, _, _, _| Err(TokenProviderError::TokenRevoked));
 
         let provider = Provider::mocked_builder().mock_token(token_mock);
         let vsc = test_fixture_scoped();

--- a/crates/keystone/src/api/v3/auth/token/show.rs
+++ b/crates/keystone/src/api/v3/auth/token/show.rs
@@ -33,6 +33,8 @@ use tracing::error;
 
 use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
 
+use openstack_keystone_core::auth::ExecutionContext;
+
 use crate::api::v3::auth::token::types::{TokenResponse, ValidateTokenParameters};
 use crate::api::{Catalog, CatalogService, auth::Auth, error::KeystoneApiError};
 use crate::keystone::ServiceState;
@@ -78,7 +80,12 @@ pub(super) async fn show(
     let vsc = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &subject_token, query.allow_expired, None)
+        .validate_to_context(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &subject_token,
+            query.allow_expired,
+            None,
+        )
         .await
         .inspect_err(|e| error!("{:?}", e.to_string()))
         .map_err(|_| KeystoneApiError::NotFound {
@@ -105,7 +112,7 @@ pub(super) async fn show(
             state
                 .provider
                 .get_catalog_provider()
-                .get_catalog(&state, true)
+                .get_catalog(&ExecutionContext::from_auth(&state, &user_auth), true)
                 .await?
                 .into_iter()
                 .map(|(s, es)| CatalogService {
@@ -187,17 +194,17 @@ mod tests {
         let mut token_mock = MockTokenProvider::default();
         token_mock
             .expect_validate_to_context()
-            .returning(move |_, _, _, _| Ok(vsc_for_mock.clone()));
+            .returning(move |_exec, _, _, _| Ok(vsc_for_mock.clone()));
         let mut catalog_mock = MockCatalogProvider::default();
         catalog_mock
             .expect_get_catalog()
-            .returning(|_, _| Ok(Vec::new()));
+            .returning(|_exec, _| Ok(Vec::new()));
 
         let mut resource_mock = MockResourceProvider::default();
         resource_mock
             .expect_get_domain()
-            .withf(|_, id: &'_ str| id == "user_domain_id")
-            .returning(|_, _| {
+            .withf(|_exec, id: &'_ str| id == "user_domain_id")
+            .returning(|_exec, _| {
                 Ok(Some(CoreDomain {
                     id: "user_domain_id".into(),
                     ..Default::default()
@@ -298,18 +305,18 @@ mod tests {
             .withf(|_, token: &'_ str, allow_expired: &Option<bool>, _| {
                 token == "bar" && *allow_expired == Some(true)
             })
-            .returning(move |_, _, _, _| Ok(vsc_for_mock.clone()));
+            .returning(move |_exec, _, _, _| Ok(vsc_for_mock.clone()));
 
         let mut catalog_mock = MockCatalogProvider::default();
         catalog_mock
             .expect_get_catalog()
-            .returning(|_, _| Ok(Vec::new()));
+            .returning(|_exec, _| Ok(Vec::new()));
 
         let mut resource_mock = MockResourceProvider::default();
         resource_mock
             .expect_get_domain()
-            .withf(|_, id: &'_ str| id == "user_domain_id")
-            .returning(|_, _| {
+            .withf(|_exec, id: &'_ str| id == "user_domain_id")
+            .returning(|_exec, _| {
                 Ok(Some(CoreDomain {
                     id: "user_domain_id".into(),
                     ..Default::default()
@@ -350,7 +357,7 @@ mod tests {
         token_mock
             .expect_validate_to_context()
             .withf(|_, token: &'_ str, _, _| token == "baz")
-            .returning(|_, _, _, _| Err(TokenProviderError::Expired));
+            .returning(|_exec, _, _, _| Err(TokenProviderError::Expired));
 
         let provider = Provider::mocked_builder().mock_token(token_mock);
         let vsc = test_fixture_scoped();
@@ -382,7 +389,7 @@ mod tests {
         token_mock
             .expect_validate_to_context()
             .withf(|_, token: &'_ str, _, _| token == "baz")
-            .returning(|_, _, _, _| Err(TokenProviderError::TokenRevoked));
+            .returning(|_exec, _, _, _| Err(TokenProviderError::TokenRevoked));
 
         let provider = Provider::mocked_builder().mock_token(token_mock);
 

--- a/crates/keystone/src/api/v3/domain/create.rs
+++ b/crates/keystone/src/api/v3/domain/create.rs
@@ -24,6 +24,7 @@ use super::types::{DomainCreateRequest, DomainResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create domain.
 ///
@@ -62,7 +63,10 @@ pub(super) async fn create(
     let created_domain = state
         .provider
         .get_resource_provider()
-        .create_domain(&state, payload.domain.into())
+        .create_domain(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            payload.domain.into(),
+        )
         .await?;
 
     // Return response with 201 CREATED status

--- a/crates/keystone/src/api/v3/domain/delete.rs
+++ b/crates/keystone/src/api/v3/domain/delete.rs
@@ -22,6 +22,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete domain by ID.
 #[utoipa::path(
@@ -43,7 +44,7 @@ pub(super) async fn remove(
     let current = state
         .provider
         .get_resource_provider()
-        .get_domain(&state, &id)
+        .get_domain(&ExecutionContext::from_auth(&state, &user_auth), &id)
         .await?;
 
     state
@@ -61,7 +62,7 @@ pub(super) async fn remove(
             state
                 .provider
                 .get_resource_provider()
-                .delete_domain(&state, &id)
+                .delete_domain(&ExecutionContext::from_auth(&state, &user_auth), &id)
                 .await?;
             Ok((StatusCode::NO_CONTENT).into_response())
         }

--- a/crates/keystone/src/api/v3/domain/list.rs
+++ b/crates/keystone/src/api/v3/domain/list.rs
@@ -26,6 +26,7 @@ use super::types::{Domain, DomainList, DomainListParameters};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List domains
 #[utoipa::path(
@@ -58,7 +59,10 @@ pub(super) async fn list(
     let domains: Vec<Domain> = state
         .provider
         .get_resource_provider()
-        .list_domains(&state, &query.into())
+        .list_domains(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/api/v3/domain/show.rs
+++ b/crates/keystone/src/api/v3/domain/show.rs
@@ -25,6 +25,7 @@ use super::types::{Domain, DomainResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get single domain
 #[utoipa::path(
@@ -46,7 +47,7 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_resource_provider()
-        .get_domain(&state, &domain_id)
+        .get_domain(&ExecutionContext::from_auth(&state, &user_auth), &domain_id)
         .await?;
 
     state

--- a/crates/keystone/src/api/v3/group/create.rs
+++ b/crates/keystone/src/api/v3/group/create.rs
@@ -19,6 +19,7 @@ use super::types::{Group, GroupCreateRequest, GroupResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create new user group.
 #[utoipa::path(
@@ -50,7 +51,7 @@ pub async fn create(
     let res = state
         .provider
         .get_identity_provider()
-        .create_group(&state, req.into())
+        .create_group(&ExecutionContext::from_auth(&state, &user_auth), req.into())
         .await?;
     Ok((
         StatusCode::CREATED,

--- a/crates/keystone/src/api/v3/group/delete.rs
+++ b/crates/keystone/src/api/v3/group/delete.rs
@@ -21,6 +21,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete group by ID.
 #[utoipa::path(
@@ -42,7 +43,7 @@ pub async fn delete(
     let current = state
         .provider
         .get_identity_provider()
-        .get_group(&state, &group_id)
+        .get_group(&ExecutionContext::from_auth(&state, &user_auth), &group_id)
         .await?;
 
     state
@@ -60,7 +61,7 @@ pub async fn delete(
             state
                 .provider
                 .get_identity_provider()
-                .delete_group(&state, &group_id)
+                .delete_group(&ExecutionContext::from_auth(&state, &user_auth), &group_id)
                 .await?;
             Ok((StatusCode::NO_CONTENT).into_response())
         }

--- a/crates/keystone/src/api/v3/group/list.rs
+++ b/crates/keystone/src/api/v3/group/list.rs
@@ -24,6 +24,7 @@ use super::types::{Group, GroupList, GroupListParameters};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List user groups.
 #[utoipa::path(
@@ -56,7 +57,10 @@ pub async fn list(
     let groups: Vec<Group> = state
         .provider
         .get_identity_provider()
-        .list_groups(&state, &query.into())
+        .list_groups(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/api/v3/group/show.rs
+++ b/crates/keystone/src/api/v3/group/show.rs
@@ -23,6 +23,7 @@ use super::types::{Group, GroupResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get a single user group by ID.
 #[utoipa::path(
@@ -44,7 +45,7 @@ pub async fn show(
     let current = state
         .provider
         .get_identity_provider()
-        .get_group(&state, &group_id)
+        .get_group(&ExecutionContext::from_auth(&state, &user_auth), &group_id)
         .await?;
     state
         .policy_enforcer

--- a/crates/keystone/src/api/v3/project/create.rs
+++ b/crates/keystone/src/api/v3/project/create.rs
@@ -24,6 +24,7 @@ use super::types::{ProjectCreateRequest, ProjectResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create project.
 ///
@@ -62,7 +63,10 @@ pub(super) async fn create(
     let created_project = state
         .provider
         .get_resource_provider()
-        .create_project(&state, payload.project.into())
+        .create_project(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            payload.project.into(),
+        )
         .await?;
 
     // Return response with 201 CREATED status

--- a/crates/keystone/src/api/v3/project/delete.rs
+++ b/crates/keystone/src/api/v3/project/delete.rs
@@ -22,6 +22,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete project by ID.
 #[utoipa::path(
@@ -43,7 +44,7 @@ pub async fn remove(
     let current = state
         .provider
         .get_resource_provider()
-        .get_project(&state, &id)
+        .get_project(&ExecutionContext::from_auth(&state, &user_auth), &id)
         .await?;
 
     state
@@ -60,7 +61,7 @@ pub async fn remove(
             state
                 .provider
                 .get_resource_provider()
-                .delete_project(&state, &id)
+                .delete_project(&ExecutionContext::from_auth(&state, &user_auth), &id)
                 .await?;
             Ok((StatusCode::NO_CONTENT).into_response())
         }

--- a/crates/keystone/src/api/v3/project/list.rs
+++ b/crates/keystone/src/api/v3/project/list.rs
@@ -26,6 +26,7 @@ use super::types::{ProjectListParameters, ProjectShortList};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List projects
 #[utoipa::path(
@@ -58,7 +59,10 @@ pub(super) async fn list(
     let projects: Vec<super::types::ProjectShort> = state
         .provider
         .get_resource_provider()
-        .list_projects(&state, &query.into())
+        .list_projects(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/api/v3/project/show.rs
+++ b/crates/keystone/src/api/v3/project/show.rs
@@ -25,6 +25,7 @@ use super::types::{Project, ProjectResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get single project
 #[utoipa::path(
@@ -46,7 +47,10 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_resource_provider()
-        .get_project(&state, &project_id)
+        .get_project(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &project_id,
+        )
         .await?;
 
     state

--- a/crates/keystone/src/api/v3/role/create.rs
+++ b/crates/keystone/src/api/v3/role/create.rs
@@ -24,6 +24,7 @@ use super::types::{RoleCreateRequest, RoleResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create a new Role.
 #[utoipa::path(
@@ -58,7 +59,10 @@ pub(super) async fn create(
     let created_role = state
         .provider
         .get_role_provider()
-        .create_role(&state, payload.into())
+        .create_role(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            payload.into(),
+        )
         .await?;
 
     // Return response with 201 Created status

--- a/crates/keystone/src/api/v3/role/delete.rs
+++ b/crates/keystone/src/api/v3/role/delete.rs
@@ -24,6 +24,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete a role.
 #[utoipa::path(
@@ -46,7 +47,7 @@ pub(super) async fn delete(
     let current = state
         .provider
         .get_role_provider()
-        .get_role(&state, &role_id)
+        .get_role(&ExecutionContext::from_auth(&state, &user_auth), &role_id)
         .await?;
 
     state
@@ -64,7 +65,7 @@ pub(super) async fn delete(
             state
                 .provider
                 .get_role_provider()
-                .delete_role(&state, &role_id)
+                .delete_role(&ExecutionContext::from_auth(&state, &user_auth), &role_id)
                 .await?;
 
             Ok(StatusCode::NO_CONTENT.into_response())

--- a/crates/keystone/src/api/v3/role/imply/check.rs
+++ b/crates/keystone/src/api/v3/role/imply/check.rs
@@ -24,6 +24,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Check if a role imply rule exists.
 #[utoipa::path(
@@ -74,7 +75,11 @@ pub(super) async fn check(
     let exists = state
         .provider
         .get_role_provider()
-        .check_role_imply_rule(&state, &prior_role_id, &implied_role_id)
+        .check_role_imply_rule(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &prior_role_id,
+            &implied_role_id,
+        )
         .await?;
 
     if exists {

--- a/crates/keystone/src/api/v3/role/imply/create.rs
+++ b/crates/keystone/src/api/v3/role/imply/create.rs
@@ -27,6 +27,7 @@ use openstack_keystone_api_types::v3::role::RoleImplyResponse;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create a role imply rule.
 #[utoipa::path(
@@ -77,7 +78,11 @@ pub(super) async fn create(
     let role_imply = state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role_id, &implied_role_id)
+        .create_role_imply_rule(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &prior_role_id,
+            &implied_role_id,
+        )
         .await?;
 
     Ok((

--- a/crates/keystone/src/api/v3/role/imply/delete.rs
+++ b/crates/keystone/src/api/v3/role/imply/delete.rs
@@ -24,6 +24,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete a role imply rule.
 #[utoipa::path(
@@ -74,7 +75,11 @@ pub(super) async fn delete(
     state
         .provider
         .get_role_provider()
-        .delete_role_imply_rule(&state, &prior_role_id, &implied_role_id)
+        .delete_role_imply_rule(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &prior_role_id,
+            &implied_role_id,
+        )
         .await?;
 
     Ok(StatusCode::NO_CONTENT.into_response())

--- a/crates/keystone/src/api/v3/role/imply/get.rs
+++ b/crates/keystone/src/api/v3/role/imply/get.rs
@@ -27,6 +27,7 @@ use openstack_keystone_api_types::v3::role::RoleImplyResponse;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get a role imply rule.
 #[utoipa::path(
@@ -77,7 +78,11 @@ pub(super) async fn get(
     let role_imply = state
         .provider
         .get_role_provider()
-        .get_role_imply_rule(&state, &prior_role_id, &implied_role_id)
+        .get_role_imply_rule(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &prior_role_id,
+            &implied_role_id,
+        )
         .await?
         .ok_or(KeystoneApiError::NotFound {
             resource: "role_imply_rule".into(),

--- a/crates/keystone/src/api/v3/role/imply/list.rs
+++ b/crates/keystone/src/api/v3/role/imply/list.rs
@@ -27,6 +27,7 @@ use openstack_keystone_api_types::v3::role::{ImplyGroup, RoleInferenceRules};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List role imply rules for a prior role.
 #[utoipa::path(
@@ -74,7 +75,10 @@ pub(super) async fn list(
     let all_rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules_by_prior(&state, &prior_role_id)
+        .list_role_imply_rules_by_prior(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &prior_role_id,
+        )
         .await?;
 
     // Get the prior role reference from the first match or resolve via get_role
@@ -84,7 +88,10 @@ pub(super) async fn list(
         let role = state
             .provider
             .get_role_provider()
-            .get_role(&state, &prior_role_id)
+            .get_role(
+                &ExecutionContext::from_auth(&state, &user_auth),
+                &prior_role_id,
+            )
             .await?;
         if let Some(role) = role {
             let role_ref: openstack_keystone_core_types::role::RoleRef = role.into();

--- a/crates/keystone/src/api/v3/role/list.rs
+++ b/crates/keystone/src/api/v3/role/list.rs
@@ -24,6 +24,7 @@ use super::types::{Role, RoleList, RoleListParameters};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List roles
 #[utoipa::path(
@@ -55,7 +56,10 @@ pub(super) async fn list(
     let roles: Vec<Role> = state
         .provider
         .get_role_provider()
-        .list_roles(&state, &query.into())
+        .list_roles(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/api/v3/role/show.rs
+++ b/crates/keystone/src/api/v3/role/show.rs
@@ -25,6 +25,7 @@ use openstack_keystone_api_types::v3::role::{Role, RoleResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get single role
 #[utoipa::path(
@@ -47,7 +48,7 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_role_provider()
-        .get_role(&state, &role_id)
+        .get_role(&ExecutionContext::from_auth(&state, &user_auth), &role_id)
         .await?;
 
     state

--- a/crates/keystone/src/api/v3/role_assignment/list.rs
+++ b/crates/keystone/src/api/v3/role_assignment/list.rs
@@ -26,6 +26,7 @@ use crate::api::v3::role_assignment::types::{
     Assignment, AssignmentList, RoleAssignmentListParameters,
 };
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List role assignments.
 #[utoipa::path(
@@ -61,7 +62,10 @@ pub(super) async fn list(
     let assignments: Result<Vec<Assignment>, _> = state
         .provider
         .get_assignment_provider()
-        .list_role_assignments(&state, &query.try_into()?)
+        .list_role_assignments(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.try_into()?,
+        )
         .await?
         .into_iter()
         .map(TryInto::try_into)

--- a/crates/keystone/src/api/v3/role_assignment/project/user/role/check.rs
+++ b/crates/keystone/src/api/v3/role_assignment/project/user/role/check.rs
@@ -27,6 +27,7 @@ use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Check whether user has role assignment on project.
 ///
@@ -68,23 +69,21 @@ pub(super) async fn check(
     };
     // Use join instead of try_join to have more constant latency preventing timing
     // attacks.
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     let (user, role, project, assignments) = tokio::join!(
         state
             .provider
             .get_identity_provider()
-            .get_user(&state, &user_id),
-        state
-            .provider
-            .get_role_provider()
-            .get_role(&state, &role_id),
+            .get_user(exec, &user_id),
+        state.provider.get_role_provider().get_role(exec, &role_id),
         state
             .provider
             .get_resource_provider()
-            .get_project(&state, &project_id),
+            .get_project(exec, &project_id),
         state
             .provider
             .get_assignment_provider()
-            .list_role_assignments(&state, &query_params)
+            .list_role_assignments(exec, &query_params)
     );
     let user = user?.ok_or_else(|| {
         info!("User {} was not found", user_id);

--- a/crates/keystone/src/api/v3/role_assignment/project/user/role/grant.rs
+++ b/crates/keystone/src/api/v3/role_assignment/project/user/role/grant.rs
@@ -26,6 +26,7 @@ use openstack_keystone_core_types::assignment::AssignmentCreate;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Assign role to user on project
 ///
@@ -59,19 +60,17 @@ pub(super) async fn grant(
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     // Use join instead of try_join to have more constant latency preventing timing
     // attacks.
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     let (user, role, project) = tokio::join!(
         state
             .provider
             .get_identity_provider()
-            .get_user(&state, &user_id),
-        state
-            .provider
-            .get_role_provider()
-            .get_role(&state, &role_id),
+            .get_user(exec, &user_id),
+        state.provider.get_role_provider().get_role(exec, &role_id),
         state
             .provider
             .get_resource_provider()
-            .get_project(&state, &project_id),
+            .get_project(exec, &project_id),
     );
     let user = user?.ok_or_else(|| {
         info!("User {} was not found", user_id);
@@ -109,7 +108,7 @@ pub(super) async fn grant(
         .provider
         .get_assignment_provider()
         .create_grant(
-            &state,
+            exec,
             AssignmentCreate::user_project(user.id, project.id, role.id, false),
         )
         .await?;

--- a/crates/keystone/src/api/v3/role_assignment/project/user/role/list.rs
+++ b/crates/keystone/src/api/v3/role_assignment/project/user/role/list.rs
@@ -29,6 +29,7 @@ use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List the roles that a user has on a project.
 #[utoipa::path(
@@ -68,19 +69,20 @@ pub(super) async fn list(
 
     // Use join instead of try_join to have more constant latency preventing timing
     // attacks.
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     let (user, project, assignments) = tokio::join!(
         state
             .provider
             .get_identity_provider()
-            .get_user(&state, &user_id),
+            .get_user(exec, &user_id),
         state
             .provider
             .get_resource_provider()
-            .get_project(&state, &project_id),
+            .get_project(exec, &project_id),
         state
             .provider
             .get_assignment_provider()
-            .list_role_assignments(&state, &query_params)
+            .list_role_assignments(exec, &query_params)
     );
     let user = user?.ok_or_else(|| {
         info!("User {} was not found", user_id);

--- a/crates/keystone/src/api/v3/role_assignment/project/user/role/revoke.rs
+++ b/crates/keystone/src/api/v3/role_assignment/project/user/role/revoke.rs
@@ -25,6 +25,7 @@ use tracing::info;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::assignment::{AssignmentBuilder, AssignmentType};
 
 /// Revoke role from user on project
@@ -63,21 +64,19 @@ pub(super) async fn revoke(
     request: Request,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     let inherited = request.uri().path().contains("inherited_to_projects");
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     // Use join instead of try_join to have more constant latency preventing timing
     // attacks.
     let (user, role, project) = tokio::join!(
         state
             .provider
             .get_identity_provider()
-            .get_user(&state, &user_id),
-        state
-            .provider
-            .get_role_provider()
-            .get_role(&state, &role_id),
+            .get_user(exec, &user_id),
+        state.provider.get_role_provider().get_role(exec, &role_id),
         state
             .provider
             .get_resource_provider()
-            .get_project(&state, &project_id)
+            .get_project(exec, &project_id)
     );
     let user = user?.ok_or_else(|| {
         info!("User {} was not found", user_id);
@@ -122,7 +121,7 @@ pub(super) async fn revoke(
     state
         .provider
         .get_assignment_provider()
-        .revoke_grant(&state, grant)
+        .revoke_grant(exec, grant)
         .await?;
 
     Ok(StatusCode::NO_CONTENT.into_response())

--- a/crates/keystone/src/api/v3/role_assignment/system/user/role/check.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/user/role/check.rs
@@ -27,6 +27,7 @@ use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Check whether user has role assignment on system.
 ///
@@ -65,19 +66,17 @@ pub(super) async fn check(
         resolve_implied_roles: false,
         ..Default::default()
     };
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     let (user, role, assignments) = tokio::join!(
         state
             .provider
             .get_identity_provider()
-            .get_user(&state, &user_id),
-        state
-            .provider
-            .get_role_provider()
-            .get_role(&state, &role_id),
+            .get_user(exec, &user_id),
+        state.provider.get_role_provider().get_role(exec, &role_id),
         state
             .provider
             .get_assignment_provider()
-            .list_role_assignments(&state, &query_params)
+            .list_role_assignments(exec, &query_params)
     );
     let user = user?.ok_or_else(|| {
         info!("User {} was not found", user_id);

--- a/crates/keystone/src/api/v3/role_assignment/system/user/role/grant.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/user/role/grant.rs
@@ -26,6 +26,7 @@ use openstack_keystone_core_types::assignment::AssignmentCreate;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Assign role to user on system
 ///
@@ -56,15 +57,13 @@ pub(super) async fn grant(
     Path((user_id, role_id)): Path<(String, String)>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     let (user, role) = tokio::join!(
         state
             .provider
             .get_identity_provider()
-            .get_user(&state, &user_id),
-        state
-            .provider
-            .get_role_provider()
-            .get_role(&state, &role_id),
+            .get_user(exec, &user_id),
+        state.provider.get_role_provider().get_role(exec, &role_id),
     );
     let user = user?.ok_or_else(|| {
         info!("User {} was not found", user_id);
@@ -95,7 +94,7 @@ pub(super) async fn grant(
         .provider
         .get_assignment_provider()
         .create_grant(
-            &state,
+            exec,
             AssignmentCreate::user_system(user.id, "system", role.id, false),
         )
         .await?;

--- a/crates/keystone/src/api/v3/role_assignment/system/user/role/list.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/user/role/list.rs
@@ -29,6 +29,7 @@ use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List the roles that a user has on the system.
 #[utoipa::path(
@@ -65,15 +66,16 @@ pub(super) async fn list(
         ..Default::default()
     };
 
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     let (user, assignments) = tokio::join!(
         state
             .provider
             .get_identity_provider()
-            .get_user(&state, &user_id),
+            .get_user(exec, &user_id),
         state
             .provider
             .get_assignment_provider()
-            .list_role_assignments(&state, &query_params)
+            .list_role_assignments(exec, &query_params)
     );
     let user = user?.ok_or_else(|| {
         info!("User {} was not found", user_id);

--- a/crates/keystone/src/api/v3/role_assignment/system/user/role/revoke.rs
+++ b/crates/keystone/src/api/v3/role_assignment/system/user/role/revoke.rs
@@ -25,6 +25,7 @@ use tracing::info;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::assignment::{AssignmentBuilder, AssignmentType};
 
 /// Revoke role from user on system
@@ -59,15 +60,13 @@ pub(super) async fn revoke(
     Path((user_id, role_id)): Path<(String, String)>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     let (user, role) = tokio::join!(
         state
             .provider
             .get_identity_provider()
-            .get_user(&state, &user_id),
-        state
-            .provider
-            .get_role_provider()
-            .get_role(&state, &role_id)
+            .get_user(exec, &user_id),
+        state.provider.get_role_provider().get_role(exec, &role_id)
     );
     let user = user?.ok_or_else(|| {
         info!("User {} was not found", user_id);
@@ -105,7 +104,7 @@ pub(super) async fn revoke(
     state
         .provider
         .get_assignment_provider()
-        .revoke_grant(&state, grant)
+        .revoke_grant(exec, grant)
         .await?;
 
     Ok(StatusCode::NO_CONTENT.into_response())

--- a/crates/keystone/src/api/v3/role_inferences.rs
+++ b/crates/keystone/src/api/v3/role_inferences.rs
@@ -25,6 +25,7 @@ use openstack_keystone_api_types::v3::role::{ImplyGroup, RoleInferencesList};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List all role inference rules.
 #[utoipa::path(
@@ -56,10 +57,11 @@ pub(super) async fn list(
         .await?;
 
     // Get all imply rules
+    let exec = &ExecutionContext::from_auth(&state, &user_auth);
     let all_rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules(&state)
+        .list_role_imply_rules(exec)
         .await?;
 
     // Group rules by prior role to build ImplyGroup entries

--- a/crates/keystone/src/api/v3/user/create.rs
+++ b/crates/keystone/src/api/v3/user/create.rs
@@ -25,6 +25,7 @@ use super::types::{User, UserCreateRequest, UserListParameters, UserResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create user
 #[utoipa::path(
@@ -57,7 +58,7 @@ pub(super) async fn create(
     let user = state
         .provider
         .get_identity_provider()
-        .create_user(&state, req.into())
+        .create_user(&ExecutionContext::from_auth(&state, &user_auth), req.into())
         .await?;
     Ok((
         StatusCode::CREATED,

--- a/crates/keystone/src/api/v3/user/delete.rs
+++ b/crates/keystone/src/api/v3/user/delete.rs
@@ -22,6 +22,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete user
 #[utoipa::path(
@@ -44,7 +45,7 @@ pub(super) async fn delete(
     let current = state
         .provider
         .get_identity_provider()
-        .get_user(&state, &user_id)
+        .get_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
         .await?;
 
     state
@@ -61,7 +62,7 @@ pub(super) async fn delete(
             state
                 .provider
                 .get_identity_provider()
-                .delete_user(&state, &user_id)
+                .delete_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
                 .await?;
             Ok((StatusCode::NO_CONTENT).into_response())
         }

--- a/crates/keystone/src/api/v3/user/groups.rs
+++ b/crates/keystone/src/api/v3/user/groups.rs
@@ -24,6 +24,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::api::v3::group::types::{Group, GroupList};
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List groups a user is member of
 ///
@@ -55,7 +56,7 @@ pub(super) async fn groups(
     let current = state
         .provider
         .get_identity_provider()
-        .get_user(&state, &user_id)
+        .get_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
         .await?;
 
     state
@@ -72,7 +73,7 @@ pub(super) async fn groups(
             let groups: Vec<Group> = state
                 .provider
                 .get_identity_provider()
-                .list_groups_of_user(&state, &user_id)
+                .list_groups_of_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
                 .await?
                 .into_iter()
                 .map(Into::into)

--- a/crates/keystone/src/api/v3/user/list.rs
+++ b/crates/keystone/src/api/v3/user/list.rs
@@ -25,6 +25,7 @@ use super::types::{User, UserList, UserListParameters};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List users
 #[utoipa::path(
@@ -57,7 +58,10 @@ pub(super) async fn list(
     let users: Vec<User> = state
         .provider
         .get_identity_provider()
-        .list_users(&state, &query.into())
+        .list_users(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/api/v3/user/show.rs
+++ b/crates/keystone/src/api/v3/user/show.rs
@@ -24,6 +24,7 @@ use super::types::{User, UserResponse};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get single user
 #[utoipa::path(
@@ -45,7 +46,7 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_identity_provider()
-        .get_user(&state, &user_id)
+        .get_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
         .await?;
 
     state

--- a/crates/keystone/src/api/v3/user/update.rs
+++ b/crates/keystone/src/api/v3/user/update.rs
@@ -25,6 +25,7 @@ use super::types::{User, UserResponse, UserUpdateRequest};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Update existing user
 #[utoipa::path(
@@ -53,7 +54,7 @@ pub(super) async fn update(
     let current = state
         .provider
         .get_identity_provider()
-        .get_user(&state, &user_id)
+        .get_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
         .await?;
 
     let existing_user = current.as_ref().map(|c| json!({"user": c}));
@@ -73,7 +74,11 @@ pub(super) async fn update(
             let user = state
                 .provider
                 .get_identity_provider()
-                .update_user(&state, &user_id, req.into())
+                .update_user(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &user_id,
+                    req.into(),
+                )
                 .await?;
             Ok((
                 StatusCode::OK,

--- a/crates/keystone/src/api/v4/mapping/ruleset/create.rs
+++ b/crates/keystone/src/api/v4/mapping/ruleset/create.rs
@@ -22,6 +22,7 @@ use validator::Validate;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create a new mapping ruleset.
 #[utoipa::path(
@@ -61,7 +62,7 @@ pub(super) async fn create(
     let res = state
         .provider
         .get_mapping_provider()
-        .create_ruleset(&state, req.into())
+        .create_ruleset(&ExecutionContext::from_auth(&state, &user_auth), req.into())
         .await?;
 
     Ok((

--- a/crates/keystone/src/api/v4/mapping/ruleset/delete.rs
+++ b/crates/keystone/src/api/v4/mapping/ruleset/delete.rs
@@ -23,6 +23,7 @@ use openstack_keystone_api_types::v4::mapping::MappingRuleSet;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete a mapping ruleset by ID.
 #[utoipa::path(
@@ -52,7 +53,10 @@ pub(super) async fn remove(
     let current = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &mapping_id)
+        .get_ruleset(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &mapping_id,
+        )
         .await?;
 
     if let Some(current) = current {
@@ -69,7 +73,10 @@ pub(super) async fn remove(
         state
             .provider
             .get_mapping_provider()
-            .delete_ruleset(&state, &mapping_id)
+            .delete_ruleset(
+                &ExecutionContext::from_auth(&state, &user_auth),
+                &mapping_id,
+            )
             .await?;
     }
 

--- a/crates/keystone/src/api/v4/mapping/ruleset/list.rs
+++ b/crates/keystone/src/api/v4/mapping/ruleset/list.rs
@@ -29,6 +29,7 @@ use openstack_keystone_core_types::mapping::MappingRuleSetListParameters as Prov
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List mapping rulesets.
 #[utoipa::path(
@@ -74,7 +75,10 @@ pub(super) async fn list(
     let rulesets: Vec<MappingRuleSet> = state
         .provider
         .get_mapping_provider()
-        .list_rulesets(&state, &provider_list_params)
+        .list_rulesets(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &provider_list_params,
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/api/v4/mapping/ruleset/mutate.rs
+++ b/crates/keystone/src/api/v4/mapping/ruleset/mutate.rs
@@ -28,6 +28,7 @@ use openstack_keystone_api_types::v4::mapping::{
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Mutate rules within a mapping ruleset imperatively.
 ///
@@ -62,7 +63,10 @@ pub(super) async fn mutate(
     let current = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &mapping_id)
+        .get_ruleset(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &mapping_id,
+        )
         .await?
         .ok_or_else(|| KeystoneApiError::NotFound {
             resource: "mapping ruleset".into(),
@@ -82,7 +86,11 @@ pub(super) async fn mutate(
     let res = state
         .provider
         .get_mapping_provider()
-        .mutate_rules(&state, &mapping_id, req.into())
+        .mutate_rules(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &mapping_id,
+            req.into(),
+        )
         .await?;
 
     Ok((

--- a/crates/keystone/src/api/v4/mapping/ruleset/show.rs
+++ b/crates/keystone/src/api/v4/mapping/ruleset/show.rs
@@ -24,6 +24,7 @@ use openstack_keystone_api_types::v4::mapping::{MappingRuleSet, MappingRuleSetRe
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Show a mapping ruleset by ID.
 #[utoipa::path(
@@ -53,7 +54,10 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &mapping_id)
+        .get_ruleset(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &mapping_id,
+        )
         .await?
         .ok_or_else(|| KeystoneApiError::NotFound {
             resource: "mapping ruleset".into(),

--- a/crates/keystone/src/api/v4/mapping/ruleset/update.rs
+++ b/crates/keystone/src/api/v4/mapping/ruleset/update.rs
@@ -27,6 +27,7 @@ use validator::Validate;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Update a mapping ruleset.
 #[utoipa::path(
@@ -60,7 +61,10 @@ pub(super) async fn update(
     let current = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &mapping_id)
+        .get_ruleset(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &mapping_id,
+        )
         .await?
         .ok_or_else(|| KeystoneApiError::NotFound {
             resource: "mapping ruleset".into(),
@@ -80,7 +84,11 @@ pub(super) async fn update(
     let res = state
         .provider
         .get_mapping_provider()
-        .update_ruleset(&state, &mapping_id, req.mapping.into())
+        .update_ruleset(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &mapping_id,
+            req.mapping.into(),
+        )
         .await?;
 
     Ok((

--- a/crates/keystone/src/api/v4/token/restriction/create.rs
+++ b/crates/keystone/src/api/v4/token/restriction/create.rs
@@ -21,6 +21,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::api::v4::token::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create the token restriction.
 ///
@@ -64,7 +65,7 @@ pub(super) async fn create(
     let res = state
         .provider
         .get_token_provider()
-        .create_token_restriction(&state, req.into())
+        .create_token_restriction(&ExecutionContext::from_auth(&state, &user_auth), req.into())
         .await?;
     Ok((
         StatusCode::CREATED,

--- a/crates/keystone/src/api/v4/token/restriction/delete.rs
+++ b/crates/keystone/src/api/v4/token/restriction/delete.rs
@@ -24,6 +24,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete Token restriction.
 ///
@@ -56,7 +57,7 @@ pub(super) async fn remove(
     let current = state
         .provider
         .get_token_provider()
-        .get_token_restriction(&state, &id, false)
+        .get_token_restriction(&ExecutionContext::from_auth(&state, &user_auth), &id, false)
         .await?;
 
     state
@@ -73,7 +74,7 @@ pub(super) async fn remove(
         state
             .provider
             .get_token_provider()
-            .delete_token_restriction(&state, &id)
+            .delete_token_restriction(&ExecutionContext::from_auth(&state, &user_auth), &id)
             .await?;
     } else {
         return Err(KeystoneApiError::NotFound {

--- a/crates/keystone/src/api/v4/token/restriction/list.rs
+++ b/crates/keystone/src/api/v4/token/restriction/list.rs
@@ -27,6 +27,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::api::v4::token::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List token restrictions.
 ///
@@ -71,7 +72,10 @@ pub(super) async fn list(
     let token_restrictions: Vec<TokenRestriction> = state
         .provider
         .get_token_provider()
-        .list_token_restrictions(&state, &provider_list_params)
+        .list_token_restrictions(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &provider_list_params,
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/api/v4/token/restriction/show.rs
+++ b/crates/keystone/src/api/v4/token/restriction/show.rs
@@ -25,6 +25,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::api::v4::token::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get single token restriction.
 ///
@@ -57,7 +58,7 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_token_provider()
-        .get_token_restriction(&state, &id, true)
+        .get_token_restriction(&ExecutionContext::from_auth(&state, &user_auth), &id, true)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {

--- a/crates/keystone/src/api/v4/token/restriction/update.rs
+++ b/crates/keystone/src/api/v4/token/restriction/update.rs
@@ -26,6 +26,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::api::v4::token::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Update existing token restriction by the ID.
 ///
@@ -65,7 +66,7 @@ pub(super) async fn update(
     let current = state
         .provider
         .get_token_provider()
-        .get_token_restriction(&state, &id, false)
+        .get_token_restriction(&ExecutionContext::from_auth(&state, &user_auth), &id, false)
         .await?;
     let existing_restriction = current.as_ref().map(|c| json!({"restriction": c}));
 
@@ -82,7 +83,11 @@ pub(super) async fn update(
     let res = state
         .provider
         .get_token_provider()
-        .update_token_restriction(&state, &id, req.into())
+        .update_token_restriction(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &id,
+            req.into(),
+        )
         .await?;
     Ok((
         StatusCode::OK,

--- a/crates/keystone/src/api/v4/user/mod.rs
+++ b/crates/keystone/src/api/v4/user/mod.rs
@@ -24,6 +24,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::api::v3::group::types::{Group, GroupList};
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use types::{User, UserCreateRequest, UserList, UserListParameters, UserResponse};
 
 pub mod types;
@@ -56,7 +57,10 @@ async fn list(
     let users: Vec<User> = state
         .provider
         .get_identity_provider()
-        .list_users(&state, &query.into())
+        .list_users(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
         .await?
         .into_iter()
         .map(Into::into)
@@ -88,7 +92,7 @@ async fn show(
                 state
                     .provider
                     .get_identity_provider()
-                    .get_user(&state, &user_id)
+                    .get_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
                     .await
                     .map(|x| {
                         x.ok_or_else(|| KeystoneApiError::NotFound {
@@ -122,7 +126,7 @@ async fn create(
     let user = state
         .provider
         .get_identity_provider()
-        .create_user(&state, req.into())
+        .create_user(&ExecutionContext::from_auth(&state, &user_auth), req.into())
         .await?;
     Ok((
         StatusCode::CREATED,
@@ -154,7 +158,7 @@ async fn remove(
     state
         .provider
         .get_identity_provider()
-        .delete_user(&state, &user_id)
+        .delete_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
         .await?;
     Ok((StatusCode::NO_CONTENT).into_response())
 }
@@ -179,7 +183,7 @@ async fn groups(
     let groups: Vec<Group> = state
         .provider
         .get_identity_provider()
-        .list_groups_of_user(&state, &user_id)
+        .list_groups_of_user(&ExecutionContext::from_auth(&state, &user_auth), &user_id)
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -75,6 +75,7 @@ use openstack_keystone::token::TokenHook;
 use openstack_keystone::trust::TrustHook;
 use openstack_keystone::webauthn;
 use openstack_keystone::{api, common};
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::db::sync_schema;
 use openstack_keystone_core::error::KeystoneError;
 use openstack_keystone_distributed_storage::{StorageApi, app::Storage};
@@ -605,7 +606,7 @@ async fn cleanup(cancel: CancellationToken, state: ServiceState) {
         tokio::select! {
             _ = interval.tick() => {
                 trace!("cleanup job tick");
-                if let Err(e) = state.provider.get_federation_provider().cleanup(&state).await {
+                if let Err(e) = state.provider.get_federation_provider().cleanup(&ExecutionContext::internal(&state)).await {
                     error!("Error during cleanup job: {}", e);
                 }
             },

--- a/crates/keystone/src/federation/api/auth.rs
+++ b/crates/keystone/src/federation/api/auth.rs
@@ -27,6 +27,7 @@ use validator::Validate;
 use crate::api::error::KeystoneApiError;
 use crate::federation::{api::error::OidcError, api::types::*};
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::federation::AuthState;
 
 use super::oidc_utils::{
@@ -93,7 +94,7 @@ pub async fn post(
     let idp = state
         .provider
         .get_federation_provider()
-        .get_identity_provider(&state, &idp_id)
+        .get_identity_provider(&ExecutionContext::internal(&state), &idp_id)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {
@@ -160,7 +161,7 @@ pub async fn post(
         .provider
         .get_federation_provider()
         .create_auth_state(
-            &state,
+            &ExecutionContext::internal(&state),
             AuthState {
                 state: csrf_token.clone(),
                 nonce: nonce.clone(),

--- a/crates/keystone/src/federation/api/common.rs
+++ b/crates/keystone/src/federation/api/common.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::mapping::error::MappingProviderError;
 use openstack_keystone_core_types::scope::Scope;
 
@@ -197,7 +198,7 @@ pub(super) async fn build_token_response(
         state
             .provider
             .get_catalog_provider()
-            .get_catalog(state, true)
+            .get_catalog(&ExecutionContext::internal(&state), true)
             .await?
             .into_iter()
             .map(|(s, es)| CatalogService {

--- a/crates/keystone/src/federation/api/identity_provider/create.rs
+++ b/crates/keystone/src/federation/api/identity_provider/create.rs
@@ -21,6 +21,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::federation::api::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create the identity provider.
 ///
@@ -64,7 +65,7 @@ pub(super) async fn create(
     let res = state
         .provider
         .get_federation_provider()
-        .create_identity_provider(&state, req.into())
+        .create_identity_provider(&ExecutionContext::from_auth(&state, &user_auth), req.into())
         .await?;
     Ok((
         StatusCode::CREATED,

--- a/crates/keystone/src/federation/api/identity_provider/delete.rs
+++ b/crates/keystone/src/federation/api/identity_provider/delete.rs
@@ -23,6 +23,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete Identity provider.
 ///
@@ -58,7 +59,7 @@ pub(super) async fn remove(
     let current = state
         .provider
         .get_federation_provider()
-        .get_identity_provider(&state, &id)
+        .get_identity_provider(&ExecutionContext::from_auth(&state, &user_auth), &id)
         .await?;
 
     state
@@ -78,7 +79,7 @@ pub(super) async fn remove(
         state
             .provider
             .get_federation_provider()
-            .delete_identity_provider(&state, &id)
+            .delete_identity_provider(&ExecutionContext::from_auth(&state, &user_auth), &id)
             .await?;
     } else {
         return Err(KeystoneApiError::NotFound {

--- a/crates/keystone/src/federation/api/identity_provider/list.rs
+++ b/crates/keystone/src/federation/api/identity_provider/list.rs
@@ -28,6 +28,7 @@ use openstack_keystone_core_types::federation::IdentityProviderListParameters as
 
 use crate::api::{KeystoneApiError, auth::Auth, common::build_pagination_links};
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// List identity providers.
 ///
@@ -98,7 +99,10 @@ pub(super) async fn list(
     let identity_providers: Vec<IdentityProvider> = state
         .provider
         .get_federation_provider()
-        .list_identity_providers(&state, &provider_list_params)
+        .list_identity_providers(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &provider_list_params,
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/federation/api/identity_provider/show.rs
+++ b/crates/keystone/src/federation/api/identity_provider/show.rs
@@ -25,6 +25,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::federation::api::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get single identity provider.
 ///
@@ -57,7 +58,7 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_federation_provider()
-        .get_identity_provider(&state, &idp_id)
+        .get_identity_provider(&ExecutionContext::from_auth(&state, &user_auth), &idp_id)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {

--- a/crates/keystone/src/federation/api/identity_provider/update.rs
+++ b/crates/keystone/src/federation/api/identity_provider/update.rs
@@ -26,6 +26,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::federation::api::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Update single identity provider.
 ///
@@ -61,7 +62,7 @@ pub(super) async fn update(
     let current = state
         .provider
         .get_federation_provider()
-        .get_identity_provider(&state, &idp_id)
+        .get_identity_provider(&ExecutionContext::from_auth(&state, &user_auth), &idp_id)
         .await?;
 
     state
@@ -77,7 +78,11 @@ pub(super) async fn update(
     let res = state
         .provider
         .get_federation_provider()
-        .update_identity_provider(&state, &idp_id, req.into())
+        .update_identity_provider(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &idp_id,
+            req.into(),
+        )
         .await?;
     Ok((
         StatusCode::OK,

--- a/crates/keystone/src/federation/api/jwt.rs
+++ b/crates/keystone/src/federation/api/jwt.rs
@@ -26,6 +26,7 @@ use crate::api::error::KeystoneApiError;
 use crate::api::v4::auth::token::types::TokenResponse as KeystoneTokenResponse;
 use crate::federation::api::error::OidcError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
@@ -108,7 +109,7 @@ pub async fn login(
     let idp = state
         .provider
         .get_federation_provider()
-        .get_identity_provider(&state, &idp_id)
+        .get_identity_provider(&ExecutionContext::internal(&state), &idp_id)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {
@@ -197,7 +198,7 @@ pub async fn login(
     let auth_result: AuthenticationResult = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &mapping_req)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &mapping_req)
         .await?;
 
     // No scope is requested in JWT flow, so we resolve unscoped token.

--- a/crates/keystone/src/federation/api/oidc.rs
+++ b/crates/keystone/src/federation/api/oidc.rs
@@ -23,6 +23,7 @@ use crate::api::v4::auth::token::types::TokenResponse as KeystoneTokenResponse;
 use crate::federation::api::error::OidcError;
 use crate::federation::api::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
@@ -63,11 +64,12 @@ pub async fn callback(
     State(state): State<ServiceState>,
     Json(query): Json<AuthCallbackParameters>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
+    let exec = ExecutionContext::internal(&state);
     // Validate auth state
     let auth_state = state
         .provider
         .get_federation_provider()
-        .get_auth_state(&state, &query.state)
+        .get_auth_state(&exec, &query.state)
         .await?
         .ok_or_else(|| KeystoneApiError::NotFound {
             resource: "auth state".into(),
@@ -81,7 +83,7 @@ pub async fn callback(
     let idp = state
         .provider
         .get_federation_provider()
-        .get_identity_provider(&state, &auth_state.idp_id)
+        .get_identity_provider(&exec, &auth_state.idp_id)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {
@@ -195,7 +197,7 @@ pub async fn callback(
     let auth_result: AuthenticationResult = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &mapping_req)
+        .authenticate_by_mapping(&exec, &mapping_req)
         .await?;
 
     // Resolve scope from the original auth request. The scope may be None

--- a/crates/keystone/src/k8s_auth/api/auth.rs
+++ b/crates/keystone/src/k8s_auth/api/auth.rs
@@ -25,6 +25,7 @@ use validator::Validate;
 use openstack_keystone_api_types::error::KeystoneApiError;
 use openstack_keystone_api_types::k8s_auth::K8sAuthRequest;
 use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core_types::auth::{AuthenticationContext, ScopeInfo, SecurityContext};
 use openstack_keystone_core_types::mapping::authorization::Authorization;
@@ -74,10 +75,11 @@ pub async fn post(
 
     let (ctx, scope) = mapping_auth(&state, &req.to_provider_with_instance_id(instance_id)).await?;
 
+    let exec = ExecutionContext::internal(&state);
     let vsc = state
         .provider
         .get_token_provider()
-        .issue_token_context(&state, &ctx, &scope)
+        .issue_token_context(exec.state(), &ctx, &scope)
         .await?;
 
     let mut api_token = TokenResponse {
@@ -89,7 +91,7 @@ pub async fn post(
         state
             .provider
             .get_catalog_provider()
-            .get_catalog(&state, true)
+            .get_catalog(&exec, true)
             .await?
             .into_iter()
             .map(|(s, es)| CatalogService {
@@ -129,7 +131,7 @@ async fn mapping_auth(
     let auth_result = state
         .provider
         .get_k8s_auth_provider()
-        .authenticate_by_k8s_mapping(state, req)
+        .authenticate_by_k8s_mapping(&ExecutionContext::internal(state), req)
         .await?;
 
     let ctx = SecurityContext::try_from(auth_result)?;
@@ -151,7 +153,10 @@ async fn mapping_auth(
         let vu = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(state, &mapping_ctx.virtual_user_id)
+            .get_virtual_user(
+                &ExecutionContext::internal(state),
+                &mapping_ctx.virtual_user_id,
+            )
             .await?
             .expect("virtual user should exist after mapping auth");
 

--- a/crates/keystone/src/k8s_auth/api/instance/create.rs
+++ b/crates/keystone/src/k8s_auth/api/instance/create.rs
@@ -24,6 +24,7 @@ use openstack_keystone_api_types::k8s_auth::{
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Create the K8s auth instance.
 ///
@@ -64,7 +65,7 @@ pub(super) async fn create(
     let res = state
         .provider
         .get_k8s_auth_provider()
-        .create_auth_instance(&state, req.into())
+        .create_auth_instance(&ExecutionContext::from_auth(&state, &user_auth), req.into())
         .await?;
     Ok((
         StatusCode::CREATED,

--- a/crates/keystone/src/k8s_auth/api/instance/delete.rs
+++ b/crates/keystone/src/k8s_auth/api/instance/delete.rs
@@ -23,6 +23,7 @@ use serde_json::json;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Delete K8s auth instance.
 ///
@@ -55,7 +56,7 @@ pub(super) async fn remove(
     let current = state
         .provider
         .get_k8s_auth_provider()
-        .get_auth_instance(&state, &id)
+        .get_auth_instance(&ExecutionContext::from_auth(&state, &user_auth), &id)
         .await?;
 
     state
@@ -72,7 +73,7 @@ pub(super) async fn remove(
         state
             .provider
             .get_k8s_auth_provider()
-            .delete_auth_instance(&state, &id)
+            .delete_auth_instance(&ExecutionContext::from_auth(&state, &user_auth), &id)
             .await?;
     } else {
         return Err(KeystoneApiError::NotFound {

--- a/crates/keystone/src/k8s_auth/api/instance/list.rs
+++ b/crates/keystone/src/k8s_auth/api/instance/list.rs
@@ -22,6 +22,8 @@ use axum::{
 use serde_json::json;
 use validator::Validate;
 
+use openstack_keystone_core::auth::ExecutionContext;
+
 use openstack_keystone_api_types::k8s_auth::*;
 use openstack_keystone_core_types::k8s_auth as provider_types;
 
@@ -82,7 +84,10 @@ pub(super) async fn list(
     let instances: Vec<K8sAuthInstance> = state
         .provider
         .get_k8s_auth_provider()
-        .list_auth_instances(&state, &list_params)
+        .list_auth_instances(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &list_params,
+        )
         .await?
         .into_iter()
         .map(Into::into)

--- a/crates/keystone/src/k8s_auth/api/instance/show.rs
+++ b/crates/keystone/src/k8s_auth/api/instance/show.rs
@@ -26,6 +26,7 @@ use openstack_keystone_api_types::k8s_auth::*;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Get single K8s auth instance.
 ///
@@ -58,7 +59,7 @@ pub(super) async fn show(
     let current = state
         .provider
         .get_k8s_auth_provider()
-        .get_auth_instance(&state, &id)
+        .get_auth_instance(&ExecutionContext::from_auth(&state, &user_auth), &id)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {

--- a/crates/keystone/src/k8s_auth/api/instance/update.rs
+++ b/crates/keystone/src/k8s_auth/api/instance/update.rs
@@ -27,6 +27,7 @@ use openstack_keystone_api_types::k8s_auth::*;
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 /// Update single K8s auth instance.
 ///
@@ -62,7 +63,10 @@ pub(super) async fn update(
     let current = state
         .provider
         .get_k8s_auth_provider()
-        .get_auth_instance(&state, &instance_id)
+        .get_auth_instance(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &instance_id,
+        )
         .await?;
 
     state
@@ -78,7 +82,11 @@ pub(super) async fn update(
     let res = state
         .provider
         .get_k8s_auth_provider()
-        .update_auth_instance(&state, &instance_id, req.into())
+        .update_auth_instance(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &instance_id,
+            req.into(),
+        )
         .await?;
     Ok((
         StatusCode::OK,

--- a/crates/resource-driver-sql/src/domain/delete.rs
+++ b/crates/resource-driver-sql/src/domain/delete.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Delete domain
+//! # Delete domain
 
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;

--- a/crates/storage/src/store/log_store.rs
+++ b/crates/storage/src/store/log_store.rs
@@ -39,6 +39,9 @@ const KEY_PURGED: &[u8] = b"purged";
 /// `[dek_version_u32; 4] ++ [term_u64; 8] ++ log_encrypt([nonce_12 ++
 /// ciphertext ++ tag_16])`.
 const DEK_VERSION_PREFIX_LEN: usize = 4;
+/// On-disk prefix length for a log entry: 8 bytes for term (BE u64).
+/// Full layout: [term_u64_BE (8)] ++ log_encrypt output [nonce_12 ++ ciphertext
+/// ++ tag_16].
 const TERM_PREFIX_LEN: usize = 8;
 /// Minimum stored size: dek_version(4) + term(8) + nonce(12) + tag(16) = 40.
 const LOG_ENTRY_MIN_LEN: usize = DEK_VERSION_PREFIX_LEN + TERM_PREFIX_LEN + 12 + 16;

--- a/crates/webauthn/src/api.rs
+++ b/crates/webauthn/src/api.rs
@@ -23,6 +23,7 @@ use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 use webauthn_rs::WebauthnBuilder;
 
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::error::KeystoneError;
 use openstack_keystone_core::keystone::ServiceState;
 
@@ -152,7 +153,7 @@ async fn cleanup(cancel: CancellationToken, state: CombinedExtensionState) {
         tokio::select! {
             _ = interval.tick() => {
                 trace!("cleanup job tick");
-                if let Err(e) = state.extension.provider.cleanup(&state.core).await {
+                if let Err(e) = state.extension.provider.cleanup(&ExecutionContext::internal(&state.core)).await {
                     error!("Error during cleanup job: {}", e);
                 }
             },

--- a/crates/webauthn/src/api/auth/finish.rs
+++ b/crates/webauthn/src/api/auth/finish.rs
@@ -25,6 +25,7 @@ use crate::{
 use openstack_keystone_api_types::error::KeystoneApiError;
 use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
 use openstack_keystone_api_types::v3::auth::token::TokenResponse;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::auth::*;
 
 /// Finish user passkey authentication.
@@ -61,7 +62,10 @@ pub async fn finish(
     let Some(s) = state
         .extension
         .provider
-        .get_user_webauthn_credential_authentication_state(&state.core, &user_id)
+        .get_user_webauthn_credential_authentication_state(
+            &ExecutionContext::internal(&state.core),
+            &user_id,
+        )
         .await?
     else {
         return Err(KeystoneApiError::UnauthorizedNoContext);
@@ -78,7 +82,10 @@ pub async fn finish(
     state
         .extension
         .provider
-        .delete_user_webauthn_credential_authentication_state(&state.core, &user_id)
+        .delete_user_webauthn_credential_authentication_state(
+            &ExecutionContext::internal(&state.core),
+            &user_id,
+        )
         .await?;
 
     let auth_result = match state
@@ -107,7 +114,7 @@ pub async fn finish(
     let mut credential = state
         .extension
         .provider
-        .get_user_webauthn_credential(&state.core, &user_id, &cred_id)
+        .get_user_webauthn_credential(&ExecutionContext::internal(&state.core), &user_id, &cred_id)
         .await?
         .ok_or(WebauthnError::CredentialNotFound(cred_id))?;
 
@@ -136,7 +143,7 @@ pub async fn finish(
         .extension
         .provider
         .update_user_webauthn_credential(
-            &state.core,
+            &ExecutionContext::internal(&state.core),
             &user_id,
             &credential.credential_id,
             &credential,
@@ -147,7 +154,7 @@ pub async fn finish(
         .core
         .provider
         .get_identity_provider()
-        .get_user(&state.core, &user_id)
+        .get_user(&ExecutionContext::internal(&state.core), &user_id)
         .await?
         .ok_or(KeystoneApiError::Conflict("user not found".into()))?;
     let auth = AuthenticationResultBuilder::default()

--- a/crates/webauthn/src/api/auth/start.rs
+++ b/crates/webauthn/src/api/auth/start.rs
@@ -17,6 +17,7 @@ use axum::{Json, extract::State, response::IntoResponse};
 use validator::Validate;
 
 use openstack_keystone_api_types::error::KeystoneApiError;
+use openstack_keystone_core::auth::ExecutionContext;
 
 use crate::api::types::{CombinedExtensionState, auth::*};
 
@@ -51,7 +52,10 @@ pub async fn start(
     let allow_credentials: Vec<webauthn_rs::prelude::Passkey> = state
         .extension
         .provider
-        .list_user_webauthn_credentials(&state.core, &req.passkey.user_id)
+        .list_user_webauthn_credentials(
+            &ExecutionContext::internal(&state.core),
+            &req.passkey.user_id,
+        )
         .await?
         .into_iter()
         .map(|x| x.data)
@@ -66,7 +70,7 @@ pub async fn start(
                 .extension
                 .provider
                 .save_user_webauthn_credential_authentication_state(
-                    &state.core,
+                    &ExecutionContext::internal(&state.core),
                     &req.passkey.user_id,
                     &auth_state,
                 )

--- a/crates/webauthn/src/api/register/finish.rs
+++ b/crates/webauthn/src/api/register/finish.rs
@@ -22,6 +22,7 @@ use validator::Validate;
 
 use openstack_keystone_api_types::error::KeystoneApiError;
 use openstack_keystone_core::api::auth::Auth;
+use openstack_keystone_core::auth::ExecutionContext;
 
 use crate::{
     WebauthnError,
@@ -61,7 +62,7 @@ pub(super) async fn finish(
         .core
         .provider
         .get_identity_provider()
-        .get_user(&state.core, &user_id)
+        .get_user(&ExecutionContext::internal(&state.core), &user_id)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {
@@ -84,7 +85,10 @@ pub(super) async fn finish(
     let Some(s) = state
         .extension
         .provider
-        .get_user_webauthn_credential_registration_state(&state.core, &user_id)
+        .get_user_webauthn_credential_registration_state(
+            &ExecutionContext::internal(&state.core),
+            &user_id,
+        )
         .await?
     else {
         return Err(KeystoneApiError::UnauthorizedNoContext);
@@ -102,7 +106,10 @@ pub(super) async fn finish(
     state
         .extension
         .provider
-        .delete_user_webauthn_credential_registration_state(&state.core, &user_id)
+        .delete_user_webauthn_credential_registration_state(
+            &ExecutionContext::internal(&state.core),
+            &user_id,
+        )
         .await?;
 
     let passkey = match state
@@ -116,7 +123,7 @@ pub(super) async fn finish(
             state
                 .extension
                 .provider
-                .create_user_webauthn_credential(&state.core, &cred)
+                .create_user_webauthn_credential(&ExecutionContext::internal(&state.core), &cred)
                 .await?
         }
         Err(err) => {

--- a/crates/webauthn/src/api/register/start.rs
+++ b/crates/webauthn/src/api/register/start.rs
@@ -22,6 +22,7 @@ use validator::Validate;
 
 use openstack_keystone_core::api::KeystoneApiError;
 use openstack_keystone_core::api::auth::Auth;
+use openstack_keystone_core::auth::ExecutionContext;
 
 use crate::{
     WebauthnError,
@@ -64,7 +65,7 @@ pub(super) async fn start(
         .core
         .provider
         .get_identity_provider()
-        .get_user(&state.core, &user_id)
+        .get_user(&ExecutionContext::internal(&state.core), &user_id)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {
@@ -96,7 +97,11 @@ pub(super) async fn start(
             state
                 .extension
                 .provider
-                .save_user_webauthn_credential_registration_state(&state.core, &user_id, &reg_state)
+                .save_user_webauthn_credential_registration_state(
+                    &ExecutionContext::internal(&state.core),
+                    &user_id,
+                    &reg_state,
+                )
                 .await?;
             Json(UserPasskeyRegistrationStartResponse::try_from(ccr).map_err(WebauthnError::from)?)
         }

--- a/crates/webauthn/src/driver/raft.rs
+++ b/crates/webauthn/src/driver/raft.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use webauthn_rs::prelude::{PasskeyAuthentication, PasskeyRegistration};
 
-use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_distributed_storage::{
     ApiStoreError, Metadata, StorageApi, StoreDataEnvelope,
 };
@@ -320,33 +320,20 @@ impl RaftDriver {
 
 #[async_trait]
 impl WebauthnApi for RaftDriver {
-    /// Cleanup expired Webauthn states.
-    ///
-    /// # Parameters
-    /// - `_state`: The service state.
-    ///
-    /// # Returns
-    /// A `Result` indicating success or failure.
     #[tracing::instrument(level = "debug", skip_all())]
-    async fn cleanup(&self, _state: &ServiceState) -> Result<(), WebauthnError> {
+    async fn cleanup<'a>(&self, _exec: &ExecutionContext<'a>) -> Result<(), WebauthnError> {
         Ok(())
     }
 
     /// Create webauthn credential for the user.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `credential`: The credential to create.
-    ///
-    /// # Returns
-    /// A `Result` containing the created credential, or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
-    async fn create_user_webauthn_credential(
+    #[tracing::instrument(level = "debug", skip(self, exec))]
+    async fn create_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         credential: &WebauthnCredential,
     ) -> Result<WebauthnCredential, WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -356,23 +343,15 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Get webauthn credential of the user by the credential_id.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `credential_id`: The credential ID.
-    ///
-    /// # Returns
-    /// A `Result` containing an `Option` with the WebauthnCredential if found,
-    /// or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn get_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
     ) -> Result<Option<WebauthnCredential>, WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -382,22 +361,15 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Delete credential for the user.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `credential_id`: The credential ID.
-    ///
-    /// # Returns
-    /// A `Result` indicating success or failure.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn delete_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
     ) -> Result<(), WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -407,20 +379,14 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Delete webauthn credential auth state for a user.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` indicating success or failure.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn delete_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<(), WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -435,20 +401,14 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Delete webauthn credential registration state for the user.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` indicating success or failure.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn delete_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<(), WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -459,21 +419,14 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Get webauthn credential auth state.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` containing an `Option` with the PasskeyAuthentication if
-    /// found, or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn get_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Option<PasskeyAuthentication>, WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -484,21 +437,14 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Get webauthn credential registration state.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` containing an `Option` with the PasskeyRegistration if found,
-    /// or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn get_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Option<PasskeyRegistration>, WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -509,20 +455,14 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// List user webauthn credentials.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` containing a list of credentials, or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn list_user_webauthn_credentials<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Vec<WebauthnCredential>, WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -532,22 +472,15 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Save webauthn credential auth state.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `auth_state`: The authentication state to save.
-    ///
-    /// # Returns
-    /// A `Result` indicating success or failure.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn save_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
         auth_state: &PasskeyAuthentication,
     ) -> Result<(), WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -563,22 +496,15 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Save webauthn credential registration state.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `reg_state`: The registration state to save.
-    ///
-    /// # Returns
-    /// A `Result` indicating success or failure.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn save_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
         reg_state: &PasskeyRegistration,
     ) -> Result<(), WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -594,24 +520,16 @@ impl WebauthnApi for RaftDriver {
     }
 
     /// Update credential data.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `credential_id`: The credential ID.
-    /// - `credential`: The credential data to update.
-    ///
-    /// # Returns
-    /// A `Result` containing the updated credential, or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn update_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
         credential: &WebauthnCredential,
     ) -> Result<WebauthnCredential, WebauthnError> {
-        let raft = state
+        let raft = exec
+            .state()
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
@@ -636,7 +554,7 @@ mod tests {
     const STATE_KEYSPACE: &str = "webauth_state_test";
 
     #[tokio::test]
-    async fn test_credential_storage() {
+    async fn test_credential_storage<'a>() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 
@@ -667,7 +585,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_credential_keys() {
+    async fn test_credential_keys<'a>() {
         let driver = RaftDriver::default();
         assert_eq!(
             driver.get_cred_key_name("user-1", "cred-1"),
@@ -677,7 +595,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_state_auth_key() {
+    async fn test_state_auth_key<'a>() {
         let driver = RaftDriver::default();
         assert_eq!(
             driver.get_user_cred_auth_state_key_name("user-1"),
@@ -686,7 +604,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_state_reg_key() {
+    async fn test_state_reg_key<'a>() {
         let driver = RaftDriver::default();
         assert_eq!(
             driver.get_user_cred_registration_state_key_name("user-1"),
@@ -695,7 +613,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_auth_state_save_and_get() {
+    async fn test_auth_state_save_and_get<'a>() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 
@@ -726,7 +644,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reg_state_save_and_get() {
+    async fn test_reg_state_save_and_get<'a>() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 
@@ -757,7 +675,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_credential_deletion() {
+    async fn test_credential_deletion<'a>() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 
@@ -788,7 +706,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_state_deletion() {
+    async fn test_state_deletion<'a>() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 

--- a/crates/webauthn/src/driver/sql.rs
+++ b/crates/webauthn/src/driver/sql.rs
@@ -19,9 +19,9 @@ use webauthn_rs::prelude::{PasskeyAuthentication, PasskeyRegistration};
 
 use openstack_keystone_core::SqlDriver as CoreSqlDriver;
 use openstack_keystone_core::SqlDriverRegistration;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::db::create_table;
 use openstack_keystone_core::error::DatabaseError;
-use openstack_keystone_core::keystone::ServiceState;
 
 use crate::{
     WebauthnError,
@@ -46,222 +46,115 @@ inventory::submit! {
 
 #[async_trait]
 impl WebauthnApi for SqlDriver {
-    /// Cleanup expired Webauthn states.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    ///
-    /// # Returns
-    /// A `Result` containing `()` on success, or a `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
-    async fn cleanup(&self, state: &ServiceState) -> Result<(), WebauthnError> {
-        state::delete_expired(&state.db).await
+    #[tracing::instrument(level = "debug", skip(self, exec))]
+    async fn cleanup<'a>(&self, exec: &ExecutionContext<'a>) -> Result<(), WebauthnError> {
+        state::delete_expired(&exec.state().db).await
     }
 
-    /// Create webauthn credential for the user.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `credential`: The credential to create.
-    ///
-    /// # Returns
-    /// A `Result` containing the created `WebauthnCredential`, or a
-    /// `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
-    async fn create_user_webauthn_credential(
+    #[tracing::instrument(level = "debug", skip(self, exec))]
+    async fn create_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         credential: &WebauthnCredential,
     ) -> Result<WebauthnCredential, WebauthnError> {
-        credential::create(&state.db, credential).await
+        credential::create(&exec.state().db, credential).await
     }
 
-    /// Get webauthn credential of the user by the credential_id.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `credential_id`: The credential ID.
-    ///
-    /// # Returns
-    /// A `Result` containing an `Option` with the `WebauthnCredential` if
-    /// found, or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn get_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
     ) -> Result<Option<WebauthnCredential>, WebauthnError> {
-        credential::find(&state.db, user_id, credential_id).await
+        credential::find(&exec.state().db, user_id, credential_id).await
     }
 
-    /// Delete credential for the user.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `credential_id`: The credential ID.
-    ///
-    /// # Returns
-    /// A `Result` containing `()` on success, or a `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn delete_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
     ) -> Result<(), WebauthnError> {
-        credential::delete(&state.db, user_id, credential_id).await?;
+        credential::delete(&exec.state().db, user_id, credential_id).await?;
         Ok(())
     }
 
-    /// Delete webauthn credential auth state for a user.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` containing `()` on success, or a `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn delete_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<(), WebauthnError> {
-        state::delete(&state.db, user_id, StateType::Auth).await
+        state::delete(&exec.state().db, user_id, StateType::Auth).await
     }
 
-    /// Delete webauthn credential registration state for the user.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` containing `()` on success, or a `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn delete_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<(), WebauthnError> {
-        state::delete(&state.db, user_id, StateType::Register).await
+        state::delete(&exec.state().db, user_id, StateType::Register).await
     }
 
-    /// Get webauthn credential auth state.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` containing an `Option` with the `PasskeyAuthentication` if
-    /// found, or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn get_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Option<PasskeyAuthentication>, WebauthnError> {
-        state::get_auth(&state.db, user_id).await
+        state::get_auth(&exec.state().db, user_id).await
     }
 
-    /// Get webauthn credential registration state.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` containing an `Option` with the `PasskeyRegistration` if
-    /// found, or an `Error`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn get_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Option<PasskeyRegistration>, WebauthnError> {
-        state::get_register(&state.db, user_id).await
+        state::get_register(&exec.state().db, user_id).await
     }
 
-    /// List user webauthn credentials.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    ///
-    /// # Returns
-    /// A `Result` containing a `Vec` of `WebauthnCredential`, or a
-    /// `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn list_user_webauthn_credentials<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Vec<WebauthnCredential>, WebauthnError> {
-        credential::list(&state.db, user_id).await
+        credential::list(&exec.state().db, user_id).await
     }
 
-    /// Save webauthn credential auth state.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `auth_state`: The authentication state to save.
-    ///
-    /// # Returns
-    /// A `Result` containing `()` on success, or a `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn save_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
         auth_state: &PasskeyAuthentication,
     ) -> Result<(), WebauthnError> {
-        state::create_auth(&state.db, user_id, auth_state).await
+        state::create_auth(&exec.state().db, user_id, auth_state).await
     }
 
-    /// Save webauthn credential registration state.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `reg_state`: The registration state to save.
-    ///
-    /// # Returns
-    /// A `Result` containing `()` on success, or a `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn save_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
         reg_state: &PasskeyRegistration,
     ) -> Result<(), WebauthnError> {
-        state::create_register(&state.db, user_id, reg_state).await
+        state::create_register(&exec.state().db, user_id, reg_state).await
     }
 
-    /// Update credential data.
-    ///
-    /// # Parameters
-    /// - `state`: The service state.
-    /// - `user_id`: The user ID.
-    /// - `credential_id`: The credential ID.
-    /// - `credential`: The updated credential data.
-    ///
-    /// # Returns
-    /// A `Result` containing the updated `WebauthnCredential`, or a
-    /// `WebauthnError`.
-    #[tracing::instrument(level = "debug", skip(self, state))]
+    #[tracing::instrument(level = "debug", skip(self, exec))]
     async fn update_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
         credential: &WebauthnCredential,
     ) -> Result<WebauthnCredential, WebauthnError> {
-        credential::update(&state.db, user_id, credential_id, credential).await
+        credential::update(&exec.state().db, user_id, credential_id, credential).await
     }
 }
 

--- a/crates/webauthn/src/types/provider.rs
+++ b/crates/webauthn/src/types/provider.rs
@@ -16,7 +16,7 @@
 use async_trait::async_trait;
 use webauthn_rs::prelude::{PasskeyAuthentication, PasskeyRegistration};
 
-use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 
 use crate::{WebauthnError, types::WebauthnCredential};
 
@@ -27,31 +27,31 @@ pub trait WebauthnApi: Send + Sync {
     /// Cleanup expired Webauthn states.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     ///
     /// # Returns
     /// A `Result` containing `()` on success, or a `WebauthnError`.
-    async fn cleanup(&self, state: &ServiceState) -> Result<(), WebauthnError>;
+    async fn cleanup<'a>(&self, exec: &ExecutionContext<'a>) -> Result<(), WebauthnError>;
 
     /// Create passkey.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `passkey`: The credential to create.
     ///
     /// # Returns
     /// A `Result` containing the created `WebauthnCredential`, or a
     /// `WebauthnError`.
-    async fn create_user_webauthn_credential(
+    async fn create_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
+        exec: &ExecutionContext<'a>,
         passkey: &WebauthnCredential,
     ) -> Result<WebauthnCredential, WebauthnError>;
 
     /// Get webauthn credential of the user by the credential_id.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     /// - `credential_id`: The credential ID.
     ///
@@ -60,15 +60,15 @@ pub trait WebauthnApi: Send + Sync {
     /// found, or an `Error`.
     async fn get_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
     ) -> Result<Option<WebauthnCredential>, WebauthnError>;
 
     /// Delete credential for the user.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     /// - `credential_id`: The credential ID.
     ///
@@ -76,43 +76,43 @@ pub trait WebauthnApi: Send + Sync {
     /// A `Result` containing `()` on success, or a `WebauthnError`.
     async fn delete_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
     ) -> Result<(), WebauthnError>;
 
-    /// Delete credential registration state for the user user.
+    /// Delete credential authentication state for the user.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     ///
     /// # Returns
     /// A `Result` containing `()` on success, or a `WebauthnError`.
     async fn delete_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<(), WebauthnError>;
 
     /// Delete credential registration state for the user.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     ///
     /// # Returns
     /// A `Result` containing `()` on success, or a `WebauthnError`.
     async fn delete_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<(), WebauthnError>;
 
     /// Get authentication state for the user.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     ///
     /// # Returns
@@ -120,14 +120,14 @@ pub trait WebauthnApi: Send + Sync {
     /// found, or an `Error`.
     async fn get_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Option<PasskeyAuthentication>, WebauthnError>;
 
     /// Get credential registration state for the user.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     ///
     /// # Returns
@@ -135,14 +135,14 @@ pub trait WebauthnApi: Send + Sync {
     /// found, or an `Error`.
     async fn get_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Option<PasskeyRegistration>, WebauthnError>;
 
     /// List credentials of the user.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     ///
     /// # Returns
@@ -150,14 +150,14 @@ pub trait WebauthnApi: Send + Sync {
     /// `WebauthnError`.
     async fn list_user_webauthn_credentials<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
     ) -> Result<Vec<WebauthnCredential>, WebauthnError>;
 
-    /// State the authentication state.
+    /// Save the authentication state.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     /// - `auth`: The authentication state to save.
     ///
@@ -165,15 +165,15 @@ pub trait WebauthnApi: Send + Sync {
     /// A `Result` containing `()` on success, or a `WebauthnError`.
     async fn save_user_webauthn_credential_authentication_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
         auth: &PasskeyAuthentication,
     ) -> Result<(), WebauthnError>;
 
     /// Save credential registration state.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     /// - `reg_state`: The registration state to save.
     ///
@@ -181,15 +181,15 @@ pub trait WebauthnApi: Send + Sync {
     /// A `Result` containing `()` on success, or a `WebauthnError`.
     async fn save_user_webauthn_credential_registration_state<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
         reg_state: &PasskeyRegistration,
     ) -> Result<(), WebauthnError>;
 
     /// Update credential data.
     ///
     /// # Parameters
-    /// - `state`: The service state.
+    /// - `exec`: The execution context.
     /// - `user_id`: The user ID.
     /// - `credential_id`: The credential ID.
     /// - `credential`: The updated credential data.
@@ -199,9 +199,9 @@ pub trait WebauthnApi: Send + Sync {
     /// `WebauthnError`.
     async fn update_user_webauthn_credential<'a>(
         &self,
-        state: &ServiceState,
-        user_id: &'a str,
-        credential_id: &'a str,
+        exec: &ExecutionContext<'a>,
+        user_id: &str,
+        credential_id: &str,
         credential: &WebauthnCredential,
     ) -> Result<WebauthnCredential, WebauthnError>;
 }

--- a/crates/webauthn/tests/api.rs
+++ b/crates/webauthn/tests/api.rs
@@ -31,6 +31,7 @@ use webauthn_authenticator_rs::softtoken::SoftToken;
 
 use openstack_keystone_api_types::webauthn::*;
 use openstack_keystone_core::assignment::MockAssignmentProvider;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::identity::MockIdentityProvider;
 use openstack_keystone_core::provider::{Provider, ProviderBuilder};
 use openstack_keystone_core::resource::MockResourceProvider;
@@ -151,7 +152,6 @@ fn get_provider_mocks(user_id: &Uuid) -> ProviderBuilder {
     let mut assignment_mock = MockAssignmentProvider::default();
     assignment_mock
         .expect_list_role_assignments()
-        .withf(|_, _s| true)
         .returning(|_, _| {
             Ok(vec![Assignment {
                 role_id: "role".into(),
@@ -165,13 +165,13 @@ fn get_provider_mocks(user_id: &Uuid) -> ProviderBuilder {
         });
     let mut identity_mock = MockIdentityProvider::default();
     let uid = user_id.to_string().clone();
-    identity_mock.expect_get_user().returning(move |_, _| {
+    identity_mock.expect_get_user().returning(move |_exec, _| {
         Ok(Some(
             UserResponseBuilder::default()
                 .id(uid.clone())
-                .domain_id("user_domain_id")
+                .domain_id(user.domain_id.clone())
                 .enabled(true)
-                .name("name")
+                .name(user.name.clone())
                 .build()
                 .unwrap(),
         ))
@@ -180,16 +180,10 @@ fn get_provider_mocks(user_id: &Uuid) -> ProviderBuilder {
 
     resource_mock
         .expect_get_project()
-        .withf(|_, id: &'_ str| id == "project_id")
-        .returning(move |_, _| Ok(Some(project.clone())));
+        .returning(move |_exec, _| Ok(Some(project.clone())));
     resource_mock
         .expect_get_domain()
-        .withf(|_, id: &'_ str| id == "user_domain_id")
-        .returning(move |_, _| Ok(Some(user_domain.clone())));
-    resource_mock
-        .expect_get_domain()
-        .withf(|_, id: &'_ str| id == "project_domain_id")
-        .returning(move |_, _| Ok(Some(project_domain.clone())));
+        .returning(move |_exec, _| Ok(Some(user_domain.clone())));
 
     provider_builder
         .mock_assignment(assignment_mock)
@@ -270,14 +264,11 @@ async fn test_webauthn_roundtrip() -> Result<()> {
         .await?;
 
     // Check the credential is actually saved in the storage
+    let exec = ExecutionContext::internal(&state.core);
     state
         .extension
         .provider
-        .get_user_webauthn_credential(
-            &state.core,
-            &user_id.to_string(),
-            &passkey.passkey.credential_id,
-        )
+        .get_user_webauthn_credential(&exec, &user_id.to_string(), &passkey.passkey.credential_id)
         .await?
         .expect("must be found");
 

--- a/crates/webauthn/tests/provider.rs
+++ b/crates/webauthn/tests/provider.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 use webauthn_authenticator_rs::WebauthnAuthenticator;
 use webauthn_authenticator_rs::softtoken::SoftToken;
 
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_webauthn::types::*;
 
 mod common;
@@ -28,6 +29,7 @@ use common::{generate_webauthn_credential, get_state};
 async fn test_webauthn_register() -> Result<()> {
     let (state, _dir) = get_state(None).await?;
     let user_id = Uuid::new_v4();
+    let exec = ExecutionContext::internal(&state.core);
 
     let (_ccr, reg_state) = state.extension.webauthn.start_passkey_registration(
         user_id,
@@ -38,16 +40,12 @@ async fn test_webauthn_register() -> Result<()> {
     state
         .extension
         .provider
-        .save_user_webauthn_credential_registration_state(
-            &state.core,
-            &user_id.to_string(),
-            &reg_state,
-        )
+        .save_user_webauthn_credential_registration_state(&exec, &user_id.to_string(), &reg_state)
         .await?;
     let reg_state_2 = state
         .extension
         .provider
-        .get_user_webauthn_credential_registration_state(&state.core, &user_id.to_string())
+        .get_user_webauthn_credential_registration_state(&exec, &user_id.to_string())
         .await?
         .unwrap();
     assert_eq!(
@@ -57,13 +55,13 @@ async fn test_webauthn_register() -> Result<()> {
     state
         .extension
         .provider
-        .delete_user_webauthn_credential_registration_state(&state.core, &user_id.to_string())
+        .delete_user_webauthn_credential_registration_state(&exec, &user_id.to_string())
         .await?;
     assert!(
         state
             .extension
             .provider
-            .get_user_webauthn_credential_registration_state(&state.core, &user_id.to_string())
+            .get_user_webauthn_credential_registration_state(&exec, &user_id.to_string())
             .await?
             .is_none()
     );
@@ -75,6 +73,7 @@ async fn test_webauthn_register() -> Result<()> {
 async fn test_webauthn_auth() -> Result<()> {
     let (state, _dir) = get_state(None).await?;
     let user_id = Uuid::new_v4();
+    let exec = ExecutionContext::internal(&state.core);
 
     let mut authenticator = WebauthnAuthenticator::new(SoftToken::new(true)?.0);
     let cred = generate_webauthn_credential(&state, &mut authenticator, user_id)?;
@@ -88,7 +87,7 @@ async fn test_webauthn_auth() -> Result<()> {
         .extension
         .provider
         .save_user_webauthn_credential_authentication_state(
-            &state.core,
+            &exec,
             &user_id.to_string(),
             &auth_state,
         )
@@ -96,7 +95,7 @@ async fn test_webauthn_auth() -> Result<()> {
     let auth_state_2 = state
         .extension
         .provider
-        .get_user_webauthn_credential_authentication_state(&state.core, &user_id.to_string())
+        .get_user_webauthn_credential_authentication_state(&exec, &user_id.to_string())
         .await?
         .unwrap();
     assert_eq!(
@@ -106,13 +105,13 @@ async fn test_webauthn_auth() -> Result<()> {
     state
         .extension
         .provider
-        .delete_user_webauthn_credential_authentication_state(&state.core, &user_id.to_string())
+        .delete_user_webauthn_credential_authentication_state(&exec, &user_id.to_string())
         .await?;
     assert!(
         state
             .extension
             .provider
-            .get_user_webauthn_credential_authentication_state(&state.core, &user_id.to_string())
+            .get_user_webauthn_credential_authentication_state(&exec, &user_id.to_string())
             .await?
             .is_none()
     );
@@ -142,6 +141,7 @@ async fn test_webauthn_credential() -> Result<()> {
     let authenticator_backend = SoftToken::new(true)?.0;
     let mut authenticator = WebauthnAuthenticator::new(authenticator_backend);
     let user_id = Uuid::new_v4();
+    let exec = ExecutionContext::internal(&state.core);
 
     let mut cred1 = generate_webauthn_credential(&state, &mut authenticator, user_id)?;
     let cred2 = generate_webauthn_credential(&state, &mut authenticator, user_id)?;
@@ -149,19 +149,19 @@ async fn test_webauthn_credential() -> Result<()> {
     let res = state
         .extension
         .provider
-        .create_user_webauthn_credential(&state.core, &cred1)
+        .create_user_webauthn_credential(&exec, &cred1)
         .await?;
     compare_credential(&res, &cred1);
     state
         .extension
         .provider
-        .create_user_webauthn_credential(&state.core, &cred2)
+        .create_user_webauthn_credential(&exec, &cred2)
         .await?;
 
     let list = state
         .extension
         .provider
-        .list_user_webauthn_credentials(&state.core, &user_id.to_string())
+        .list_user_webauthn_credentials(&exec, &user_id.to_string())
         .await?;
     assert_eq!(2, list.len());
     assert!(
@@ -178,26 +178,26 @@ async fn test_webauthn_credential() -> Result<()> {
     let res = state
         .extension
         .provider
-        .update_user_webauthn_credential(&state.core, &cred1.user_id, &cred1.credential_id, &cred1)
+        .update_user_webauthn_credential(&exec, &cred1.user_id, &cred1.credential_id, &cred1)
         .await?;
     compare_credential(&cred1, &res);
     let updated_cred = state
         .extension
         .provider
-        .get_user_webauthn_credential(&state.core, &cred1.user_id, &cred1.credential_id)
+        .get_user_webauthn_credential(&exec, &cred1.user_id, &cred1.credential_id)
         .await?
         .expect("must be found");
     compare_credential(&cred1, &updated_cred);
     state
         .extension
         .provider
-        .delete_user_webauthn_credential(&state.core, &cred1.user_id, &cred1.credential_id)
+        .delete_user_webauthn_credential(&exec, &cred1.user_id, &cred1.credential_id)
         .await?;
     assert!(
         state
             .extension
             .provider
-            .get_user_webauthn_credential(&state.core, &cred1.user_id, &cred1.credential_id)
+            .get_user_webauthn_credential(&exec, &cred1.user_id, &cred1.credential_id)
             .await?
             .is_none()
     );
@@ -205,7 +205,7 @@ async fn test_webauthn_credential() -> Result<()> {
         &state
             .extension
             .provider
-            .get_user_webauthn_credential(&state.core, &cred2.user_id, &cred2.credential_id)
+            .get_user_webauthn_credential(&exec, &cred2.user_id, &cred2.credential_id)
             .await?
             .expect("must be present"),
         &cred2,
@@ -220,6 +220,7 @@ async fn test_webauthn_roundtrip() -> Result<()> {
     let authenticator_backend = SoftToken::new(true)?.0;
     let origin = Url::parse("https://keystone.local")?;
     let mut authenticator = WebauthnAuthenticator::new(authenticator_backend);
+    let exec = ExecutionContext::internal(&state.core);
 
     // init new cred registration
     let (ccr, reg_state) = state.extension.webauthn.start_passkey_registration(
@@ -232,11 +233,7 @@ async fn test_webauthn_roundtrip() -> Result<()> {
     state
         .extension
         .provider
-        .save_user_webauthn_credential_registration_state(
-            &state.core,
-            &user_id.to_string(),
-            &reg_state,
-        )
+        .save_user_webauthn_credential_registration_state(&exec, &user_id.to_string(), &reg_state)
         .await?;
 
     // user signs request
@@ -245,7 +242,7 @@ async fn test_webauthn_roundtrip() -> Result<()> {
     let reg_state_2 = state
         .extension
         .provider
-        .get_user_webauthn_credential_registration_state(&state.core, &user_id.to_string())
+        .get_user_webauthn_credential_registration_state(&exec, &user_id.to_string())
         .await?
         .unwrap();
 
@@ -262,7 +259,7 @@ async fn test_webauthn_roundtrip() -> Result<()> {
     state
         .extension
         .provider
-        .create_user_webauthn_credential(&state.core, &cred)
+        .create_user_webauthn_credential(&exec, &cred)
         .await?;
 
     // user inits authentication
@@ -276,7 +273,7 @@ async fn test_webauthn_roundtrip() -> Result<()> {
         .extension
         .provider
         .save_user_webauthn_credential_authentication_state(
-            &state.core,
+            &exec,
             &user_id.to_string(),
             &auth_state,
         )
@@ -295,7 +292,7 @@ async fn test_webauthn_roundtrip() -> Result<()> {
     let auth_state_2 = state
         .extension
         .provider
-        .get_user_webauthn_credential_authentication_state(&state.core, &user_id.to_string())
+        .get_user_webauthn_credential_authentication_state(&exec, &user_id.to_string())
         .await?
         .unwrap();
 

--- a/tests/api/src/auth/project.rs
+++ b/tests/api/src/auth/project.rs
@@ -16,6 +16,8 @@ use std::sync::Arc;
 
 use eyre::Result;
 
+use crate::common::get_session_by_user_password;
+use crate::guard::ResourceGuard;
 use openstack_keystone_api_types::v3::project::ProjectShort;
 use openstack_sdk::api::rest_endpoint_prelude::*;
 use openstack_sdk::{AsyncOpenStack, api::QueryAsync};

--- a/tests/integration/src/application_credential.rs
+++ b/tests/integration/src/application_credential.rs
@@ -13,10 +13,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Report;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::application_credential::ApplicationCredentialCreate;
 use std::sync::Arc;
 
-use openstack_keystone::application_credential::ApplicationCredentialApi;
 use openstack_keystone_core::keystone::Service;
 use openstack_keystone_core_types::application_credential as types;
 
@@ -35,7 +35,7 @@ async fn create_application_credential(
     let res = state
         .provider
         .get_application_credential_provider()
-        .create_application_credential(state, data)
+        .create_application_credential(&ExecutionContext::internal(&state), data)
         .await?;
     Ok(res)
 }

--- a/tests/integration/src/application_credential/access_rule.rs
+++ b/tests/integration/src/application_credential/access_rule.rs
@@ -17,9 +17,8 @@ use eyre::Report;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::application_credential::{
-    ApplicationCredentialApi, ApplicationCredentialProviderError,
-};
+use openstack_keystone::application_credential::ApplicationCredentialProviderError;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::application_credential::*;
 
 use crate::common::get_state;
@@ -36,7 +35,7 @@ async fn test_access_rule_crd() -> Result<(), Report> {
     // Create
     let created = provider
         .create_access_rule(
-            &state,
+            &ExecutionContext::internal(&state),
             AccessRuleCreate {
                 id: None,
                 path: Some("/v2.1/servers".into()),
@@ -54,13 +53,15 @@ async fn test_access_rule_crd() -> Result<(), Report> {
 
     // Get
     let fetched = provider
-        .get_access_rule(&state, &user.id, &created.id)
+        .get_access_rule(&ExecutionContext::internal(&state), &user.id, &created.id)
         .await?
         .expect("access rule is present");
     assert_eq!(fetched, created, "fetched rule matches the created one");
 
     // List
-    let listed = provider.list_access_rules(&state, &user.id).await?;
+    let listed = provider
+        .list_access_rules(&ExecutionContext::internal(&state), &user.id)
+        .await?;
     assert!(
         listed.iter().any(|r| r.id == created.id),
         "created rule is listed"
@@ -68,11 +69,11 @@ async fn test_access_rule_crd() -> Result<(), Report> {
 
     // Delete
     provider
-        .delete_access_rule(&state, &user.id, &created.id)
+        .delete_access_rule(&ExecutionContext::internal(&state), &user.id, &created.id)
         .await?;
     assert!(
         provider
-            .get_access_rule(&state, &user.id, &created.id)
+            .get_access_rule(&ExecutionContext::internal(&state), &user.id, &created.id)
             .await?
             .is_none(),
         "rule is gone after delete"
@@ -91,7 +92,7 @@ async fn test_delete_access_rule_not_found() -> Result<(), Report> {
     let result = state
         .provider
         .get_application_credential_provider()
-        .delete_access_rule(&state, &user.id, "missing")
+        .delete_access_rule(&ExecutionContext::internal(&state), &user.id, "missing")
         .await;
 
     assert!(
@@ -118,7 +119,7 @@ async fn test_delete_access_rule_in_use() -> Result<(), Report> {
     let rule_id = Uuid::new_v4().to_string();
     provider
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 access_rules: Some(vec![AccessRuleCreate {
                     id: Some(rule_id.clone()),
@@ -137,7 +138,7 @@ async fn test_delete_access_rule_in_use() -> Result<(), Report> {
         .await?;
 
     let result = provider
-        .delete_access_rule(&state, &user.id, &rule_id)
+        .delete_access_rule(&ExecutionContext::internal(&state), &user.id, &rule_id)
         .await;
 
     assert!(

--- a/tests/integration/src/application_credential/create.rs
+++ b/tests/integration/src/application_credential/create.rs
@@ -19,9 +19,8 @@ use secrecy::ExposeSecret;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::application_credential::{
-    ApplicationCredentialApi, ApplicationCredentialProviderError,
-};
+use openstack_keystone::application_credential::ApplicationCredentialProviderError;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::application_credential::*;
 use openstack_keystone_core_types::role::*;
 
@@ -55,7 +54,7 @@ async fn test_create_basic() -> Result<(), Report> {
     let cred: ApplicationCredentialCreateResponse = state
         .provider
         .get_application_credential_provider()
-        .create_application_credential(&state, sot.clone())
+        .create_application_credential(&ExecutionContext::internal(&state), sot.clone())
         .await?;
 
     assert!(
@@ -101,7 +100,7 @@ async fn test_create_id_reuse() -> Result<(), Report> {
     let cred: ApplicationCredentialCreateResponse = state
         .provider
         .get_application_credential_provider()
-        .create_application_credential(&state, sot.clone())
+        .create_application_credential(&ExecutionContext::internal(&state), sot.clone())
         .await?;
 
     assert_eq!(
@@ -125,7 +124,7 @@ async fn test_create_secret_reuse() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 name: Uuid::new_v4().to_string(),
                 project_id: project.id.clone(),
@@ -157,7 +156,7 @@ async fn test_create_nonexisting_role() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 name: Uuid::new_v4().to_string(),
                 project_id: project.id.clone(),
@@ -192,7 +191,7 @@ async fn test_create_role() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 name: Uuid::new_v4().to_string(),
                 project_id: project.id.clone(),

--- a/tests/integration/src/application_credential/get.rs
+++ b/tests/integration/src/application_credential/get.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeSet;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::application_credential::ApplicationCredentialApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::application_credential::*;
 use openstack_keystone_core_types::role::*;
 
@@ -38,7 +38,7 @@ async fn test_get() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 access_rules: Some(vec![AccessRuleCreate {
                     id: None,
@@ -60,7 +60,7 @@ async fn test_get() -> Result<(), Report> {
     let cred: ApplicationCredential = state
         .provider
         .get_application_credential_provider()
-        .get_application_credential(&state, &sot.id)
+        .get_application_credential(&ExecutionContext::internal(&state), &sot.id)
         .await?
         .expect("appcred found");
 

--- a/tests/integration/src/application_credential/list.rs
+++ b/tests/integration/src/application_credential/list.rs
@@ -16,7 +16,7 @@
 use eyre::Report;
 use tracing_test::traced_test;
 
-use openstack_keystone::application_credential::ApplicationCredentialApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::application_credential::*;
 
 use crate::common::get_state;
@@ -37,7 +37,7 @@ async fn test_list() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .list_application_credentials(
-            &state,
+            &ExecutionContext::internal(&state),
             &ApplicationCredentialListParameters {
                 user_id: user.id.clone(),
                 ..Default::default()
@@ -52,7 +52,7 @@ async fn test_list() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .list_application_credentials(
-            &state,
+            &ExecutionContext::internal(&state),
             &ApplicationCredentialListParameters {
                 user_id: "missing".into(),
                 ..Default::default()
@@ -85,7 +85,7 @@ async fn test_list_limit() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .list_application_credentials(
-            &state,
+            &ExecutionContext::internal(&state),
             &ApplicationCredentialListParameters {
                 user_id: user.id.clone(),
                 limit: Some(5),
@@ -120,7 +120,7 @@ async fn test_list_by_name() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .list_application_credentials(
-            &state,
+            &ExecutionContext::internal(&state),
             &ApplicationCredentialListParameters {
                 user_id: user.id.clone(),
                 name: Some(ac1.name.clone()),

--- a/tests/integration/src/assignment.rs
+++ b/tests/integration/src/assignment.rs
@@ -14,8 +14,8 @@
 use eyre::Result;
 use std::sync::Arc;
 
-use openstack_keystone::assignment::AssignmentApi;
 use openstack_keystone::keystone::Service;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::assignment::*;
 
 mod grant;
@@ -30,7 +30,7 @@ pub async fn grant_role_to_user_on_project<U: Into<String>, P: Into<String>, R: 
         .provider
         .get_assignment_provider()
         .create_grant(
-            state,
+            &ExecutionContext::internal(&state),
             AssignmentCreate::user_project(user, project, role, false),
         )
         .await?;
@@ -69,7 +69,7 @@ pub async fn check_grant(state: &Arc<Service>, assignment: &Assignment) -> Resul
     let assignments = state
         .provider
         .get_assignment_provider()
-        .list_role_assignments(state, &params.build()?)
+        .list_role_assignments(&ExecutionContext::internal(&state), &params.build()?)
         .await?;
     Ok(!assignments.is_empty())
 }

--- a/tests/integration/src/assignment/grant/list.rs
+++ b/tests/integration/src/assignment/grant/list.rs
@@ -17,9 +17,8 @@ use eyre::Result;
 use std::collections::BTreeSet;
 use tracing_test::traced_test;
 
-use openstack_keystone::assignment::AssignmentApi;
-use openstack_keystone::identity::IdentityApi;
 use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::assignment::*;
 
 use crate::common::get_state;
@@ -32,7 +31,7 @@ async fn list_grants(
     Ok(state
         .provider
         .get_assignment_provider()
-        .list_role_assignments(state, params)
+        .list_role_assignments(&ExecutionContext::internal(&state), params)
         .await?
         .into_iter()
         .map(|grant| grant.role_id)
@@ -61,7 +60,7 @@ async fn test_list_user_roles() -> Result<()> {
     state
         .provider
         .get_identity_provider()
-        .add_user_to_group(&state, &user.id, &group.id)
+        .add_user_to_group(&ExecutionContext::internal(&state), &user.id, &group.id)
         .await?;
     for assignment in [
         AssignmentCreate::user_domain(&user.id, &domain.id, &role_a.id, false),
@@ -76,7 +75,7 @@ async fn test_list_user_roles() -> Result<()> {
         state
             .provider
             .get_assignment_provider()
-            .create_grant(&state, assignment)
+            .create_grant(&ExecutionContext::internal(&state), assignment)
             .await?;
     }
 
@@ -219,7 +218,7 @@ async fn test_list_role_assignments_by_user_same_role_multiple_scopes() -> Resul
         state
             .provider
             .get_assignment_provider()
-            .create_grant(&state, assignment)
+            .create_grant(&ExecutionContext::internal(&state), assignment)
             .await?;
     }
 
@@ -227,7 +226,7 @@ async fn test_list_role_assignments_by_user_same_role_multiple_scopes() -> Resul
         .provider
         .get_assignment_provider()
         .list_role_assignments(
-            &state,
+            &ExecutionContext::internal(&state),
             &RoleAssignmentListParametersBuilder::default()
                 .user_id(user.id.clone())
                 .build()?,
@@ -263,7 +262,7 @@ async fn test_list_role_assignments_by_role_id_same_role_multiple_scopes() -> Re
         state
             .provider
             .get_assignment_provider()
-            .create_grant(&state, assignment)
+            .create_grant(&ExecutionContext::internal(&state), assignment)
             .await?;
     }
 
@@ -271,7 +270,7 @@ async fn test_list_role_assignments_by_role_id_same_role_multiple_scopes() -> Re
         .provider
         .get_assignment_provider()
         .list_role_assignments(
-            &state,
+            &ExecutionContext::internal(&state),
             &RoleAssignmentListParametersBuilder::default()
                 .role_id(role.id.clone())
                 .build()?,

--- a/tests/integration/src/assignment/grant/revoke.rs
+++ b/tests/integration/src/assignment/grant/revoke.rs
@@ -19,10 +19,9 @@ use std::ops::Deref;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::application_credential::ApplicationCredentialApi;
-use openstack_keystone::assignment::AssignmentApi;
 use openstack_keystone::auth::*;
 use openstack_keystone::token::{TokenApi, TokenProviderError};
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::application_credential::*;
 use openstack_keystone_core_types::assignment::*;
 use openstack_keystone_core_types::resource::*;
@@ -61,7 +60,7 @@ async fn test_revoke_user_project_grant() -> Result<()> {
     state
         .provider
         .get_assignment_provider()
-        .revoke_grant(&state, assignment.clone())
+        .revoke_grant(&ExecutionContext::internal(&state), assignment.clone())
         .await?;
 
     // Verify grant no longer exists
@@ -117,7 +116,7 @@ async fn test_revoke_user_project_grant_auth_impact() -> Result<()> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 access_rules: None,
                 name: Uuid::new_v4().to_string(),
@@ -162,7 +161,7 @@ async fn test_revoke_user_project_grant_auth_impact() -> Result<()> {
     let pre_revoke_token_context = state
         .provider
         .get_token_provider()
-        .issue_token_context(&state, &ctx, &authz.clone())
+        .issue_token_context(&ExecutionContext::internal(&state), &ctx, &authz.clone())
         .await?;
     let pre_revoke_encoded = state
         .provider
@@ -174,7 +173,12 @@ async fn test_revoke_user_project_grant_auth_impact() -> Result<()> {
         state
             .provider
             .get_token_provider()
-            .validate_to_context(&state, &pre_revoke_encoded, None, None)
+            .validate_to_context(
+                &ExecutionContext::internal(&state),
+                &pre_revoke_encoded,
+                None,
+                None
+            )
             .await
             .is_ok(),
         "Token should be valid before revocation"
@@ -184,7 +188,7 @@ async fn test_revoke_user_project_grant_auth_impact() -> Result<()> {
     state
         .provider
         .get_assignment_provider()
-        .revoke_grant(&state, assignment_a.clone())
+        .revoke_grant(&ExecutionContext::internal(&state), assignment_a.clone())
         .await?;
     // CHECK 1: listing roles no longer returns the revoked role
     assert!(
@@ -198,7 +202,12 @@ async fn test_revoke_user_project_grant_auth_impact() -> Result<()> {
             state
                 .provider
                 .get_token_provider()
-                .validate_to_context(&state, &pre_revoke_encoded, None, None)
+                .validate_to_context(
+                    &ExecutionContext::internal(&state),
+                    &pre_revoke_encoded,
+                    None,
+                    None
+                )
                 .await,
             Err(TokenProviderError::TokenRevoked)
         ),
@@ -213,7 +222,7 @@ async fn test_revoke_user_project_grant_auth_impact() -> Result<()> {
     let post_revoke_token_ctx = state
         .provider
         .get_token_provider()
-        .issue_token_context(&state, &ctx, &authz.clone())
+        .issue_token_context(&ExecutionContext::internal(&state), &ctx, &authz.clone())
         .await?;
     let post_revoke_encoded = state
         .provider
@@ -223,7 +232,12 @@ async fn test_revoke_user_project_grant_auth_impact() -> Result<()> {
     let validated = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &post_revoke_encoded, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &post_revoke_encoded,
+            None,
+            None,
+        )
         .await?;
 
     let roles = validated

--- a/tests/integration/src/catalog.rs
+++ b/tests/integration/src/catalog.rs
@@ -23,9 +23,9 @@ use eyre::Result;
 
 use openstack_keystone::keystone::Service;
 use openstack_keystone::keystone::ServiceState;
-use openstack_keystone_core::catalog::CatalogApi;
 // The catalog domain type is also called `Service`, which clashes with the
 // Keystone `Service` state struct imported above, so it is aliased here.
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::Service as CatalogService;
 use openstack_keystone_core_types::catalog::*;
 
@@ -50,7 +50,7 @@ pub async fn create_endpoint(
     let res = state
         .provider
         .get_catalog_provider()
-        .create_endpoint(state, data)
+        .create_endpoint(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))
@@ -65,7 +65,7 @@ pub async fn create_region(
     let res = state
         .provider
         .get_catalog_provider()
-        .create_region(state, data)
+        .create_region(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))
@@ -80,7 +80,7 @@ pub async fn create_service(
     let res = state
         .provider
         .get_catalog_provider()
-        .create_service(state, data)
+        .create_service(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))

--- a/tests/integration/src/catalog/endpoint/create.rs
+++ b/tests/integration/src/catalog/endpoint/create.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{EndpointCreate, ServiceCreate};
 
 use crate::catalog::{create_endpoint, create_service};
@@ -72,7 +72,7 @@ async fn test_create_id_too_long() -> Result<()> {
         .provider
         .get_catalog_provider()
         .create_endpoint(
-            &state,
+            &ExecutionContext::internal(&state),
             EndpointCreate {
                 enabled: true,
                 extra: HashMap::new(),

--- a/tests/integration/src/catalog/endpoint/delete.rs
+++ b/tests/integration/src/catalog/endpoint/delete.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{EndpointCreate, ServiceCreate};
 
 use crate::catalog::create_service;
@@ -43,7 +43,7 @@ async fn test_delete() -> Result<()> {
 
     let endpoint = provider
         .create_endpoint(
-            &state,
+            &ExecutionContext::internal(&state),
             EndpointCreate {
                 enabled: true,
                 extra: HashMap::new(),
@@ -56,9 +56,13 @@ async fn test_delete() -> Result<()> {
         )
         .await?;
 
-    provider.delete_endpoint(&state, &endpoint.id).await?;
+    provider
+        .delete_endpoint(&ExecutionContext::internal(&state), &endpoint.id)
+        .await?;
 
-    let fetched = provider.get_endpoint(&state, &endpoint.id).await?;
+    let fetched = provider
+        .get_endpoint(&ExecutionContext::internal(&state), &endpoint.id)
+        .await?;
     assert!(fetched.is_none(), "endpoint should be gone after delete");
     Ok(())
 }

--- a/tests/integration/src/catalog/endpoint/get.rs
+++ b/tests/integration/src/catalog/endpoint/get.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{EndpointCreate, ServiceCreate};
 
 use crate::catalog::{create_endpoint, create_service};
@@ -56,7 +56,7 @@ async fn test_get() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_endpoint(&state, &endpoint.id)
+        .get_endpoint(&ExecutionContext::internal(&state), &endpoint.id)
         .await?;
 
     assert!(fetched.is_some());
@@ -75,7 +75,7 @@ async fn test_get_not_found() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_endpoint(&state, "does-not-exist")
+        .get_endpoint(&ExecutionContext::internal(&state), "does-not-exist")
         .await?;
     assert!(fetched.is_none());
     Ok(())

--- a/tests/integration/src/catalog/endpoint/list.rs
+++ b/tests/integration/src/catalog/endpoint/list.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{
     EndpointCreate, EndpointListParameters, ServiceCreate,
 };
@@ -59,7 +59,10 @@ async fn test_list() -> Result<()> {
     let endpoints = state
         .provider
         .get_catalog_provider()
-        .list_endpoints(&state, &EndpointListParameters::default())
+        .list_endpoints(
+            &ExecutionContext::internal(&state),
+            &EndpointListParameters::default(),
+        )
         .await?;
 
     let ids: Vec<&str> = endpoints.iter().map(|e| e.id.as_str()).collect();
@@ -90,7 +93,7 @@ async fn test_list_filter_by_interface() -> Result<()> {
         .provider
         .get_catalog_provider()
         .list_endpoints(
-            &state,
+            &ExecutionContext::internal(&state),
             &EndpointListParameters {
                 interface: Some("public".to_string()),
                 service_id: Some(service.id.clone()),

--- a/tests/integration/src/catalog/endpoint/update.rs
+++ b/tests/integration/src/catalog/endpoint/update.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{EndpointCreate, EndpointUpdate, ServiceCreate};
 
 use crate::catalog::{create_endpoint, create_service};
@@ -57,7 +57,7 @@ async fn test_update() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_endpoint(
-            &state,
+            &ExecutionContext::internal(&state),
             &endpoint.id,
             EndpointUpdate {
                 enabled: Some(false),
@@ -73,7 +73,7 @@ async fn test_update() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_endpoint(&state, &endpoint.id)
+        .get_endpoint(&ExecutionContext::internal(&state), &endpoint.id)
         .await?
         .unwrap();
     assert!(!fetched.enabled);
@@ -89,7 +89,7 @@ async fn test_update_not_found() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_endpoint(
-            &state,
+            &ExecutionContext::internal(&state),
             "missing",
             EndpointUpdate {
                 enabled: Some(true),
@@ -138,7 +138,7 @@ async fn test_update_interface_too_long() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_endpoint(
-            &state,
+            &ExecutionContext::internal(&state),
             &endpoint.id,
             EndpointUpdate {
                 interface: Some(too_long),

--- a/tests/integration/src/catalog/region/create.rs
+++ b/tests/integration/src/catalog/region/create.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::RegionCreate;
 
 use crate::catalog::create_region;
@@ -85,7 +85,7 @@ async fn test_create_description_too_long() -> Result<()> {
         .provider
         .get_catalog_provider()
         .create_region(
-            &state,
+            &ExecutionContext::internal(&state),
             RegionCreate {
                 id: None,
                 description: Some(too_long),

--- a/tests/integration/src/catalog/region/delete.rs
+++ b/tests/integration/src/catalog/region/delete.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::RegionCreate;
 
 use crate::common::get_state;
@@ -31,7 +31,7 @@ async fn test_delete() -> Result<()> {
 
     let region = provider
         .create_region(
-            &state,
+            &ExecutionContext::internal(&state),
             RegionCreate {
                 id: Some("del".to_string()),
                 description: None,
@@ -41,9 +41,13 @@ async fn test_delete() -> Result<()> {
         )
         .await?;
 
-    provider.delete_region(&state, &region.id).await?;
+    provider
+        .delete_region(&ExecutionContext::internal(&state), &region.id)
+        .await?;
 
-    let fetched = provider.get_region(&state, &region.id).await?;
+    let fetched = provider
+        .get_region(&ExecutionContext::internal(&state), &region.id)
+        .await?;
     assert!(fetched.is_none(), "region should be gone after delete");
     Ok(())
 }

--- a/tests/integration/src/catalog/region/get.rs
+++ b/tests/integration/src/catalog/region/get.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::RegionCreate;
 
 use crate::catalog::create_region;
@@ -42,7 +42,7 @@ async fn test_get() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_region(&state, &region.id)
+        .get_region(&ExecutionContext::internal(&state), &region.id)
         .await?;
 
     assert!(fetched.is_some());
@@ -59,7 +59,7 @@ async fn test_get_not_found() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_region(&state, "does-not-exist")
+        .get_region(&ExecutionContext::internal(&state), "does-not-exist")
         .await?;
     assert!(fetched.is_none());
     Ok(())

--- a/tests/integration/src/catalog/region/list.rs
+++ b/tests/integration/src/catalog/region/list.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{RegionCreate, RegionListParameters};
 
 use crate::catalog::create_region;
@@ -52,7 +52,10 @@ async fn test_list() -> Result<()> {
     let regions = state
         .provider
         .get_catalog_provider()
-        .list_regions(&state, &RegionListParameters::default())
+        .list_regions(
+            &ExecutionContext::internal(&state),
+            &RegionListParameters::default(),
+        )
         .await?;
 
     let ids: Vec<&str> = regions.iter().map(|r| r.id.as_str()).collect();
@@ -110,7 +113,7 @@ async fn test_list_filter_by_parent() -> Result<()> {
         .provider
         .get_catalog_provider()
         .list_regions(
-            &state,
+            &ExecutionContext::internal(&state),
             &RegionListParameters {
                 parent_region_id: Some("parent".to_string()),
             },

--- a/tests/integration/src/catalog/region/update.rs
+++ b/tests/integration/src/catalog/region/update.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{RegionCreate, RegionUpdate};
 
 use crate::catalog::create_region;
@@ -43,7 +43,7 @@ async fn test_update() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_region(
-            &state,
+            &ExecutionContext::internal(&state),
             &region.id,
             RegionUpdate {
                 description: Some("new".to_string()),
@@ -58,7 +58,7 @@ async fn test_update() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_region(&state, &region.id)
+        .get_region(&ExecutionContext::internal(&state), &region.id)
         .await?
         .unwrap();
     assert_eq!(fetched.description.as_deref(), Some("new"));
@@ -73,7 +73,7 @@ async fn test_update_not_found() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_region(
-            &state,
+            &ExecutionContext::internal(&state),
             "missing",
             RegionUpdate {
                 description: Some("x".to_string()),
@@ -109,7 +109,7 @@ async fn test_update_description_too_long() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_region(
-            &state,
+            &ExecutionContext::internal(&state),
             &region.id,
             RegionUpdate {
                 description: Some(too_long),

--- a/tests/integration/src/catalog/service/create.rs
+++ b/tests/integration/src/catalog/service/create.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::ServiceCreate;
 
 use crate::catalog::create_service;
@@ -64,7 +64,7 @@ async fn test_create_id_too_long() -> Result<()> {
         .provider
         .get_catalog_provider()
         .create_service(
-            &state,
+            &ExecutionContext::internal(&state),
             ServiceCreate {
                 enabled: true,
                 extra: HashMap::new(),

--- a/tests/integration/src/catalog/service/delete.rs
+++ b/tests/integration/src/catalog/service/delete.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::ServiceCreate;
 
 use crate::common::get_state;
@@ -31,7 +31,7 @@ async fn test_delete() -> Result<()> {
 
     let service = provider
         .create_service(
-            &state,
+            &ExecutionContext::internal(&state),
             ServiceCreate {
                 enabled: true,
                 extra: HashMap::new(),
@@ -41,9 +41,13 @@ async fn test_delete() -> Result<()> {
         )
         .await?;
 
-    provider.delete_service(&state, &service.id).await?;
+    provider
+        .delete_service(&ExecutionContext::internal(&state), &service.id)
+        .await?;
 
-    let fetched = provider.get_service(&state, &service.id).await?;
+    let fetched = provider
+        .get_service(&ExecutionContext::internal(&state), &service.id)
+        .await?;
     assert!(fetched.is_none(), "service should be gone after delete");
     Ok(())
 }

--- a/tests/integration/src/catalog/service/get.rs
+++ b/tests/integration/src/catalog/service/get.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::ServiceCreate;
 
 use crate::catalog::create_service;
@@ -47,7 +47,7 @@ async fn test_get() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_service(&state, &service.id)
+        .get_service(&ExecutionContext::internal(&state), &service.id)
         .await?;
 
     assert!(fetched.is_some());
@@ -65,7 +65,7 @@ async fn test_get_not_found() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_service(&state, "does-not-exist")
+        .get_service(&ExecutionContext::internal(&state), "does-not-exist")
         .await?;
     assert!(fetched.is_none());
     Ok(())

--- a/tests/integration/src/catalog/service/list.rs
+++ b/tests/integration/src/catalog/service/list.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{ServiceCreate, ServiceListParameters};
 
 use crate::catalog::create_service;
@@ -43,7 +43,10 @@ async fn test_list() -> Result<()> {
     let services = state
         .provider
         .get_catalog_provider()
-        .list_services(&state, &ServiceListParameters::default())
+        .list_services(
+            &ExecutionContext::internal(&state),
+            &ServiceListParameters::default(),
+        )
         .await?;
 
     let ids: Vec<&str> = services.iter().map(|s| s.id.as_str()).collect();
@@ -64,7 +67,7 @@ async fn test_list_filter_by_type() -> Result<()> {
         .provider
         .get_catalog_provider()
         .list_services(
-            &state,
+            &ExecutionContext::internal(&state),
             &ServiceListParameters {
                 name: None,
                 r#type: Some("compute".to_string()),

--- a/tests/integration/src/catalog/service/update.rs
+++ b/tests/integration/src/catalog/service/update.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::catalog::CatalogApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::catalog::{ServiceCreate, ServiceUpdate};
 
 use crate::catalog::create_service;
@@ -43,7 +43,7 @@ async fn test_update() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_service(
-            &state,
+            &ExecutionContext::internal(&state),
             &service.id,
             ServiceUpdate {
                 enabled: Some(false),
@@ -59,7 +59,7 @@ async fn test_update() -> Result<()> {
     let fetched = state
         .provider
         .get_catalog_provider()
-        .get_service(&state, &service.id)
+        .get_service(&ExecutionContext::internal(&state), &service.id)
         .await?
         .unwrap();
     assert!(!fetched.enabled);
@@ -75,7 +75,7 @@ async fn test_update_not_found() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_service(
-            &state,
+            &ExecutionContext::internal(&state),
             "missing",
             ServiceUpdate {
                 enabled: Some(true),
@@ -110,7 +110,7 @@ async fn test_update_type_too_long() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_service(
-            &state,
+            &ExecutionContext::internal(&state),
             &service.id,
             ServiceUpdate {
                 r#type: Some(too_long),
@@ -161,7 +161,7 @@ async fn test_update_extra_overwrites() -> Result<()> {
         .provider
         .get_catalog_provider()
         .update_service(
-            &state,
+            &ExecutionContext::internal(&state),
             &service.id,
             ServiceUpdate {
                 extra: update_extra,

--- a/tests/integration/src/identity.rs
+++ b/tests/integration/src/identity.rs
@@ -17,9 +17,9 @@ use std::sync::Arc;
 
 use eyre::Result;
 
-use openstack_keystone::identity::IdentityApi;
 use openstack_keystone::keystone::Service;
 use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::identity::*;
 
 use crate::common::*;
@@ -39,7 +39,7 @@ pub async fn create_user(
     let res = state
         .provider
         .get_identity_provider()
-        .create_user(state, data)
+        .create_user(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))
@@ -52,7 +52,7 @@ pub async fn create_group(
     let res = state
         .provider
         .get_identity_provider()
-        .create_group(state, data)
+        .create_group(&ExecutionContext::internal(&state), data)
         .await?;
     Ok(AsyncResourceGuard::new(res, state.clone()))
 }

--- a/tests/integration/src/identity/service_account/create.rs
+++ b/tests/integration/src/identity/service_account/create.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::identity::IdentityApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::identity::*;
 
 use crate::common::get_state;
@@ -34,7 +34,7 @@ async fn test_create() -> Result<()> {
         .provider
         .get_identity_provider()
         .create_service_account(
-            &state,
+            &ExecutionContext::internal(&state),
             ServiceAccountCreate {
                 domain_id: domain.id.clone(),
                 enabled: Some(true),
@@ -51,7 +51,7 @@ async fn test_create() -> Result<()> {
     let user = state
         .provider
         .get_identity_provider()
-        .get_user(&state, &sa.id)
+        .get_user(&ExecutionContext::internal(&state), &sa.id)
         .await?
         .expect("user found");
     assert_eq!(user.domain_id, domain.id);

--- a/tests/integration/src/identity/service_account/get.rs
+++ b/tests/integration/src/identity/service_account/get.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::identity::IdentityApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::identity::*;
 
 use crate::common::get_state;
@@ -34,7 +34,7 @@ async fn test_get() -> Result<()> {
         .provider
         .get_identity_provider()
         .create_service_account(
-            &state,
+            &ExecutionContext::internal(&state),
             ServiceAccountCreate {
                 domain_id: domain.id.clone(),
                 enabled: Some(true),
@@ -47,14 +47,14 @@ async fn test_get() -> Result<()> {
     let _user = state
         .provider
         .get_identity_provider()
-        .get_user(&state, &sa.id)
+        .get_user(&ExecutionContext::internal(&state), &sa.id)
         .await?
         .expect("user found");
 
     let _sa = state
         .provider
         .get_identity_provider()
-        .get_service_account(&state, &sa.id)
+        .get_service_account(&ExecutionContext::internal(&state), &sa.id)
         .await?
         .expect("sa found");
     Ok(())

--- a/tests/integration/src/identity/user/create.rs
+++ b/tests/integration/src/identity/user/create.rs
@@ -18,7 +18,7 @@ use tracing_test::traced_test;
 use uuid::Uuid;
 
 use chrono::Utc;
-use openstack_keystone::identity::IdentityApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationError;
 use openstack_keystone_core_types::identity::*;
 
@@ -38,7 +38,7 @@ async fn test_create_local_with_password() -> Result<()> {
         .provider
         .get_identity_provider()
         .create_user(
-            &state,
+            &ExecutionContext::internal(&state),
             UserCreateBuilder::default()
                 .id(&uid)
                 .name("name")
@@ -71,7 +71,7 @@ async fn test_create_local_with_no_password() -> Result<()> {
         .provider
         .get_identity_provider()
         .create_user(
-            &state,
+            &ExecutionContext::internal(&state),
             UserCreateBuilder::default()
                 .id(&uid)
                 .name("name")
@@ -103,7 +103,7 @@ async fn test_create_with_password_and_expiry_days() -> eyre::Result<()> {
     let prov = state.provider.get_identity_provider();
     let user = prov
         .create_user(
-            &state,
+            &ExecutionContext::internal(&state),
             UserCreateBuilder::default()
                 .id(&uid)
                 .name("testuser")
@@ -134,7 +134,7 @@ async fn test_create_with_password_and_authenticate() -> Result<()> {
 
     let prov = state.provider.get_identity_provider();
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -148,7 +148,7 @@ async fn test_create_with_password_and_authenticate() -> Result<()> {
     // Authenticate with the created password
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("initial")
@@ -173,7 +173,7 @@ async fn test_create_with_password_and_unique_count() -> Result<()> {
 
     let prov = state.provider.get_identity_provider();
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -187,7 +187,7 @@ async fn test_create_with_password_and_unique_count() -> Result<()> {
     // Authenticate with the created password (should still work)
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("initial")
@@ -212,7 +212,7 @@ async fn test_create_disabled_user_with_password() -> Result<()> {
     let prov = state.provider.get_identity_provider();
     let user = prov
         .create_user(
-            &state,
+            &ExecutionContext::internal(&state),
             UserCreateBuilder::default()
                 .id(&uid)
                 .name("disabled_user")
@@ -228,7 +228,7 @@ async fn test_create_disabled_user_with_password() -> Result<()> {
     // Try to authenticate - should fail
     match prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("initial")
@@ -258,7 +258,7 @@ async fn test_create_with_password_and_default_project_id() -> Result<()> {
     let prov = state.provider.get_identity_provider();
     let user = prov
         .create_user(
-            &state,
+            &ExecutionContext::internal(&state),
             UserCreateBuilder::default()
                 .id(&uid)
                 .name("testuser")
@@ -289,7 +289,7 @@ async fn test_create_with_password_and_get_user() -> Result<()> {
 
     let prov = state.provider.get_identity_provider();
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -302,7 +302,7 @@ async fn test_create_with_password_and_get_user() -> Result<()> {
 
     // Fetch user and verify password_expires_at is populated
     let user = prov
-        .get_user(&state, &uid)
+        .get_user(&ExecutionContext::internal(&state), &uid)
         .await?
         .expect("user should be found");
     assert!(
@@ -324,7 +324,7 @@ async fn test_create_with_expiry_and_authenticate() -> Result<()> {
 
     let prov = state.provider.get_identity_provider();
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -338,7 +338,7 @@ async fn test_create_with_expiry_and_authenticate() -> Result<()> {
     // Authenticate should work (password is fresh, not expired)
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("initial")
@@ -352,7 +352,7 @@ async fn test_create_with_expiry_and_authenticate() -> Result<()> {
 
     // Verify password_expires_at is set in response
     let user = prov
-        .get_user(&state, &uid)
+        .get_user(&ExecutionContext::internal(&state), &uid)
         .await?
         .expect("user should be found");
     assert!(user.password_expires_at.is_some());
@@ -371,7 +371,7 @@ async fn test_create_with_expiry_and_unique_count() -> Result<()> {
     let prov = state.provider.get_identity_provider();
     let user = prov
         .create_user(
-            &state,
+            &ExecutionContext::internal(&state),
             UserCreateBuilder::default()
                 .id(&uid)
                 .name("testuser")
@@ -390,7 +390,7 @@ async fn test_create_with_expiry_and_unique_count() -> Result<()> {
     // Authenticate should work
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("initial")

--- a/tests/integration/src/identity/user/get.rs
+++ b/tests/integration/src/identity/user/get.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::identity::IdentityApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::identity::*;
 
 use crate::common::get_state;
@@ -33,7 +33,7 @@ async fn test_get_local() -> Result<()> {
         .provider
         .get_identity_provider()
         .create_user(
-            &state,
+            &ExecutionContext::internal(&state),
             UserCreateBuilder::default()
                 .name(Uuid::new_v4().to_string())
                 .domain_id(domain.id.clone())
@@ -45,7 +45,7 @@ async fn test_get_local() -> Result<()> {
     let user = state
         .provider
         .get_identity_provider()
-        .get_user(&state, &sot.id)
+        .get_user(&ExecutionContext::internal(&state), &sot.id)
         .await?
         .expect("user found");
     assert_eq!(user.default_project_id, sot.default_project_id);

--- a/tests/integration/src/identity/user/list.rs
+++ b/tests/integration/src/identity/user/list.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::identity::IdentityApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::identity::*;
 
 use crate::common::get_state;
@@ -35,7 +35,7 @@ async fn test_list() -> Result<()> {
             .provider
             .get_identity_provider()
             .create_user(
-                &state,
+                &ExecutionContext::internal(&state),
                 UserCreateBuilder::default()
                     .name(Uuid::new_v4().to_string())
                     .domain_id(domain.id.clone())
@@ -48,7 +48,10 @@ async fn test_list() -> Result<()> {
     let users: Vec<UserResponse> = state
         .provider
         .get_identity_provider()
-        .list_users(&state, &UserListParameters::default())
+        .list_users(
+            &ExecutionContext::internal(&state),
+            &UserListParameters::default(),
+        )
         .await?
         .into_iter()
         .collect();

--- a/tests/integration/src/identity/user/update.rs
+++ b/tests/integration/src/identity/user/update.rs
@@ -18,7 +18,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::identity::IdentityApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationError;
 use openstack_keystone_core_types::identity::*;
 
@@ -37,7 +37,7 @@ async fn test_update_password_basic() -> Result<()> {
     let prov = state.provider.get_identity_provider();
 
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -51,7 +51,7 @@ async fn test_update_password_basic() -> Result<()> {
     // Old password works
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("old_pass")
@@ -62,7 +62,7 @@ async fn test_update_password_basic() -> Result<()> {
 
     // Update password
     prov.update_user(
-        &state,
+        &ExecutionContext::internal(&state),
         &uid,
         UserUpdateBuilder::default().password("new_pass").build()?,
     )
@@ -71,7 +71,7 @@ async fn test_update_password_basic() -> Result<()> {
     // Old password is rejected
     match prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("old_pass")
@@ -90,7 +90,7 @@ async fn test_update_password_basic() -> Result<()> {
     // New password works
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("new_pass")
@@ -113,7 +113,7 @@ async fn test_update_password_with_expiry() -> Result<()> {
     let prov = state.provider.get_identity_provider();
 
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -126,7 +126,10 @@ async fn test_update_password_with_expiry() -> Result<()> {
 
     // Check expires_at after create
     let now_create = Utc::now();
-    let user = prov.get_user(&state, &uid).await?.expect("user found");
+    let user = prov
+        .get_user(&ExecutionContext::internal(&state), &uid)
+        .await?
+        .expect("user found");
     assert!(
         user.password_expires_at.is_some(),
         "expires_at should be set after create"
@@ -135,7 +138,7 @@ async fn test_update_password_with_expiry() -> Result<()> {
 
     // Update password
     prov.update_user(
-        &state,
+        &ExecutionContext::internal(&state),
         &uid,
         UserUpdateBuilder::default().password("new_pass").build()?,
     )
@@ -143,7 +146,10 @@ async fn test_update_password_with_expiry() -> Result<()> {
 
     // Check expires_at after update — should be ~90 days from update time
     let now_update = Utc::now();
-    let user = prov.get_user(&state, &uid).await?.expect("user found");
+    let user = prov
+        .get_user(&ExecutionContext::internal(&state), &uid)
+        .await?
+        .expect("user found");
     assert!(
         user.password_expires_at.is_some(),
         "expires_at should still be set after update"
@@ -153,7 +159,7 @@ async fn test_update_password_with_expiry() -> Result<()> {
     // New password works
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("new_pass")
@@ -176,7 +182,7 @@ async fn test_update_password_no_expiry_configured() -> Result<()> {
 
     // Create user with password (default config: no expiry)
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -187,7 +193,10 @@ async fn test_update_password_no_expiry_configured() -> Result<()> {
     )
     .await?;
 
-    let user = prov.get_user(&state, &uid).await?.expect("user found");
+    let user = prov
+        .get_user(&ExecutionContext::internal(&state), &uid)
+        .await?
+        .expect("user found");
     assert!(
         user.password_expires_at.is_none(),
         "expires_at should be None without config"
@@ -195,14 +204,17 @@ async fn test_update_password_no_expiry_configured() -> Result<()> {
 
     // Update password
     prov.update_user(
-        &state,
+        &ExecutionContext::internal(&state),
         &uid,
         UserUpdateBuilder::default().password("new_pass").build()?,
     )
     .await?;
 
     // Still no expiry
-    let user = prov.get_user(&state, &uid).await?.expect("user found");
+    let user = prov
+        .get_user(&ExecutionContext::internal(&state), &uid)
+        .await?
+        .expect("user found");
     assert!(
         user.password_expires_at.is_none(),
         "expires_at should still be None after update"
@@ -223,7 +235,7 @@ async fn test_update_password_with_history() -> Result<()> {
 
     // Create with pass1
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -237,7 +249,7 @@ async fn test_update_password_with_history() -> Result<()> {
     // pass1 works
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("pass1")
@@ -248,7 +260,7 @@ async fn test_update_password_with_history() -> Result<()> {
 
     // Update to pass2
     prov.update_user(
-        &state,
+        &ExecutionContext::internal(&state),
         &uid,
         UserUpdateBuilder::default().password("pass2").build()?,
     )
@@ -257,7 +269,7 @@ async fn test_update_password_with_history() -> Result<()> {
     // pass1 rejected
     match prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("pass1")
@@ -276,7 +288,7 @@ async fn test_update_password_with_history() -> Result<()> {
     // pass2 accepted
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("pass2")
@@ -299,7 +311,7 @@ async fn test_update_name_and_password_combined() -> Result<()> {
 
     // Create user
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("old_name")
@@ -313,7 +325,7 @@ async fn test_update_name_and_password_combined() -> Result<()> {
     // Update both name and password
     let updated = prov
         .update_user(
-            &state,
+            &ExecutionContext::internal(&state),
             &uid,
             UserUpdateBuilder::default()
                 .name("new_name")
@@ -326,7 +338,7 @@ async fn test_update_name_and_password_combined() -> Result<()> {
     // Old password rejected
     match prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("old_pass")
@@ -345,7 +357,7 @@ async fn test_update_name_and_password_combined() -> Result<()> {
     // New password works
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("new_pass")
@@ -369,7 +381,7 @@ async fn test_update_password_with_expiry_and_history() -> Result<()> {
 
     // Create with pass1
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -382,7 +394,7 @@ async fn test_update_password_with_expiry_and_history() -> Result<()> {
 
     // Update to pass2
     prov.update_user(
-        &state,
+        &ExecutionContext::internal(&state),
         &uid,
         UserUpdateBuilder::default().password("pass2").build()?,
     )
@@ -391,7 +403,7 @@ async fn test_update_password_with_expiry_and_history() -> Result<()> {
     // pass1 rejected
     match prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("pass1")
@@ -410,7 +422,7 @@ async fn test_update_password_with_expiry_and_history() -> Result<()> {
     // pass2 accepted
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("pass2")
@@ -421,7 +433,10 @@ async fn test_update_password_with_expiry_and_history() -> Result<()> {
 
     // expires_at ≈ 90d from update
     let now = Utc::now();
-    let user = prov.get_user(&state, &uid).await?.expect("user found");
+    let user = prov
+        .get_user(&ExecutionContext::internal(&state), &uid)
+        .await?
+        .expect("user found");
     assert_expires_at_approx(user.password_expires_at.as_ref(), now, 90);
 
     Ok(())
@@ -438,7 +453,7 @@ async fn test_update_password_expiry_config_change() -> Result<()> {
 
     // Create with default config (no expiry)
     prov.create_user(
-        &state,
+        &ExecutionContext::internal(&state),
         UserCreateBuilder::default()
             .id(&uid)
             .name("testuser")
@@ -449,7 +464,10 @@ async fn test_update_password_expiry_config_change() -> Result<()> {
     )
     .await?;
 
-    let user = prov.get_user(&state, &uid).await?.expect("user found");
+    let user = prov
+        .get_user(&ExecutionContext::internal(&state), &uid)
+        .await?
+        .expect("user found");
     assert!(
         user.password_expires_at.is_none(),
         "expires_at should be None without config"
@@ -459,7 +477,7 @@ async fn test_update_password_expiry_config_change() -> Result<()> {
     setup_test_config(&state, Some(90), None).await;
 
     prov.update_user(
-        &state,
+        &ExecutionContext::internal(&state),
         &uid,
         UserUpdateBuilder::default().password("new_pass").build()?,
     )
@@ -467,7 +485,10 @@ async fn test_update_password_expiry_config_change() -> Result<()> {
 
     // Now expires_at should be set
     let now = Utc::now();
-    let user = prov.get_user(&state, &uid).await?.expect("user found");
+    let user = prov
+        .get_user(&ExecutionContext::internal(&state), &uid)
+        .await?
+        .expect("user found");
     assert!(
         user.password_expires_at.is_some(),
         "expires_at should be set after config change + update"
@@ -477,7 +498,7 @@ async fn test_update_password_expiry_config_change() -> Result<()> {
     // New password works
     let auth = prov
         .authenticate_by_password(
-            &state,
+            &ExecutionContext::internal(&state),
             &UserPasswordAuthRequestBuilder::default()
                 .id(&uid)
                 .password("new_pass")

--- a/tests/integration/src/identity/user_group.rs
+++ b/tests/integration/src/identity/user_group.rs
@@ -14,7 +14,7 @@
 
 use eyre::Report;
 
-use openstack_keystone_core::identity::IdentityApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core_types::identity::*;
 
@@ -28,7 +28,7 @@ where
     Ok(state
         .provider
         .get_identity_provider()
-        .list_groups_of_user(state, user_id.as_ref())
+        .list_groups_of_user(&ExecutionContext::internal(&state), user_id.as_ref())
         .await?
         .into_iter()
         .collect())

--- a/tests/integration/src/identity/user_group/add.rs
+++ b/tests/integration/src/identity/user_group/add.rs
@@ -16,9 +16,8 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::identity::IdentityApi;
-
 use super::*;
+use openstack_keystone_core::auth::ExecutionContext;
 
 use crate::common::get_state;
 use crate::{create_domain, create_group, create_user};
@@ -36,13 +35,18 @@ async fn test_expiring_groups() -> Result<()> {
     state
         .provider
         .get_identity_provider()
-        .add_user_to_group(&state, &user.id, &group_a.id)
+        .add_user_to_group(&ExecutionContext::internal(&state), &user.id, &group_a.id)
         .await?;
 
     state
         .provider
         .get_identity_provider()
-        .add_user_to_group_expiring(&state, &user.id, &group_b.id, "idp_id")
+        .add_user_to_group_expiring(
+            &ExecutionContext::internal(&state),
+            &user.id,
+            &group_b.id,
+            "idp_id",
+        )
         .await?;
 
     let groups = list_user_groups(&state, &user.id).await?;

--- a/tests/integration/src/identity/user_group/list.rs
+++ b/tests/integration/src/identity/user_group/list.rs
@@ -23,11 +23,10 @@ use openstack_keystone_identity_driver_sql::entity::{
     prelude::ExpiringUserGroupMembership as DbExpiringUserGroupMembership,
 };
 
-use openstack_keystone::identity::IdentityApi;
-
 use super::*;
 use crate::common::get_state;
 use crate::{create_domain, create_group, create_user};
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[tokio::test]
 async fn test_list_user_groups() -> Result<(), Report> {
@@ -38,7 +37,7 @@ async fn test_list_user_groups() -> Result<(), Report> {
     state
         .provider
         .get_identity_provider()
-        .add_user_to_group(&state, &user.id, &group.id)
+        .add_user_to_group(&ExecutionContext::internal(&state), &user.id, &group.id)
         .await?;
 
     assert_eq!(
@@ -66,14 +65,19 @@ async fn test_expiring_groups() -> Result<(), Report> {
     state
         .provider
         .get_identity_provider()
-        .add_user_to_group(&state, &user.id, &group_a.id)
+        .add_user_to_group(&ExecutionContext::internal(&state), &user.id, &group_a.id)
         .await?;
 
     // non expired membership
     state
         .provider
         .get_identity_provider()
-        .add_user_to_group_expiring(&state, &user.id, &group_b.id, "idp_id")
+        .add_user_to_group_expiring(
+            &ExecutionContext::internal(&state),
+            &user.id,
+            &group_b.id,
+            "idp_id",
+        )
         .await?;
 
     // TODO: Find a way to add expired group membership for the test

--- a/tests/integration/src/k8s_auth/instance.rs
+++ b/tests/integration/src/k8s_auth/instance.rs
@@ -17,9 +17,9 @@ use std::sync::Arc;
 
 use eyre::Result;
 
-use openstack_keystone::k8s_auth::K8sAuthApi;
 use openstack_keystone::keystone::Service;
 use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::k8s_auth::*;
 
 mod create;
@@ -45,7 +45,7 @@ pub async fn create_k8s_auth_instance(
     let res = state
         .provider
         .get_k8s_auth_provider()
-        .create_auth_instance(state, data)
+        .create_auth_instance(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))

--- a/tests/integration/src/k8s_auth/instance/create.rs
+++ b/tests/integration/src/k8s_auth/instance/create.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::k8s_auth::K8sAuthApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::k8s_auth::*;
 
 use crate::common::get_state;
@@ -39,7 +39,7 @@ async fn test_create() -> Result<()> {
     let res = state
         .provider
         .get_k8s_auth_provider()
-        .create_auth_instance(&state, sot.clone())
+        .create_auth_instance(&ExecutionContext::internal(&state), sot.clone())
         .await?;
     assert_eq!(sot.name, res.name);
     assert_eq!(sot.id.unwrap(), res.id);
@@ -50,7 +50,7 @@ async fn test_create() -> Result<()> {
     state
         .provider
         .get_k8s_auth_provider()
-        .delete_auth_instance(&state, &res.id)
+        .delete_auth_instance(&ExecutionContext::internal(&state), &res.id)
         .await?;
     Ok(())
 }

--- a/tests/integration/src/k8s_auth/instance/delete.rs
+++ b/tests/integration/src/k8s_auth/instance/delete.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::k8s_auth::K8sAuthApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::k8s_auth::*;
 
 use crate::common::get_state;
@@ -31,7 +31,7 @@ async fn test_delete() -> Result<()> {
         .provider
         .get_k8s_auth_provider()
         .create_auth_instance(
-            &state,
+            &ExecutionContext::internal(&state),
             K8sAuthInstanceCreate {
                 ca_cert: Some("ca".into()),
                 disable_local_ca_jwt: Some(true),
@@ -47,7 +47,7 @@ async fn test_delete() -> Result<()> {
     state
         .provider
         .get_k8s_auth_provider()
-        .delete_auth_instance(&state, &res.id)
+        .delete_auth_instance(&ExecutionContext::internal(&state), &res.id)
         .await?;
     Ok(())
 }

--- a/tests/integration/src/k8s_auth/instance/get.rs
+++ b/tests/integration/src/k8s_auth/instance/get.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::k8s_auth::K8sAuthApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::k8s_auth::*;
 
 use super::create_k8s_auth_instance;
@@ -46,7 +46,7 @@ async fn test_get_config() -> Result<()> {
     let res = state
         .provider
         .get_k8s_auth_provider()
-        .get_auth_instance(&state, &k8s_conf.id)
+        .get_auth_instance(&ExecutionContext::internal(&state), &k8s_conf.id)
         .await?
         .expect("instance should be there");
     assert_eq!(res.id, k8s_conf.id);
@@ -66,7 +66,10 @@ async fn test_get_instance_missing() -> Result<()> {
         state
             .provider
             .get_k8s_auth_provider()
-            .get_auth_instance(&state, &uuid::Uuid::new_v4().to_string())
+            .get_auth_instance(
+                &ExecutionContext::internal(&state),
+                &uuid::Uuid::new_v4().to_string()
+            )
             .await?
             .is_none()
     );

--- a/tests/integration/src/k8s_auth/instance/list.rs
+++ b/tests/integration/src/k8s_auth/instance/list.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::k8s_auth::K8sAuthApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::k8s_auth::*;
 
 use super::create_k8s_auth_instance;
@@ -60,7 +60,10 @@ async fn test_list() -> Result<()> {
     let res = state
         .provider
         .get_k8s_auth_provider()
-        .list_auth_instances(&state, &K8sAuthInstanceListParameters::default())
+        .list_auth_instances(
+            &ExecutionContext::internal(&state),
+            &K8sAuthInstanceListParameters::default(),
+        )
         .await?;
     assert!(res.contains(&k8s_conf));
     assert!(res.contains(&k8s_conf2));
@@ -103,7 +106,7 @@ async fn test_list_name() -> Result<()> {
         .provider
         .get_k8s_auth_provider()
         .list_auth_instances(
-            &state,
+            &ExecutionContext::internal(&state),
             &K8sAuthInstanceListParameters {
                 name: k8s_conf.name.clone(),
                 ..Default::default()
@@ -151,7 +154,7 @@ async fn test_list_domain() -> Result<()> {
         .provider
         .get_k8s_auth_provider()
         .list_auth_instances(
-            &state,
+            &ExecutionContext::internal(&state),
             &K8sAuthInstanceListParameters {
                 domain_id: Some(domain.id.clone()),
                 ..Default::default()

--- a/tests/integration/src/k8s_auth/instance/update.rs
+++ b/tests/integration/src/k8s_auth/instance/update.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::k8s_auth::K8sAuthApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::k8s_auth::*;
 
 use super::create_k8s_auth_instance;
@@ -50,7 +50,7 @@ async fn test_update() -> Result<()> {
     let res = state
         .provider
         .get_k8s_auth_provider()
-        .update_auth_instance(&state, &k8s_conf.id, req)
+        .update_auth_instance(&ExecutionContext::internal(&state), &k8s_conf.id, req)
         .await?;
     assert_eq!(k8s_conf.id, res.id);
     assert_eq!(Some("new_name".into()), res.name);

--- a/tests/integration/src/macros.rs
+++ b/tests/integration/src/macros.rs
@@ -18,10 +18,11 @@ macro_rules! impl_deleter {
         impl ResourceDeleter<$resource> for Arc<$state> {
             fn delete(&self, resource: $resource) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
                 Box::pin(async move {
+                    let exec = openstack_keystone_core::auth::ExecutionContext::internal(&self);
                     let _ = self
                         .provider
                         .$provider_getter()
-                        .$method(self, &resource.id)
+                        .$method(&exec, &resource.id)
                         .await;
                 })
             }

--- a/tests/integration/src/mapping/authenticate.rs
+++ b/tests/integration/src/mapping/authenticate.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use eyre::Result;
 
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationContext;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
 use openstack_keystone_core_types::mapping::rule::{ClaimCondition, MatchCondition, MatchCriteria};
@@ -71,7 +71,7 @@ async fn test_authenticate_happy_path() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -82,7 +82,7 @@ async fn test_authenticate_happy_path() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -139,7 +139,7 @@ async fn test_authenticate_global_ruleset() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -150,7 +150,7 @@ async fn test_authenticate_global_ruleset() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 

--- a/tests/integration/src/mapping/k8s.rs
+++ b/tests/integration/src/mapping/k8s.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use eyre::Result;
 
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationContext;
 use openstack_keystone_core_types::mapping::error::MappingProviderError;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
@@ -102,7 +102,7 @@ async fn test_k8s_happy_path() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -113,7 +113,7 @@ async fn test_k8s_happy_path() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -183,7 +183,7 @@ async fn test_k8s_no_matching_rule() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await;
 
     assert!(result.is_err());
@@ -255,7 +255,7 @@ async fn test_k8s_any_of_match() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -265,7 +265,7 @@ async fn test_k8s_any_of_match() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -334,7 +334,7 @@ async fn test_k8s_matches_regex() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -344,7 +344,7 @@ async fn test_k8s_matches_regex() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -417,7 +417,7 @@ async fn test_k8s_all_of_strict() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -447,7 +447,7 @@ async fn test_k8s_all_of_strict() -> Result<()> {
     let result_missing = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request_missing)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request_missing)
         .await;
 
     assert!(result_missing.is_err());
@@ -519,7 +519,7 @@ async fn test_k8s_with_authorizations() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -529,7 +529,7 @@ async fn test_k8s_with_authorizations() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -603,7 +603,7 @@ async fn test_k8s_template_interpolation() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -613,7 +613,7 @@ async fn test_k8s_template_interpolation() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -676,7 +676,7 @@ async fn test_k8s_disabled_ruleset() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await;
 
     assert!(result.is_err());
@@ -739,7 +739,7 @@ async fn test_k8s_unique_workload_id() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     let first_vuser_id = match result.context {
@@ -762,7 +762,7 @@ async fn test_k8s_unique_workload_id() -> Result<()> {
     let result2 = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request2)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request2)
         .await?;
 
     let second_vuser_id = match result2.context {
@@ -777,7 +777,7 @@ async fn test_k8s_unique_workload_id() -> Result<()> {
     let vuser = state
         .provider
         .get_mapping_provider()
-        .get_virtual_user(&state, &first_vuser_id)
+        .get_virtual_user(&ExecutionContext::internal(&state), &first_vuser_id)
         .await?
         .expect("virtual user should exist");
 
@@ -851,7 +851,7 @@ async fn test_k8s_aud_claim_passthrough() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -943,7 +943,7 @@ async fn test_k8s_rule_priority() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -1025,7 +1025,7 @@ async fn test_k8s_project_authorization() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -1035,7 +1035,7 @@ async fn test_k8s_project_authorization() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -1152,7 +1152,7 @@ async fn test_k8s_rule_name_hint() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -1188,7 +1188,7 @@ async fn test_k8s_rule_name_hint() -> Result<()> {
     let result_fallback = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request_fallback)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request_fallback)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result_fallback.context {
@@ -1224,7 +1224,7 @@ async fn test_k8s_rule_name_hint() -> Result<()> {
     let result_standard = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request_standard)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request_standard)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result_standard.context {
@@ -1258,7 +1258,7 @@ async fn test_k8s_rule_name_hint() -> Result<()> {
     let result_missing_hint = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request_missing_hint)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request_missing_hint)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result_missing_hint.context {

--- a/tests/integration/src/mapping/ruleset.rs
+++ b/tests/integration/src/mapping/ruleset.rs
@@ -19,7 +19,7 @@ use eyre::Result;
 
 use openstack_keystone::keystone::Service;
 use openstack_keystone::keystone::ServiceState;
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::mapping::*;
 
 mod create;
@@ -35,10 +35,11 @@ use crate::common::*;
 impl ResourceDeleter<MappingRuleSet> for Arc<Service> {
     fn delete(&self, resource: MappingRuleSet) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
+            let exec = ExecutionContext::internal(self);
             let _ = self
                 .provider
                 .get_mapping_provider()
-                .delete_ruleset(self, &resource.mapping_id)
+                .delete_ruleset(&exec, &resource.mapping_id)
                 .await;
         })
     }
@@ -51,7 +52,7 @@ pub async fn create_ruleset(
     let res = state
         .provider
         .get_mapping_provider()
-        .create_ruleset(state, data)
+        .create_ruleset(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))

--- a/tests/integration/src/mapping/ruleset/delete.rs
+++ b/tests/integration/src/mapping/ruleset/delete.rs
@@ -16,10 +16,9 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::mapping::MappingApi;
-
 use super::create_ruleset;
 use super::sample_ruleset_create;
+use openstack_keystone_core::auth::ExecutionContext;
 
 use crate::common::get_state;
 use crate::create_domain;
@@ -34,13 +33,13 @@ async fn test_delete() -> Result<()> {
     state
         .provider
         .get_mapping_provider()
-        .delete_ruleset(&state, &ruleset.mapping_id)
+        .delete_ruleset(&ExecutionContext::internal(&state), &ruleset.mapping_id)
         .await?;
 
     let res = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &ruleset.mapping_id)
+        .get_ruleset(&ExecutionContext::internal(&state), &ruleset.mapping_id)
         .await?;
 
     assert!(res.is_none());
@@ -56,13 +55,13 @@ async fn test_delete_global() -> Result<()> {
     state
         .provider
         .get_mapping_provider()
-        .delete_ruleset(&state, &ruleset.mapping_id)
+        .delete_ruleset(&ExecutionContext::internal(&state), &ruleset.mapping_id)
         .await?;
 
     let res = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &ruleset.mapping_id)
+        .get_ruleset(&ExecutionContext::internal(&state), &ruleset.mapping_id)
         .await?;
 
     assert!(res.is_none());
@@ -76,7 +75,10 @@ async fn test_delete_missing() -> Result<()> {
     state
         .provider
         .get_mapping_provider()
-        .delete_ruleset(&state, &uuid::Uuid::new_v4().simple().to_string())
+        .delete_ruleset(
+            &ExecutionContext::internal(&state),
+            &uuid::Uuid::new_v4().simple().to_string(),
+        )
         .await?;
     Ok(())
 }

--- a/tests/integration/src/mapping/ruleset/get.rs
+++ b/tests/integration/src/mapping/ruleset/get.rs
@@ -16,10 +16,9 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::mapping::MappingApi;
-
 use super::create_ruleset;
 use super::sample_ruleset_create;
+use openstack_keystone_core::auth::ExecutionContext;
 
 use crate::common::get_state;
 use crate::create_domain;
@@ -35,7 +34,7 @@ async fn test_get() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &ruleset.mapping_id)
+        .get_ruleset(&ExecutionContext::internal(&state), &ruleset.mapping_id)
         .await?
         .expect("ruleset should be present");
 
@@ -59,7 +58,7 @@ async fn test_get_global() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &ruleset.mapping_id)
+        .get_ruleset(&ExecutionContext::internal(&state), &ruleset.mapping_id)
         .await?
         .expect("ruleset should be present");
 
@@ -78,7 +77,10 @@ async fn test_get_missing() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .get_ruleset(&state, &uuid::Uuid::new_v4().simple().to_string())
+        .get_ruleset(
+            &ExecutionContext::internal(&state),
+            &uuid::Uuid::new_v4().simple().to_string(),
+        )
         .await?;
 
     assert!(res.is_none());

--- a/tests/integration/src/mapping/ruleset/is_system.rs
+++ b/tests/integration/src/mapping/ruleset/is_system.rs
@@ -14,7 +14,7 @@
 
 use eyre::Result;
 
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::mapping::error::MappingProviderError;
 use openstack_keystone_core_types::mapping::*;
 
@@ -53,7 +53,7 @@ async fn test_system_ruleset_immutable() -> Result<()> {
         .provider
         .get_mapping_provider()
         .update_ruleset(
-            &state,
+            &ExecutionContext::internal(&state),
             &mapping_id,
             MappingRuleSetUpdate {
                 enabled: Some(false),
@@ -74,7 +74,7 @@ async fn test_system_ruleset_immutable() -> Result<()> {
         .provider
         .get_mapping_provider()
         .mutate_rules(
-            &state,
+            &ExecutionContext::internal(&state),
             &mapping_id,
             RuleMutations {
                 mutations: vec![RuleMutation::Delete {
@@ -94,7 +94,7 @@ async fn test_system_ruleset_immutable() -> Result<()> {
     let delete_result = state
         .provider
         .get_mapping_provider()
-        .delete_ruleset(&state, &mapping_id)
+        .delete_ruleset(&ExecutionContext::internal(&state), &mapping_id)
         .await;
 
     assert!(delete_result.is_err());
@@ -135,7 +135,7 @@ async fn test_system_global_ruleset_immutable() -> Result<()> {
         .provider
         .get_mapping_provider()
         .update_ruleset(
-            &state,
+            &ExecutionContext::internal(&state),
             &mapping_id,
             MappingRuleSetUpdate {
                 enabled: Some(false),
@@ -156,7 +156,7 @@ async fn test_system_global_ruleset_immutable() -> Result<()> {
         .provider
         .get_mapping_provider()
         .mutate_rules(
-            &state,
+            &ExecutionContext::internal(&state),
             &mapping_id,
             RuleMutations {
                 mutations: vec![RuleMutation::Delete {
@@ -176,7 +176,7 @@ async fn test_system_global_ruleset_immutable() -> Result<()> {
     let delete_result = state
         .provider
         .get_mapping_provider()
-        .delete_ruleset(&state, &mapping_id)
+        .delete_ruleset(&ExecutionContext::internal(&state), &mapping_id)
         .await;
 
     assert!(delete_result.is_err());

--- a/tests/integration/src/mapping/ruleset/list.rs
+++ b/tests/integration/src/mapping/ruleset/list.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::mapping::MappingRuleSetListParameters;
 
 use super::create_ruleset;
@@ -37,7 +37,10 @@ async fn test_list() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .list_rulesets(&state, &MappingRuleSetListParameters::default())
+        .list_rulesets(
+            &ExecutionContext::internal(&state),
+            &MappingRuleSetListParameters::default(),
+        )
         .await?;
 
     assert!(res.contains(&ruleset1));
@@ -60,7 +63,7 @@ async fn test_list_domain() -> Result<()> {
         .provider
         .get_mapping_provider()
         .list_rulesets(
-            &state,
+            &ExecutionContext::internal(&state),
             &MappingRuleSetListParameters {
                 domain_id: Some(domain.id.clone()),
                 ..Default::default()
@@ -85,7 +88,10 @@ async fn test_list_global() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .list_rulesets(&state, &MappingRuleSetListParameters::default())
+        .list_rulesets(
+            &ExecutionContext::internal(&state),
+            &MappingRuleSetListParameters::default(),
+        )
         .await?;
 
     assert!(res.contains(&ruleset1));
@@ -97,7 +103,7 @@ async fn test_list_global() -> Result<()> {
         .provider
         .get_mapping_provider()
         .list_rulesets(
-            &state,
+            &ExecutionContext::internal(&state),
             &MappingRuleSetListParameters {
                 domain_id: Some(domain.id.clone()),
                 ..Default::default()
@@ -127,7 +133,7 @@ async fn test_list_enabled() -> Result<()> {
         .provider
         .get_mapping_provider()
         .list_rulesets(
-            &state,
+            &ExecutionContext::internal(&state),
             &MappingRuleSetListParameters {
                 enabled: Some(true),
                 ..Default::default()

--- a/tests/integration/src/mapping/ruleset/mutate.rs
+++ b/tests/integration/src/mapping/ruleset/mutate.rs
@@ -14,7 +14,7 @@
 
 use eyre::Result;
 
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::mapping::error::MappingProviderError;
 use openstack_keystone_core_types::mapping::mutation::{RuleMutation, RuleMutations, RulePosition};
 use openstack_keystone_core_types::mapping::*;
@@ -52,7 +52,7 @@ async fn test_mutate_rules_insert_before() -> Result<()> {
         .provider
         .get_mapping_provider()
         .mutate_rules(
-            &state,
+            &ExecutionContext::internal(&state),
             &ruleset_guard.mapping_id,
             RuleMutations {
                 mutations: vec![RuleMutation::Insert {
@@ -94,7 +94,7 @@ async fn test_mutate_rules_update() -> Result<()> {
         .provider
         .get_mapping_provider()
         .mutate_rules(
-            &state,
+            &ExecutionContext::internal(&state),
             &ruleset_guard.mapping_id,
             RuleMutations {
                 mutations: vec![RuleMutation::Update {
@@ -135,7 +135,7 @@ async fn test_mutate_rules_delete() -> Result<()> {
         .provider
         .get_mapping_provider()
         .mutate_rules(
-            &state,
+            &ExecutionContext::internal(&state),
             &ruleset_guard.mapping_id,
             RuleMutations {
                 mutations: vec![RuleMutation::Delete {
@@ -178,7 +178,7 @@ async fn test_mutate_rules_global() -> Result<()> {
         .provider
         .get_mapping_provider()
         .mutate_rules(
-            &state,
+            &ExecutionContext::internal(&state),
             &ruleset_guard.mapping_id,
             RuleMutations {
                 mutations: vec![RuleMutation::Insert {
@@ -215,7 +215,7 @@ async fn test_mutate_rules_invalid_anchor() -> Result<()> {
         .provider
         .get_mapping_provider()
         .mutate_rules(
-            &state,
+            &ExecutionContext::internal(&state),
             &ruleset_guard.mapping_id,
             RuleMutations {
                 mutations: vec![RuleMutation::Insert {

--- a/tests/integration/src/mapping/ruleset/update.rs
+++ b/tests/integration/src/mapping/ruleset/update.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::mapping::rule::MappingRule;
 use openstack_keystone_core_types::mapping::*;
 
@@ -57,7 +57,11 @@ async fn test_update() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .update_ruleset(&state, &ruleset.mapping_id, req)
+        .update_ruleset(
+            &ExecutionContext::internal(&state),
+            &ruleset.mapping_id,
+            req,
+        )
         .await?;
 
     assert_eq!(ruleset.mapping_id, res.mapping_id);
@@ -89,7 +93,11 @@ async fn test_update_allowed_domains() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .update_ruleset(&state, &ruleset.mapping_id, req)
+        .update_ruleset(
+            &ExecutionContext::internal(&state),
+            &ruleset.mapping_id,
+            req,
+        )
         .await?;
 
     assert_eq!(ruleset.mapping_id, res.mapping_id);
@@ -137,7 +145,11 @@ async fn test_update_global() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .update_ruleset(&state, &ruleset.mapping_id, req)
+        .update_ruleset(
+            &ExecutionContext::internal(&state),
+            &ruleset.mapping_id,
+            req,
+        )
         .await?;
 
     assert_eq!(ruleset.mapping_id, res.mapping_id);
@@ -157,7 +169,7 @@ async fn test_update_missing() -> Result<()> {
         .provider
         .get_mapping_provider()
         .update_ruleset(
-            &state,
+            &ExecutionContext::internal(&state),
             &uuid::Uuid::new_v4().simple().to_string(),
             MappingRuleSetUpdate::default(),
         )

--- a/tests/integration/src/mapping/spiffe.rs
+++ b/tests/integration/src/mapping/spiffe.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use eyre::Result;
 
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationContext;
 use openstack_keystone_core_types::mapping::error::MappingProviderError;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
@@ -92,7 +92,7 @@ async fn test_spiffe_happy_path() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -103,7 +103,7 @@ async fn test_spiffe_happy_path() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -148,7 +148,7 @@ async fn test_spiffe_no_fallback_when_no_matching_rule() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await;
 
     assert!(result.is_err());
@@ -209,7 +209,7 @@ async fn test_spiffe_system_ruleset() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -219,7 +219,7 @@ async fn test_spiffe_system_ruleset() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -287,7 +287,7 @@ async fn test_spiffe_claim_condition_any_of() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -297,7 +297,7 @@ async fn test_spiffe_claim_condition_any_of() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -361,7 +361,7 @@ async fn test_spiffe_any_of_no_match() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await;
 
     assert!(result.is_err());
@@ -426,7 +426,7 @@ async fn test_spiffe_matches_regex() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -436,7 +436,7 @@ async fn test_spiffe_matches_regex() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 
@@ -517,7 +517,7 @@ async fn test_spiffe_all_of_strict_with_auth() -> Result<()> {
     let result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     if let AuthenticationContext::Mapping(ctx) = result.context {
@@ -527,7 +527,7 @@ async fn test_spiffe_all_of_strict_with_auth() -> Result<()> {
         let vuser = state
             .provider
             .get_mapping_provider()
-            .get_virtual_user(&state, &ctx.virtual_user_id)
+            .get_virtual_user(&ExecutionContext::internal(&state), &ctx.virtual_user_id)
             .await?
             .expect("virtual user should exist");
 

--- a/tests/integration/src/mapping/vuser.rs
+++ b/tests/integration/src/mapping/vuser.rs
@@ -16,7 +16,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use openstack_keystone::keystone::Service;
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::mapping::VirtualUser;
 
 mod delete;
@@ -31,7 +31,7 @@ impl ResourceDeleter<VirtualUser> for Arc<Service> {
             let _ = self
                 .provider
                 .get_mapping_provider()
-                .delete_virtual_user(self, &resource.user_id)
+                .delete_virtual_user(&ExecutionContext::internal(self), &resource.user_id)
                 .await;
         })
     }

--- a/tests/integration/src/mapping/vuser/delete.rs
+++ b/tests/integration/src/mapping/vuser/delete.rs
@@ -16,9 +16,8 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::mapping::MappingApi;
-
 use crate::common::get_state;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[traced_test]
 #[tokio::test]
@@ -27,7 +26,10 @@ async fn test_delete_missing() -> Result<()> {
     state
         .provider
         .get_mapping_provider()
-        .delete_virtual_user(&state, &uuid::Uuid::new_v4().simple().to_string())
+        .delete_virtual_user(
+            &ExecutionContext::internal(&state),
+            &uuid::Uuid::new_v4().simple().to_string(),
+        )
         .await?;
     Ok(())
 }

--- a/tests/integration/src/mapping/vuser/get.rs
+++ b/tests/integration/src/mapping/vuser/get.rs
@@ -16,9 +16,8 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone_core::mapping::MappingApi;
-
 use crate::common::get_state;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[traced_test]
 #[tokio::test]
@@ -27,7 +26,10 @@ async fn test_get_missing() -> Result<()> {
     let res = state
         .provider
         .get_mapping_provider()
-        .get_virtual_user(&state, &uuid::Uuid::new_v4().simple().to_string())
+        .get_virtual_user(
+            &ExecutionContext::internal(&state),
+            &uuid::Uuid::new_v4().simple().to_string(),
+        )
         .await?;
 
     assert!(res.is_none());

--- a/tests/integration/src/mapping/vuser/lifecycle.rs
+++ b/tests/integration/src/mapping/vuser/lifecycle.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use eyre::Result;
 
-use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationContext;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;
 use openstack_keystone_core_types::mapping::rule::{ClaimCondition, MatchCondition, MatchCriteria};
@@ -69,7 +69,7 @@ async fn test_virtual_user_lifecycle() -> Result<()> {
     let auth_result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     let virtual_user_id = match auth_result.context {
@@ -80,7 +80,7 @@ async fn test_virtual_user_lifecycle() -> Result<()> {
     let vu = state
         .provider
         .get_mapping_provider()
-        .get_virtual_user(&state, &virtual_user_id)
+        .get_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?
         .expect("virtual user should exist");
     assert!(vu.enabled);
@@ -88,14 +88,14 @@ async fn test_virtual_user_lifecycle() -> Result<()> {
     let disabled_vu = state
         .provider
         .get_mapping_provider()
-        .disable_virtual_user(&state, &virtual_user_id)
+        .disable_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?;
     assert!(!disabled_vu.enabled);
 
     let vu_check = state
         .provider
         .get_mapping_provider()
-        .get_virtual_user(&state, &virtual_user_id)
+        .get_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?
         .expect("virtual user should still exist");
     assert!(!vu_check.enabled);
@@ -103,14 +103,14 @@ async fn test_virtual_user_lifecycle() -> Result<()> {
     let enabled_vu = state
         .provider
         .get_mapping_provider()
-        .enable_virtual_user(&state, &virtual_user_id)
+        .enable_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?;
     assert!(enabled_vu.enabled);
 
     let vu_final = state
         .provider
         .get_mapping_provider()
-        .get_virtual_user(&state, &virtual_user_id)
+        .get_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?
         .expect("virtual user should still exist");
     assert!(vu_final.enabled);
@@ -159,7 +159,7 @@ async fn test_virtual_user_lifecycle_global() -> Result<()> {
     let auth_result = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&state, &request)
+        .authenticate_by_mapping(&ExecutionContext::internal(&state), &request)
         .await?;
 
     let virtual_user_id = match auth_result.context {
@@ -170,7 +170,7 @@ async fn test_virtual_user_lifecycle_global() -> Result<()> {
     let vu = state
         .provider
         .get_mapping_provider()
-        .get_virtual_user(&state, &virtual_user_id)
+        .get_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?
         .expect("virtual user should exist");
     assert!(vu.enabled);
@@ -179,14 +179,14 @@ async fn test_virtual_user_lifecycle_global() -> Result<()> {
     let disabled_vu = state
         .provider
         .get_mapping_provider()
-        .disable_virtual_user(&state, &virtual_user_id)
+        .disable_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?;
     assert!(!disabled_vu.enabled);
 
     let vu_check = state
         .provider
         .get_mapping_provider()
-        .get_virtual_user(&state, &virtual_user_id)
+        .get_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?
         .expect("virtual user should still exist");
     assert!(!vu_check.enabled);
@@ -194,14 +194,14 @@ async fn test_virtual_user_lifecycle_global() -> Result<()> {
     let enabled_vu = state
         .provider
         .get_mapping_provider()
-        .enable_virtual_user(&state, &virtual_user_id)
+        .enable_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?;
     assert!(enabled_vu.enabled);
 
     let vu_final = state
         .provider
         .get_mapping_provider()
-        .get_virtual_user(&state, &virtual_user_id)
+        .get_virtual_user(&ExecutionContext::internal(&state), &virtual_user_id)
         .await?
         .expect("virtual user should still exist");
     assert!(vu_final.enabled);

--- a/tests/integration/src/resource.rs
+++ b/tests/integration/src/resource.rs
@@ -22,7 +22,7 @@ use eyre::Result;
 
 use openstack_keystone::keystone::Service;
 use openstack_keystone::keystone::ServiceState;
-use openstack_keystone::resource::ResourceApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::resource::*;
 
 use crate::common::*;
@@ -38,7 +38,7 @@ pub async fn create_project(
     let res = state
         .provider
         .get_resource_provider()
-        .create_project(state, data)
+        .create_project(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))
@@ -51,7 +51,7 @@ pub async fn create_domain(
     let res = state
         .provider
         .get_resource_provider()
-        .create_domain(state, data)
+        .create_domain(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))

--- a/tests/integration/src/resource/domain/delete.rs
+++ b/tests/integration/src/resource/domain/delete.rs
@@ -16,10 +16,9 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::resource::ResourceApi;
-
 use crate::common::get_state;
 use crate::create_domain;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[traced_test]
 #[tokio::test]
@@ -30,13 +29,13 @@ async fn test_delete() -> Result<()> {
     state
         .provider
         .get_resource_provider()
-        .delete_domain(&state, &domain.id)
+        .delete_domain(&ExecutionContext::internal(&state), &domain.id)
         .await?;
     assert!(
         state
             .provider
             .get_resource_provider()
-            .get_domain(&state, &domain.id)
+            .get_domain(&ExecutionContext::internal(&state), &domain.id)
             .await?
             .is_none()
     );

--- a/tests/integration/src/resource/domain/get.rs
+++ b/tests/integration/src/resource/domain/get.rs
@@ -16,10 +16,9 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::resource::ResourceApi;
-
 use crate::common::get_state;
 use crate::create_domain;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[traced_test]
 #[tokio::test]
@@ -30,7 +29,7 @@ async fn test_get_domain() -> Result<()> {
     let res = state
         .provider
         .get_resource_provider()
-        .get_domain(&state, &domain.id)
+        .get_domain(&ExecutionContext::internal(&state), &domain.id)
         .await?
         .expect("domain should be there");
     assert_eq!(res.id, domain.id);
@@ -48,7 +47,10 @@ async fn test_get_domain_missing() -> Result<()> {
         state
             .provider
             .get_resource_provider()
-            .get_domain(&state, &uuid::Uuid::new_v4().to_string())
+            .get_domain(
+                &ExecutionContext::internal(&state),
+                &uuid::Uuid::new_v4().to_string()
+            )
             .await?
             .is_none()
     );

--- a/tests/integration/src/resource/domain/list.rs
+++ b/tests/integration/src/resource/domain/list.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::resource::ResourceApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::resource::*;
 
 use crate::common::get_state;
@@ -32,7 +32,10 @@ async fn test_list() -> Result<()> {
     let res = state
         .provider
         .get_resource_provider()
-        .list_domains(&state, &DomainListParameters::default())
+        .list_domains(
+            &ExecutionContext::internal(&state),
+            &DomainListParameters::default(),
+        )
         .await?;
     // Check that created domains are in the list
     assert!(res.iter().any(|d| d.id == domain.id));
@@ -51,7 +54,7 @@ async fn test_list_by_id() -> Result<()> {
         .provider
         .get_resource_provider()
         .list_domains(
-            &state,
+            &ExecutionContext::internal(&state),
             &DomainListParameters {
                 ids: Some(std::collections::HashSet::from_iter(vec![
                     domain.id.clone(),

--- a/tests/integration/src/resource/project/delete.rs
+++ b/tests/integration/src/resource/project/delete.rs
@@ -16,11 +16,10 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::resource::ResourceApi;
-
 use crate::common::get_state;
 use crate::create_domain;
 use crate::create_project;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[traced_test]
 #[tokio::test]
@@ -32,13 +31,13 @@ async fn test_delete() -> Result<()> {
     state
         .provider
         .get_resource_provider()
-        .delete_project(&state, &project.id)
+        .delete_project(&ExecutionContext::internal(&state), &project.id)
         .await?;
     assert!(
         state
             .provider
             .get_resource_provider()
-            .get_project(&state, &project.id)
+            .get_project(&ExecutionContext::internal(&state), &project.id)
             .await?
             .is_none()
     );

--- a/tests/integration/src/resource/project/get.rs
+++ b/tests/integration/src/resource/project/get.rs
@@ -16,11 +16,10 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::resource::ResourceApi;
-
 use crate::common::get_state;
 use crate::create_domain;
 use crate::create_project;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[traced_test]
 #[tokio::test]
@@ -32,7 +31,7 @@ async fn test_get_project() -> Result<()> {
     let res = state
         .provider
         .get_resource_provider()
-        .get_project(&state, &project.id)
+        .get_project(&ExecutionContext::internal(&state), &project.id)
         .await?
         .expect("project should be there");
     assert_eq!(res.id, project.id);
@@ -51,7 +50,10 @@ async fn test_get_project_missing() -> Result<()> {
         state
             .provider
             .get_resource_provider()
-            .get_project(&state, &uuid::Uuid::new_v4().to_string())
+            .get_project(
+                &ExecutionContext::internal(&state),
+                &uuid::Uuid::new_v4().to_string()
+            )
             .await?
             .is_none()
     );

--- a/tests/integration/src/resource/project/list.rs
+++ b/tests/integration/src/resource/project/list.rs
@@ -16,7 +16,7 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
-use openstack_keystone::resource::ResourceApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::resource::*;
 
 use crate::common::get_state;
@@ -34,7 +34,10 @@ async fn test_list() -> Result<()> {
     let res = state
         .provider
         .get_resource_provider()
-        .list_projects(&state, &ProjectListParameters::default())
+        .list_projects(
+            &ExecutionContext::internal(&state),
+            &ProjectListParameters::default(),
+        )
         .await?;
     assert!(res.contains(&project.resource));
     assert!(res.contains(&project2.resource));
@@ -53,7 +56,7 @@ async fn test_list_by_id() -> Result<()> {
         .provider
         .get_resource_provider()
         .list_projects(
-            &state,
+            &ExecutionContext::internal(&state),
             &ProjectListParameters {
                 ids: Some(std::collections::HashSet::from_iter(vec![
                     project.id.clone(),

--- a/tests/integration/src/revoke.rs
+++ b/tests/integration/src/revoke.rs
@@ -18,8 +18,7 @@ use tracing_test::traced_test;
 use uuid::Uuid;
 
 use openstack_keystone::auth::*;
-use openstack_keystone::revoke::RevokeApi;
-use openstack_keystone::token::TokenApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::identity::*;
 use openstack_keystone_core_types::resource::*;
 use openstack_keystone_core_types::resource::{DomainBuilder, ProjectBuilder};
@@ -82,7 +81,7 @@ async fn test_token_revoked() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -109,28 +108,36 @@ async fn test_token_revoked() -> Result<(), Report> {
     let vsc = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await?;
 
     assert!(
         !state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
 
     state
         .provider
         .get_revoke_provider()
-        .revoke_token(&state, vsc.inner().token().unwrap())
+        .revoke_token(
+            &ExecutionContext::internal(&state),
+            vsc.inner().token().unwrap(),
+        )
         .await?;
 
     assert!(
         state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
     Ok(())
@@ -187,7 +194,7 @@ async fn test_revoked_event_role() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -214,14 +221,19 @@ async fn test_revoked_event_role() -> Result<(), Report> {
     let vsc = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await?;
 
     assert!(
         !state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
 
@@ -229,7 +241,7 @@ async fn test_revoked_event_role() -> Result<(), Report> {
         .provider
         .get_revoke_provider()
         .create_revocation_event(
-            &state,
+            &ExecutionContext::internal(&state),
             RevocationEventCreateBuilder::default()
                 .role_id(role.id.clone())
                 .revoked_at(Utc::now())
@@ -242,7 +254,7 @@ async fn test_revoked_event_role() -> Result<(), Report> {
         state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
     Ok(())
@@ -299,7 +311,7 @@ async fn test_revoked_event_user() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -326,14 +338,19 @@ async fn test_revoked_event_user() -> Result<(), Report> {
     let vsc = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await?;
 
     assert!(
         !state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
 
@@ -341,7 +358,7 @@ async fn test_revoked_event_user() -> Result<(), Report> {
         .provider
         .get_revoke_provider()
         .create_revocation_event(
-            &state,
+            &ExecutionContext::internal(&state),
             RevocationEventCreateBuilder::default()
                 .user_id(user.id.clone())
                 .revoked_at(Utc::now())
@@ -354,7 +371,7 @@ async fn test_revoked_event_user() -> Result<(), Report> {
         state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
     Ok(())
@@ -411,7 +428,7 @@ async fn test_revoked_event_project() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -438,14 +455,19 @@ async fn test_revoked_event_project() -> Result<(), Report> {
     let vsc = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await?;
 
     assert!(
         !state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
 
@@ -453,7 +475,7 @@ async fn test_revoked_event_project() -> Result<(), Report> {
         .provider
         .get_revoke_provider()
         .create_revocation_event(
-            &state,
+            &ExecutionContext::internal(&state),
             RevocationEventCreateBuilder::default()
                 .project_id(project.id.clone())
                 .revoked_at(Utc::now())
@@ -466,7 +488,7 @@ async fn test_revoked_event_project() -> Result<(), Report> {
         state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
     Ok(())

--- a/tests/integration/src/role.rs
+++ b/tests/integration/src/role.rs
@@ -19,7 +19,7 @@ use eyre::Result;
 
 use openstack_keystone::keystone::Service;
 use openstack_keystone::keystone::ServiceState;
-use openstack_keystone::role::RoleApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::role::*;
 
 use crate::common::*;
@@ -38,7 +38,7 @@ pub async fn create_role(
     let res = state
         .provider
         .get_role_provider()
-        .create_role(state, data)
+        .create_role(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))

--- a/tests/integration/src/role/imply_rules/create.rs
+++ b/tests/integration/src/role/imply_rules/create.rs
@@ -16,10 +16,9 @@
 use eyre::Result;
 use uuid::Uuid;
 
-use openstack_keystone::role::RoleApi;
-
 use crate::common::get_state;
 use crate::create_role;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[tokio::test]
 async fn test_create_imply_rule() -> Result<()> {
@@ -30,7 +29,11 @@ async fn test_create_imply_rule() -> Result<()> {
     let rule = state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     assert_eq!(rule.prior_role.id, prior_role.id);
@@ -60,7 +63,11 @@ async fn test_create_imply_rule_with_domain_roles() -> Result<()> {
     let rule = state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     assert_eq!(rule.prior_role.id, prior_role.id);
@@ -85,7 +92,11 @@ async fn test_create_imply_rule_global_roles() -> Result<()> {
     let rule = state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     assert_eq!(rule.prior_role.id, prior_role.id);

--- a/tests/integration/src/role/imply_rules/delete.rs
+++ b/tests/integration/src/role/imply_rules/delete.rs
@@ -16,10 +16,9 @@
 use eyre::Result;
 use uuid::Uuid;
 
-use openstack_keystone::role::RoleApi;
-
 use crate::common::get_state;
 use crate::create_role;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[tokio::test]
 async fn test_delete_imply_rule() -> Result<()> {
@@ -30,14 +29,22 @@ async fn test_delete_imply_rule() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     assert!(
         state
             .provider
             .get_role_provider()
-            .get_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+            .get_role_imply_rule(
+                &ExecutionContext::internal(&state),
+                &prior_role.id,
+                &implied_role.id
+            )
             .await?
             .is_some()
     );
@@ -45,14 +52,22 @@ async fn test_delete_imply_rule() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .delete_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .delete_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     assert!(
         state
             .provider
             .get_role_provider()
-            .get_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+            .get_role_imply_rule(
+                &ExecutionContext::internal(&state),
+                &prior_role.id,
+                &implied_role.id
+            )
             .await?
             .is_none()
     );
@@ -69,7 +84,11 @@ async fn test_delete_nonexistent_imply_rule() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .delete_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .delete_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     Ok(())
@@ -92,20 +111,32 @@ async fn test_delete_imply_rule_with_domain_roles() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     state
         .provider
         .get_role_provider()
-        .delete_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .delete_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     assert!(
         state
             .provider
             .get_role_provider()
-            .get_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+            .get_role_imply_rule(
+                &ExecutionContext::internal(&state),
+                &prior_role.id,
+                &implied_role.id
+            )
             .await?
             .is_none()
     );

--- a/tests/integration/src/role/imply_rules/get.rs
+++ b/tests/integration/src/role/imply_rules/get.rs
@@ -16,10 +16,9 @@
 use eyre::Result;
 use uuid::Uuid;
 
-use openstack_keystone::role::RoleApi;
-
 use crate::common::get_state;
 use crate::create_role;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[tokio::test]
 async fn test_get_imply_rule() -> Result<()> {
@@ -30,13 +29,21 @@ async fn test_get_imply_rule() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     let rule = state
         .provider
         .get_role_provider()
-        .get_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .get_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?
         .unwrap();
 
@@ -59,7 +66,11 @@ async fn test_get_nonexistent_imply_rule() -> Result<()> {
     let rule = state
         .provider
         .get_role_provider()
-        .get_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .get_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     assert!(rule.is_none());
@@ -84,13 +95,21 @@ async fn test_get_imply_rule_with_domain_roles() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     let rule = state
         .provider
         .get_role_provider()
-        .get_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .get_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?
         .unwrap();
 
@@ -114,27 +133,27 @@ async fn test_get_imply_rule_wrong_pair() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &role_a.id, &role_b.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &role_a.id, &role_b.id)
         .await?;
 
     let rule_ab = state
         .provider
         .get_role_provider()
-        .get_role_imply_rule(&state, &role_a.id, &role_b.id)
+        .get_role_imply_rule(&ExecutionContext::internal(&state), &role_a.id, &role_b.id)
         .await?;
     assert!(rule_ab.is_some());
 
     let rule_ac = state
         .provider
         .get_role_provider()
-        .get_role_imply_rule(&state, &role_a.id, &role_c.id)
+        .get_role_imply_rule(&ExecutionContext::internal(&state), &role_a.id, &role_c.id)
         .await?;
     assert!(rule_ac.is_none());
 
     let rule_ba = state
         .provider
         .get_role_provider()
-        .get_role_imply_rule(&state, &role_b.id, &role_a.id)
+        .get_role_imply_rule(&ExecutionContext::internal(&state), &role_b.id, &role_a.id)
         .await?;
     assert!(rule_ba.is_none());
 

--- a/tests/integration/src/role/imply_rules/list.rs
+++ b/tests/integration/src/role/imply_rules/list.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use std::collections::BTreeSet;
 use uuid::Uuid;
 
-use openstack_keystone::role::RoleApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::role::*;
 
 use crate::common::get_state;
@@ -34,7 +34,7 @@ async fn test_list_imply_rules_empty() -> Result<()> {
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules(&state)
+        .list_role_imply_rules(&ExecutionContext::internal(&state))
         .await?;
 
     assert!(rules.is_empty());
@@ -51,13 +51,17 @@ async fn test_list_imply_rules_single() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules(&state)
+        .list_role_imply_rules(&ExecutionContext::internal(&state))
         .await?;
 
     assert_eq!(rules.len(), 1);
@@ -78,23 +82,23 @@ async fn test_list_imply_rules_multiple() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &role_a.id, &role_b.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &role_a.id, &role_b.id)
         .await?;
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &role_a.id, &role_c.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &role_a.id, &role_c.id)
         .await?;
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &role_b.id, &role_d.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &role_b.id, &role_d.id)
         .await?;
 
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules(&state)
+        .list_role_imply_rules(&ExecutionContext::internal(&state))
         .await?;
 
     assert_eq!(rules.len(), 3);
@@ -116,26 +120,34 @@ async fn test_list_imply_rules_after_delete() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules(&state)
+        .list_role_imply_rules(&ExecutionContext::internal(&state))
         .await?;
     assert_eq!(rules.len(), 1);
 
     state
         .provider
         .get_role_provider()
-        .delete_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .delete_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules(&state)
+        .list_role_imply_rules(&ExecutionContext::internal(&state))
         .await?;
     assert!(rules.is_empty());
 
@@ -159,13 +171,17 @@ async fn test_list_imply_rules_with_domain_roles() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules(&state)
+        .list_role_imply_rules(&ExecutionContext::internal(&state))
         .await?;
 
     assert_eq!(rules.len(), 1);
@@ -194,18 +210,26 @@ async fn test_list_imply_rules_mixed_global_and_domain_roles() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &global_prior.id, &global_implied.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &global_prior.id,
+            &global_implied.id,
+        )
         .await?;
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &domain_prior.id, &domain_implied.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &domain_prior.id,
+            &domain_implied.id,
+        )
         .await?;
 
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules(&state)
+        .list_role_imply_rules(&ExecutionContext::internal(&state))
         .await?;
 
     assert_eq!(rules.len(), 2);

--- a/tests/integration/src/role/imply_rules/list_by_prior.rs
+++ b/tests/integration/src/role/imply_rules/list_by_prior.rs
@@ -16,10 +16,9 @@
 use eyre::Result;
 use uuid::Uuid;
 
-use openstack_keystone::role::RoleApi;
-
 use crate::common::get_state;
 use crate::create_role;
+use openstack_keystone_core::auth::ExecutionContext;
 
 #[tokio::test]
 async fn test_list_imply_rules_by_prior_empty() -> Result<()> {
@@ -29,7 +28,7 @@ async fn test_list_imply_rules_by_prior_empty() -> Result<()> {
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules_by_prior(&state, &prior_role.id)
+        .list_role_imply_rules_by_prior(&ExecutionContext::internal(&state), &prior_role.id)
         .await?;
 
     assert!(rules.is_empty());
@@ -46,13 +45,17 @@ async fn test_list_imply_rules_by_prior_single() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior_role.id, &implied_role.id)
+        .create_role_imply_rule(
+            &ExecutionContext::internal(&state),
+            &prior_role.id,
+            &implied_role.id,
+        )
         .await?;
 
     let rules = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules_by_prior(&state, &prior_role.id)
+        .list_role_imply_rules_by_prior(&ExecutionContext::internal(&state), &prior_role.id)
         .await?;
 
     assert_eq!(rules.len(), 1);
@@ -74,28 +77,28 @@ async fn test_list_imply_rules_by_prior_multiple() -> Result<()> {
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &role_a.id, &role_b.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &role_a.id, &role_b.id)
         .await?;
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &role_a.id, &role_c.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &role_a.id, &role_c.id)
         .await?;
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &role_a.id, &role_d.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &role_a.id, &role_d.id)
         .await?;
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &role_b.id, &role_e.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &role_b.id, &role_e.id)
         .await?;
 
     let rules_a = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules_by_prior(&state, &role_a.id)
+        .list_role_imply_rules_by_prior(&ExecutionContext::internal(&state), &role_a.id)
         .await?;
 
     assert_eq!(rules_a.len(), 3);
@@ -106,7 +109,7 @@ async fn test_list_imply_rules_by_prior_multiple() -> Result<()> {
     let rules_b = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules_by_prior(&state, &role_b.id)
+        .list_role_imply_rules_by_prior(&ExecutionContext::internal(&state), &role_b.id)
         .await?;
 
     assert_eq!(rules_b.len(), 1);
@@ -126,18 +129,18 @@ async fn test_list_imply_rules_by_prior_filters_out_other_prior_roles() -> Resul
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior1.id, &implied.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &prior1.id, &implied.id)
         .await?;
     state
         .provider
         .get_role_provider()
-        .create_role_imply_rule(&state, &prior2.id, &implied.id)
+        .create_role_imply_rule(&ExecutionContext::internal(&state), &prior2.id, &implied.id)
         .await?;
 
     let rules1 = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules_by_prior(&state, &prior1.id)
+        .list_role_imply_rules_by_prior(&ExecutionContext::internal(&state), &prior1.id)
         .await?;
 
     assert_eq!(rules1.len(), 1);
@@ -146,7 +149,7 @@ async fn test_list_imply_rules_by_prior_filters_out_other_prior_roles() -> Resul
     let rules2 = state
         .provider
         .get_role_provider()
-        .list_role_imply_rules_by_prior(&state, &prior2.id)
+        .list_role_imply_rules_by_prior(&ExecutionContext::internal(&state), &prior2.id)
         .await?;
 
     assert_eq!(rules2.len(), 1);

--- a/tests/integration/src/role/list.rs
+++ b/tests/integration/src/role/list.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeSet;
 use uuid::Uuid;
 
 use openstack_keystone::keystone::ServiceState;
-use openstack_keystone::role::RoleApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::role::*;
 
 use crate::common::get_state;
@@ -28,7 +28,7 @@ async fn list_roles(state: &ServiceState, params: &RoleListParameters) -> Result
     Ok(state
         .provider
         .get_role_provider()
-        .list_roles(state, params)
+        .list_roles(&ExecutionContext::internal(&state), params)
         .await?
         .into_iter()
         .map(|role| role.id)

--- a/tests/integration/src/token/token_restriction.rs
+++ b/tests/integration/src/token/token_restriction.rs
@@ -19,7 +19,7 @@ use eyre::Result;
 
 use openstack_keystone::keystone::Service;
 use openstack_keystone::keystone::ServiceState;
-use openstack_keystone::token::TokenApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::token::*;
 
 use crate::common::*;
@@ -39,7 +39,7 @@ pub async fn create_token_restriction(
     let res = state
         .provider
         .get_token_provider()
-        .create_token_restriction(state, data)
+        .create_token_restriction(&ExecutionContext::internal(&state), data)
         .await
         .unwrap();
     Ok(AsyncResourceGuard::new(res, state.clone()))

--- a/tests/integration/src/token/validate.rs
+++ b/tests/integration/src/token/validate.rs
@@ -17,6 +17,7 @@ use eyre::Report;
 use std::sync::Arc;
 
 use openstack_keystone_core::assignment::AssignmentApi;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::keystone::Service;
 use openstack_keystone_core_types::assignment::*;
 
@@ -33,7 +34,7 @@ async fn grant_role_to_user_on_project<U: Into<String>, P: Into<String>, R: Into
         .provider
         .get_assignment_provider()
         .create_grant(
-            state,
+            &ExecutionContext::internal(&state),
             AssignmentCreate::user_project(user, project, role, false),
         )
         .await?;
@@ -50,7 +51,7 @@ async fn revoke_role_from_user_on_project<U: Into<String>, P: Into<String>, R: I
         .provider
         .get_assignment_provider()
         .revoke_grant(
-            state,
+            &ExecutionContext::internal(&state),
             AssignmentBuilder::default()
                 .actor_id(user)
                 .role_id(role)

--- a/tests/integration/src/token/validate/application_credential.rs
+++ b/tests/integration/src/token/validate/application_credential.rs
@@ -15,13 +15,12 @@
 
 use chrono::Utc;
 use eyre::Report;
-use openstack_keystone::revoke::RevokeApi;
 use tracing_test::traced_test;
 use uuid::Uuid;
 
-use openstack_keystone::application_credential::ApplicationCredentialApi;
 use openstack_keystone::auth::*;
 use openstack_keystone::token::{FernetToken, TokenApi, TokenProviderError};
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::application_credential::*;
 use openstack_keystone_core_types::resource::{DomainBuilder, ProjectBuilder};
 use openstack_keystone_core_types::role::*;
@@ -48,7 +47,7 @@ async fn test_valid() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 access_rules: None,
                 name: Uuid::new_v4().to_string(),
@@ -81,7 +80,7 @@ async fn test_valid() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -107,7 +106,12 @@ async fn test_valid() -> Result<(), Report> {
     let unpacked_token = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await;
 
     if let Ok(ref vsc_result) = unpacked_token {
@@ -151,7 +155,7 @@ async fn test_expired() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 access_rules: None,
                 expires_at: Some(Utc::now()),
@@ -184,7 +188,7 @@ async fn test_expired() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -232,7 +236,7 @@ async fn test_valid_fewer_roles() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 access_rules: None,
                 name: Uuid::new_v4().to_string(),
@@ -265,7 +269,7 @@ async fn test_valid_fewer_roles() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -291,7 +295,12 @@ async fn test_valid_fewer_roles() -> Result<(), Report> {
     let unpacked_token = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await;
 
     if let Ok(ref vsc_result) = unpacked_token {
@@ -339,7 +348,7 @@ async fn test_valid_all_roles_revoked() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 access_rules: None,
                 name: Uuid::new_v4().to_string(),
@@ -372,7 +381,7 @@ async fn test_valid_all_roles_revoked() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -398,7 +407,12 @@ async fn test_valid_all_roles_revoked() -> Result<(), Report> {
     let unpacked_token = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await;
 
     if let Err(TokenProviderError::Authentication(AuthenticationError::ActorHasNoRolesOnTarget)) =
@@ -428,7 +442,7 @@ async fn test_token_revoked() -> Result<(), Report> {
         .provider
         .get_application_credential_provider()
         .create_application_credential(
-            &state,
+            &ExecutionContext::internal(&state),
             ApplicationCredentialCreate {
                 access_rules: None,
                 name: Uuid::new_v4().to_string(),
@@ -461,7 +475,7 @@ async fn test_token_revoked() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::Project {
                 project: ProjectBuilder::default()
@@ -487,20 +501,28 @@ async fn test_token_revoked() -> Result<(), Report> {
     let vsc = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await?;
 
     state
         .provider
         .get_revoke_provider()
-        .revoke_token(&state, vsc.inner().token().unwrap())
+        .revoke_token(
+            &ExecutionContext::internal(&state),
+            vsc.inner().token().unwrap(),
+        )
         .await?;
 
     assert!(
         state
             .provider
             .get_revoke_provider()
-            .is_token_revoked(&state, &vsc)
+            .is_token_revoked(&ExecutionContext::internal(&state), &vsc)
             .await?
     );
     Ok(())

--- a/tests/integration/src/token/validate/trust.rs
+++ b/tests/integration/src/token/validate/trust.rs
@@ -21,10 +21,9 @@ use tracing_test::traced_test;
 use openstack_keystone_trust_driver_sql::entity::{trust as db_trust, trust_role as db_trust_role};
 
 use openstack_keystone::keystone::Service;
-use openstack_keystone::resource::ResourceApi;
 use openstack_keystone::token::{FernetToken, TokenApi, TokenProviderError};
-use openstack_keystone::trust::TrustApi;
 use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
+use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::*;
 use openstack_keystone_core_types::trust::*;
 
@@ -75,7 +74,7 @@ async fn get_trust<U: AsRef<str>>(state: &Arc<Service>, id: U) -> Result<Option<
     Ok(state
         .provider
         .get_trust_provider()
-        .get_trust(state, id.as_ref())
+        .get_trust(&ExecutionContext::internal(&state), id.as_ref())
         .await?)
 }
 
@@ -122,13 +121,19 @@ async fn test_valid() -> Result<(), Report> {
     let trust_project = state
         .provider
         .get_resource_provider()
-        .get_project(&state, &trust.project_id.clone().unwrap())
+        .get_project(
+            &ExecutionContext::internal(&state),
+            &trust.project_id.clone().unwrap(),
+        )
         .await?
         .expect("trust project exists");
     let project_domain = state
         .provider
         .get_resource_provider()
-        .get_domain(&state, &trust_project.domain_id)
+        .get_domain(
+            &ExecutionContext::internal(&state),
+            &trust_project.domain_id,
+        )
         .await?
         .expect("trust project domain exists");
 
@@ -136,7 +141,7 @@ async fn test_valid() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::TrustProject(Box::new(TrustProjectInfo {
                 trust: trust.clone(),
@@ -154,7 +159,12 @@ async fn test_valid() -> Result<(), Report> {
     let vsc_result = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await;
 
     if let Ok(ref vsc_result) = vsc_result {
@@ -228,13 +238,19 @@ async fn test_valid_redelegated() -> Result<(), Report> {
     let trust_project = state
         .provider
         .get_resource_provider()
-        .get_project(&state, &trust.project_id.clone().unwrap())
+        .get_project(
+            &ExecutionContext::internal(&state),
+            &trust.project_id.clone().unwrap(),
+        )
         .await?
         .expect("trust project exists");
     let project_domain = state
         .provider
         .get_resource_provider()
-        .get_domain(&state, &trust_project.domain_id)
+        .get_domain(
+            &ExecutionContext::internal(&state),
+            &trust_project.domain_id,
+        )
         .await?
         .expect("trust project domain exists");
 
@@ -242,7 +258,7 @@ async fn test_valid_redelegated() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::TrustProject(Box::new(TrustProjectInfo {
                 trust: trust.clone(),
@@ -260,7 +276,12 @@ async fn test_valid_redelegated() -> Result<(), Report> {
     let vsc_result = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await;
 
     if let Ok(ref vsc_result) = vsc_result {
@@ -334,13 +355,19 @@ async fn test_fewer_roles() -> Result<(), Report> {
     let trust_project = state
         .provider
         .get_resource_provider()
-        .get_project(&state, &trust.project_id.clone().unwrap())
+        .get_project(
+            &ExecutionContext::internal(&state),
+            &trust.project_id.clone().unwrap(),
+        )
         .await?
         .expect("trust project exists");
     let project_domain = state
         .provider
         .get_resource_provider()
-        .get_domain(&state, &trust_project.domain_id)
+        .get_domain(
+            &ExecutionContext::internal(&state),
+            &trust_project.domain_id,
+        )
         .await?
         .expect("trust project domain exists");
 
@@ -348,7 +375,7 @@ async fn test_fewer_roles() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::TrustProject(Box::new(TrustProjectInfo {
                 trust: trust.clone(),
@@ -368,7 +395,12 @@ async fn test_fewer_roles() -> Result<(), Report> {
     let unpacked_token = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await;
 
     if let Err(TokenProviderError::Authentication(AuthenticationError::ActorHasNoRolesOnTarget)) =
@@ -431,13 +463,19 @@ async fn test_exclude_local_roles() -> Result<(), Report> {
     let trust_project = state
         .provider
         .get_resource_provider()
-        .get_project(&state, &trust.project_id.clone().unwrap())
+        .get_project(
+            &ExecutionContext::internal(&state),
+            &trust.project_id.clone().unwrap(),
+        )
         .await?
         .expect("trust project exists");
     let project_domain = state
         .provider
         .get_resource_provider()
-        .get_domain(&state, &trust_project.domain_id)
+        .get_domain(
+            &ExecutionContext::internal(&state),
+            &trust_project.domain_id,
+        )
         .await?
         .expect("trust project domain exists");
 
@@ -445,7 +483,7 @@ async fn test_exclude_local_roles() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::TrustProject(Box::new(TrustProjectInfo {
                 trust: trust.clone(),
@@ -463,7 +501,12 @@ async fn test_exclude_local_roles() -> Result<(), Report> {
     let vsc_result = state
         .provider
         .get_token_provider()
-        .validate_to_context(&state, &encoded_token, None, None)
+        .validate_to_context(
+            &ExecutionContext::internal(&state),
+            &encoded_token,
+            None,
+            None,
+        )
         .await;
 
     if let Ok(ref vsc_result) = vsc_result {
@@ -549,13 +592,19 @@ async fn test_trust_populated_in_api_token_response() -> Result<(), Report> {
     let trust_project = state
         .provider
         .get_resource_provider()
-        .get_project(&state, &trust.project_id.clone().unwrap())
+        .get_project(
+            &ExecutionContext::internal(&state),
+            &trust.project_id.clone().unwrap(),
+        )
         .await?
         .expect("trust project exists");
     let project_domain = state
         .provider
         .get_resource_provider()
-        .get_domain(&state, &trust_project.domain_id)
+        .get_domain(
+            &ExecutionContext::internal(&state),
+            &trust_project.domain_id,
+        )
         .await?
         .expect("trust project domain exists");
 
@@ -563,7 +612,7 @@ async fn test_trust_populated_in_api_token_response() -> Result<(), Report> {
         .provider
         .get_token_provider()
         .issue_token_context(
-            &state,
+            &ExecutionContext::internal(&state),
             &ctx,
             &ScopeInfo::TrustProject(Box::new(TrustProjectInfo {
                 trust: trust.clone(),

--- a/tools/start-api.sh
+++ b/tools/start-api.sh
@@ -82,7 +82,7 @@ tools/start-spire.sh
 
 cargo build --bins
 
-SPIFFE_ENDPOINT_SOCKET=$SPIFFE_ENDPOINT_SOCKET ./target/debug/keystone --config "$CONFIG_FILE" &
+KEYSTONE_DEV_KEK=4242424242424242424242424242424242424242424242424242424242424242 SPIFFE_ENDPOINT_SOCKET=$SPIFFE_ENDPOINT_SOCKET ./target/debug/keystone --config "$CONFIG_FILE" &
 AXUM_PID=$!
 
 echo "$AXUM_PID" > "$STATE_DIR/keystone.pid"
@@ -95,7 +95,7 @@ for i in {1..30}; do
         until [ -S "${STATE_DIR}/keystone.sock" ]; do
           sleep 0.5
         done
-        SPIFFE_ENDPOINT_SOCKET=${SPIFFE_ENDPOINT_SOCKET} ./target/debug/keystone-manage --config "${CONFIG_FILE}" bootstrap --bootstrap-password password
+        KEYSTONE_DEV_KEK=4242424242424242424242424242424242424242424242424242424242424242 SPIFFE_ENDPOINT_SOCKET=${SPIFFE_ENDPOINT_SOCKET} ./target/debug/keystone-manage --config "${CONFIG_FILE}" bootstrap --bootstrap-password password
 
         # Export env vars for nextest to inject into test processes
         echo "KEYSTONE_URL=http://localhost:8080" >> "$NEXTEST_ENV"
@@ -105,6 +105,7 @@ for i in {1..30}; do
         echo "OS_USER_DOMAIN_ID=default" >> "$NEXTEST_ENV"
         echo "OS_PROJECT_NAME=admin" >> "$NEXTEST_ENV"
         echo "OS_PROJECT_DOMAIN_ID=default" >> "$NEXTEST_ENV"
+        echo "KEYSTONE_DEV_KEK=4242424242424242424242424242424242424242424242424242424242424242" >> "$NEXTEST_ENV"
         echo "Server started and bootstrapped successfully."
         exit 0
     fi

--- a/tools/teardown-api.sh
+++ b/tools/teardown-api.sh
@@ -11,5 +11,6 @@ if [ -f "$PID_FILE" ]; then
 fi
 if [ -f "$SPIRE_PID_DIR/agent.pid" ]; then kill "$(cat "$SPIRE_PID_DIR/agent.pid")" 2>/dev/null || true; fi
 if [ -f "$SPIRE_PID_DIR/server.pid" ]; then kill "$(cat "$SPIRE_PID_DIR/server.pid")" 2>/dev/null || true; fi
+rm -rf /tmp/nextest/keystone/raft
 
 echo "Cleanup complete. Logs preserved in $STATE_DIR and $SPIRE_PID_DIR."


### PR DESCRIPTION
Refactor all provider API trait methods to accept ExecutionContext
instead of ServiceState. ExecutionContext wraps ServiceState and
Option<&'a ValidatedSecurityContext>, enabling policy enforcement to
access the current authenticated user's security context.

This is necessary to be able to pass also the ValidatedSecurityContext
to providers for implementing audit

Key changes:
- All provider API traits take &ExecutionContext<'a> as first param
- Authenticated CRUD handlers use ExecutionContext::from_auth(state,
  ctx)
- Internal/auth flows use ExecutionContext::internal(state)
- issue_token_context keeps &ServiceState signature (non-CRUD method)
- Fixed double-nested ExecutionContext::internal in test code
- Added KEYSTONE_DEV_KEK env var to start-api.sh for test consistency

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
