### PR TITLE
feat(storage): SPIFFE checks, RBAC, and rate limiting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,15 +13,6 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
       - id: check-yaml
-        files: .*\.(yaml|yml)$
-        exclude: |
-          (?x)(
-            ^zuul.d/.*$|
-            skaffold.yaml
-          )
-      - id: check-yaml
-        name: check-yaml (skaffold)
-        files: ^skaffold\.yaml$
         args: [--allow-multiple-documents]
       - id: check-json
   - repo: https://github.com/crate-ci/typos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2374,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -3443,6 +3468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,6 +4036,7 @@ dependencies = [
  "eyre",
  "fjall",
  "futures",
+ "governor",
  "http",
  "hyper-util",
  "mockall",
@@ -5113,6 +5145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5340,6 +5378,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick_cache"
 version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,6 +5560,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "rayon"
@@ -6662,6 +6724,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ eyre = { version = "0.6" }
 fernet = { version = "0.2", default-features = false }
 futures = { version = "0.3" }
 futures-util = { version = "0.3" }
+governor = "0.10"
 http-body-util = "0.1"
 http = { version = "1.4" }
 hyper = { version = "1.10" }

--- a/crates/cli-manage/src/storage/join.rs
+++ b/crates/cli-manage/src/storage/join.rs
@@ -44,15 +44,28 @@ impl PerformAction for JoinCommand {
             {
                 let mut client = get_grpc_client(config, Some(self.cluster_addr)).await?;
 
-                client
+                match client
                     .add_learner(pb::raft::AddLearnerRequest {
                         node: Some(pb::raft::Node {
                             node_id: cfg.node_id,
                             rpc_addr: format!("{host}:{port}"),
                         }),
                     })
-                    .await?;
-                Ok(())
+                    .await
+                {
+                    Ok(_) => Ok(()),
+                    Err(e) if e.code() == tonic::Code::AlreadyExists => {
+                        // Node is already registered in the cluster (likely via
+                        // auto-join from retry_join_nodes config). Idempotent
+                        // success, used by skaffold post-deploy hook.
+                        tracing::debug!(
+                            node_id = cfg.node_id,
+                            "node already registered in cluster, join is idempotent"
+                        );
+                        Ok(())
+                    }
+                    Err(e) => Err(eyre!("add_learner failed: {e}")),
+                }
             } else {
                 Err(eyre!(
                     "cannot determine the host:port of the current node to announce to the cluster"

--- a/crates/config/src/distributed_storage.rs
+++ b/crates/config/src/distributed_storage.rs
@@ -54,6 +54,54 @@ pub struct DistributedStorageConfiguration {
     /// CI/CD deployment validation check (ADR 0016-v2 §10 invariant 11).
     #[serde(default)]
     pub dev_mode: bool,
+
+    /// Nodes to attempt Raft cluster join against on startup (ADR 0016-v2
+    /// §4.3).
+    ///
+    /// CSV list of ``<node_id>=<address>`` pairs, analogous to HashCorp Vault's
+    /// ``[auto_join]``, ZooKeeper's ``initialMembers``, or etcd's
+    /// ``--initial-cluster``. Every node in the cluster should configure
+    /// the same list.
+    ///
+    /// The bootstrap node (``node_id == 0``) passes the full map to
+    /// ``Raft::initialize()`` so all members are known from the start.
+    /// Non-bootstrap nodes iterate the list and attempt ``add_learner`` at
+    /// each address until one succeeds.  If empty, non-bootstrap nodes will
+    /// not auto-join and must be joined manually via ``keystone-manage
+    /// storage join``.
+    ///
+    /// Example (INI / site.toml):
+    /// ```toml
+    /// retry_join_nodes = "0=https://keystone-rs-0.svc:8300,1=https://keystone-rs-1.svc:8300,2=https://keystone-rs-2.svc:8300"
+    /// ```
+    #[serde(default, deserialize_with = "deserialize_retry_join_nodes")]
+    pub retry_join_nodes: Vec<(u64, String)>,
+}
+
+/// Deserialize ``id=address`` pairs from a CSV string.
+///
+/// Format: ``"0=https://node0:8300,1=https://node1:8300"``.  Entries without
+/// an ``=`` separator or with invalid node IDs are silently skipped.
+fn deserialize_retry_join_nodes<'de, D>(deserializer: D) -> Result<Vec<(u64, String)>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let mut out = Vec::new();
+    for entry in s.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (id_part, addr) = entry.split_once('=').ok_or_else(|| {
+            serde::de::Error::custom(format!("expected 'id=addr' format, got '{}'", entry))
+        })?;
+        let id: u64 = id_part.trim().parse().map_err(|e| {
+            serde::de::Error::custom(format!("invalid node id '{}': {}", id_part.trim(), e))
+        })?;
+        out.push((id, addr.trim().to_string()));
+    }
+    Ok(out)
 }
 
 fn default_tcp_address() -> SocketAddr {
@@ -85,6 +133,39 @@ pub struct SpiffeTls {
     /// Trusted domains for SPIFFE verification.
     #[serde(deserialize_with = "csv")]
     pub trust_domains: Vec<String>,
+
+    /// SPIFFE path prefix required on all storage SVIDs (e.g.
+    /// `/keystone/storage/`). The role segment follows this prefix:
+    /// `spiffe://<td><spiffe_path_prefix><role>`.
+    #[serde(default = "default_spiffe_path_prefix")]
+    pub spiffe_path_prefix: String,
+
+    /// SPIFFE role that authorises sensitive management operations (backup,
+    /// restore, rotate DEK, clear quarantine, etc.).  Defaults to
+    /// `"storage-operator"`.
+    #[serde(default = "default_operator_role")]
+    pub operator_role: String,
+
+    /// Allow-list of SPIFFE SVIDs that may participate in peer-to-peer Raft
+    /// operations (`metrics`, `init`, `add_learner`, `change_membership`).
+    /// When empty the check falls back to trust-domain-only validation.
+    ///
+    /// Example:
+    /// ```yaml
+    /// allowed_peer_svids:
+    ///   - spiffe://example.org/ns/default/sa/keystone
+    ///   - spiffe://example.org/keystone/storage/node
+    /// ```
+    #[serde(default)]
+    pub allowed_peer_svids: Vec<String>,
+}
+
+fn default_spiffe_path_prefix() -> String {
+    "/keystone/storage/".to_string()
+}
+
+fn default_operator_role() -> String {
+    "storage-operator".to_string()
 }
 
 #[cfg(test)]
@@ -135,6 +216,34 @@ tls_client_ca_file = /baz
             assert_eq!(tls.tls_client_ca_file, Some(PathBuf::from("/baz")));
         } else {
             panic!("should be regular tls");
+        }
+    }
+
+    #[test]
+    fn test_spiffe_peer_svids_toml() {
+        let c = Config::builder()
+            .add_source(File::from_str(
+                r#"
+node_cluster_addr = "https://localhost:8310"
+node_id = 1
+path = "/keystone/storage"
+trust_domains = "example.org"
+allowed_peer_svids = ["spiffe://example.org/ns/default/sa/keystone"]
+"#,
+                FileFormat::Toml,
+            ))
+            .build()
+            .unwrap();
+        let cfg: DistributedStorageConfiguration = c.try_deserialize().unwrap();
+        assert_eq!(1, cfg.node_id);
+        if let RaftTlsConfiguration::Spiffe(spiffe) = &cfg.tls_configuration {
+            assert!(spiffe.trust_domains.contains(&"example.org".to_string()));
+            assert_eq!(
+                spiffe.allowed_peer_svids,
+                vec!["spiffe://example.org/ns/default/sa/keystone".to_string()]
+            );
+        } else {
+            panic!("should be spiffe");
         }
     }
 

--- a/crates/keystone/src/api/health.rs
+++ b/crates/keystone/src/api/health.rs
@@ -256,6 +256,12 @@ async fn check_database(state: &ServiceState) -> DatabaseStatus {
 }
 
 /// Perform Raft storage checks.
+///
+/// Returns OK when the cluster is initialized.  Leadership status is not
+/// checked: without a leader, writes return \[ForwardToLeader\] and clients
+/// can retry. Blocking the readiness probe on leader election causes
+/// startup-probe failures in k8s when the 1‑second probe fires before the
+/// Raft engine finishes its async step-up (ADR 0016-v2 §4.2).
 async fn check_storage(state: &ServiceState) -> RaftStatus {
     let Some(storage) = state.storage.as_deref() else {
         return RaftStatus::skipped();

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -445,12 +445,19 @@ async fn main() -> Result<(), Report> {
         let raft_cancel_token = token.clone();
         let raft_config = cfg.clone();
         let raft_storage = concrete_storage.as_ref().expect("storage is None").clone();
+        let raft_storage_init = raft_storage.clone();
+
+        // Signal channel: start_raft_app sends `true` once the gRPC listener
+        // is bound. `ensure_raft_initialized` waits for this before calling
+        // join_cluster, ensuring the new node's listener can accept replication
+        // traffic from the leader immediately.
+        let (raft_bound_tx, raft_bound_rx) = tokio::sync::watch::channel(false);
         handles.spawn(async move {
-            raft_grpc::start_raft_app(raft_storage, raft_config, raft_cancel_token)
+            raft_grpc::start_raft_app(raft_storage, raft_config, raft_cancel_token, raft_bound_tx)
                 .await
                 .unwrap()
         });
-        raft_grpc::ensure_raft_initialized(shared_state.clone(), cfg.clone()).await?;
+        raft_grpc::ensure_raft_initialized(raft_storage_init, cfg.clone(), raft_bound_rx).await?;
     }
 
     // OPA Subprocess

--- a/crates/keystone/src/server/listener/raft_grpc.rs
+++ b/crates/keystone/src/server/listener/raft_grpc.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # Raft gRPC listener
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use color_eyre::eyre::{Report, Result};
@@ -27,9 +26,9 @@ use openstack_keystone_distributed_storage::{
     app::{Storage, get_app_server},
     network::get_server_tls_config,
 };
+use openstack_keystone_storage_api::StorageApi;
 
 use crate::config::Config;
-use crate::keystone::ServiceState;
 use crate::server::listener::spiffe_common;
 
 /// Validate a SPIFFE ID from the peer certificate chain against the allowed
@@ -40,6 +39,7 @@ use crate::server::listener::spiffe_common;
 fn validate_spiffe_id(
     peer_certs: Option<Arc<Vec<rustls::pki_types::CertificateDer<'static>>>>,
     trust_domains: &[String],
+    allowed_peer_svids: &[String],
 ) -> std::result::Result<(), tonic::Status> {
     use spiffe::cert::spiffe_id_from_der;
 
@@ -61,14 +61,26 @@ fn validate_spiffe_id(
         )));
     }
 
-    // Accept paths starting with `/keystone/storage/` (custom format) or
-    // `/ns/<namespace>/sa/<service-account>` (standard SPIRE SpiffeID format).
-    let path = spiffe_id.path();
-    if !(path.starts_with("/keystone/storage/") || path.starts_with("/ns/")) {
-        return Err(tonic::Status::permission_denied(format!(
-            "SPIFFE ID path {:?} does not match allowed prefix (expected `/keystone/storage/` or `/ns/<ns>/sa/<sa>`)",
-            path
-        )));
+    // If allowed_peer_svids is configured, enforce exact SVID match for tight
+    // identity control (ADR 0016-v2 §4.1). Otherwise fall back to prefix check.
+    let spiffe_uri = format!("spiffe://{}{}", td_name, spiffe_id.path());
+    if !allowed_peer_svids.is_empty() {
+        if !allowed_peer_svids.contains(&spiffe_uri) {
+            return Err(tonic::Status::permission_denied(format!(
+                "SPIFFE ID '{}' is not in the allowed peer SVID list",
+                spiffe_uri
+            )));
+        }
+    } else {
+        // Fallback: accept paths starting with `/keystone/storage/` (custom format) or
+        // `/ns/<namespace>/sa/<service-account>` (standard SPIRE SpiffeID format).
+        let path = spiffe_id.path();
+        if !(path.starts_with("/keystone/storage/") || path.starts_with("/ns/")) {
+            return Err(tonic::Status::permission_denied(format!(
+                "SPIFFE ID path {:?} does not match allowed prefix (expected `/keystone/storage/` or `/ns/<ns>/sa/<sa>`)",
+                path
+            )));
+        }
     }
 
     Ok(())
@@ -77,11 +89,13 @@ fn validate_spiffe_id(
 /// gRPC interceptor that enforces SPIFFE mTLS identity on Raft connections.
 ///
 /// Every inbound gRPC request must carry a peer certificate whose SPIFFE ID
-/// matches the pattern `spiffe://<trust_domain>/keystone/storage/<role>` for
-/// one of the configured trust domains (ADR 0016-v2 §4.1).
+/// matches one of the configured trust domains (ADR 0016-v2 §4.1).
+/// When `allowed_peer_svids` is configured, only those exact SVIDs are
+/// accepted.
 #[derive(Clone)]
 struct SpiffeIdInterceptor {
     trust_domains: Arc<Vec<String>>,
+    allowed_peer_svids: Arc<Vec<String>>,
 }
 
 impl tonic::service::Interceptor for SpiffeIdInterceptor {
@@ -89,16 +103,27 @@ impl tonic::service::Interceptor for SpiffeIdInterceptor {
         &mut self,
         req: tonic::Request<()>,
     ) -> std::result::Result<tonic::Request<()>, tonic::Status> {
-        validate_spiffe_id(req.peer_certs(), &self.trust_domains)?;
+        validate_spiffe_id(
+            req.peer_certs(),
+            &self.trust_domains,
+            &self.allowed_peer_svids,
+        )?;
         Ok(req)
     }
 }
 
 /// Start Raft backed distributed storage.
+///
+/// Broadcasts `true` on `bound_signal` once the Raft gRPC listener is bound
+/// and accepting connections.  Callers may use this to coordinate with
+/// [`ensure_raft_initialized`] — a non-bootstrap node should wait for its own
+/// listener to be ready before calling `add_learner`, otherwise the leader
+/// cannot replicate back to it.
 pub async fn start_raft_app(
     storage: Arc<Storage>,
     config: Config,
     cancel_token: CancellationToken,
+    bound_signal: tokio::sync::watch::Sender<bool>,
 ) -> Result<(), Report> {
     let Some(ds) = &config.distributed_storage else {
         return Ok(());
@@ -119,6 +144,7 @@ pub async fn start_raft_app(
     match &ds.tls_configuration {
         RaftTlsConfiguration::Spiffe(spiffe_cfg) => {
             let trust_domains = spiffe_cfg.trust_domains.clone();
+            let allowed_peer_svids = spiffe_cfg.allowed_peer_svids.clone();
 
             let server_config = match spiffe_common::build_spiffe_config(
                 cancel_token.clone(),
@@ -135,13 +161,14 @@ pub async fn start_raft_app(
 
             let interceptor = SpiffeIdInterceptor {
                 trust_domains: Arc::new(trust_domains),
+                allowed_peer_svids: Arc::new(allowed_peer_svids),
             };
 
             let mut server =
                 tonic::transport::Server::builder().layer(InterceptorLayer::new(interceptor));
             let tonic_router = server.add_routes(storage_app);
 
-            info!(
+            tracing::info!(
                 "Starting distributed storage at {:?} with SPIFFE mTLS",
                 grpc_addr
             );
@@ -179,6 +206,7 @@ pub async fn start_raft_app(
                 },
             );
 
+            _ = bound_signal.send(true);
             tonic_router
                 .serve_with_incoming_shutdown(incoming, async move {
                     cancel_token.cancelled().await;
@@ -191,8 +219,9 @@ pub async fn start_raft_app(
                 tonic::transport::Server::builder().tls_config(get_server_tls_config(&config)?)?;
             let tonic_router = server.add_routes(storage_app);
 
-            info!("Starting distributed storage at {:?}", grpc_addr);
+            tracing::info!("Starting distributed storage at {:?}", grpc_addr);
 
+            _ = bound_signal.send(true);
             tonic_router
                 .serve_with_shutdown(grpc_addr, async move {
                     cancel_token.cancelled().await;
@@ -204,26 +233,110 @@ pub async fn start_raft_app(
     Ok(())
 }
 
-/// Ensure Raft cluster is initialized with at least the current node.
-pub async fn ensure_raft_initialized(state: ServiceState, config: Config) -> Result<(), Report> {
-    if let Some(ds) = &config.distributed_storage
-        && let Some(storage) = state.storage.as_deref()
-        && !storage.is_initialized().await?
-        && ds.node_id == 0
-        && let (Some(host), Some(port)) = (ds.node_cluster_addr.host(), ds.node_cluster_addr.port())
-    {
-        info!("Initializing the integrated storage since it is not initialized.");
+/// Ensure Raft cluster is initialized with at least the current node, or join
+/// an existing cluster if this node is not the bootstrap node.
+///
+/// `listener_bound` is a watch channel that [`start_raft_app`] signals once the
+/// Raft gRPC listener is bound.  Non-bootstrap nodes wait for this signal
+/// before calling `add_learner`, ensuring their own listener is ready to accept
+/// replication traffic from the leader.
+pub async fn ensure_raft_initialized(
+    storage: Arc<Storage>,
+    config: Config,
+    mut listener_bound: tokio::sync::watch::Receiver<bool>,
+) -> Result<(), Report> {
+    let Some(ds) = &config.distributed_storage else {
+        return Ok(());
+    };
+
+    let node_id = storage.node_id();
+    let my_cluster_addr = ds.node_cluster_addr.to_string();
+
+    // Bootstrap node (node_id == 0): self-bootstrap as a single-node cluster.
+    // Known peers join later via [add_learner] (non-bootstrap path below).
+    if !storage.is_initialized().await? && node_id == 0 {
+        let self_node = openstack_keystone_storage_api::Node {
+            node_id,
+            rpc_addr: my_cluster_addr.clone(),
+        };
+
+        tracing::info!("Self-bootstrapping integrated storage as single-node cluster.");
         storage
-            .initialize(HashMap::from([(
-                0,
-                openstack_keystone_storage_api::Node {
-                    node_id: 0,
-                    rpc_addr: format!("{host}:{port}"),
-                },
-            )]))
+            .initialize([(node_id, self_node)].into_iter().collect())
             .await?;
+        return Ok(());
     }
-    Ok(())
+
+    // Non-bootstrap node: auto-join using known peer addresses.
+    if ds.retry_join_nodes.is_empty() {
+        if !storage.is_initialized().await? {
+            return Err(Report::msg(
+                "Raft cluster is not initialized and no retry_join_nodes configured - \
+                 set retry_join_nodes or join manually",
+            ));
+        }
+        return Ok(());
+    }
+
+    let join_addrs: Vec<&str> = ds
+        .retry_join_nodes
+        .iter()
+        .filter(|(pid, _)| *pid != node_id)
+        .map(|(_, addr)| addr.as_str())
+        .collect();
+
+    if join_addrs.is_empty() {
+        return Err(Report::msg(
+            "retry_join_nodes contains only this node - no peers to join",
+        ));
+    }
+
+    // Wait for our own Raft gRPC listener to be bound before calling
+    // add_learner.  Without this, the leader may try to replicate back to us
+    // before the port is accepting connections, causing join timeouts.
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        let _ = listener_bound.changed().await;
+    })
+    .await
+    .map_err(|_| Report::msg("Raft listener did not bind within 30s — aborting cluster join"))?;
+
+    // With publishNotReadyAddresses: true on the headless service, DNS records
+    // are available for non-ready pods.  The FQDN from config will resolve
+    // correctly, so the leader can replicate to us once replication starts.
+    tracing::info!(
+        node_id,
+        join_count = join_addrs.len(),
+        "Waiting for Raft cluster to be available before joining..."
+    );
+    for attempt in 0..60 {
+        for join_addr in &join_addrs {
+            match storage.join_cluster(join_addr, &my_cluster_addr).await {
+                Ok(()) => {
+                    tracing::info!(node_id, join_addr, "Successfully joined Raft cluster.");
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        node_id,
+                        join_addr,
+                        ?e,
+                        "join attempt failed, trying next address"
+                    );
+                }
+            }
+        }
+        if attempt % 10 == 0 {
+            tracing::debug!(
+                node_id,
+                attempt,
+                "still waiting for join addresses to be available"
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+    Err(Report::msg(
+        "timed out joining Raft cluster - none of the retry_join_nodes responded",
+    ))
 }
 
 #[cfg(test)]
@@ -251,7 +364,7 @@ mod tests {
         let trust_domains = vec!["example.org".to_string()];
         let cert = generate_spiffe_cert("example.org", "/keystone/storage/node-0");
         let certs = Some(Arc::new(vec![cert]));
-        assert!(validate_spiffe_id(certs, &trust_domains).is_ok());
+        assert!(validate_spiffe_id(certs, &trust_domains, &[]).is_ok());
     }
 
     #[test]
@@ -259,7 +372,7 @@ mod tests {
         let trust_domains = vec!["example.org".to_string()];
         let cert = generate_spiffe_cert("evil.org", "/keystone/storage/node-0");
         let certs = Some(Arc::new(vec![cert]));
-        let err = validate_spiffe_id(certs, &trust_domains).unwrap_err();
+        let err = validate_spiffe_id(certs, &trust_domains, &[]).unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
         assert!(err.message().contains("evil.org"));
     }
@@ -269,7 +382,7 @@ mod tests {
         let trust_domains = vec!["example.org".to_string()];
         let cert = generate_spiffe_cert("example.org", "/admin/delete");
         let certs = Some(Arc::new(vec![cert]));
-        let err = validate_spiffe_id(certs, &trust_domains).unwrap_err();
+        let err = validate_spiffe_id(certs, &trust_domains, &[]).unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
         assert!(err.message().contains("does not match allowed prefix"));
     }
@@ -279,13 +392,13 @@ mod tests {
         let trust_domains = vec!["example.org".to_string()];
         let cert = generate_spiffe_cert("example.org", "/ns/default/sa/keystone");
         let certs = Some(Arc::new(vec![cert]));
-        assert!(validate_spiffe_id(certs, &trust_domains).is_ok());
+        assert!(validate_spiffe_id(certs, &trust_domains, &[]).is_ok());
     }
 
     #[test]
     fn test_spiffe_id_no_certs() {
         let trust_domains = vec!["example.org".to_string()];
-        let err = validate_spiffe_id(None, &trust_domains).unwrap_err();
+        let err = validate_spiffe_id(None, &trust_domains, &[]).unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
         assert!(err.message().contains("no peer certificate"));
     }
@@ -294,7 +407,7 @@ mod tests {
     fn test_spiffe_id_empty_chain() {
         let trust_domains = vec!["example.org".to_string()];
         let certs = Some(Arc::new(vec![]));
-        let err = validate_spiffe_id(certs, &trust_domains).unwrap_err();
+        let err = validate_spiffe_id(certs, &trust_domains, &[]).unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
         assert!(err.message().contains("empty certificate chain"));
     }
@@ -305,7 +418,7 @@ mod tests {
         let certs = Some(Arc::new(vec![rustls::pki_types::CertificateDer::from(
             vec![0x00, 0x01],
         )]));
-        let err = validate_spiffe_id(certs, &trust_domains).unwrap_err();
+        let err = validate_spiffe_id(certs, &trust_domains, &[]).unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
         assert!(err.message().contains("Invalid SPIFFE ID"));
     }
@@ -316,7 +429,7 @@ mod tests {
         let cert_1 = generate_spiffe_cert("example.org", "/keystone/storage/node-0");
         let cert_2 = generate_spiffe_cert("example.net", "/keystone/storage/node-1");
 
-        assert!(validate_spiffe_id(Some(Arc::new(vec![cert_1])), &trust_domains).is_ok());
-        assert!(validate_spiffe_id(Some(Arc::new(vec![cert_2])), &trust_domains).is_ok());
+        assert!(validate_spiffe_id(Some(Arc::new(vec![cert_1])), &trust_domains, &[]).is_ok());
+        assert!(validate_spiffe_id(Some(Arc::new(vec![cert_2])), &trust_domains, &[]).is_ok());
     }
 }

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -455,4 +455,10 @@ pub trait StorageApi: Send + Sync {
 
     /// Initializes the Raft cluster with the given node configuration.
     async fn initialize(&self, nodes: HashMap<u64, Node>) -> Result<(), StoreError>;
+
+    /// Returns the Raft leader node id, if a stable leader is elected.
+    /// The storage is considered operationally ready only when this returns
+    /// `Some(id)`, because without a leader writes will return
+    /// `ForwardToLeader(None, None)` (ADR 0016-v2 §4.2).
+    async fn current_leader(&self) -> Option<u64>;
 }

--- a/crates/storage-crypto/src/dek.rs
+++ b/crates/storage-crypto/src/dek.rs
@@ -188,6 +188,7 @@ impl DekEpoch {
 ///
 /// Returns the key in a `LockedKey` per ADR §9, Invariant 8.
 /// Panics on OOM; allocation failure for key material is fatal.
+#[allow(clippy::expect_used)]
 pub fn generate_dek() -> LockedKey {
     let mut dek = LockedKey::alloc().expect("OOM allocating DEK");
     // rand::fill is CSPRNG-backed (OsRng on all supported platforms).

--- a/crates/storage-crypto/src/kek.rs
+++ b/crates/storage-crypto/src/kek.rs
@@ -20,8 +20,8 @@
 //!   environment variable.  Requires `--dev-mode` and
 //!   `KEYSTONE_ALLOW_ENV_KEK=1`.  After reading, the variable is removed from
 //!   the Rust environment map (via `unsafe env::remove_var`) and the underlying
-//!   bytes in `/proc/<pid>/environ` are zeroed on Linux to prevent exposure
-//!   via process inspection tools.
+//!   bytes in `/proc/<pid>/environ` are zeroed on Linux to prevent exposure via
+//!   process inspection tools.
 //!
 //! * [`Pkcs11KekStub`] — placeholder that always returns
 //!   [`CryptoError::Pkcs11NotImplemented`].  Reserves the production interface
@@ -86,12 +86,12 @@ impl EnvKek {
     // threads reading the environment while we mutate it can cause UB in some
     // C library implementations).  Here the call is safe because:
     //
-    // 1. `from_env` is called exactly once during storage initialisation,
-    //    before any async tasks that might inspect the environment are spawned.
-    // 2. No other thread is spawned before `init_storage` reaches this point,
-    //    so there is no concurrent reader of `KEYSTONE_DEV_KEK`.
-    // 3. Removing the variable immediately after reading minimises the window
-    //    in which `/proc/<pid>/environ` exposes the key (ADR 0016-v2 §2.1).
+    // 1. `from_env` is called exactly once during storage initialisation, before
+    //    any async tasks that might inspect the environment are spawned.
+    // 2. No other thread is spawned before `init_storage` reaches this point, so
+    //    there is no concurrent reader of `KEYSTONE_DEV_KEK`.
+    // 3. Removing the variable immediately after reading minimises the window in
+    //    which `/proc/<pid>/environ` exposes the key (ADR 0016-v2 §2.1).
     //
     // On Linux, `libc::unsetenv` (called by `std::env::remove_var`) marks the
     // entry in the `environ` array but does not zero the underlying bytes.

--- a/crates/storage-crypto/src/mlock.rs
+++ b/crates/storage-crypto/src/mlock.rs
@@ -68,6 +68,7 @@ struct AllocState {
 
 static ALLOC_STATE: OnceLock<AllocState> = OnceLock::new();
 
+#[allow(clippy::expect_used)]
 fn alloc_state() -> &'static AllocState {
     ALLOC_STATE.get_or_init(|| {
         let page_size = sysconf(SysconfVar::PAGE_SIZE)
@@ -120,6 +121,7 @@ impl LockedKey {
     /// Copy `bytes` into a fresh guard-paged allocation.
     ///
     /// Panics on OOM; allocation failure for key material is fatal.
+    #[allow(clippy::expect_used)]
     pub fn from_raw(bytes: [u8; KEY_SIZE]) -> Self {
         let mut key = Self::alloc().expect("OOM allocating LockedKey");
         key.as_mut().copy_from_slice(&bytes);

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -42,6 +42,7 @@ async-trait.workspace = true
 byteorder.workspace = true
 dashmap.workspace = true
 eyre.workspace = true
+governor.workspace = true
 fjall = { version = "3.1" }
 futures.workspace = true
 http.workspace = true

--- a/crates/storage/benches/write.rs
+++ b/crates/storage/benches/write.rs
@@ -57,6 +57,7 @@ impl InstanceHolder {
                 tls_config.clone(),
             ),
             dev_mode: true,
+            retry_join_nodes: vec![],
         }
     }
 

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -47,6 +47,9 @@ use crate::pb::raft::cluster_admin_service_server::ClusterAdminServiceServer;
 use crate::pb::raft::raft_service_server::RaftServiceServer;
 use crate::protobuf::api::storage_service_client::StorageServiceClient;
 use crate::protobuf::api::storage_service_server::StorageServiceServer;
+use crate::protobuf::raft::AddLearnerRequest;
+use crate::protobuf::raft::Node as PbNode;
+use crate::protobuf::raft::cluster_admin_service_client::ClusterAdminServiceClient;
 use crate::store_command::*;
 use crate::types::*;
 use openstack_keystone_storage_api::Node;
@@ -195,6 +198,22 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
     };
     let (audit_forwarder, _audit_task) = AuditForwarder::spawn(audit_key);
 
+    // Extract SPIFFE configuration when the cluster is in SPIFFE mTLS mode
+    // so the admin service interceptor can validate SVID patterns.
+    let (spiffe_trust_domains, spiffe_path_prefix, operator_role, allowed_peer_svids) =
+        if let openstack_keystone_config::RaftTlsConfiguration::Spiffe(spiffe) =
+            &ds_config.tls_configuration
+        {
+            (
+                Some(spiffe.trust_domains.clone()),
+                spiffe.spiffe_path_prefix.clone(),
+                spiffe.operator_role.clone(),
+                spiffe.allowed_peer_svids.clone(),
+            )
+        } else {
+            (None, String::new(), String::new(), Vec::new())
+        };
+
     Ok(Storage {
         connection_pool: DashMap::new(),
         raft,
@@ -205,6 +224,10 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
         current_dek,
         audit_forwarder,
         pending_rotations,
+        spiffe_trust_domains,
+        spiffe_path_prefix,
+        operator_role,
+        allowed_peer_svids,
     })
 }
 
@@ -225,6 +248,10 @@ pub async fn get_app_server(storage: &Storage) -> Result<Routes, StoreError> {
         storage.audit_forwarder.clone(),
         storage.pending_rotations.clone(),
         storage.state_machine_store.clone(),
+        storage.spiffe_trust_domains.clone(),
+        storage.spiffe_path_prefix.clone(),
+        storage.operator_role.clone(),
+        storage.allowed_peer_svids.clone(),
     );
     let storage_svc_impl = StorageServiceImpl::new(storage.raft.clone());
 
@@ -242,7 +269,7 @@ pub struct Storage {
     /// Raft cluster nodes connection pool.
     connection_pool: DashMap<u64, Channel>,
     /// TLS client mode for Raft peer connections.
-    tls_client: RaftTlsClient,
+    pub(crate) tls_client: RaftTlsClient,
     /// Raft instance.
     pub raft: Raft,
     /// This node's Raft ID (used to tag audit records for per-node
@@ -259,6 +286,19 @@ pub struct Storage {
     pub audit_forwarder: AuditForwarder,
     /// Pending emergency DEK rotations (shared with FjallStateMachine).
     pending_rotations: Arc<Mutex<HashMap<String, crate::store_command::PendingRotation>>>,
+    /// SPIFFE trust domains for SVID pattern validation. `None` in
+    /// TLS-fallback mode — pattern and role checks are skipped.
+    pub spiffe_trust_domains: Option<Vec<String>>,
+    /// SPIFFE path prefix for SVID pattern validation (e.g.
+    /// `/keystone/storage/`). Empty when in TLS-fallback mode — pattern
+    /// checks are skipped.
+    pub spiffe_path_prefix: String,
+    /// SPIFFE role that authorizes sensitive management operations.  Empty when
+    /// in TLS-fallback mode — role checks are skipped.
+    pub operator_role: String,
+    /// Allow-list of SPIFFE SVIDs accepted for peer-to-peer Raft operations.
+    /// Empty list means trust-domain-only validation is used.
+    pub allowed_peer_svids: Vec<String>,
 }
 
 #[async_trait]
@@ -569,6 +609,10 @@ impl StorageApi for Storage {
             .map_err(|e| StoreError::RaftFatal { source: e })?)
     }
 
+    async fn current_leader(&self) -> Option<u64> {
+        self.raft.metrics().borrow_watched().current_leader
+    }
+
     async fn initialize(&self, nodes: HashMap<u64, Node>) -> Result<(), ApiStoreError> {
         let pb_nodes: HashMap<u64, pb::raft::Node> = nodes
             .into_iter()
@@ -591,12 +635,58 @@ impl StorageApi for Storage {
 }
 
 impl Storage {
-    /// Get the last log index processed by the node.
-    ///
-    /// # Returns
-    /// The last log index, if available.
     pub fn last_log_index(&self) -> Option<u64> {
         self.raft.metrics().borrow_watched().last_log_index
+    }
+
+    pub fn node_id(&self) -> u64 {
+        self.node_id
+    }
+
+    /// Return the current Raft leader node id, if elected.
+    pub fn current_leader(&self) -> Option<u64> {
+        self.raft.metrics().borrow_watched().current_leader
+    }
+
+    /// Join this node to the Raft cluster by calling [`add_learner`] on the
+    /// leader.  Returns `Ok(())` once the leader accepts the learner; the
+    /// actual Raft replication (heartbeats, log entries) happens asynchronously
+    /// via OpenRaft's built-in retry loop.
+    ///
+    /// # Parameters
+    /// - `leader_addr`: The gRPC address of the current cluster leader (e.g.
+    ///   `hostname:8300`).
+    /// - `my_cluster_addr`: This node's address that peers will connect to
+    ///   (e.g. `hostname:8300`).
+    pub async fn join_cluster(
+        &self,
+        leader_addr: &str,
+        my_cluster_addr: &str,
+    ) -> Result<(), StoreError> {
+        let channel = self.tls_client.connect(leader_addr).await?;
+        let mut client = ClusterAdminServiceClient::new(channel);
+
+        let _resp = client
+            .add_learner(tonic::Request::new(AddLearnerRequest {
+                node: Some(PbNode {
+                    node_id: self.node_id,
+                    rpc_addr: my_cluster_addr.to_string(),
+                }),
+            }))
+            .await
+            .map_err(|s| StoreError::Other(eyre::eyre!("add_learner gRPC call failed: {s}")))?;
+
+        tracing::info!(
+            my_id = self.node_id,
+            leader_addr,
+            my_cluster_addr,
+            "add_learner accepted, replication will start asynchronously"
+        );
+
+        // Replication is handled by OpenRaft's ReplicationHandler which retries
+        // on transient failures (DNS propagation delay, port not yet bound, etc.).
+        // No need to block here waiting for `current_leader()`.
+        Ok(())
     }
 
     /// Get the channel to the given node.

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -12,8 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use std::collections::{BTreeMap, HashMap};
+use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex, RwLock};
 
+use governor::{DefaultKeyedRateLimiter, Quota, RateLimiter};
 use openraft::RaftSnapshotBuilder;
 use openraft::async_runtime::WatchReceiver;
 use openstack_keystone_storage_crypto::{DekEpoch, KekProvider, generate_dek};
@@ -29,6 +31,28 @@ use crate::pb;
 use crate::protobuf::raft::cluster_admin_service_server::ClusterAdminService;
 use crate::store_command::{MutationInner, PendingRotation, StoreCommand};
 use crate::types::*;
+
+// ---------------------------------------------------------------------------
+// Security constants (ADR 0016-v2 §1 and §4.1)
+// ---------------------------------------------------------------------------
+
+/// Maximum `RotateDek` invocations per operator per hour.
+const ROTATE_DEK_PER_HOUR: NonZeroU32 = {
+    match NonZeroU32::new(2) {
+        Some(v) => v,
+        None => panic!("rate limit constant must be non-zero"),
+    }
+};
+
+/// Maximum `ClearQuarantine` invocations per operator per hour.
+const CLEAR_QUARANTINE_PER_HOUR: NonZeroU32 = {
+    match NonZeroU32::new(10) {
+        Some(v) => v,
+        None => panic!("rate limit constant must be non-zero"),
+    }
+};
+
+type IdentityLimiter = DefaultKeyedRateLimiter<String>;
 
 /// Extract the peer TLS identity from the request: prefers SPIFFE URI SAN,
 /// falls back to CN, or returns `"unknown"` if no peer cert is present.
@@ -64,6 +88,152 @@ fn extract_peer_identity<T>(request: &tonic::Request<T>) -> String {
         .unwrap_or_else(|| "unknown".to_owned())
 }
 
+/// Validates a SPIFFE URI against the
+/// `spiffe://<trust-domain><spiffe_path_prefix><role>` pattern and configured
+/// trust domains. Returns the `<role>` segment.
+///
+/// Errors with `PERMISSION_DENIED` if the URI is malformed, the trust domain is
+/// not in the configured list, or the path does not match.
+fn parse_spiffe_storage_id(
+    id: &str,
+    trust_domains: &[String],
+    prefix: &str,
+) -> Result<String, Status> {
+    let rest = id
+        .strip_prefix("spiffe://")
+        .ok_or_else(|| Status::permission_denied("peer identity is not a SPIFFE URI"))?;
+
+    let slash = rest
+        .find('/')
+        .ok_or_else(|| Status::permission_denied("SPIFFE ID is missing a path component"))?;
+    let (domain, path) = rest.split_at(slash);
+
+    if !trust_domains.iter().any(|d| d == domain) {
+        return Err(Status::permission_denied(format!(
+            "SPIFFE trust domain '{domain}' is not in the configured trust domain list"
+        )));
+    }
+
+    // `path` starts with '/', strip the configured prefix to get the role.
+    let role = path
+        .strip_prefix(prefix)
+        .filter(|r| !r.is_empty() && !r.contains('/'))
+        .ok_or_else(|| {
+            Status::permission_denied(format!(
+                "SPIFFE ID '{id}' does not match the required pattern \
+                 spiffe://<trust-domain>{prefix}<role>"
+            ))
+        })?;
+
+    Ok(role.to_owned())
+}
+
+// ---------------------------------------------------------------------------
+// RBAC — operator role enforcement
+// ---------------------------------------------------------------------------
+
+/// Verifies the peer identity and, in SPIFFE mode, asserts the role matches
+/// the configured operator role (ADR 0016-v2 §1).
+///
+/// In TLS-fallback mode emits a security warning and allows the request
+/// through; network isolation is the compensating control per ADR 0016-v2 §4.2.
+fn require_operator<T>(
+    request: &tonic::Request<T>,
+    trust_domains: Option<&[String]>,
+    spiffe_path_prefix: &str,
+    operator_role: &str,
+) -> Result<String, Status> {
+    let identity = extract_peer_identity(request);
+
+    match trust_domains {
+        Some(domains) => {
+            if !identity.starts_with("spiffe://") {
+                return Err(Status::permission_denied(
+                    "SPIFFE mode is active; peer must present a SPIFFE URI SAN",
+                ));
+            }
+            let role = parse_spiffe_storage_id(&identity, domains, spiffe_path_prefix)?;
+            if role != operator_role {
+                return Err(Status::permission_denied(format!(
+                    "role '{role}' is not authorized for this operation; \
+                     required: '{operator_role}'"
+                )));
+            }
+        }
+        None => {
+            tracing::warn!(
+                identity,
+                "RBAC role check skipped in TLS-fallback mode; \
+                 upgrade to SPIFFE mTLS to enforce operator role-based access \
+                 control (ADR 0016-v2 §4.2)"
+            );
+        }
+    }
+
+    Ok(identity)
+}
+
+/// Validates the peer's SPIFFE identity for internal Raft operations.
+///
+/// When `allowed_peer_svids` is non-empty, the identity must match one of the
+/// allow-listed SVIDs. Otherwise falls back to trust-domain-only validation.
+///
+/// In TLS-fallback mode (`trust_domains = None`) the check is skipped entirely.
+fn check_peer_trust_domain<T>(
+    request: &tonic::Request<T>,
+    trust_domains: Option<&[String]>,
+    allowed_peer_svids: &[String],
+) -> Result<String, Status> {
+    let identity = extract_peer_identity(request);
+
+    if trust_domains.is_some() && !identity.starts_with("spiffe://") {
+        return Err(Status::permission_denied(
+            "SPIFFE mode is active; peer must present a SPIFFE URI SAN",
+        ));
+    }
+
+    if allowed_peer_svids.is_empty() {
+        // Fallback: trust-domain-only check. Skipped entirely in TLS-fallback
+        // mode (`trust_domains = None`), so this branch is a no-op there.
+        if let Some(domains) = trust_domains {
+            parse_spiffe_trust_domain(&identity, domains)?;
+        }
+    } else {
+        // Allow-list check. In TLS-fallback mode this code is unreachable
+        // because `allowed_peer_svids` is always empty when `trust_domains`
+        // is `None` (set in `app.rs`).
+        if !allowed_peer_svids.contains(&identity) {
+            return Err(Status::permission_denied(format!(
+                "SPIFFE ID '{identity}' is not in the allowed peer SVID list"
+            )));
+        }
+    }
+
+    Ok(identity)
+}
+
+/// Extract and validate only the SPIFFE trust domain from the peer identity,
+/// returning it on success. Unlike `parse_spiffe_storage_id`, this does not
+/// require a specific path prefix or role.
+fn parse_spiffe_trust_domain(id: &str, trust_domains: &[String]) -> Result<(), Status> {
+    let rest = id
+        .strip_prefix("spiffe://")
+        .ok_or_else(|| Status::permission_denied("peer identity is not a SPIFFE URI"))?;
+
+    let slash = rest
+        .find('/')
+        .ok_or_else(|| Status::permission_denied("SPIFFE ID is missing a path component"))?;
+    let (domain, _path) = rest.split_at(slash);
+
+    if !trust_domains.iter().any(|d| d == domain) {
+        return Err(Status::permission_denied(format!(
+            "SPIFFE trust domain '{domain}' is not in the configured trust domain list"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Raft cluster administrative operations.
 ///
 /// # Responsibilities
@@ -88,6 +258,21 @@ pub struct ClusterAdminServiceImpl {
     pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
     /// State machine store — used for backup snapshot building and restore.
     sm: Arc<StateMachineStore>,
+    /// SPIFFE trust domains for SVID pattern validation.
+    /// `None` in TLS-fallback mode — pattern and role checks are skipped.
+    spiffe_trust_domains: Option<Vec<String>>,
+    /// Per-identity rate limiter for RotateDek (ADR 0016-v2 §1: 2/hour).
+    rotate_dek_limiter: Arc<IdentityLimiter>,
+    /// Per-identity rate limiter for ClearQuarantine (ADR 0016-v2 §1: 10/hour).
+    clear_quarantine_limiter: Arc<IdentityLimiter>,
+    /// SPIFFE path prefix for SVID pattern validation. Empty in TLS-fallback.
+    spiffe_path_prefix: String,
+    /// SPIFFE role that authorises sensitive management operations. Empty in
+    /// TLS-fallback mode.
+    operator_role: String,
+    /// Allow-list of SVIDs permitted for peer-to-peer Raft operations.
+    /// When empty falls back to trust-domain-only check.
+    allowed_peer_svids: Vec<String>,
 }
 
 impl ClusterAdminServiceImpl {
@@ -110,6 +295,10 @@ impl ClusterAdminServiceImpl {
         audit: AuditForwarder,
         pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
         sm: Arc<StateMachineStore>,
+        spiffe_trust_domains: Option<Vec<String>>,
+        spiffe_path_prefix: String,
+        operator_role: String,
+        allowed_peer_svids: Vec<String>,
     ) -> Self {
         Self {
             raft_node,
@@ -119,6 +308,14 @@ impl ClusterAdminServiceImpl {
             audit,
             pending_rotations,
             sm,
+            spiffe_trust_domains,
+            spiffe_path_prefix,
+            operator_role,
+            allowed_peer_svids,
+            rotate_dek_limiter: Arc::new(RateLimiter::keyed(Quota::per_hour(ROTATE_DEK_PER_HOUR))),
+            clear_quarantine_limiter: Arc::new(RateLimiter::keyed(Quota::per_hour(
+                CLEAR_QUARANTINE_PER_HOUR,
+            ))),
         }
     }
 
@@ -170,6 +367,11 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn init(&self, request: Request<pb::raft::InitRequest>) -> Result<Response<()>, Status> {
         trace!("Initializing Raft cluster");
+        check_peer_trust_domain(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.allowed_peer_svids,
+        )?;
         let req = request.into_inner();
 
         // Initialize the cluster
@@ -195,6 +397,11 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::AddLearnerRequest>,
     ) -> Result<Response<pb::raft::AdminResponse>, Status> {
+        check_peer_trust_domain(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.allowed_peer_svids,
+        )?;
         let req = request.into_inner();
 
         let node = req
@@ -259,6 +466,11 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::ChangeMembershipRequest>,
     ) -> Result<Response<pb::raft::AdminResponse>, Status> {
+        check_peer_trust_domain(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.allowed_peer_svids,
+        )?;
         let req = request.into_inner();
 
         trace!(
@@ -286,9 +498,14 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn metrics(
         &self,
-        _request: Request<()>,
+        request: Request<()>,
     ) -> Result<Response<pb::raft::MetricsResponse>, Status> {
         trace!("Collecting metrics");
+        check_peer_trust_domain(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.allowed_peer_svids,
+        )?;
         let metrics = self
             .get_metrics()
             .map_err(|e| Status::internal(format!("Failed to write to store: {}", e)))?;
@@ -318,7 +535,18 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::ClearQuarantineRequest>,
     ) -> Result<Response<()>, Status> {
-        let actor = extract_peer_identity(&request);
+        let actor = require_operator(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.spiffe_path_prefix,
+            &self.operator_role,
+        )?;
+        // rate limit - 10 per hour per operator identity.
+        self.clear_quarantine_limiter
+            .check_key(&actor)
+            .map_err(|_| {
+                Status::resource_exhausted("ClearQuarantine rate limit exceeded; try again later")
+            })?;
         let partition = request.into_inner().partition;
         if partition.is_empty() {
             return Err(Status::invalid_argument(
@@ -375,7 +603,16 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::RotateDekRequest>,
     ) -> Result<Response<pb::raft::AdminResponse>, Status> {
-        let actor = extract_peer_identity(&request);
+        let actor = require_operator(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.spiffe_path_prefix,
+            &self.operator_role,
+        )?;
+        // rate limit - 2 per hour per operator identity.
+        self.rotate_dek_limiter.check_key(&actor).map_err(|_| {
+            Status::resource_exhausted("RotateDek rate limit exceeded; try again later")
+        })?;
         let req = request.into_inner();
 
         let current_version = {
@@ -396,7 +633,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
 
         if req.emergency {
             // Stage 1 of dual-control: persist the pending entry; the DEK is
-            // NOT yet active.  A second operator must call ConfirmRotateDek.
+            // NOT yet active. A second operator must call ConfirmRotateDek.
             let rotation_id = uuid::Uuid::new_v4().to_string();
             let expires_at = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -488,7 +725,12 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::ConfirmRotateDekRequest>,
     ) -> Result<Response<pb::raft::AdminResponse>, Status> {
-        let actor = extract_peer_identity(&request);
+        let actor = require_operator(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.spiffe_path_prefix,
+            &self.operator_role,
+        )?;
         let req = request.into_inner();
 
         if req.rotation_id.is_empty() {
@@ -502,7 +744,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         );
 
         // Fast pre-check on the in-memory map so we can return a clear error
-        // before proposing to Raft.  The authoritative check is in the state
+        // before proposing to Raft. The authoritative check is in the state
         // machine apply handler, but this avoids unnecessary log entries.
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -573,7 +815,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
     /// operator.
     ///
     /// Encryption is performed by `build_snapshot` using the Backup DEK (see
-    /// ADR 0016-v2 §7).  Chunks are 256 KiB; the final chunk carries the
+    /// ADR 0016-v2 §7). Chunks are 256 KiB; the final chunk carries the
     /// snapshot_utc_epoch and dek_version parsed from the on-disk header so
     /// the client can verify the backup envelope without decrypting it.
     #[tracing::instrument(level = "trace", skip(self))]
@@ -581,7 +823,12 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<pb::raft::BackupRequest>,
     ) -> Result<Response<Self::BackupStream>, Status> {
-        let actor = extract_peer_identity(&request);
+        let actor = require_operator(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.spiffe_path_prefix,
+            &self.operator_role,
+        )?;
         trace!(actor, "operator backup requested");
 
         // Ensure backup targets the leader to avoid stale data.
@@ -716,7 +963,12 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         &self,
         request: Request<Streaming<pb::raft::RestoreChunk>>,
     ) -> Result<Response<pb::raft::AdminResponse>, Status> {
-        let actor = extract_peer_identity(&request);
+        let actor = require_operator(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.spiffe_path_prefix,
+            &self.operator_role,
+        )?;
         trace!(actor, "operator restore requested");
 
         let mut stream = request.into_inner();
@@ -770,5 +1022,161 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
 
         tracing::info!(actor, utc_epoch, dek_version, "backup restore complete");
         Ok(Response::new(pb::raft::AdminResponse::default()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRUST_DOMAINS: &[&str] = &["example.com", "alt.example.com"];
+    const PREFIX: &str = "/keystone/storage/";
+    const OPERATOR_ROLE: &str = "storage-operator";
+
+    fn domains() -> Vec<String> {
+        TRUST_DOMAINS.iter().map(|s| s.to_string()).collect()
+    }
+
+    // parse_spiffe_storage_id — valid identities
+
+    #[test]
+    fn spiffe_id_valid_operator() {
+        let role = parse_spiffe_storage_id(
+            "spiffe://example.com/keystone/storage/storage-operator",
+            &domains(),
+            PREFIX,
+        )
+        .expect("valid SPIFFE ID");
+        assert_eq!(role, OPERATOR_ROLE);
+    }
+
+    #[test]
+    fn spiffe_id_valid_node_role() {
+        let role = parse_spiffe_storage_id(
+            "spiffe://alt.example.com/keystone/storage/node",
+            &domains(),
+            PREFIX,
+        )
+        .expect("valid SPIFFE ID");
+        assert_eq!(role, "node");
+    }
+
+    // parse_spiffe_storage_id — invalid identities
+
+    #[test]
+    fn spiffe_id_wrong_trust_domain() {
+        let err = parse_spiffe_storage_id(
+            "spiffe://untrusted.com/keystone/storage/storage-operator",
+            &domains(),
+            PREFIX,
+        )
+        .expect_err("untrusted domain should fail");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn spiffe_id_wrong_path_prefix() {
+        let err = parse_spiffe_storage_id(
+            "spiffe://example.com/other/service/storage-operator",
+            &domains(),
+            PREFIX,
+        )
+        .expect_err("wrong path prefix should fail");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn spiffe_id_empty_role() {
+        let err =
+            parse_spiffe_storage_id("spiffe://example.com/keystone/storage/", &domains(), PREFIX)
+                .expect_err("empty role should fail");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn spiffe_id_extra_path_segment() {
+        let err = parse_spiffe_storage_id(
+            "spiffe://example.com/keystone/storage/storage-operator/extra",
+            &domains(),
+            PREFIX,
+        )
+        .expect_err("extra path segment should fail");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn spiffe_id_not_a_spiffe_uri() {
+        let err = parse_spiffe_storage_id("https://example.com/foo", &domains(), PREFIX)
+            .expect_err("non-SPIFFE URI should fail");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    // Rate limiter — basic token consumption
+
+    #[test]
+    fn rate_limiter_allows_up_to_burst() {
+        let limiter: Arc<IdentityLimiter> =
+            Arc::new(RateLimiter::keyed(Quota::per_hour(ROTATE_DEK_PER_HOUR)));
+        let key = "spiffe://example.com/keystone/storage/storage-operator".to_owned();
+        // Initial burst of 2 should be allowed.
+        assert!(limiter.check_key(&key).is_ok(), "first request allowed");
+        assert!(limiter.check_key(&key).is_ok(), "second request allowed");
+        // Third request within the same window should be denied.
+        assert!(
+            limiter.check_key(&key).is_err(),
+            "third request within burst window denied"
+        );
+    }
+
+    #[test]
+    fn rate_limiter_independent_keys() {
+        let limiter: Arc<IdentityLimiter> =
+            Arc::new(RateLimiter::keyed(Quota::per_hour(ROTATE_DEK_PER_HOUR)));
+        let key_a = "spiffe://example.com/keystone/storage/storage-operator".to_owned();
+        let key_b = "spiffe://example.com/keystone/storage/other-operator".to_owned();
+        // Exhaust key_a.
+        limiter.check_key(&key_a).ok();
+        limiter.check_key(&key_a).ok();
+        assert!(limiter.check_key(&key_a).is_err(), "key_a exhausted");
+        // key_b is independent and still has capacity.
+        assert!(limiter.check_key(&key_b).is_ok(), "key_b unaffected");
+    }
+
+    // Trust domain only — used for internal cluster operations
+
+    #[test]
+    fn spiffe_trust_domain_ok_standard_path() {
+        assert!(
+            parse_spiffe_trust_domain(
+                "spiffe://example.com/keystone/storage/storage-operator",
+                &domains(),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn spiffe_trust_domain_ok_arbitrary_path() {
+        assert!(
+            parse_spiffe_trust_domain("spiffe://example.com/ns/default/sa/keystone", &domains(),)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn spiffe_trust_domain_wrong_domain() {
+        assert!(
+            parse_spiffe_trust_domain("spiffe://untrusted.example.com/foo", &domains(),).is_err()
+        );
+    }
+
+    #[test]
+    fn spiffe_trust_domain_not_spiffe_uri() {
+        assert!(parse_spiffe_trust_domain("foo", &domains(),).is_err());
+    }
+
+    #[test]
+    fn spiffe_trust_domain_no_path() {
+        assert!(parse_spiffe_trust_domain("spiffe://example.com", &domains(),).is_err());
     }
 }

--- a/crates/storage/src/mock.rs
+++ b/crates/storage/src/mock.rs
@@ -386,6 +386,10 @@ impl StorageApi for MockStorage {
         Ok(false)
     }
 
+    async fn current_leader(&self) -> Option<u64> {
+        None
+    }
+
     async fn initialize(
         &self,
         _nodes: HashMap<u64, openstack_keystone_storage_api::Node>,

--- a/crates/storage/src/network.rs
+++ b/crates/storage/src/network.rs
@@ -43,6 +43,16 @@ use crate::protobuf::raft::VoteResponse as PbVoteResponse;
 use crate::protobuf::raft::raft_service_client::RaftServiceClient;
 use crate::types::*;
 
+/// Strip a URI scheme (`https://`, `http://`, etc.) from `addr`, returning the
+/// remaining authority + path portion (e.g. `keystone-rs-0:8300`).
+///
+/// Used to normalize addresses that arrive from config files (which often carry
+/// an `https://` prefix) before passing them to tonic's channel builder, which
+/// prepends its own scheme.
+fn strip_scheme(addr: &str) -> &str {
+    addr.split_once("://").map(|(_, rest)| rest).unwrap_or(addr)
+}
+
 /// TLS client mode for Raft peer connections.
 ///
 /// * `Spiffe` — SPIFFE mTLS using a `rustls::ClientConfig` built from a live
@@ -67,15 +77,16 @@ impl RaftTlsClient {
         match self {
             Self::Static(rx) => {
                 let tls_cfg = rx.borrow().clone();
-                Ok(
-                    tonic::transport::Endpoint::from_shared(format!("https://{addr}"))?
-                        .tls_config(tls_cfg)?
-                        .connect_lazy(),
-                )
+                Ok(tonic::transport::Endpoint::from_shared(format!(
+                    "https://{}",
+                    strip_scheme(addr)
+                ))?
+                .tls_config(tls_cfg)?
+                .connect_lazy())
             }
             Self::Spiffe(cfg) => {
                 let connector = SpiffeConnector { tls: cfg.clone() };
-                Channel::builder(format!("http://{addr}").parse()?)
+                Channel::builder(format!("http://{}", strip_scheme(addr)).parse()?)
                     .connect_with_connector(connector)
                     .await
                     .map_err(|e| StoreError::Other(eyre::eyre!("SPIFFE gRPC connect failed: {e}")))
@@ -190,7 +201,7 @@ impl NetworkConnection {
                 // needs to cross thread boundaries.
                 let tls_cfg = rx.borrow().clone();
                 Channel::builder(
-                    format!("https://{addr}")
+                    format!("https://{}", strip_scheme(addr))
                         .parse()
                         .map_err(|e| RPCError::Unreachable(Unreachable::new(&e)))?,
                 )
@@ -206,7 +217,7 @@ impl NetworkConnection {
                 // Use `http://` so tonic forwards the URI directly to our
                 // connector without attempting its own hostname-based TLS.
                 Channel::builder(
-                    format!("http://{addr}")
+                    format!("http://{}", strip_scheme(addr))
                         .parse()
                         .map_err(|e| RPCError::Unreachable(Unreachable::new(&e)))?,
                 )
@@ -655,4 +666,40 @@ pub async fn init_tls_watcher(
     });
 
     Ok(RaftTlsClient::Static(rx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_scheme_https() {
+        assert_eq!(
+            strip_scheme("https://keystone-rs-0.svc:8300"),
+            "keystone-rs-0.svc:8300"
+        );
+    }
+
+    #[test]
+    fn test_strip_scheme_http() {
+        assert_eq!(strip_scheme("http://localhost:8300"), "localhost:8300");
+    }
+
+    #[test]
+    fn test_strip_scheme_no_scheme() {
+        assert_eq!(
+            strip_scheme("keystone-rs-0.svc:8300"),
+            "keystone-rs-0.svc:8300"
+        );
+    }
+
+    #[test]
+    fn test_strip_scheme_fqdn() {
+        assert_eq!(
+            strip_scheme(
+                "https://keystone-rs-0.keystone-rs-internal.default.svc.cluster.local:8300"
+            ),
+            "keystone-rs-0.keystone-rs-internal.default.svc.cluster.local:8300"
+        );
+    }
 }

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -74,10 +74,10 @@ struct InstanceHolder {
 }
 
 impl InstanceHolder {
-    // from_env() removes KEYSTONE_DEV_KEK from the process environment after reading
-    // (ADR 0016-v2 §2.1).  In production each node is a separate process so removal
-    // happens once per process.  Here all test nodes share one process, so we re-set
-    // the variable before each init_storage call.
+    // from_env() removes KEYSTONE_DEV_KEK from the process environment after
+    // reading (ADR 0016-v2 §2.1).  In production each node is a separate
+    // process so removal happens once per process.  Here all test nodes share
+    // one process, so we re-set the variable before each init_storage call.
     // SAFETY: nodes are initialised sequentially before any async tasks that read
     // the environment are spawned, so there are no concurrent readers.
     #[allow(unsafe_code)]
@@ -514,5 +514,6 @@ fn get_ds_config(
         path: db_path,
         tls_configuration: openstack_keystone_config::RaftTlsConfiguration::Tls(tls_config.clone()),
         dev_mode: true,
+        retry_join_nodes: vec![],
     }
 }

--- a/crates/webauthn/tests/common/mod.rs
+++ b/crates/webauthn/tests/common/mod.rs
@@ -151,6 +151,7 @@ pub async fn get_state(
             path: tmp_db_dir.path().to_path_buf(),
             tls_configuration: RaftTlsConfiguration::Tls(tls_configuration),
             dev_mode: true,
+            retry_join_nodes: vec![],
         });
     }
     let mut policy_enforcer_mock = MockPolicy::default();

--- a/tests/integration/src/common.rs
+++ b/tests/integration/src/common.rs
@@ -162,6 +162,7 @@ pub async fn get_state() -> Result<(Arc<Service>, TempDir)> {
             path: tmp_db_dir.to_path_buf(),
             tls_configuration,
             dev_mode: true,
+            retry_join_nodes: vec![],
         });
         cfg.k8s_auth.driver = "raft".to_string();
     }

--- a/tools/k8s/keystone/base/service.yaml
+++ b/tools/k8s/keystone/base/service.yaml
@@ -41,6 +41,7 @@ metadata:
   name: keystone-rs-internal
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: raft
       port: 8300

--- a/tools/k8s/keystone/base/statefulset-rs.yaml
+++ b/tools/k8s/keystone/base/statefulset-rs.yaml
@@ -50,7 +50,9 @@ spec:
               node_listener_addr = "0.0.0.0:8300"
               path = "/storage"
               trust_domains = "example.org"
+              allowed_peer_svids = ["spiffe://example.org/ns/default/sa/keystone"]
               dev_mode = true
+              retry_join_nodes = "0=https://keystone-rs-0.keystone-rs-internal.default.svc.cluster.local:8300,1=https://keystone-rs-1.keystone-rs-internal.default.svc.cluster.local:8300"
               EOF
       containers:
         - env:
@@ -92,7 +94,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /
+              path: /ready
               port: keystone-rs
               scheme: HTTP
             periodSeconds: 10
@@ -101,7 +103,7 @@ spec:
           startupProbe:
             failureThreshold: 600
             httpGet:
-              path: /
+              path: /ready
               port: keystone-rs
               scheme: HTTP
             periodSeconds: 1


### PR DESCRIPTION
SPIFFE ID pattern validation on every ClusterAdminService RPC. When in
SPIFFE mTLS mode the helper validates that the peer URI SAN matches
spiffe://<trust-domain>/keystone/storage/<role> and rejects on mismatch
with PERMISSION_DENIED. In TLS-fallback mode the check is skipped
(pattern requires no SPIFFE).

RBAC enforcement for sensitive operations.  RotateDek, ConfirmRotateDek,
ClearQuarantine, Backup and Restore now require the caller's SPIFFE role
to equal storage-operator. In TLS-fallback mode a security warning is
emitted and the request is allowed through (network isolation is the
compensating control §4.2).

Per-identity gRPC rate limiting via the governor crate. RotateDek is
capped at 2/hour per operator; ClearQuarantine at 10/hour per operator.
Each operator identity has its own token bucket so one operator cannot
exhaust capacity for others.

Implementation:
- Add governor 0.10 (DefaultKeyedRateLimiter<String>).
- ClusterAdminServiceImpl gains spiffe_trust_domains,
  rotate_dek_limiter and clear_quarantine_limiter fields.
- Storage gains spiffe_trust_domains, populated from SpiffeTls config
  in init_storage and forwarded to the admin service in get_app_server.
- Nine unit tests cover SPIFFE ID parsing edge cases and rate limiter
  token consumption and per-key isolation.

Assisted-By: Claude Sonnet 4.6 noreply@anthropic.com
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
