### PR TITLE
feat: audit framework (ADR-0023) phase 3

### DIFF
--- a/crates/audit/src/dispatcher.rs
+++ b/crates/audit/src/dispatcher.rs
@@ -220,10 +220,10 @@ impl AuditDispatcher {
 /// JCS requires:
 /// - Object keys sorted lexicographically (Unicode code point order)
 /// - Compact form (no extra whitespace)
-/// - `null` for absent optional fields (we use `skip_serializing_if` on
-///   the struct level, so `None` fields are omitted — this matches the
-///   SIEM verification path which removes the `signature` key and
-///   re-serializes the remainder)
+/// - `null` for absent optional fields (we use `skip_serializing_if` on the
+///   struct level, so `None` fields are omitted — this matches the SIEM
+///   verification path which removes the `signature` key and re-serializes the
+///   remainder)
 ///
 /// We achieve key ordering by round-tripping through `serde_json::Value`
 /// and sorting object keys recursively before re-serializing. This is

--- a/crates/audit/src/kdf.rs
+++ b/crates/audit/src/kdf.rs
@@ -71,7 +71,8 @@ mod tests {
     fn known_vector() {
         // Pre-computed reference value for SIEM implementors and cross-language
         // verification. Regenerate with:
-        //   cargo test -p openstack-keystone-audit kdf::tests::known_vector -- --nocapture
+        //   cargo test -p openstack-keystone-audit kdf::tests::known_vector --
+        // --nocapture
         let key = derive_audit_hmac_key(KEK, "keystone-node-1");
         let hex: String = key.iter().map(|b| format!("{b:02x}")).collect();
         assert_eq!(

--- a/crates/audit/src/spool.rs
+++ b/crates/audit/src/spool.rs
@@ -202,6 +202,10 @@ pub async fn replay_spool(
 
     if skipped > 0 {
         quarantine_spool(path)?;
+    } else {
+        // Truncate spool file after clean replay so previously-shipped events
+        // are not re-dispatched on next startup.
+        truncate_spool(path)?;
     }
 
     info!(replayed, skipped, "spool replay complete");
@@ -218,6 +222,15 @@ fn quarantine_spool(path: &Path) -> Result<(), SpoolError> {
         quarantine = %quarantine.display(),
         "spool file quarantined due to corrupted/tampered lines"
     );
+    Ok(())
+}
+
+/// Truncate the spool file after a clean replay.
+///
+/// Previously-shipped events are re-dispatched during replay. Truncating
+/// ensures they are not re-dispatched again on next startup.
+fn truncate_spool(path: &Path) -> Result<(), SpoolError> {
+    std::fs::File::create(path)?;
     Ok(())
 }
 
@@ -297,6 +310,16 @@ mod tests {
         // Both events should have been dispatched to the critical channel.
         assert!(rx2.critical.try_recv().is_ok());
         assert!(rx2.critical.try_recv().is_ok());
+        // Spool file should be truncated after clean replay.
+        assert!(
+            path.exists(),
+            "spool file must still exist after clean replay"
+        );
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            contents.is_empty(),
+            "spool file must be empty after clean replay"
+        );
     }
 
     #[tokio::test]

--- a/crates/audit/src/types.rs
+++ b/crates/audit/src/types.rs
@@ -44,8 +44,8 @@ pub struct CadfEventPayload {
 
 impl CadfEventPayload {
     /// Construct a new unsigned payload. The `seq`, `boot_session_id`, and
-    /// `hmac_key_version` fields are placeholders; `AuditDispatcher::finalize_event`
-    /// fills them in when signing.
+    /// `hmac_key_version` fields are placeholders;
+    /// `AuditDispatcher::finalize_event` fills them in when signing.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,

--- a/crates/audit/tests/hmac_vectors.rs
+++ b/crates/audit/tests/hmac_vectors.rs
@@ -175,4 +175,5 @@ fn hmac_roundtrip_deterministic_payload() {
 }
 
 // Tamper-detection test lives in `crates/audit/src/types.rs` as a unit test,
-// where it has pub(crate) access to `CadfEvent::signature` to simulate tampering.
+// where it has pub(crate) access to `CadfEvent::signature` to simulate
+// tampering.

--- a/crates/core-types/src/events.rs
+++ b/crates/core-types/src/events.rs
@@ -70,6 +70,10 @@ pub enum EventPayload {
     Group {
         id: String,
     },
+    GroupMembership {
+        user_id: String,
+        group_ids: Vec<String>,
+    },
 
     // Resources
     Project {
@@ -114,6 +118,37 @@ pub enum EventPayload {
         id: String,
     },
     Service {
+        id: String,
+    },
+
+    // Identity service accounts
+    ServiceAccount {
+        id: String,
+    },
+
+    // Token
+    TokenRestriction {
+        id: String,
+    },
+
+    // Federation
+    IdentityProvider {
+        id: String,
+    },
+    AuthState {
+        id: String,
+    },
+
+    // Mapping
+    MappingRuleSet {
+        mapping_id: String,
+    },
+    VirtualUser {
+        user_id: String,
+    },
+
+    // Kubernetes auth
+    K8sAuthInstance {
         id: String,
     },
 

--- a/crates/core/src/application_credential/service.rs
+++ b/crates/core/src/application_credential/service.rs
@@ -32,6 +32,7 @@ use crate::application_credential::{
     backend::ApplicationCredentialBackend,
 };
 use crate::auth::ExecutionContext;
+use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
 
 /// Application Credential Provider.
@@ -79,26 +80,47 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
     ) -> Result<AccessRule, ApplicationCredentialProviderError> {
         let mut rule = rule;
         rule.validate()?;
-        // The provider prepares the final data; the driver only persists it.
         if rule.id.is_none() {
             rule.id = Some(Uuid::new_v4().simple().to_string());
         }
         let user_id = rule.user_id.clone();
-        let access_rule = self
-            .backend_driver
-            .create_access_rule(ctx.state(), rule)
-            .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::AccessRule {
-                    id: access_rule.id.clone(),
-                    user_id,
+        let access_rule = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let rule_clone = rule.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::AccessRule {
+                        id: rule_clone.id.clone().unwrap_or_default(),
+                        user_id: user_id.clone(),
+                    },
+                ),
+                operation: async {
+                    backend_driver.create_access_rule(ctx.state(), rule_clone).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| ApplicationCredentialProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let access_rule = self
+                .backend_driver
+                .create_access_rule(ctx.state(), rule)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::AccessRule {
+                        id: access_rule.id.clone(),
+                        user_id,
+                    },
+                ))
+                .await;
+
+            access_rule
+        };
 
         Ok(access_rule)
     }
@@ -119,7 +141,6 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
         rec: ApplicationCredentialCreate,
     ) -> Result<ApplicationCredentialCreateResponse, ApplicationCredentialProviderError> {
         rec.validate()?;
-        // TODO: implement some filters.
         let roles: HashSet<String> = ctx
             .state()
             .provider
@@ -136,7 +157,6 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
                 ));
             }
         }
-        // TODO: Check app creds count
         let mut new_rec = rec;
         if new_rec.id.is_none() {
             new_rec.id = Some(Uuid::new_v4().simple().to_string());
@@ -152,21 +172,45 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
         if new_rec.secret.is_none() {
             new_rec.secret = Some(generate_secret());
         }
-        let response = self
-            .backend_driver
-            .create_application_credential(ctx.state(), new_rec.clone())
-            .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::ApplicationCredential {
-                    id: new_rec.id.unwrap_or_default(),
-                    project_id: new_rec.project_id.clone(),
+        let cred_id = new_rec.id.clone().unwrap_or_default();
+        let project_id = new_rec.project_id.clone();
+        let response = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let new_rec_clone = new_rec.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::ApplicationCredential {
+                        id: cred_id.clone(),
+                        project_id: project_id.clone(),
+                    },
+                ),
+                operation: async {
+                    backend_driver.create_application_credential(ctx.state(), new_rec_clone).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| ApplicationCredentialProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let response = self
+                .backend_driver
+                .create_application_credential(ctx.state(), new_rec)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::ApplicationCredential {
+                        id: cred_id,
+                        project_id,
+                    },
+                ))
+                .await;
+
+            response
+        };
 
         Ok(response)
     }
@@ -187,20 +231,39 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
         user_id: &'a str,
         id: &'a str,
     ) -> Result<(), ApplicationCredentialProviderError> {
-        self.backend_driver
-            .delete_access_rule(ctx.state(), user_id, id)
-            .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::AccessRule {
-                    id: id.to_string(),
-                    user_id: user_id.to_string(),
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::AccessRule {
+                        id: id.to_string(),
+                        user_id: user_id.to_string(),
+                    },
+                ),
+                operation: async {
+                    self.backend_driver.delete_access_rule(ctx.state(), user_id, id).await?;
+                    Ok::<(), ApplicationCredentialProviderError>(())
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| ApplicationCredentialProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .delete_access_rule(ctx.state(), user_id, id)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::AccessRule {
+                        id: id.to_string(),
+                        user_id: user_id.to_string(),
+                    },
+                ))
+                .await;
+        }
 
         Ok(())
     }

--- a/crates/core/src/assignment/service.rs
+++ b/crates/core/src/assignment/service.rs
@@ -23,6 +23,7 @@ use openstack_keystone_core_types::role::{Role, RoleListParameters};
 
 use crate::assignment::{AssignmentApi, AssignmentProviderError, backend::AssignmentBackend};
 use crate::auth::ExecutionContext;
+use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
 
 pub struct AssignmentService {
@@ -67,47 +68,100 @@ impl AssignmentApi for AssignmentService {
         ctx: &ExecutionContext<'a>,
         grant: AssignmentCreate,
     ) -> Result<Assignment, AssignmentProviderError> {
-        let assignment = self.backend_driver.create_grant(ctx.state(), grant).await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::RoleAssignment {
-                    role_id: assignment.role_id.clone(),
-                    user_id: match &assignment.r#type {
-                        AssignmentType::UserDomain
-                        | AssignmentType::UserProject
-                        | AssignmentType::UserSystem => Some(assignment.actor_id.clone()),
-                        _ => None,
+        let assignment = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let grant_clone = grant.clone();
+            let grant_type = grant.r#type;
+            let grant_role_id = grant.role_id.clone();
+            let grant_actor_id = grant.actor_id.clone();
+            let grant_target_id = grant.target_id.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::RoleAssignment {
+                        role_id: grant_role_id.clone(),
+                        user_id: match grant_type {
+                            AssignmentType::UserDomain
+                            | AssignmentType::UserProject
+                            | AssignmentType::UserSystem => Some(grant_actor_id.clone()),
+                            _ => None,
+                        },
+                        group_id: match grant_type {
+                            AssignmentType::GroupDomain
+                            | AssignmentType::GroupProject
+                            | AssignmentType::GroupSystem => Some(grant_actor_id.clone()),
+                            _ => None,
+                        },
+                        domain_id: match grant_type {
+                            AssignmentType::UserDomain | AssignmentType::GroupDomain => {
+                                Some(grant_target_id.clone())
+                            }
+                            _ => None,
+                        },
+                        project_id: match grant_type {
+                            AssignmentType::UserProject | AssignmentType::GroupProject => {
+                                Some(grant_target_id.clone())
+                            }
+                            _ => None,
+                        },
+                        system_id: match grant_type {
+                            AssignmentType::UserSystem | AssignmentType::GroupSystem => {
+                                Some(grant_target_id.clone())
+                            }
+                            _ => None,
+                        },
                     },
-                    group_id: match &assignment.r#type {
-                        AssignmentType::GroupDomain
-                        | AssignmentType::GroupProject
-                        | AssignmentType::GroupSystem => Some(assignment.actor_id.clone()),
-                        _ => None,
-                    },
-                    domain_id: match &assignment.r#type {
-                        AssignmentType::UserDomain | AssignmentType::GroupDomain => {
-                            Some(assignment.target_id.clone())
-                        }
-                        _ => None,
-                    },
-                    project_id: match &assignment.r#type {
-                        AssignmentType::UserProject | AssignmentType::GroupProject => {
-                            Some(assignment.target_id.clone())
-                        }
-                        _ => None,
-                    },
-                    system_id: match &assignment.r#type {
-                        AssignmentType::UserSystem | AssignmentType::GroupSystem => {
-                            Some(assignment.target_id.clone())
-                        }
-                        _ => None,
-                    },
+                ),
+                operation: async {
+                    backend_driver.create_grant(ctx.state(), grant_clone).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| AssignmentProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let assignment = self.backend_driver.create_grant(ctx.state(), grant).await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::RoleAssignment {
+                        role_id: assignment.role_id.clone(),
+                        user_id: match &assignment.r#type {
+                            AssignmentType::UserDomain
+                            | AssignmentType::UserProject
+                            | AssignmentType::UserSystem => Some(assignment.actor_id.clone()),
+                            _ => None,
+                        },
+                        group_id: match &assignment.r#type {
+                            AssignmentType::GroupDomain
+                            | AssignmentType::GroupProject
+                            | AssignmentType::GroupSystem => Some(assignment.actor_id.clone()),
+                            _ => None,
+                        },
+                        domain_id: match &assignment.r#type {
+                            AssignmentType::UserDomain | AssignmentType::GroupDomain => {
+                                Some(assignment.target_id.clone())
+                            }
+                            _ => None,
+                        },
+                        project_id: match &assignment.r#type {
+                            AssignmentType::UserProject | AssignmentType::GroupProject => {
+                                Some(assignment.target_id.clone())
+                            }
+                            _ => None,
+                        },
+                        system_id: match &assignment.r#type {
+                            AssignmentType::UserSystem | AssignmentType::GroupSystem => {
+                                Some(assignment.target_id.clone())
+                            }
+                            _ => None,
+                        },
+                    },
+                ))
+                .await;
+            assignment
+        };
 
         Ok(assignment)
     }
@@ -161,23 +215,15 @@ impl AssignmentApi for AssignmentService {
         ctx: &ExecutionContext<'a>,
         grant: Assignment,
     ) -> Result<(), AssignmentProviderError> {
-        // Call backend with reference (no move)
-        self.backend_driver
-            .revoke_grant(ctx.state(), &grant)
-            .await?;
-
-        // Determine user_id or group_id
         let user_id = match &grant.r#type {
             AssignmentType::UserDomain
             | AssignmentType::UserProject
             | AssignmentType::UserSystem => Some(grant.actor_id.clone()),
-
             AssignmentType::GroupDomain
             | AssignmentType::GroupProject
             | AssignmentType::GroupSystem => None,
         };
 
-        // Determine project_id or domain_id
         let (project_id, domain_id) = match &grant.r#type {
             AssignmentType::UserProject | AssignmentType::GroupProject => {
                 (Some(grant.target_id.clone()), None)
@@ -188,11 +234,65 @@ impl AssignmentApi for AssignmentService {
             AssignmentType::UserSystem | AssignmentType::GroupSystem => (None, None),
         };
 
+        let role_id = grant.role_id.clone();
+
+        if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::RoleAssignment {
+                        role_id: role_id.clone(),
+                        user_id: match &grant.r#type {
+                            AssignmentType::UserDomain
+                            | AssignmentType::UserProject
+                            | AssignmentType::UserSystem => Some(grant.actor_id.clone()),
+                            _ => None,
+                        },
+                        group_id: match &grant.r#type {
+                            AssignmentType::GroupDomain
+                            | AssignmentType::GroupProject
+                            | AssignmentType::GroupSystem => Some(grant.actor_id.clone()),
+                            _ => None,
+                        },
+                        domain_id: match &grant.r#type {
+                            AssignmentType::UserDomain | AssignmentType::GroupDomain => {
+                                Some(grant.target_id.clone())
+                            }
+                            _ => None,
+                        },
+                        project_id: match &grant.r#type {
+                            AssignmentType::UserProject | AssignmentType::GroupProject => {
+                                Some(grant.target_id.clone())
+                            }
+                            _ => None,
+                        },
+                        system_id: match &grant.r#type {
+                            AssignmentType::UserSystem | AssignmentType::GroupSystem => {
+                                Some(grant.target_id.clone())
+                            }
+                            _ => None,
+                        },
+                    },
+                ),
+                operation: async {
+                    backend_driver.revoke_grant(ctx.state(), &grant).await
+                },
+                on_audit_error: |_: AuditDispatchError| AssignmentProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .revoke_grant(ctx.state(), &grant)
+                .await?;
+        }
+
         let revocation_event = RevocationEventCreate {
             domain_id,
             project_id,
             user_id,
-            role_id: Some(grant.role_id.clone()),
+            role_id: Some(role_id),
             trust_id: None,
             consumer_id: None,
             access_token_id: None,
@@ -208,46 +308,6 @@ impl AssignmentApi for AssignmentService {
             .get_revoke_provider()
             .create_revocation_event(ctx, revocation_event)
             .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::RoleAssignment {
-                    role_id: grant.role_id.clone(),
-                    user_id: match &grant.r#type {
-                        AssignmentType::UserDomain
-                        | AssignmentType::UserProject
-                        | AssignmentType::UserSystem => Some(grant.actor_id.clone()),
-                        _ => None,
-                    },
-                    group_id: match &grant.r#type {
-                        AssignmentType::GroupDomain
-                        | AssignmentType::GroupProject
-                        | AssignmentType::GroupSystem => Some(grant.actor_id.clone()),
-                        _ => None,
-                    },
-                    domain_id: match &grant.r#type {
-                        AssignmentType::UserDomain | AssignmentType::GroupDomain => {
-                            Some(grant.target_id.clone())
-                        }
-                        _ => None,
-                    },
-                    project_id: match &grant.r#type {
-                        AssignmentType::UserProject | AssignmentType::GroupProject => {
-                            Some(grant.target_id.clone())
-                        }
-                        _ => None,
-                    },
-                    system_id: match &grant.r#type {
-                        AssignmentType::UserSystem | AssignmentType::GroupSystem => {
-                            Some(grant.target_id.clone())
-                        }
-                        _ => None,
-                    },
-                },
-            ))
-            .await;
 
         Ok(())
     }

--- a/crates/core/src/cadf_hook.rs
+++ b/crates/core/src/cadf_hook.rs
@@ -13,9 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! CADF audit hook and shared initiator-builder helpers (ADR 0023 Phase 3.4).
 //!
-//! [`CadfAuditHook`] translates `(ValidatedSecurityContext, Event, AuditOutcome)`
-//! triples into signed [`CadfEvent`]s and dispatches them via the critical
-//! channel of an [`AuditDispatcher`].
+//! [`CadfAuditHook`] translates `(ValidatedSecurityContext, Event,
+//! AuditOutcome)` triples into signed [`CadfEvent`]s and dispatches them via
+//! the critical channel of an [`AuditDispatcher`].
 //!
 //! The initiator-builder helpers are also used by the perimeter audit path in
 //! `crates/keystone/src/audit.rs`.
@@ -68,6 +68,9 @@ fn build_target_from_event(event: &Event) -> Target {
     let (raw_id, type_uri): (&str, &str) = match &event.payload {
         EventPayload::User { id } => (id, "data/security/identity/user"),
         EventPayload::Group { id } => (id, "data/security/identity/group"),
+        EventPayload::GroupMembership { user_id: id, .. } => {
+            (id, "data/security/identity/group-membership")
+        }
         EventPayload::Project { id } => (id, "data/security/account/project"),
         EventPayload::Domain { id } => (id, "data/security/account/domain"),
         EventPayload::Role { id } => (id, "data/security/authz/role"),
@@ -85,6 +88,15 @@ fn build_target_from_event(event: &Event) -> Target {
         EventPayload::Region { id } => (id, "data/compute/catalog/region"),
         EventPayload::Service { id } => (id, "data/compute/catalog/service"),
         EventPayload::Trust { id } => (id, "data/security/identity/trust"),
+        EventPayload::ServiceAccount { id } => (id, "data/security/identity/service-account"),
+        EventPayload::TokenRestriction { id } => (id, "data/security/identity/token-restriction"),
+        EventPayload::IdentityProvider { id } => (id, "data/security/identity/identity-provider"),
+        EventPayload::AuthState { id } => (id, "data/security/identity/auth-state"),
+        EventPayload::MappingRuleSet { mapping_id: id } => {
+            (id, "data/security/identity/mapping-ruleset")
+        }
+        EventPayload::VirtualUser { user_id: id } => (id, "data/security/identity/virtual-user"),
+        EventPayload::K8sAuthInstance { id } => (id, "data/security/identity/k8s-auth-instance"),
     };
     Target {
         id: sanitize_audit_id(raw_id),
@@ -162,7 +174,8 @@ fn outcome_reason(outcome: &AuditOutcome) -> Option<String> {
 /// CADF implementation of [`AuditHook`] (ADR 0023 Phase 3.4).
 ///
 /// Translates `(ValidatedSecurityContext, Event, AuditOutcome)` triples into
-/// signed [`CadfEvent`]s and dispatches them via [`AuditDispatcher::dispatch_critical`].
+/// signed [`CadfEvent`]s and dispatches them via
+/// [`AuditDispatcher::dispatch_critical`].
 pub struct CadfAuditHook {
     dispatcher: Arc<AuditDispatcher>,
 }
@@ -203,7 +216,11 @@ impl AuditHook for CadfAuditHook {
         match self.dispatcher.dispatch_critical(signed).await {
             Ok(()) => Ok(()),
             Err(_) => {
-                self.dispatcher.record_postaudit_drop();
+                // Only count as post-audit drop for terminal outcomes (Success/Failure).
+                // Pre-audit Attempt failures represent blockage before any commit.
+                if !matches!(outcome, AuditOutcome::Attempt) {
+                    self.dispatcher.record_postaudit_drop();
+                }
                 Err(AuditDispatchError::DispatcherDead)
             }
         }

--- a/crates/core/src/catalog/service.rs
+++ b/crates/core/src/catalog/service.rs
@@ -22,6 +22,7 @@ use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 
 use crate::auth::ExecutionContext;
 use crate::catalog::{CatalogApi, CatalogProviderError, backend::CatalogBackend};
+use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
 
 pub struct CatalogService {
@@ -66,20 +67,39 @@ impl CatalogApi for CatalogService {
         endpoint: EndpointCreate,
     ) -> Result<Endpoint, CatalogProviderError> {
         endpoint.validate()?;
-        let endpoint = self
-            .backend_driver
-            .create_endpoint(exec.state(), endpoint)
-            .await?;
-
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::Endpoint {
-                    id: endpoint.id.clone(),
+        let endpoint = if let Some(vsc) = exec.ctx() {
+            let backend_driver = &self.backend_driver;
+            let endpoint_clone = endpoint.clone();
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::Endpoint { id: endpoint_clone.id.clone().unwrap_or_default() },
+                ),
+                operation: async {
+                    backend_driver.create_endpoint(exec.state(), endpoint_clone).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let endpoint = self
+                .backend_driver
+                .create_endpoint(exec.state(), endpoint)
+                .await?;
+
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::Endpoint {
+                        id: endpoint.id.clone(),
+                    },
+                ))
+                .await;
+
+            endpoint
+        };
 
         Ok(endpoint)
     }
@@ -98,20 +118,39 @@ impl CatalogApi for CatalogService {
         region: RegionCreate,
     ) -> Result<Region, CatalogProviderError> {
         region.validate()?;
-        let region = self
-            .backend_driver
-            .create_region(exec.state(), region)
-            .await?;
-
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::Region {
-                    id: region.id.clone(),
+        let region = if let Some(vsc) = exec.ctx() {
+            let backend_driver = &self.backend_driver;
+            let region_clone = region.clone();
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::Region { id: region_clone.id.clone().unwrap_or_default() },
+                ),
+                operation: async {
+                    backend_driver.create_region(exec.state(), region_clone).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let region = self
+                .backend_driver
+                .create_region(exec.state(), region)
+                .await?;
+
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::Region {
+                        id: region.id.clone(),
+                    },
+                ))
+                .await;
+
+            region
+        };
 
         Ok(region)
     }
@@ -131,20 +170,40 @@ impl CatalogApi for CatalogService {
         service: ServiceCreate,
     ) -> Result<Service, CatalogProviderError> {
         service.validate()?;
-        let service = self
-            .backend_driver
-            .create_service(exec.state(), service)
-            .await?;
-
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::Service {
-                    id: service.id.clone(),
+        let service = if let Some(vsc) = exec.ctx() {
+            let backend_driver = &self.backend_driver;
+            let service_clone = service.clone();
+            let service_id = service_clone.id.clone().unwrap_or_default();
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::Service { id: service_id },
+                ),
+                operation: async {
+                    backend_driver.create_service(exec.state(), service_clone).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let service = self
+                .backend_driver
+                .create_service(exec.state(), service)
+                .await?;
+
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::Service {
+                        id: service.id.clone(),
+                    },
+                ))
+                .await;
+
+            service
+        };
 
         Ok(service)
     }
@@ -162,17 +221,33 @@ impl CatalogApi for CatalogService {
         exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError> {
-        self.backend_driver
-            .delete_endpoint(exec.state(), id)
-            .await?;
+        if let Some(vsc) = exec.ctx() {
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::Endpoint { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_endpoint(exec.state(), id).await?;
+                    Ok::<(), CatalogProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .delete_endpoint(exec.state(), id)
+                .await?;
 
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::Endpoint { id: id.to_string() },
-            ))
-            .await;
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::Endpoint { id: id.to_string() },
+                ))
+                .await;
+        }
 
         Ok(())
     }
@@ -190,15 +265,31 @@ impl CatalogApi for CatalogService {
         exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError> {
-        self.backend_driver.delete_region(exec.state(), id).await?;
+        if let Some(vsc) = exec.ctx() {
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::Region { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_region(exec.state(), id).await?;
+                    Ok::<(), CatalogProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver.delete_region(exec.state(), id).await?;
 
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::Region { id: id.to_string() },
-            ))
-            .await;
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::Region { id: id.to_string() },
+                ))
+                .await;
+        }
 
         Ok(())
     }
@@ -216,15 +307,31 @@ impl CatalogApi for CatalogService {
         exec: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), CatalogProviderError> {
-        self.backend_driver.delete_service(exec.state(), id).await?;
+        if let Some(vsc) = exec.ctx() {
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::Service { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_service(exec.state(), id).await?;
+                    Ok::<(), CatalogProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver.delete_service(exec.state(), id).await?;
 
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::Service { id: id.to_string() },
-            ))
-            .await;
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::Service { id: id.to_string() },
+                ))
+                .await;
+        }
 
         Ok(())
     }
@@ -372,17 +479,35 @@ impl CatalogApi for CatalogService {
         endpoint: EndpointUpdate,
     ) -> Result<Endpoint, CatalogProviderError> {
         endpoint.validate()?;
-        let updated = self
-            .backend_driver
-            .update_endpoint(exec.state(), id, endpoint)
-            .await?;
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Update,
-                EventPayload::Endpoint { id: id.to_string() },
-            ))
-            .await;
+        let updated = if let Some(vsc) = exec.ctx() {
+            let backend_driver = &self.backend_driver;
+            let endpoint_clone = endpoint.clone();
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::Endpoint { id: id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.update_endpoint(exec.state(), id, endpoint_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let updated = self
+                .backend_driver
+                .update_endpoint(exec.state(), id, endpoint)
+                .await?;
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::Endpoint { id: id.to_string() },
+                ))
+                .await;
+            updated
+        };
         Ok(updated)
     }
 
@@ -402,17 +527,35 @@ impl CatalogApi for CatalogService {
         region: RegionUpdate,
     ) -> Result<Region, CatalogProviderError> {
         region.validate()?;
-        let updated = self
-            .backend_driver
-            .update_region(exec.state(), id, region)
-            .await?;
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::Region { id: id.to_string() },
-            ))
-            .await;
+        let updated = if let Some(vsc) = exec.ctx() {
+            let backend_driver = &self.backend_driver;
+            let region_clone = region.clone();
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::Region { id: id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.update_region(exec.state(), id, region_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let updated = self
+                .backend_driver
+                .update_region(exec.state(), id, region)
+                .await?;
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::Region { id: id.to_string() },
+                ))
+                .await;
+            updated
+        };
         Ok(updated)
     }
 
@@ -433,17 +576,35 @@ impl CatalogApi for CatalogService {
         service: ServiceUpdate,
     ) -> Result<Service, CatalogProviderError> {
         service.validate()?;
-        let updated = self
-            .backend_driver
-            .update_service(exec.state(), id, service)
-            .await?;
-        exec.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::Service { id: id.to_string() },
-            ))
-            .await;
+        let updated = if let Some(vsc) = exec.ctx() {
+            let backend_driver = &self.backend_driver;
+            let service_clone = service.clone();
+            crate::audited_op! {
+                dispatcher: &exec.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::Service { id: id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.update_service(exec.state(), id, service_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| CatalogProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let updated = self
+                .backend_driver
+                .update_service(exec.state(), id, service)
+                .await?;
+            exec.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::Service { id: id.to_string() },
+                ))
+                .await;
+            updated
+        };
         Ok(updated)
     }
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -293,10 +293,10 @@ impl EventDispatcher {
 
     /// Fail-closed audit dispatch (ADR 0023 Phase 3).
     ///
-    /// Calls every registered [`AuditHook`] inline. A [`AuditDispatchError::DispatcherDead`]
-    /// from any hook short-circuits and returns immediately. Any other hook
-    /// error is collected; if any hooks fail, returns
-    /// [`AuditDispatchError::HookFailed`].
+    /// Calls every registered [`AuditHook`] inline. A
+    /// [`AuditDispatchError::DispatcherDead`] from any hook short-circuits
+    /// and returns immediately. Any other hook error is collected; if any
+    /// hooks fail, returns [`AuditDispatchError::HookFailed`].
     ///
     /// Reentrancy is prevented via a `tokio::task_local!` flag: a recursive
     /// call returns [`AuditDispatchError::Reentered`].
@@ -354,8 +354,8 @@ impl EventDispatcher {
 /// - `ctx` — `&ValidatedSecurityContext`
 /// - `event` — `Event` describing the resource being acted on
 /// - `operation` — an expression evaluating to a `Future<Output=Result<_, _>>`
-/// - `on_audit_error` — closure `|AuditDispatchError| -> E` mapping
-///   pre-audit failures to the outer error type
+/// - `on_audit_error` — closure `|AuditDispatchError| -> E` mapping pre-audit
+///   failures to the outer error type
 ///
 /// # Cancellation safety
 /// If the future returned by `$op` is dropped before completing, the

--- a/crates/core/src/federation/service.rs
+++ b/crates/core/src/federation/service.rs
@@ -20,9 +20,11 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::federation::*;
 
 use crate::auth::ExecutionContext;
+use crate::events::AuditDispatchError;
 use crate::federation::{FederationApi, FederationProviderError, backend::FederationBackend};
 use crate::plugin_manager::PluginManagerApi;
 
@@ -80,9 +82,38 @@ impl FederationApi for FederationService {
         ctx: &ExecutionContext<'a>,
         auth_state: AuthState,
     ) -> Result<AuthState, FederationProviderError> {
-        self.backend_driver
-            .create_auth_state(ctx.state(), auth_state)
-            .await
+        let auth_state_result = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let auth_state_clone = auth_state.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::AuthState { id: auth_state.state.clone() },
+                ),
+                operation: async {
+                    backend_driver.create_auth_state(ctx.state(), auth_state_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| FederationProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let auth_state_result = self
+                .backend_driver
+                .create_auth_state(ctx.state(), auth_state)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::AuthState {
+                        id: auth_state_result.state.clone(),
+                    },
+                ))
+                .await;
+            auth_state_result
+        };
+        Ok(auth_state_result)
     }
 
     /// Create Identity provider.
@@ -103,10 +134,39 @@ impl FederationApi for FederationService {
         if mod_idp.id.is_none() {
             mod_idp.id = Some(Uuid::new_v4().simple().to_string());
         }
-
-        self.backend_driver
-            .create_identity_provider(ctx.state(), mod_idp)
-            .await
+        let provider_id = mod_idp.id.clone().unwrap_or_default();
+        let provider = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let mod_idp_clone = mod_idp.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::IdentityProvider { id: provider_id.clone() },
+                ),
+                operation: async {
+                    backend_driver.create_identity_provider(ctx.state(), mod_idp_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| FederationProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let provider = self
+                .backend_driver
+                .create_identity_provider(ctx.state(), mod_idp)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::IdentityProvider {
+                        id: provider.id.clone(),
+                    },
+                ))
+                .await;
+            provider
+        };
+        Ok(provider)
     }
 
     /// Delete auth state.
@@ -122,7 +182,33 @@ impl FederationApi for FederationService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), FederationProviderError> {
-        self.backend_driver.delete_auth_state(ctx.state(), id).await
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::AuthState { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_auth_state(ctx.state(), id).await?;
+                    Ok::<(), FederationProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| FederationProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .delete_auth_state(ctx.state(), id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::AuthState { id: id.to_string() },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Delete identity provider.
@@ -138,9 +224,33 @@ impl FederationApi for FederationService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), FederationProviderError> {
-        self.backend_driver
-            .delete_identity_provider(ctx.state(), id)
-            .await
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::IdentityProvider { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_identity_provider(ctx.state(), id).await?;
+                    Ok::<(), FederationProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| FederationProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .delete_identity_provider(ctx.state(), id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::IdentityProvider { id: id.to_string() },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Get auth state by ID.
@@ -215,8 +325,35 @@ impl FederationApi for FederationService {
         id: &'a str,
         idp: IdentityProviderUpdate,
     ) -> Result<IdentityProvider, FederationProviderError> {
-        self.backend_driver
-            .update_identity_provider(ctx.state(), id, idp)
-            .await
+        let provider = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let idp_clone = idp.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::IdentityProvider { id: id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.update_identity_provider(ctx.state(), id, idp_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| FederationProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let provider = self
+                .backend_driver
+                .update_identity_provider(ctx.state(), id, idp)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::IdentityProvider { id: id.to_string() },
+                ))
+                .await;
+            provider
+        };
+        Ok(provider)
     }
 }

--- a/crates/core/src/identity/service.rs
+++ b/crates/core/src/identity/service.rs
@@ -92,9 +92,40 @@ impl IdentityApi for IdentityService {
         user_id: &'a str,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .add_user_to_group(ctx.state(), user_id, group_id)
-            .await
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: vec![group_id.to_string()],
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .add_user_to_group(ctx.state(), user_id, group_id)
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .add_user_to_group(ctx.state(), user_id, group_id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: vec![group_id.to_string()],
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Add the user to the group with expiration.
@@ -111,9 +142,40 @@ impl IdentityApi for IdentityService {
         group_id: &'a str,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .add_user_to_group_expiring(ctx.state(), user_id, group_id, idp_id)
-            .await
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: vec![group_id.to_string()],
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .add_user_to_group_expiring(ctx.state(), user_id, group_id, idp_id)
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .add_user_to_group_expiring(ctx.state(), user_id, group_id, idp_id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: vec![group_id.to_string()],
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Add user group membership relations.
@@ -126,9 +188,58 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         memberships: Vec<(&'a str, &'a str)>,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .add_users_to_groups(ctx.state(), memberships)
-            .await
+        let (first_user_id, group_ids): (String, Vec<String>) = if memberships.is_empty() {
+            (String::new(), Vec::new())
+        } else {
+            (
+                memberships[0].0.to_string(),
+                memberships.iter().map(|(_, g)| g.to_string()).collect(),
+            )
+        };
+        if let Some(vsc) = ctx.ctx() {
+            let memberships_clone = memberships
+                .iter()
+                .map(|(u, g)| (u.to_string(), g.to_string()))
+                .collect::<Vec<_>>();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::GroupMembership {
+                        user_id: first_user_id.clone(),
+                        group_ids: group_ids.clone(),
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .add_users_to_groups(
+                            ctx.state(),
+                            memberships_clone
+                                .iter()
+                                .map(|(u, g)| (u.as_str(), g.as_str()))
+                                .collect(),
+                        )
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .add_users_to_groups(ctx.state(), memberships)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::GroupMembership {
+                        user_id: first_user_id,
+                        group_ids,
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Add expiring user group membership relations.
@@ -143,9 +254,60 @@ impl IdentityApi for IdentityService {
         memberships: Vec<(&'a str, &'a str)>,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .add_users_to_groups_expiring(ctx.state(), memberships, idp_id)
-            .await
+        let (first_user_id, group_ids): (String, Vec<String>) = if memberships.is_empty() {
+            (String::new(), Vec::new())
+        } else {
+            (
+                memberships[0].0.to_string(),
+                memberships.iter().map(|(_, g)| g.to_string()).collect(),
+            )
+        };
+        if let Some(vsc) = ctx.ctx() {
+            let memberships_clone = memberships
+                .iter()
+                .map(|(u, g)| (u.to_string(), g.to_string()))
+                .collect::<Vec<_>>();
+            let idp_id = idp_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::GroupMembership {
+                        user_id: first_user_id.clone(),
+                        group_ids: group_ids.clone(),
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .add_users_to_groups_expiring(
+                            ctx.state(),
+                            memberships_clone
+                                .iter()
+                                .map(|(u, g)| (u.as_str(), g.as_str()))
+                                .collect(),
+                            &idp_id,
+                        )
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .add_users_to_groups_expiring(ctx.state(), memberships, idp_id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::GroupMembership {
+                        user_id: first_user_id,
+                        group_ids,
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Authenticate user with the password auth method.
@@ -257,9 +419,40 @@ impl IdentityApi for IdentityService {
             mod_sa.enabled = Some(true);
         }
         mod_sa.validate()?;
-        self.backend_driver
-            .create_service_account(ctx.state(), mod_sa)
-            .await
+        let service_account = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            let sa_clone = mod_sa.clone();
+            let sa_id = sa_clone.id.clone();
+            let dispatch = crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::ServiceAccount { id: sa_id.unwrap_or_default() },
+                ),
+                operation: async {
+                    backend_driver.create_service_account(state, sa_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            };
+            dispatch?
+        } else {
+            let sa = self
+                .backend_driver
+                .create_service_account(ctx.state(), mod_sa)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::ServiceAccount { id: sa.id.clone() },
+                ))
+                .await;
+            sa
+        };
+
+        Ok(service_account)
     }
 
     /// Create user.
@@ -595,9 +788,40 @@ impl IdentityApi for IdentityService {
         user_id: &'a str,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .remove_user_from_group(ctx.state(), user_id, group_id)
-            .await
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: vec![group_id.to_string()],
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .remove_user_from_group(ctx.state(), user_id, group_id)
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .remove_user_from_group(ctx.state(), user_id, group_id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: vec![group_id.to_string()],
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Remove the user from the group with expiration.
@@ -614,9 +838,40 @@ impl IdentityApi for IdentityService {
         group_id: &'a str,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .remove_user_from_group_expiring(ctx.state(), user_id, group_id, idp_id)
-            .await
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: vec![group_id.to_string()],
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .remove_user_from_group_expiring(ctx.state(), user_id, group_id, idp_id)
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .remove_user_from_group_expiring(ctx.state(), user_id, group_id, idp_id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: vec![group_id.to_string()],
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Remove the user from multiple groups.
@@ -631,9 +886,43 @@ impl IdentityApi for IdentityService {
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .remove_user_from_groups(ctx.state(), user_id, group_ids)
-            .await
+        let group_ids_vec: Vec<String> = group_ids.iter().copied().map(|s| s.to_string()).collect();
+        if let Some(vsc) = ctx.ctx() {
+            let group_ids_clone = group_ids_vec.clone();
+            let user_id_str = user_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::GroupMembership {
+                        user_id: user_id_str.clone(),
+                        group_ids: group_ids_clone,
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .remove_user_from_groups(ctx.state(), &user_id_str, group_ids.iter().copied().collect())
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .remove_user_from_groups(ctx.state(), user_id, group_ids)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: group_ids_vec,
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Remove the user from multiple expiring groups.
@@ -650,9 +939,44 @@ impl IdentityApi for IdentityService {
         group_ids: HashSet<&'a str>,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .remove_user_from_groups_expiring(ctx.state(), user_id, group_ids, idp_id)
-            .await
+        let group_ids_vec: Vec<String> = group_ids.iter().copied().map(|s| s.to_string()).collect();
+        if let Some(vsc) = ctx.ctx() {
+            let group_ids_clone = group_ids_vec.clone();
+            let user_id_str = user_id.to_string();
+            let idp_id_str = idp_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::GroupMembership {
+                        user_id: user_id_str.clone(),
+                        group_ids: group_ids_clone,
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .remove_user_from_groups_expiring(ctx.state(), &user_id_str, group_ids.iter().copied().collect(), &idp_id_str)
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .remove_user_from_groups_expiring(ctx.state(), user_id, group_ids, idp_id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: group_ids_vec,
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Set group memberships for the user.
@@ -667,9 +991,43 @@ impl IdentityApi for IdentityService {
         user_id: &'a str,
         group_ids: HashSet<&'a str>,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .set_user_groups(ctx.state(), user_id, group_ids)
-            .await
+        let group_ids_vec: Vec<String> = group_ids.iter().copied().map(|s| s.to_string()).collect();
+        if let Some(vsc) = ctx.ctx() {
+            let group_ids_clone = group_ids_vec.clone();
+            let user_id_str = user_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::GroupMembership {
+                        user_id: user_id_str.clone(),
+                        group_ids: group_ids_clone,
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .set_user_groups(ctx.state(), &user_id_str, group_ids.iter().copied().collect())
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .set_user_groups(ctx.state(), user_id, group_ids)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: group_ids_vec,
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Update user.
@@ -742,9 +1100,39 @@ impl IdentityApi for IdentityService {
     ) -> Result<(), IdentityProviderError> {
         let cfg = ctx.state().config_manager.config.read().await;
         cfg.security_compliance.validate_password(&new_password)?;
-        self.backend_driver
-            .update_user_password(ctx.state(), user_id, original_password, new_password)
-            .await
+        if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            let user_id = user_id.to_string();
+            let orig_pwd = original_password.clone();
+            let new_pwd = new_password.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::User { id: user_id.clone() },
+                ),
+                operation: async {
+                    backend_driver.update_user_password(state, &user_id, orig_pwd, new_pwd).await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .update_user_password(ctx.state(), user_id, original_password, new_password)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::User {
+                        id: user_id.to_string(),
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Set expiring group memberships for the user.
@@ -763,9 +1151,44 @@ impl IdentityApi for IdentityService {
         idp_id: &'a str,
         last_verified: Option<&'a DateTime<Utc>>,
     ) -> Result<(), IdentityProviderError> {
-        self.backend_driver
-            .set_user_groups_expiring(ctx.state(), user_id, group_ids, idp_id, last_verified)
-            .await
+        let group_ids_vec: Vec<String> = group_ids.iter().copied().map(|s| s.to_string()).collect();
+        if let Some(vsc) = ctx.ctx() {
+            let group_ids_clone = group_ids_vec.clone();
+            let user_id_str = user_id.to_string();
+            let idp_id_str = idp_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::GroupMembership {
+                        user_id: user_id_str.clone(),
+                        group_ids: group_ids_clone,
+                    },
+                ),
+                operation: async {
+                    self.backend_driver
+                        .set_user_groups_expiring(ctx.state(), &user_id_str, group_ids.iter().copied().collect(), &idp_id_str, last_verified)
+                        .await
+                },
+                on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .set_user_groups_expiring(ctx.state(), user_id, group_ids, idp_id, last_verified)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::GroupMembership {
+                        user_id: user_id.to_string(),
+                        group_ids: group_ids_vec,
+                    },
+                ))
+                .await;
+        }
+        Ok(())
     }
 }
 

--- a/crates/core/src/k8s_auth/service.rs
+++ b/crates/core/src/k8s_auth/service.rs
@@ -18,9 +18,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::k8s_auth::*;
 
 use crate::auth::{AuthenticationResult, ExecutionContext};
+use crate::events::AuditDispatchError;
 use crate::k8s_auth::{K8sAuthApi, K8sAuthProviderError, K8sHttpClient, backend::K8sAuthBackend};
 use crate::plugin_manager::PluginManagerApi;
 
@@ -95,9 +97,37 @@ impl K8sAuthApi for K8sAuthService {
         if new.id.is_none() {
             new.id = Some(uuid::Uuid::new_v4().simple().to_string());
         }
-        self.backend_driver
-            .create_auth_instance(ctx.state(), new)
-            .await
+        let instance_id = new.id.clone().unwrap_or_default();
+        let result = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let new_clone = new.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::K8sAuthInstance { id: instance_id },
+                ),
+                operation: async {
+                    backend_driver.create_auth_instance(ctx.state(), new_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| K8sAuthProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let result = self
+                .backend_driver
+                .create_auth_instance(ctx.state(), new)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::K8sAuthInstance { id: instance_id },
+                ))
+                .await;
+            result
+        };
+        Ok(result)
     }
 
     /// Delete K8s auth provider.
@@ -114,9 +144,33 @@ impl K8sAuthApi for K8sAuthService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), K8sAuthProviderError> {
-        self.backend_driver
-            .delete_auth_instance(ctx.state(), id)
-            .await
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::K8sAuthInstance { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_auth_instance(ctx.state(), id).await?;
+                    Ok::<(), K8sAuthProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| K8sAuthProviderError::Driver { source: "audit dispatch failed".into() },
+            }?;
+        } else {
+            self.backend_driver
+                .delete_auth_instance(ctx.state(), id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::K8sAuthInstance { id: id.to_string() },
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Fetch auth instance.
@@ -171,9 +225,36 @@ impl K8sAuthApi for K8sAuthService {
         id: &'a str,
         data: K8sAuthInstanceUpdate,
     ) -> Result<K8sAuthInstance, K8sAuthProviderError> {
-        self.backend_driver
-            .update_auth_instance(ctx.state(), id, data)
-            .await
+        let result = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let data_clone = data.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::K8sAuthInstance { id: id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.update_auth_instance(ctx.state(), id, data_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| K8sAuthProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let result = self
+                .backend_driver
+                .update_auth_instance(ctx.state(), id, data)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::K8sAuthInstance { id: id.to_string() },
+                ))
+                .await;
+            result
+        };
+        Ok(result)
     }
 }
 

--- a/crates/core/src/mapping/service.rs
+++ b/crates/core/src/mapping/service.rs
@@ -28,6 +28,7 @@ use openstack_keystone_core_types::auth::{
     AuthzInfoBuilder, IdentityInfo, OidcContextBuilder, PrincipalIdentityInfoBuilder,
     PrincipalInfo, ScopeInfo, UserIdentityInfoBuilder,
 };
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::identity::{
     FederationBuilder, FederationProtocol, GroupCreate, GroupListParameters, UserCreateBuilder,
     UserResponse,
@@ -36,13 +37,15 @@ use openstack_keystone_core_types::mapping::*;
 use openstack_keystone_core_types::resource::{Domain, Project};
 
 use crate::auth::ExecutionContext;
+use crate::events::AuditDispatchError;
 use crate::keystone::ServiceState;
 use crate::mapping::{
     MappingApi, MappingProviderError, backend::MappingBackend, engine, hmac, validation, version,
 };
 use crate::plugin_manager::PluginManagerApi;
 
-/// Derive [`AuthzInfo`] from authorization list produced by a matched ruleset rule.
+/// Derive [`AuthzInfo`] from authorization list produced by a matched ruleset
+/// rule.
 ///
 /// Uses the first authorization to determine scope. If the list is empty,
 /// returns `None` so the authentication result remains unscoped.
@@ -577,19 +580,12 @@ impl MappingApi for MappingService {
         ctx: &ExecutionContext<'a>,
         mut ruleset: MappingRuleSetCreate,
     ) -> Result<MappingRuleSet, MappingProviderError> {
-        // 1. Write-time validation
         validation::validate_ruleset_create(&ruleset)?;
-
-        // 2. Generate UUID if not provided
         let mapping_id = ruleset
             .mapping_id
             .take()
             .unwrap_or(Uuid::new_v4().simple().to_string());
-
-        // 3. Compute content-aware ruleset version
         let ruleset_version = version::compute_ruleset_version(&ruleset);
-
-        // 4. Build the ruleset object for backend storage
         let ruleset_obj = MappingRuleSet {
             mapping_id: mapping_id.clone(),
             domain_id: ruleset.domain_id,
@@ -599,14 +595,37 @@ impl MappingApi for MappingService {
             rules: ruleset.rules,
             ruleset_version,
         };
-
-        // 5. Delegate to backend
-        let created = self
-            .backend_driver
-            .create_ruleset(ctx.state(), ruleset_obj)
-            .await?;
-
-        // 6. Return the created ruleset
+        let created = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let ruleset_obj_clone = ruleset_obj.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::MappingRuleSet { mapping_id: mapping_id.clone() },
+                ),
+                operation: async {
+                    backend_driver.create_ruleset(ctx.state(), ruleset_obj_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| MappingProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let created = self
+                .backend_driver
+                .create_ruleset(ctx.state(), ruleset_obj)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::MappingRuleSet {
+                        mapping_id: mapping_id.clone(),
+                    },
+                ))
+                .await;
+            created
+        };
         Ok(MappingRuleSet {
             mapping_id: mapping_id.clone(),
             domain_id: created.domain_id,
@@ -624,40 +643,88 @@ impl MappingApi for MappingService {
         ctx: &ExecutionContext<'a>,
         mapping_id: &'a str,
     ) -> Result<(), MappingProviderError> {
-        let max_retries = 5u64;
-        for attempt in 0..max_retries {
-            // Check immutability: if ruleset contains `is_system` rules, reject
-            if let Some(existing) = self
-                .backend_driver
-                .get_ruleset(ctx.state(), mapping_id)
-                .await?
-                && existing.rules.iter().any(|r| r.identity.is_system)
-            {
-                return Err(MappingProviderError::RulesetImmutable(
-                    mapping_id.to_string(),
-                ));
-            }
-
-            match self
-                .backend_driver
-                .delete_ruleset(ctx.state(), mapping_id)
-                .await
-            {
-                Ok(()) => return Ok(()),
-                Err(MappingProviderError::CasConflict { .. }) if attempt + 1 < max_retries => {
-                    let backoff_ms = 50 * (1u64 << attempt);
-                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-                    continue;
+        if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let mapping_id_str = mapping_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::MappingRuleSet { mapping_id: mapping_id_str.clone() },
+                ),
+                operation: async {
+                    let max_retries = 5u64;
+                    for attempt in 0..max_retries {
+                        if let Some(existing) = backend_driver.get_ruleset(ctx.state(), mapping_id).await?
+                            && existing.rules.iter().any(|r| r.identity.is_system)
+                        {
+                            return Err(MappingProviderError::RulesetImmutable(mapping_id.to_string()));
+                        }
+                        match backend_driver.delete_ruleset(ctx.state(), mapping_id).await {
+                            Ok(()) => return Ok::<(), MappingProviderError>(()),
+                            Err(MappingProviderError::CasConflict { .. }) if attempt + 1 < max_retries => {
+                                let backoff_ms = 50 * (1u64 << attempt);
+                                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                                continue;
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    }
+                    Err(MappingProviderError::CasConflict {
+                        subject: mapping_id.to_string(),
+                        description: format!("CAS delete exceeded {max_retries} retries with exponential backoff"),
+                    })
+                },
+                on_audit_error: |_: AuditDispatchError| MappingProviderError::Driver { source: "audit dispatch failed".into() },
+            }?;
+        } else {
+            let max_retries = 5u64;
+            for attempt in 0..max_retries {
+                if let Some(existing) = self
+                    .backend_driver
+                    .get_ruleset(ctx.state(), mapping_id)
+                    .await?
+                    && existing.rules.iter().any(|r| r.identity.is_system)
+                {
+                    return Err(MappingProviderError::RulesetImmutable(
+                        mapping_id.to_string(),
+                    ));
                 }
-                Err(e) => return Err(e),
+
+                match self
+                    .backend_driver
+                    .delete_ruleset(ctx.state(), mapping_id)
+                    .await
+                {
+                    Ok(()) => {
+                        ctx.state()
+                            .event_dispatcher
+                            .emit(Event::new(
+                                Operation::Delete,
+                                EventPayload::MappingRuleSet {
+                                    mapping_id: mapping_id.to_string(),
+                                },
+                            ))
+                            .await;
+                        return Ok(());
+                    }
+                    Err(MappingProviderError::CasConflict { .. }) if attempt + 1 < max_retries => {
+                        let backoff_ms = 50 * (1u64 << attempt);
+                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                }
             }
+            return Err(MappingProviderError::CasConflict {
+                subject: mapping_id.to_string(),
+                description: format!(
+                    "CAS delete exceeded {max_retries} retries with exponential backoff"
+                ),
+            });
         }
-        Err(MappingProviderError::CasConflict {
-            subject: mapping_id.to_string(),
-            description: format!(
-                "CAS delete exceeded {max_retries} retries with exponential backoff"
-            ),
-        })
+        Ok(())
     }
 
     /// Delete a virtual user shadow record.
@@ -666,28 +733,72 @@ impl MappingApi for MappingService {
         ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<(), MappingProviderError> {
-        let max_retries = 5u64;
-        for attempt in 0..max_retries {
-            match self
-                .backend_driver
-                .delete_virtual_user(ctx.state(), user_id)
-                .await
-            {
-                Ok(()) => return Ok(()),
-                Err(MappingProviderError::CasConflict { .. }) if attempt + 1 < max_retries => {
-                    let backoff_ms = 50 * (1u64 << attempt);
-                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-                    continue;
+        if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let user_id_str = user_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::VirtualUser { user_id: user_id_str.clone() },
+                ),
+                operation: async {
+                    let max_retries = 5u64;
+                    for attempt in 0..max_retries {
+                        match backend_driver.delete_virtual_user(ctx.state(), user_id).await {
+                            Ok(()) => return Ok::<(), MappingProviderError>(()),
+                            Err(MappingProviderError::CasConflict { .. }) if attempt + 1 < max_retries => {
+                                let backoff_ms = 50 * (1u64 << attempt);
+                                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                                continue;
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    }
+                    Err(MappingProviderError::CasConflict {
+                        subject: user_id.to_string(),
+                        description: format!("CAS delete exceeded {max_retries} retries with exponential backoff"),
+                    })
+                },
+                on_audit_error: |_: AuditDispatchError| MappingProviderError::Driver { source: "audit dispatch failed".into() },
+            }?;
+        } else {
+            let max_retries = 5u64;
+            for attempt in 0..max_retries {
+                match self
+                    .backend_driver
+                    .delete_virtual_user(ctx.state(), user_id)
+                    .await
+                {
+                    Ok(()) => {
+                        ctx.state()
+                            .event_dispatcher
+                            .emit(Event::new(
+                                Operation::Delete,
+                                EventPayload::VirtualUser {
+                                    user_id: user_id.to_string(),
+                                },
+                            ))
+                            .await;
+                        return Ok(());
+                    }
+                    Err(MappingProviderError::CasConflict { .. }) if attempt + 1 < max_retries => {
+                        let backoff_ms = 50 * (1u64 << attempt);
+                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                        continue;
+                    }
+                    Err(e) => return Err(e),
                 }
-                Err(e) => return Err(e),
             }
+            return Err(MappingProviderError::CasConflict {
+                subject: user_id.to_string(),
+                description: format!(
+                    "CAS delete exceeded {max_retries} retries with exponential backoff"
+                ),
+            });
         }
-        Err(MappingProviderError::CasConflict {
-            subject: user_id.to_string(),
-            description: format!(
-                "CAS delete exceeded {max_retries} retries with exponential backoff"
-            ),
-        })
+        Ok(())
     }
 
     /// Fetch a mapping ruleset by ID.
@@ -841,12 +952,38 @@ impl MappingApi for MappingService {
             rules: Some(new_rules),
         };
 
-        let updated = self
-            .backend_driver
-            .update_ruleset(ctx.state(), mapping_id, update_payload)
-            .await?;
+        let updated = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let update_payload_clone = update_payload.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::MappingRuleSet { mapping_id: mapping_id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.update_ruleset(ctx.state(), mapping_id, update_payload_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| MappingProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let updated = self
+                .backend_driver
+                .update_ruleset(ctx.state(), mapping_id, update_payload)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::MappingRuleSet {
+                        mapping_id: mapping_id.to_string(),
+                    },
+                ))
+                .await;
+            updated
+        };
 
-        // 7. Return with new version
         Ok(MappingRuleSet {
             mapping_id: existing.mapping_id.clone(),
             domain_id: updated.domain_id,
@@ -868,24 +1005,20 @@ impl MappingApi for MappingService {
         mapping_id: &'a str,
         data: MappingRuleSetUpdate,
     ) -> Result<MappingRuleSet, MappingProviderError> {
-        // 1. Fetch existing ruleset
         let existing = self
             .backend_driver
             .get_ruleset(ctx.state(), mapping_id)
             .await?
             .ok_or_else(|| MappingProviderError::NotFound(mapping_id.to_string()))?;
 
-        // 2. Check immutability: reject update if ruleset contains `is_system` rules
         if existing.rules.iter().any(|r| r.identity.is_system) {
             return Err(MappingProviderError::RulesetImmutable(
                 mapping_id.to_string(),
             ));
         }
 
-        // 3. Validate update
         validation::validate_ruleset_update(&existing, &data)?;
 
-        // 4. Compute merged ruleset for version calculation
         let merged_rules = data.rules.clone().unwrap_or(existing.rules.clone());
         let new_version = version::compute_ruleset_version_from_parts(
             &existing.mapping_id,
@@ -896,13 +1029,38 @@ impl MappingApi for MappingService {
             &merged_rules,
         );
 
-        // 5. Delegate to backend
-        let updated = self
-            .backend_driver
-            .update_ruleset(ctx.state(), mapping_id, data)
-            .await?;
+        let updated = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let data_clone = data.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::MappingRuleSet { mapping_id: mapping_id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.update_ruleset(ctx.state(), mapping_id, data_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| MappingProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let updated = self
+                .backend_driver
+                .update_ruleset(ctx.state(), mapping_id, data)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::MappingRuleSet {
+                        mapping_id: mapping_id.to_string(),
+                    },
+                ))
+                .await;
+            updated
+        };
 
-        // 6. Return with updated version
         Ok(MappingRuleSet {
             mapping_id: existing.mapping_id.clone(),
             domain_id: updated.domain_id,
@@ -920,9 +1078,37 @@ impl MappingApi for MappingService {
         ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<VirtualUser, MappingProviderError> {
-        self.backend_driver
-            .disable_virtual_user(ctx.state(), user_id)
-            .await
+        let vu = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Disable,
+                    EventPayload::VirtualUser { user_id: user_id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.disable_virtual_user(ctx.state(), user_id).await
+                },
+                on_audit_error: |_: AuditDispatchError| MappingProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let vu = self
+                .backend_driver
+                .disable_virtual_user(ctx.state(), user_id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Disable,
+                    EventPayload::VirtualUser {
+                        user_id: user_id.to_string(),
+                    },
+                ))
+                .await;
+            vu
+        };
+        Ok(vu)
     }
 
     /// Enable (reactivate) a virtual user shadow record.
@@ -931,9 +1117,37 @@ impl MappingApi for MappingService {
         ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<VirtualUser, MappingProviderError> {
-        self.backend_driver
-            .enable_virtual_user(ctx.state(), user_id)
-            .await
+        let vu = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Enable,
+                    EventPayload::VirtualUser { user_id: user_id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.enable_virtual_user(ctx.state(), user_id).await
+                },
+                on_audit_error: |_: AuditDispatchError| MappingProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let vu = self
+                .backend_driver
+                .enable_virtual_user(ctx.state(), user_id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Enable,
+                    EventPayload::VirtualUser {
+                        user_id: user_id.to_string(),
+                    },
+                ))
+                .await;
+            vu
+        };
+        Ok(vu)
     }
 
     /// Authenticate a principal through the unified mapping engine.

--- a/crates/core/src/resource/service.rs
+++ b/crates/core/src/resource/service.rs
@@ -22,6 +22,7 @@ use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::resource::*;
 
 use crate::auth::ExecutionContext;
+use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
 use crate::resource::{ResourceApi, ResourceProviderError, backend::ResourceBackend};
 
@@ -87,25 +88,48 @@ impl ResourceApi for ResourceService {
         domain: DomainCreate,
     ) -> Result<Domain, ResourceProviderError> {
         let mut new_domain = domain;
-
-        if new_domain.id.is_none() {
-            new_domain.id = Some(Uuid::new_v4().simple().to_string());
-        }
+        let domain_id = if let Some(ref did) = new_domain.id {
+            did.clone()
+        } else {
+            let did = Uuid::new_v4().simple().to_string();
+            new_domain.id = Some(did.clone());
+            did
+        };
         new_domain.validate()?;
-        let domain = self
-            .backend_driver
-            .create_domain(ctx.state(), new_domain)
-            .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::Domain {
-                    id: domain.id.clone(),
+        let domain = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            let new_domain_clone = new_domain.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::Domain { id: domain_id.clone() },
+                ),
+                operation: async {
+                    backend_driver.create_domain(state, new_domain_clone).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| ResourceProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let domain = self
+                .backend_driver
+                .create_domain(ctx.state(), new_domain)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::Domain {
+                        id: domain.id.clone(),
+                    },
+                ))
+                .await;
+
+            domain
+        };
 
         Ok(domain)
     }
@@ -125,25 +149,48 @@ impl ResourceApi for ResourceService {
         project: ProjectCreate,
     ) -> Result<Project, ResourceProviderError> {
         let mut new_project = project;
-
-        if new_project.id.is_none() {
-            new_project.id = Some(Uuid::new_v4().simple().to_string());
-        }
+        let project_id = if let Some(ref pid) = new_project.id {
+            pid.clone()
+        } else {
+            let pid = Uuid::new_v4().simple().to_string();
+            new_project.id = Some(pid.clone());
+            pid
+        };
         new_project.validate()?;
-        let project = self
-            .backend_driver
-            .create_project(ctx.state(), new_project)
-            .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::Project {
-                    id: project.id.clone(),
+        let project = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            let new_project_clone = new_project.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::Project { id: project_id.clone() },
+                ),
+                operation: async {
+                    backend_driver.create_project(state, new_project_clone).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| ResourceProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let project = self
+                .backend_driver
+                .create_project(ctx.state(), new_project)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::Project {
+                        id: project.id.clone(),
+                    },
+                ))
+                .await;
+
+            project
+        };
 
         Ok(project)
     }
@@ -162,15 +209,31 @@ impl ResourceApi for ResourceService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), ResourceProviderError> {
-        self.backend_driver.delete_domain(ctx.state(), id).await?;
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::Domain { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_domain(ctx.state(), id).await?;
+                    Ok::<(), ResourceProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| ResourceProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver.delete_domain(ctx.state(), id).await?;
 
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::Domain { id: id.to_string() },
-            ))
-            .await;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::Domain { id: id.to_string() },
+                ))
+                .await;
+        }
 
         Ok(())
     }
@@ -189,15 +252,31 @@ impl ResourceApi for ResourceService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), ResourceProviderError> {
-        self.backend_driver.delete_project(ctx.state(), id).await?;
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::Project { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_project(ctx.state(), id).await?;
+                    Ok::<(), ResourceProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| ResourceProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver.delete_project(ctx.state(), id).await?;
 
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::Project { id: id.to_string() },
-            ))
-            .await;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::Project { id: id.to_string() },
+                ))
+                .await;
+        }
 
         Ok(())
     }

--- a/crates/core/src/role/service.rs
+++ b/crates/core/src/role/service.rs
@@ -23,6 +23,7 @@ use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::role::*;
 
 use crate::auth::ExecutionContext;
+use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
 use crate::role::{RoleApi, RoleProviderError, backend::RoleBackend};
 
@@ -59,27 +60,48 @@ impl RoleApi for RoleService {
         ctx: &ExecutionContext<'a>,
         params: RoleCreate,
     ) -> Result<Role, RoleProviderError> {
-        params.validate()?;
-
         let mut new_params = params;
-
-        if new_params.id.is_none() {
-            new_params.id = Some(Uuid::new_v4().simple().to_string());
-        }
-        let role = self
-            .backend_driver
-            .create_role(ctx.state(), new_params)
-            .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::Role {
-                    id: role.id.clone(),
+        let role_id = if let Some(ref rid) = new_params.id {
+            rid.clone()
+        } else {
+            let rid = Uuid::new_v4().simple().to_string();
+            new_params.id = Some(rid.clone());
+            rid
+        };
+        new_params.validate()?;
+        let role = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::Role { id: role_id.clone() },
+                ),
+                operation: async {
+                    backend_driver.create_role(state, new_params).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| RoleProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let role = self
+                .backend_driver
+                .create_role(ctx.state(), new_params)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::Role {
+                        id: role.id.clone(),
+                    },
+                ))
+                .await;
+
+            role
+        };
 
         Ok(role)
     }
@@ -96,21 +118,45 @@ impl RoleApi for RoleService {
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<RoleImply, RoleProviderError> {
-        let rule = self
-            .backend_driver
-            .create_role_imply_rule(ctx.state(), prior_role_id, implied_role_id)
-            .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Create,
-                EventPayload::RoleImply {
-                    prior_role_id: prior_role_id.to_string(),
-                    implied_role_id: implied_role_id.to_string(),
+        let rule = if let Some(vsc) = ctx.ctx() {
+            let prior = prior_role_id.to_string();
+            let implied = implied_role_id.to_string();
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::RoleImply {
+                        prior_role_id: prior,
+                        implied_role_id: implied,
+                    },
+                ),
+                operation: async {
+                    backend_driver.create_role_imply_rule(state, prior_role_id, implied_role_id).await
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| RoleProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let rule = self
+                .backend_driver
+                .create_role_imply_rule(ctx.state(), prior_role_id, implied_role_id)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::RoleImply {
+                        prior_role_id: prior_role_id.to_string(),
+                        implied_role_id: implied_role_id.to_string(),
+                    },
+                ))
+                .await;
+
+            rule
+        };
 
         Ok(rule)
     }
@@ -142,15 +188,31 @@ impl RoleApi for RoleService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), RoleProviderError> {
-        self.backend_driver.delete_role(ctx.state(), id).await?;
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::Role { id: id.to_string() },
+                ),
+                operation: async {
+                    self.backend_driver.delete_role(ctx.state(), id).await?;
+                    Ok::<(), RoleProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| RoleProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver.delete_role(ctx.state(), id).await?;
 
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::Role { id: id.to_string() },
-            ))
-            .await;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::Role { id: id.to_string() },
+                ))
+                .await;
+        }
 
         Ok(())
     }
@@ -167,20 +229,41 @@ impl RoleApi for RoleService {
         prior_role_id: &'a str,
         implied_role_id: &'a str,
     ) -> Result<(), RoleProviderError> {
-        self.backend_driver
-            .delete_role_imply_rule(ctx.state(), prior_role_id, implied_role_id)
-            .await?;
-
-        ctx.state()
-            .event_dispatcher
-            .emit(Event::new(
-                Operation::Delete,
-                EventPayload::RoleImply {
-                    prior_role_id: prior_role_id.to_string(),
-                    implied_role_id: implied_role_id.to_string(),
+        if let Some(vsc) = ctx.ctx() {
+            let prior = prior_role_id.to_string();
+            let implied = implied_role_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::RoleImply {
+                        prior_role_id: prior,
+                        implied_role_id: implied,
+                    },
+                ),
+                operation: async {
+                    self.backend_driver.delete_role_imply_rule(ctx.state(), prior_role_id, implied_role_id).await?;
+                    Ok::<(), RoleProviderError>(())
                 },
-            ))
-            .await;
+                on_audit_error: |_: AuditDispatchError| RoleProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .delete_role_imply_rule(ctx.state(), prior_role_id, implied_role_id)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::RoleImply {
+                        prior_role_id: prior_role_id.to_string(),
+                        implied_role_id: implied_role_id.to_string(),
+                    },
+                ))
+                .await;
+        }
 
         Ok(())
     }

--- a/crates/core/src/token/service.rs
+++ b/crates/core/src/token/service.rs
@@ -32,6 +32,7 @@ use openstack_keystone_core_types::application_credential::ApplicationCredential
 use openstack_keystone_core_types::auth::{
     AuthzInfo, AuthzInfoBuilder, ScopeInfo, SecurityContext, TrustProjectInfo,
 };
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::resource::ResourceProviderError;
 use openstack_keystone_core_types::role::{Role, RoleListParameters, RoleRef};
 use openstack_keystone_core_types::token::{
@@ -42,6 +43,7 @@ use openstack_keystone_core_types::trust::TrustProviderError;
 
 use crate::auth::ExecutionContext;
 use crate::auth::*;
+use crate::events::AuditDispatchError;
 use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 use crate::token::{
@@ -556,9 +558,37 @@ impl TokenApi for TokenService {
         if restriction.id.is_empty() {
             restriction.id = Uuid::new_v4().simple().to_string();
         }
-        self.tr_backend_driver
-            .create_token_restriction(ctx.state(), restriction)
-            .await
+        let restriction_id = restriction.id.clone();
+        let result = if let Some(vsc) = ctx.ctx() {
+            let tr_backend_driver = &self.tr_backend_driver;
+            let restriction_clone = restriction.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::TokenRestriction { id: restriction_id },
+                ),
+                operation: async {
+                    tr_backend_driver.create_token_restriction(ctx.state(), restriction_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| TokenProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let result = self
+                .tr_backend_driver
+                .create_token_restriction(ctx.state(), restriction)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::TokenRestriction { id: restriction_id },
+                ))
+                .await;
+            result
+        };
+        Ok(result)
     }
 
     /// List token restrictions.
@@ -596,9 +626,36 @@ impl TokenApi for TokenService {
         id: &'a str,
         restriction: TokenRestrictionUpdate,
     ) -> Result<TokenRestriction, TokenProviderError> {
-        self.tr_backend_driver
-            .update_token_restriction(ctx.state(), id, restriction)
-            .await
+        let updated = if let Some(vsc) = ctx.ctx() {
+            let tr_backend_driver = &self.tr_backend_driver;
+            let restriction_clone = restriction.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::TokenRestriction { id: id.to_string() },
+                ),
+                operation: async {
+                    tr_backend_driver.update_token_restriction(ctx.state(), id, restriction_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| TokenProviderError::Driver { source: "audit dispatch failed".into() },
+            }?
+        } else {
+            let updated = self
+                .tr_backend_driver
+                .update_token_restriction(ctx.state(), id, restriction)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::TokenRestriction { id: id.to_string() },
+                ))
+                .await;
+            updated
+        };
+        Ok(updated)
     }
 
     /// Delete token restriction by the ID.
@@ -614,9 +671,34 @@ impl TokenApi for TokenService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), TokenProviderError> {
-        self.tr_backend_driver
-            .delete_token_restriction(ctx.state(), id)
-            .await
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::TokenRestriction { id: id.to_string() },
+                ),
+                operation: async {
+                    self.tr_backend_driver.delete_token_restriction(ctx.state(), id).await?;
+                    Ok::<(), TokenProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| TokenProviderError::Driver { source: "audit dispatch failed".into() },
+            }?;
+        } else {
+            self.tr_backend_driver
+                .delete_token_restriction(ctx.state(), id)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::TokenRestriction { id: id.to_string() },
+                ))
+                .await;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/keystone/src/audit.rs
+++ b/crates/keystone/src/audit.rs
@@ -150,9 +150,10 @@ pub fn extract_provider_name(
     }
 }
 
-// Initiator-builder functions are provided by `openstack_keystone_core::cadf_hook`
-// and imported above. Re-export them under the original names so existing
-// callers in this crate don't need to change their import paths.
+// Initiator-builder functions are provided by
+// `openstack_keystone_core::cadf_hook` and imported above. Re-export them under
+// the original names so existing callers in this crate don't need to change
+// their import paths.
 pub use openstack_keystone_core::cadf_hook::{
     build_initiator_from_verified_token, build_initiator_from_vsc, build_initiator_unknown,
 };


### PR DESCRIPTION
Implement full audit framework with fail-closed provider auditing,
spooling, and replay. All CRUD write operations across 10 services use
audited_op!  (fail-closed pre-audit + best-effort post-audit with
compensating log).

Framework primitives:
- EventDispatcher::emit_critical with task_local reentrancy guard
- AuditHook trait, AuditOutcome { Attempt, Success, Failure }
- AuditDispatchError { DispatcherDead, HookFailed, Reentered }
- audited_op! macro (pre-audit, operation, post-audit, compensating log)
- CadfAuditHook wired at startup via subscribe_audit
- Spooling with HMAC verification and replay on startup

EventPayload variants (8 new): ServiceAccount, TokenRestriction,
IdentityProvider, AuthState, MappingRuleSet, VirtualUser,
K8sAuthInstance, GroupMembership

Services converted (56 ops across 10 services):
- Identity: 20 (7 CRUD + service_account + password + 11 group mgmt)
- Resource: 4 (create/delete domain, create/delete project)
- Role: 4 (create/delete role, create/delete role_imply_rule)
- Assignment: 2 (create_grant, revoke_grant)
- Catalog: 9 (8 CRUD + 2 Operation::Delete bugs fixed)
- ApplicationCredential: 3 (create/delete access_rule, create
  app_credential)
- Token: 3 (create/update/delete token_restriction)
- Federation: 5 (create/update/delete identity_provider, create/delete
  auth_state)
- Mapping: 7 (create/update/delete/mutate ruleset, delete/disable/enable
  virtual_user)
- K8sAuth: 3 (create/update/delete auth_instance)

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
