### PR TITLE
refactor(core): Remove spiffe crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3964,7 +3964,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sha2 0.11.0",
- "spiffe",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,7 +34,6 @@ sha2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
-spiffe.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -20,7 +20,6 @@ use axum::{
     extract::{FromRef, FromRequestParts},
     http::request::Parts,
 };
-use spiffe::SpiffeId;
 use tracing::{debug, error};
 
 use openstack_keystone_config::Interface;
@@ -30,6 +29,7 @@ use openstack_keystone_core_types::mapping::resolution::IdentitySource;
 
 use crate::api::KeystoneApiError;
 use crate::auth::{ExecutionContext, ValidatedSecurityContext};
+use crate::common::SpiffeId;
 use crate::keystone::ServiceState;
 
 #[derive(Debug, Clone)]
@@ -209,7 +209,6 @@ mod tests {
     use openstack_keystone_config::{AdminInterface, Config, ConfigManager};
 
     use openstack_keystone_core_types::mapping::MappingProviderError;
-    use spiffe::SpiffeId;
     use std::sync::Arc;
 
     async fn create_test_state(mapping_provider: MockMappingProvider) -> ServiceState {

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -14,3 +14,5 @@
 //! # Common functionality
 
 pub mod password_hashing;
+pub mod spiffe_id;
+pub use spiffe_id::SpiffeId;

--- a/crates/core/src/common/spiffe_id.rs
+++ b/crates/core/src/common/spiffe_id.rs
@@ -1,0 +1,64 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Thin SPIFFE ID representation
+//!
+//! Decouples the core crate from the `spiffe` crate. Listeners in the server
+//! crate parse the full `spiffe::SpiffeId` from TLS peer certificates and
+//! convert it into this type before inserting it into request extensions.
+
+use std::fmt;
+
+/// A parsed SPIFFE ID carrying the full URI and its trust domain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpiffeId {
+    /// Full SPIFFE URI, e.g. `spiffe://example.org/workload`.
+    pub id: String,
+    /// Trust domain extracted from the URI, e.g. `example.org`.
+    pub trust_domain: String,
+}
+
+impl SpiffeId {
+    /// Parse a SPIFFE URI of the form `spiffe://<trust-domain>[/path]`.
+    ///
+    /// Returns `None` if the URI does not start with `spiffe://` or the trust
+    /// domain segment is empty.
+    pub fn new(uri: &str) -> Option<Self> {
+        let without_scheme = uri.strip_prefix("spiffe://")?;
+        let trust_domain = without_scheme
+            .split('/')
+            .next()
+            .filter(|s| !s.is_empty())?
+            .to_string();
+        Some(Self {
+            id: uri.to_string(),
+            trust_domain,
+        })
+    }
+
+    /// Returns the full SPIFFE URI.
+    pub fn as_str(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the trust domain of this SPIFFE ID.
+    pub fn trust_domain_name(&self) -> &str {
+        &self.trust_domain
+    }
+}
+
+impl fmt::Display for SpiffeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.id)
+    }
+}

--- a/crates/keystone/src/federation/api/common.rs
+++ b/crates/keystone/src/federation/api/common.rs
@@ -198,7 +198,7 @@ pub(super) async fn build_token_response(
         state
             .provider
             .get_catalog_provider()
-            .get_catalog(&ExecutionContext::internal(&state), true)
+            .get_catalog(&ExecutionContext::internal(state), true)
             .await?
             .into_iter()
             .map(|(s, es)| CatalogService {

--- a/crates/keystone/src/server/listener/spiffe_tls.rs
+++ b/crates/keystone/src/server/listener/spiffe_tls.rs
@@ -24,6 +24,8 @@ use tower::Service;
 use tower_http::normalize_path::NormalizePath;
 use tracing::info;
 
+use openstack_keystone_core::common::SpiffeId as CoreSpiffeId;
+
 use crate::config::Interface;
 use crate::server::listener::spiffe_common;
 
@@ -60,10 +62,17 @@ pub async fn start_axum_app(
                 tokio::spawn(async move {
                     match acceptor.accept(stream).await {
                         Ok((tls_stream, peer_identity)) => {
+                            let spiffe_id = peer_identity.spiffe_id().and_then(|s| {
+                                let id = CoreSpiffeId::new(&s.to_string());
+                                if id.is_none() {
+                                    tracing::warn!("peer presented a SPIFFE certificate with an unparsable SVID '{}'; dropping identity", s);
+                                }
+                                id
+                            });
 
                             let hyper_service = hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
                                 let mut app = app.clone();
-                                let spiffe_id = peer_identity.spiffe_id().cloned();
+                                let spiffe_id = spiffe_id.clone();
                                 let interface_clone = interface_clone.clone();
                                 async move {
                                     let mut req = req;

--- a/crates/keystone/src/server/listener/spiffe_tls_uds.rs
+++ b/crates/keystone/src/server/listener/spiffe_tls_uds.rs
@@ -20,7 +20,7 @@ use color_eyre::eyre::{Report, Result};
 use eyre::Context;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
-use spiffe::SpiffeId;
+use openstack_keystone_core::common::SpiffeId as CoreSpiffeId;
 use spiffe::cert::spiffe_id_from_der;
 use tokio::fs;
 use tokio::net::UnixListener;
@@ -120,11 +120,19 @@ pub async fn start_axum_app(
                     match acceptor.accept(stream).await {
                         Ok(tls_stream) => {
                             let (_, connection) = tls_stream.get_ref();
-                            let spiffe_id: Option<SpiffeId> = connection
+                            let spiffe_id: Option<CoreSpiffeId> = connection
                                 .peer_certificates()
                                 .and_then(|certs| certs.first())
                                 .map(|leaf| spiffe_id_from_der(leaf))
-                                .transpose().unwrap_or_default();
+                                .transpose()
+                                .unwrap_or_default()
+                                .and_then(|s| {
+                                    let id = CoreSpiffeId::new(&s.to_string());
+                                    if id.is_none() {
+                                        tracing::warn!("peer presented a SPIFFE certificate with an unparsable SVID '{}'; dropping identity", s);
+                                    }
+                                    id
+                                });
 
                             let hyper_service = hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
                                 let mut app = app.clone();

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -586,7 +586,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
 
         // Ensure backup targets the leader to avoid stale data.
         let current_leader = self.raft_node.metrics().borrow_watched().current_leader;
-        if current_leader.map_or(true, |l| l != self.node_id) {
+        if current_leader != Some(self.node_id) {
             return Err(Status::failed_precondition(
                 "backup must be directed at the current cluster leader",
             ));
@@ -740,7 +740,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
             .map_err(|e| Status::invalid_argument(format!("invalid backup blob: {e}")))?;
 
         // install_full_snapshot requires the node to be a committed leader.
-        let vote = self.raft_node.metrics().borrow_watched().vote.clone();
+        let vote = self.raft_node.metrics().borrow_watched().vote;
         if !vote.committed {
             return Err(Status::failed_precondition(
                 "node is not a committed leader; direct restore to the current cluster leader",


### PR DESCRIPTION
Introduce a thin `SpiffeId` type in `crates/core/src/common/spiffe_id`
that carries only the fields needed by the authentication layer (full
URI and trust domain). Listeners in the server crate convert the fully
validated `spiffe::SpiffeId` into this type before inserting it into
Axum request extensions, keeping the `spiffe` crate dependency
confined to `openstack-keystone` where the mTLS and workload-API
integration live. An unparseable SVID (which should not occur in
practice since the upstream crate already validated it) now emits a
warning and drops the identity, ensuring the request fails closed
rather than silently falling back to token authentication.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
