### PR TITLE
test: Add resource provider integration tests

### DIFF
--- a/tests/integration/src/resource/domain/create.rs
+++ b/tests/integration/src/resource/domain/create.rs
@@ -16,6 +16,9 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::resource::DomainCreateBuilder;
+
 use crate::common::get_state;
 
 #[traced_test]
@@ -33,5 +36,47 @@ async fn test_create() -> Result<()> {
 
     assert_eq!(name, domain.name);
     assert!(domain.enabled);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_invalid_name_too_long() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .create_domain(
+            &ExecutionContext::internal(&state),
+            DomainCreateBuilder::default()
+                .name("x".repeat(256))
+                .build()?,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "creating a domain with an over-length name is rejected"
+    );
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_invalid_empty_name() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .create_domain(
+            &ExecutionContext::internal(&state),
+            DomainCreateBuilder::default().name("").build()?,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "creating a domain with an empty name is rejected"
+    );
     Ok(())
 }

--- a/tests/integration/src/resource/domain/get.rs
+++ b/tests/integration/src/resource/domain/get.rs
@@ -56,3 +56,48 @@ async fn test_get_domain_missing() -> Result<()> {
     );
     Ok(())
 }
+
+#[traced_test]
+#[tokio::test]
+async fn test_find_domain_by_name() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let res = state
+        .provider
+        .get_resource_provider()
+        .find_domain_by_name(&ExecutionContext::internal(&state), &domain.name)
+        .await?
+        .expect("domain found by name");
+    assert_eq!(res.id, domain.id);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_find_domain_by_name_missing() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let res = state
+        .provider
+        .get_resource_provider()
+        .find_domain_by_name(&ExecutionContext::internal(&state), "no-such-domain")
+        .await?;
+    assert!(res.is_none(), "an unknown domain name returns None");
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_domain_enabled() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let enabled = state
+        .provider
+        .get_resource_provider()
+        .get_domain_enabled(&ExecutionContext::internal(&state), &domain.id)
+        .await?;
+    assert!(enabled, "a newly created domain is enabled");
+    Ok(())
+}

--- a/tests/integration/src/resource/project/create.rs
+++ b/tests/integration/src/resource/project/create.rs
@@ -16,6 +16,9 @@
 use eyre::Result;
 use tracing_test::traced_test;
 
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::resource::ProjectCreateBuilder;
+
 use crate::common::get_state;
 use crate::create_domain;
 use crate::create_project;
@@ -30,5 +33,53 @@ async fn test_create() -> Result<()> {
     assert!(!project.name.is_empty());
     assert_eq!(project.domain_id, domain.id);
     assert!(project.enabled);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_invalid_name_too_long() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .create_project(
+            &ExecutionContext::internal(&state),
+            ProjectCreateBuilder::default()
+                .name("x".repeat(256))
+                .domain_id(domain.id.clone())
+                .build()?,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "creating a project with an over-length name is rejected"
+    );
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_invalid_empty_name() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .create_project(
+            &ExecutionContext::internal(&state),
+            ProjectCreateBuilder::default()
+                .name("")
+                .domain_id(domain.id.clone())
+                .build()?,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "creating a project with an empty name is rejected"
+    );
     Ok(())
 }

--- a/tests/integration/src/resource/project/get.rs
+++ b/tests/integration/src/resource/project/get.rs
@@ -59,3 +59,90 @@ async fn test_get_project_missing() -> Result<()> {
     );
     Ok(())
 }
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_project_by_name() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+
+    let res = state
+        .provider
+        .get_resource_provider()
+        .get_project_by_name(
+            &ExecutionContext::internal(&state),
+            &project.name,
+            &domain.id,
+        )
+        .await?
+        .expect("project found by name");
+    assert_eq!(res.id, project.id);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_project_by_name_missing() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let res = state
+        .provider
+        .get_resource_provider()
+        .get_project_by_name(
+            &ExecutionContext::internal(&state),
+            "no-such-project",
+            &domain.id,
+        )
+        .await?;
+    assert!(res.is_none(), "an unknown project name returns None");
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_project_parents() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let parent = create_project!(state, domain.id.clone())?;
+    let child = create_project!(state, domain.id.clone(), parent.id.clone())?;
+
+    let parents = state
+        .provider
+        .get_resource_provider()
+        .get_project_parents(&ExecutionContext::internal(&state), &child.id)
+        .await?
+        .expect("parents returned");
+    assert!(
+        parents.iter().any(|p| p.id == parent.id),
+        "the parent project is in the chain"
+    );
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_project_parents_multi_level() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let grandparent = create_project!(state, domain.id.clone())?;
+    let parent = create_project!(state, domain.id.clone(), grandparent.id.clone())?;
+    let child = create_project!(state, domain.id.clone(), parent.id.clone())?;
+
+    let parents = state
+        .provider
+        .get_resource_provider()
+        .get_project_parents(&ExecutionContext::internal(&state), &child.id)
+        .await?
+        .expect("parents returned");
+    assert!(
+        parents.iter().any(|p| p.id == parent.id),
+        "the parent project is in the ancestor chain"
+    );
+    assert!(
+        parents.iter().any(|p| p.id == grandparent.id),
+        "the grandparent project is in the ancestor chain"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Fills in the missing integration test coverage for the resource provider, following the existing test patterns and harness.

* Domain lookups: find_domain_by_name (found and missing) and get_domain_enabled.
* Project lookups: get_project_by_name (found and missing) and get_project_parents (verifying a parent/child hierarchy).
* Negative cases: creating a domain or project with an over-length name is rejected. Resource delete is idempotent, it returns Ok for a missing id, so a delete-not-found error case isn't applicable; get-not-found is already covered.
* All tests use the existing harness (get_state, create_domain!, create_project!) and the public provider API via ExecutionContext; no production code is changed.

Closes #448

Note: this contribution was developed with AI assistance.