### PR TITLE
fix: Resolve raft replication state races

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -127,6 +127,8 @@ jobs:
           curl http://localhost:8080/v3/auth/tokens -H "X-Auth-Token: ${TOKEN2}" -H "X-Subject-Token: ${TOKEN2}" | jq
 
       - name: Run api tests
+        env:
+          RUST_LOG: "info,reqwest=off,h2=off,hyper=off"
         run: cargo test --test api
 
       # - name: Run interop tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,9 +3655,9 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40148cf75ead81993d5910bc72275e542e4e01a90241bf1905236843fe3009d"
+checksum = "543cde97b501169472efb6d5724c9c44531dfd7c5acf6ea1399ea39e4fecb727"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -3668,7 +3668,7 @@ dependencies = [
  "derive_more",
  "display-more",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "maplit",
  "openraft-macros",
  "openraft-rt",
@@ -3684,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec23cd291c763fb17d8dabf7cc4eacaefd45d02e52a4df88ce50c702f030689"
+checksum = "5d43c6ef109db505b8ef57de389b34d54927181f3a07819f09c9f0a6cf0ff72c"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -3697,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c2d12e376df204612bb2016d652ea2d48b8edeaa04263facbe2fc7a11e3ef"
+checksum = "dd3e555284a21902ba525163451fb86c24329e8617143387b0dbddfd7e362de9"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3710,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.21"
+version = "0.10.0-alpha.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8c01f2a456a864282bc4eaf76f1f78ab040d80416fd30fd15b8ab88faa337a"
+checksum = "2514284b14f28321f8a5614bf82ebae5e2bf8a444d6d879a460a684f71b5c2f7"
 dependencies = [
  "futures-util",
  "openraft-rt",
@@ -4089,6 +4089,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serial_test",
  "spiffe",
  "spiffe-rustls",
  "temp-env",
@@ -6576,6 +6577,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ itertools = { version = "0.15" }
 mockall = { version = "0.14" }
 mockall_double = { version = "0.3" }
 nix = { version = "0.31", default-features = false }
-openraft = { version = "=0.10.0-alpha.21" }
+openraft = { version = "=0.10.0-alpha.27" }
 openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "crates/api-types" }
 openstack-keystone-audit = { version = "0.1.0", path = "crates/audit" }
 openstack-keystone-appcred-driver-sql = { version = "0.1", path = "crates/appcred-driver-sql/" }
@@ -125,6 +125,7 @@ rmp-serde = "1.3"
 rustls = { version = "0.23" }
 schemars = { version = "1.2" }
 scopeguard = "1.2.0"
+serial_test = { version = "3.2" }
 sea-orm = { version = "1.1", default-features = false }
 sea-orm-migration = { version = "1.1", default-features = false }
 secrecy = { version = "0.10" }

--- a/crates/core-types/src/auth.rs
+++ b/crates/core-types/src/auth.rs
@@ -767,10 +767,9 @@ impl SecurityContext {
     #[must_use = "discarding the result ignores scope assignment errors"]
     pub fn set_authorization_scope(&mut self, scope: ScopeInfo) -> Result<(), AuthenticationError> {
         self.validate_scope_boundaries(&scope)?;
-        let authorization = AuthzInfo {
-            roles: None,
-            scope: scope.clone(),
-        };
+        // Preserve existing roles if available, otherwise fall back to None.
+        let roles = self.authorization.as_ref().and_then(|a| a.roles.clone());
+        let authorization = AuthzInfo { roles, scope };
         self.authorization = Some(authorization);
         Ok(())
     }
@@ -2641,6 +2640,37 @@ mod tests {
             })
         ));
         assert!(ctx.authorization().unwrap().roles.is_none());
+    }
+
+    #[test]
+    fn test_set_authorization_scope_preserves_roles() {
+        let mut ctx = make_password_context(make_principal("uid"));
+        let roles = vec![RoleRef {
+            domain_id: None,
+            id: "role-a".to_string(),
+            name: None,
+        }];
+        // Pre-set authorization with roles on one scope
+        ctx.set_authorization(AuthzInfo {
+            roles: Some(roles.clone()),
+            scope: ScopeInfo::Unscoped,
+        });
+        assert!(ctx.authorization().unwrap().roles.is_some());
+
+        // Re-scope to Project — roles should be preserved
+        let new_scope = ScopeInfo::Project {
+            project: make_project(),
+            project_domain: make_domain(),
+        };
+        assert!(ctx.set_authorization_scope(new_scope).is_ok());
+        assert!(matches!(
+            ctx.authorization().unwrap().scope,
+            ScopeInfo::Project { .. }
+        ));
+        assert_eq!(
+            ctx.authorization().as_ref().and_then(|a| a.roles.as_ref()),
+            Some(&roles)
+        );
     }
 
     #[test]

--- a/crates/core-types/src/mapping/auth.rs
+++ b/crates/core-types/src/mapping/auth.rs
@@ -65,4 +65,7 @@ pub struct MappingContext {
 
     /// Virtual user shadow record ID.
     pub virtual_user_id: String,
+
+    /// System-service flag, preserved from initial match evaluation.
+    pub is_system: bool,
 }

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -15,7 +15,7 @@ use std::collections::HashSet;
 use std::ops::Deref;
 
 use chrono::Utc;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use openstack_keystone_core_types::assignment::{
     AssignmentProviderError, RoleAssignmentListParametersBuilder,
@@ -192,82 +192,203 @@ impl ValidatedSecurityContext {
             AuthenticationContext::Token(..) => {}
             AuthenticationContext::WebauthN => {}
             AuthenticationContext::Mapping(mc) => {
-                // Read virtual user shadow record to get allowed authorizations
-                let vu = state
-                    .provider
-                    .get_mapping_provider()
-                    .get_virtual_user(&ExecutionContext::internal(state), &mc.virtual_user_id)
-                    .await
-                    .auth_context("fetching virtual user for scope resolution")?
-                    .ok_or(AuthenticationError::ActorHasNoRolesOnTarget)
-                    .auth_context("virtual user not found")?;
+                // Extract data from mc before modifying ctx (mc borrows ctx).
+                let virtual_user_id = mc.virtual_user_id.clone();
+                let is_system = mc.is_system;
 
-                let resolved_scope = if vu.is_system && matches!(scope_clone, ScopeInfo::Unscoped) {
-                    // Override Unscoped -> System("all") for system principals.
-                    // The auth handler passes Unscoped for mapping engine principals;
-                    // this determines the correct scope from the shadow record.
-                    ctx.set_authorization_scope(ScopeInfo::System("all".into()))?;
-                    ScopeInfo::System("all".into())
-                } else {
-                    scope_clone.clone()
-                };
+                // Fast path: if authorization was already derived during
+                // authenticate_ephemeral (from match_result.authorizations),
+                // use it directly to avoid a second storage read that could
+                // race with Raft replication on follower nodes.
+                let roles_prepopulated = ctx
+                    .authorization()
+                    .and_then(|a| a.effective_roles())
+                    .map(|r| r.to_vec());
 
-                if vu.authorizations.is_empty() {
-                    // No authorizations - fall through with no scope
-                } else {
-                    // Find authorization matching the resolved scope (by type + specific ID)
-                    let roles = match &resolved_scope {
-                        ScopeInfo::Domain(domain) => vu.authorizations.iter().find_map(|a| {
-                            if let Authorization::Domain { domain_id, roles } = a
-                                && *domain_id == domain.id
-                            {
-                                Some(roles.clone())
-                            } else {
-                                None
-                            }
-                        }),
-                        ScopeInfo::Project {
-                            project,
-                            project_domain,
-                        } => vu.authorizations.iter().find_map(|a| {
-                            if let Authorization::Project {
-                                project_id,
-                                project_domain_id,
-                                roles,
-                            } = a
-                                && *project_id == project.id
-                                && *project_domain_id == project_domain.id
-                            {
-                                Some(roles.clone())
-                            } else {
-                                None
-                            }
-                        }),
-                        ScopeInfo::System(system_id) => vu.authorizations.iter().find_map(|a| {
-                            if let Authorization::System {
-                                system_id: s,
-                                roles,
-                            } = a
-                                && s.as_str() == system_id.as_str()
-                            {
-                                Some(roles.clone())
-                            } else {
-                                None
-                            }
-                        }),
-                        ScopeInfo::Unscoped | ScopeInfo::TrustProject(_) => None,
+                debug!(
+                    virtual_user_id = &virtual_user_id,
+                    is_system,
+                    scope = ?scope_clone,
+                    roles_prepopulated = roles_prepopulated.as_ref().map(|r| r.len()),
+                    "Mapping: validate_security_context — checking prepopulated roles"
+                );
+
+                if let Some(roles) = roles_prepopulated {
+                    let resolved_scope = if is_system && matches!(scope_clone, ScopeInfo::Unscoped)
+                    {
+                        ctx.set_authorization_scope(ScopeInfo::System("all".into()))?;
+                        ScopeInfo::System("all".into())
+                    } else {
+                        scope_clone.clone()
                     };
 
-                    if let Some(roles) = roles {
-                        let authz =
-                            openstack_keystone_core_types::auth::AuthzInfoBuilder::default()
-                                .scope(resolved_scope)
-                                .roles(roles)
-                                .build()
-                                .map_err(
-                                    openstack_keystone_core_types::auth::AuthenticationError::from,
-                                )?;
-                        ctx.set_authorization(authz);
+                    debug!(
+                        virtual_user_id = &virtual_user_id,
+                        scope = ?resolved_scope,
+                        role_count = roles.len(),
+                        "Mapping: fast path — prepopulated roles, skipping storage read"
+                    );
+
+                    let authz_for_scope =
+                        openstack_keystone_core_types::auth::AuthzInfoBuilder::default()
+                            .scope(resolved_scope.clone())
+                            .roles(roles)
+                            .build()
+                            .map_err(
+                                openstack_keystone_core_types::auth::AuthenticationError::from,
+                            )?;
+                    ctx.set_authorization(authz_for_scope);
+                } else if is_system && matches!(scope_clone, ScopeInfo::Unscoped) {
+                    // Even with no pre-set roles, a system principal requesting
+                    // unscoped should be upgraded to system scope.
+                    debug!(
+                        virtual_user_id = &virtual_user_id,
+                        "Mapping: is_system=true with Unscoped, upgrading to System, slow path"
+                    );
+                    ctx.set_authorization_scope(ScopeInfo::System("all".into()))?;
+
+                    // Slow path: read virtual user to obtain authorizations.
+                    let vu = get_virtual_user_or_error(state, &virtual_user_id).await?;
+
+                    if vu.authorizations.is_empty() {
+                        // No authorizations - fall through with no roles
+                    } else {
+                        // Scope was already overridden to System("all") above.
+                        let resolved_scope = ScopeInfo::System("all".into());
+                        let roles = match &resolved_scope {
+                            ScopeInfo::Domain(domain) => vu.authorizations.iter().find_map(|a| {
+                                if let Authorization::Domain { domain_id, roles } = a
+                                    && *domain_id == domain.id
+                                {
+                                    Some(roles.clone())
+                                } else {
+                                    None
+                                }
+                            }),
+                            ScopeInfo::Project {
+                                project,
+                                project_domain,
+                            } => vu.authorizations.iter().find_map(|a| {
+                                if let Authorization::Project {
+                                    project_id,
+                                    project_domain_id,
+                                    roles,
+                                } = a
+                                    && *project_id == project.id
+                                    && *project_domain_id == project_domain.id
+                                {
+                                    Some(roles.clone())
+                                } else {
+                                    None
+                                }
+                            }),
+                            ScopeInfo::System(system_id) => {
+                                vu.authorizations.iter().find_map(|a| {
+                                    if let Authorization::System {
+                                        system_id: s,
+                                        roles,
+                                    } = a
+                                        && s.as_str() == system_id.as_str()
+                                    {
+                                        Some(roles.clone())
+                                    } else {
+                                        None
+                                    }
+                                })
+                            }
+                            ScopeInfo::Unscoped | ScopeInfo::TrustProject(_) => None,
+                        };
+
+                        if let Some(roles) = roles {
+                            let authz =
+                                openstack_keystone_core_types::auth::AuthzInfoBuilder::default()
+                                    .scope(resolved_scope)
+                                    .roles(roles)
+                                    .build()
+                                    .map_err(
+                                        openstack_keystone_core_types::auth::AuthenticationError::from,
+                                    )?;
+                            ctx.set_authorization(authz);
+                        }
+                    }
+                } else if matches!(scope_clone, ScopeInfo::Unscoped) {
+                    // Unscoped with no pre-populated roles: skip storage read.
+                    // There's nothing to derive from the virtual user, and a read
+                    // would race with Raft replication during auth.
+                    debug!(
+                        virtual_user_id = &virtual_user_id,
+                        "Mapping: Unscoped with no prepopulated roles, skipping storage read"
+                    );
+                    let _ = ctx.set_authorization_scope(scope_clone);
+                } else {
+                    // Slow path: read virtual user to obtain authorizations.
+                    debug!(
+                        virtual_user_id = &virtual_user_id,
+                        scope = ?scope_clone,
+                        "Mapping: slow path — reading virtual user for role resolution"
+                    );
+                    let vu = get_virtual_user_or_error(state, &virtual_user_id).await?;
+
+                    let resolved_scope = scope_clone.clone();
+
+                    if vu.authorizations.is_empty() {
+                        // No authorizations - fall through with no scope
+                    } else {
+                        let roles = match &resolved_scope {
+                            ScopeInfo::Domain(domain) => vu.authorizations.iter().find_map(|a| {
+                                if let Authorization::Domain { domain_id, roles } = a
+                                    && *domain_id == domain.id
+                                {
+                                    Some(roles.clone())
+                                } else {
+                                    None
+                                }
+                            }),
+                            ScopeInfo::Project {
+                                project,
+                                project_domain,
+                            } => vu.authorizations.iter().find_map(|a| {
+                                if let Authorization::Project {
+                                    project_id,
+                                    project_domain_id,
+                                    roles,
+                                } = a
+                                    && *project_id == project.id
+                                    && *project_domain_id == project_domain.id
+                                {
+                                    Some(roles.clone())
+                                } else {
+                                    None
+                                }
+                            }),
+                            ScopeInfo::System(system_id) => {
+                                vu.authorizations.iter().find_map(|a| {
+                                    if let Authorization::System {
+                                        system_id: s,
+                                        roles,
+                                    } = a
+                                        && s.as_str() == system_id.as_str()
+                                    {
+                                        Some(roles.clone())
+                                    } else {
+                                        None
+                                    }
+                                })
+                            }
+                            ScopeInfo::Unscoped | ScopeInfo::TrustProject(_) => None,
+                        };
+
+                        if let Some(roles) = roles {
+                            let authz =
+                                openstack_keystone_core_types::auth::AuthzInfoBuilder::default()
+                                    .scope(resolved_scope)
+                                    .roles(roles)
+                                    .build()
+                                    .map_err(
+                                        openstack_keystone_core_types::auth::AuthenticationError::from,
+                                    )?;
+                            ctx.set_authorization(authz);
+                        }
                     }
                 }
             }
@@ -277,6 +398,11 @@ impl ValidatedSecurityContext {
         // Populate roles before locking
         if let Some(authz) = ctx.authorization() {
             let role_vec = calculate_effective_roles(state, &ctx, &authz.scope).await?;
+            debug!(
+                scope = ?authz.scope,
+                role_count = role_vec.len(),
+                "calculated effective_roles"
+            );
             ctx.set_effective_roles(role_vec);
         }
 
@@ -285,6 +411,15 @@ impl ValidatedSecurityContext {
             && authz.effective_roles().is_none_or(|r| r.is_empty())
             && !ctx.is_admin()
         {
+            let virtual_user_id = match ctx.authentication_context() {
+                AuthenticationContext::Mapping(mc) => Some(mc.virtual_user_id.as_str()),
+                _ => None,
+            };
+            warn!(
+                virtual_user_id,
+                scope = ?authz.scope,
+                "ActorHasNoRolesOnTarget — returning 401"
+            );
             return Err(AuthenticationError::ActorHasNoRolesOnTarget);
         }
         Ok(ValidatedSecurityContext(ctx))
@@ -389,6 +524,23 @@ impl<'a> Deref for ExecutionContext<'a> {
     fn deref(&self) -> &Self::Target {
         self.state
     }
+}
+
+// Expand scope role information.
+// Fetch the virtual user shadow record from storage.
+async fn get_virtual_user_or_error(
+    state: &ServiceState,
+    virtual_user_id: &str,
+) -> Result<openstack_keystone_core_types::mapping::VirtualUser, AuthenticationError> {
+    let exec = ExecutionContext::internal(state);
+    state
+        .provider
+        .get_mapping_provider()
+        .get_virtual_user(&exec, virtual_user_id)
+        .await
+        .auth_context("fetching virtual user for scope resolution")?
+        .ok_or(AuthenticationError::ActorHasNoRolesOnTarget)
+        .auth_context("virtual user not found")
 }
 
 // Expand scope role information.
@@ -2288,6 +2440,7 @@ mod tests {
             mapping_id: "map-1".to_string(),
             matched_rule_name: "rule-1".to_string(),
             virtual_user_id: vir_id.to_string(),
+            is_system: false,
         };
 
         let ctx = SecurityContextTestingBuilder::default()
@@ -2358,6 +2511,7 @@ mod tests {
             mapping_id: "map-1".to_string(),
             matched_rule_name: "rule-1".to_string(),
             virtual_user_id: vir_id.to_string(),
+            is_system: false,
         };
 
         let ctx = SecurityContextTestingBuilder::default()
@@ -2427,6 +2581,7 @@ mod tests {
             mapping_id: "map-1".to_string(),
             matched_rule_name: "rule-1".to_string(),
             virtual_user_id: vir_id.to_string(),
+            is_system: false,
         };
 
         let ctx = SecurityContextTestingBuilder::default()
@@ -2509,6 +2664,7 @@ mod tests {
             mapping_id: "map-1".to_string(),
             matched_rule_name: "rule-1".to_string(),
             virtual_user_id: vir_id.to_string(),
+            is_system: false,
         };
 
         let ctx = SecurityContextTestingBuilder::default()
@@ -2549,6 +2705,7 @@ mod tests {
             mapping_id: "map-1".to_string(),
             matched_rule_name: "rule-1".to_string(),
             virtual_user_id: vir_id.to_string(),
+            is_system: false,
         };
 
         let ctx = SecurityContextTestingBuilder::default()
@@ -2614,6 +2771,7 @@ mod tests {
             mapping_id: "map-1".to_string(),
             matched_rule_name: "rule-1".to_string(),
             virtual_user_id: vir_id.to_string(),
+            is_system: false,
         };
 
         let ctx = SecurityContextTestingBuilder::default()
@@ -2677,6 +2835,7 @@ mod tests {
             mapping_id: "map-1".to_string(),
             matched_rule_name: "system-rule".to_string(),
             virtual_user_id: vir_id.to_string(),
+            is_system: true,
         };
 
         let ctx = SecurityContextTestingBuilder::default()
@@ -2761,6 +2920,7 @@ mod tests {
             mapping_id: "map-1".to_string(),
             matched_rule_name: "system-rule".to_string(),
             virtual_user_id: vir_id.to_string(),
+            is_system: true,
         };
 
         let ctx = SecurityContextTestingBuilder::default()
@@ -2776,5 +2936,218 @@ mod tests {
             result,
             Err(AuthenticationError::ActorHasNoRolesOnTarget)
         ));
+    }
+
+    // --- Mapping fast path: pre-set project authorization skips storage read ---
+    #[tokio::test]
+    async fn test_new_for_scope_mapping_fast_path_project() {
+        let pid = "project-1";
+        let vir_id = "vu-fast-path-project-0000000000000000";
+        let rid = "admin";
+        let roles = vec![role_ref(rid, "admin")];
+
+        let authz = AuthzInfoBuilder::default()
+            .scope(make_project_scope(pid))
+            .roles(roles.clone())
+            .build()
+            .unwrap();
+
+        let mc = MappingContext {
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "rule-1".to_string(),
+            virtual_user_id: vir_id.to_string(),
+            is_system: false,
+        };
+
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Mapping(mc))
+            .principal(make_user_identity(vir_id))
+            .authorization(authz)
+            .build();
+
+        // No mock mapping provider — get_virtual_user must NOT be called
+        let state = get_mocked_state(None, None).await;
+
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, make_project_scope(pid), &state).await;
+
+        let validated = result.unwrap();
+        let eff = validated
+            .0
+            .authorization()
+            .unwrap()
+            .effective_roles()
+            .unwrap();
+        assert_eq!(eff.len(), 1);
+        assert_eq!(eff[0].id, rid);
+    }
+
+    // --- Mapping fast path: is_system upgrade with pre-set system roles skips
+    // storage read ---
+    #[tokio::test]
+    async fn test_new_for_scope_mapping_fast_path_system_unscoped_upgrade() {
+        let vir_id = "vu-fast-path-system-0000000000000000";
+        let rid = "admin";
+        let roles = vec![role_ref(rid, "admin")];
+
+        let authz = AuthzInfoBuilder::default()
+            .scope(ScopeInfo::System("all".into()))
+            .roles(roles.clone())
+            .build()
+            .unwrap();
+
+        let mc = MappingContext {
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "system-rule".to_string(),
+            virtual_user_id: vir_id.to_string(),
+            is_system: true,
+        };
+
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Mapping(mc))
+            .principal(make_user_identity(vir_id))
+            .authorization(authz)
+            .build();
+
+        // No mock mapping provider — get_virtual_user must NOT be called
+        let state = get_mocked_state(None, None).await;
+
+        // Pass Unscoped — is_system with pre-set roles should upgrade to
+        // System("all") without storage read
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, ScopeInfo::Unscoped, &state).await;
+
+        let validated = result.unwrap();
+        assert!(matches!(
+            validated.0.authorization().unwrap().scope,
+            ScopeInfo::System(ref s) if s == "all"
+        ));
+        let eff = validated
+            .0
+            .authorization()
+            .unwrap()
+            .effective_roles()
+            .unwrap();
+        assert_eq!(eff.len(), 1);
+        assert_eq!(eff[0].id, rid);
+    }
+
+    // --- Mapping fast path: pre-set domain roles skip storage read ---
+    #[tokio::test]
+    async fn test_new_for_scope_mapping_fast_path_domain() {
+        let did = "domain-1";
+        let vir_id = "vu-fast-path-domain-0000000000000000";
+        let rid = "reader";
+        let roles = vec![role_ref(rid, "reader")];
+
+        let authz = AuthzInfoBuilder::default()
+            .scope(make_domain_scope(did))
+            .roles(roles.clone())
+            .build()
+            .unwrap();
+
+        let mc = MappingContext {
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "rule-1".to_string(),
+            virtual_user_id: vir_id.to_string(),
+            is_system: false,
+        };
+
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Mapping(mc))
+            .principal(make_user_identity(vir_id))
+            .authorization(authz)
+            .build();
+
+        // No mock mapping provider — get_virtual_user must NOT be called
+        let state = get_mocked_state(None, None).await;
+
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, make_domain_scope(did), &state).await;
+
+        let validated = result.unwrap();
+        let eff = validated
+            .0
+            .authorization()
+            .unwrap()
+            .effective_roles()
+            .unwrap();
+        assert_eq!(eff.len(), 1);
+        assert_eq!(eff[0].id, rid);
+    }
+
+    // --- Mapping slow path: is_system true, unscoped scope, no pre-set auth,
+    // reads virtual user from storage ---
+    #[tokio::test]
+    async fn test_new_for_scope_mapping_slow_path_system_unscoped() {
+        let vir_id = "vu-slow-path-system-0000000000000000";
+        let rid = "admin";
+        let roles = vec![role_ref(rid, "admin")];
+
+        let vu = VirtualUser {
+            user_id: vir_id.to_string(),
+            unique_workload_id: "workload-sys-slow".to_string(),
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "system-rule".to_string(),
+            domain_id: None,
+            resolved_user_name: "system-user".to_string(),
+            is_system: true,
+            resolved_group_bindings: vec![],
+            authorizations: vec![Authorization::System {
+                system_id: "all".to_string(),
+                roles: roles.clone(),
+            }],
+            ruleset_version: 1,
+            enabled: true,
+            created_at: 0,
+            last_authenticated_at: 0,
+        };
+
+        let mut mapping_mock = MockMappingProvider::new();
+        mapping_mock
+            .expect_get_virtual_user()
+            .returning(move |_e, id: &str| {
+                if id == vir_id {
+                    Ok(Some(vu.clone()))
+                } else {
+                    Ok(None)
+                }
+            });
+
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_mapping(mapping_mock)),
+        )
+        .await;
+
+        let mc = MappingContext {
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "system-rule".to_string(),
+            virtual_user_id: vir_id.to_string(),
+            is_system: true,
+        };
+
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Mapping(mc))
+            .principal(make_user_identity(vir_id))
+            .build();
+
+        // No pre-set authorization — slow path with storage read
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, ScopeInfo::Unscoped, &state).await;
+
+        let validated = result.unwrap();
+        assert!(matches!(
+            validated.0.authorization().unwrap().scope,
+            ScopeInfo::System(ref s) if s == "all"
+        ));
+        let eff = validated
+            .0
+            .authorization()
+            .unwrap()
+            .effective_roles()
+            .unwrap();
+        assert_eq!(eff.len(), 1);
+        assert_eq!(eff[0].id, rid);
     }
 }

--- a/crates/core/src/k8s_auth/auth.rs
+++ b/crates/core/src/k8s_auth/auth.rs
@@ -189,11 +189,19 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::json;
 
+    use openstack_keystone_core_types::auth::ScopeInfo;
+    use openstack_keystone_core_types::k8s_auth::{K8sClaims, QueryTokenReviewResult};
+    use openstack_keystone_core_types::mapping::resolution::IdentitySource;
+    use openstack_keystone_core_types::mapping::*;
+    use openstack_keystone_core_types::role::RoleRef;
+
     use super::*;
     use crate::k8s_auth::K8sHttpClient;
     use crate::k8s_auth::backend::MockK8sAuthBackend;
+    use crate::mapping::backend::MockMappingBackend;
+    use crate::mapping::service::MappingService;
+    use crate::provider::Provider;
     use crate::tests::get_mocked_state;
-    use openstack_keystone_core_types::k8s_auth::{K8sClaims, QueryTokenReviewResult};
 
     struct TestK8sHttpClient;
 
@@ -352,5 +360,273 @@ mod tests {
             result,
             Err(K8sAuthProviderError::AuthInstanceNotActive(x)) if x == "cid"
         ));
+    }
+
+    // ───────── Integration tests: full k8s -> mapping engine flow ─────────
+
+    struct MockK8sHttpClientOk;
+
+    #[async_trait]
+    impl K8sHttpClient for MockK8sHttpClientOk {
+        async fn query_token_review(
+            &self,
+            _instance: &K8sAuthInstance,
+            _jwt: &str,
+        ) -> Result<QueryTokenReviewResult, K8sAuthProviderError> {
+            Ok(QueryTokenReviewResult {
+                claims: K8sClaims {
+                    aud: vec!["kubernetes".to_string()],
+                    exp: 0,
+                    sub: "system:serviceaccount:default:sa".to_string(),
+                },
+                token_review: json!({
+                    "status": {
+                        "authenticated": true,
+                        "user": {
+                            "username": "system:serviceaccount:default:sa"
+                        }
+                    }
+                }),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_k8s_authenticate_by_mapping_full_flow_project_authz() {
+        // 1. Build MappingService with mock backend
+        let mut mapping_backend = MockMappingBackend::new();
+
+        let source = IdentitySource::K8s {
+            cluster_id: "k8s-cluster-1".to_string(),
+        };
+
+        let rules = vec![MappingRule {
+            name: "any-sa".to_string(),
+            description: None,
+            r#match: MatchCriteria::AllOf(vec![
+                MatchCondition::Condition(ClaimCondition::MatchesRegex {
+                    claim: "k8s.serviceaccount.name".to_string(),
+                    regex: ".*".to_string(),
+                }),
+                MatchCondition::Condition(ClaimCondition::MatchesRegex {
+                    claim: "k8s.serviceaccount.namespace".to_string(),
+                    regex: ".*".to_string(),
+                }),
+            ]),
+            identity: IdentityBinding {
+                identity_mode: Some(IdentityMode::Ephemeral),
+                user_name: "svc-k8s".to_string(),
+                user_id: None,
+                user_domain_id: None,
+                is_system: false,
+            },
+            authorizations: vec![Authorization::Project {
+                project_id: "proj-123".to_string(),
+                project_domain_id: "default".to_string(),
+                roles: vec![RoleRef {
+                    id: "member-role".to_string(),
+                    name: Some("member".to_string()),
+                    domain_id: None,
+                }],
+            }],
+            groups: vec![],
+        }];
+
+        let matching_ruleset = MappingRuleSet {
+            mapping_id: "k8s-mapping".to_string(),
+            domain_id: Some("default".to_string()),
+            source: source.clone(),
+            domain_resolution_mode: DomainResolutionMode::Fixed,
+            enabled: true,
+            rules,
+            ruleset_version: 1,
+        };
+        let ruleset_clone = matching_ruleset.clone();
+
+        mapping_backend
+            .expect_get_ruleset_by_source()
+            .returning(move |_, _, _| Ok(Some(ruleset_clone.clone())));
+        mapping_backend
+            .expect_get_virtual_user()
+            .returning(|_, _| Ok(None));
+        mapping_backend
+            .expect_create_virtual_user()
+            .returning(|_, vu| Ok(vu));
+
+        let mapping_service = MappingService::from_driver(mapping_backend);
+
+        // 2. Wire mapping service into provider
+        let provider_builder = Provider::mocked_builder().mock_mapping(mapping_service);
+
+        // 3. Build ServiceState with salt for HMAC
+        let mut cfg = openstack_keystone_config::Config::default();
+        cfg.mapping.cluster_salt = Some(SecretString::from("test-salt-for-hmac-derivation!"));
+
+        let state = get_mocked_state(Some(cfg), Some(provider_builder)).await;
+
+        // 4. Build K8sAuthService with mock backend + mock HTTP client
+        let instance = K8sAuthInstance {
+            ca_cert: None,
+            disable_local_ca_jwt: false,
+            domain_id: "default".to_string(),
+            enabled: true,
+            host: "http://localhost:6443".to_string(),
+            id: "k8s-cluster-1".to_string(),
+            name: Some("test".to_string()),
+        };
+
+        let mut k8s_backend = MockK8sAuthBackend::new();
+        k8s_backend
+            .expect_get_auth_instance()
+            .returning(move |_, _| Ok(Some(instance.clone())));
+
+        let k8s_service = K8sAuthService {
+            backend_driver: Arc::new(k8s_backend),
+            http_client: Arc::new(MockK8sHttpClientOk),
+        };
+
+        // 5. Execute authenticate
+        let result = k8s_service
+            .authenticate_by_mapping(
+                &ExecutionContext::internal(&state),
+                &K8sAuthRequest {
+                    auth_instance_id: "k8s-cluster-1".to_string(),
+                    jwt: SecretString::from("valid.jwt.token"),
+                    rule_name: None,
+                },
+            )
+            .await
+            .expect("authentication should succeed");
+
+        // 6. Verify: authorization is set with correct scope and roles
+        let authz = result
+            .authorization
+            .expect("authorization should be set by derive_authz_info");
+
+        match authz.scope {
+            ScopeInfo::Project {
+                ref project,
+                ref project_domain,
+            } => {
+                assert_eq!(project.id, "proj-123");
+                assert_eq!(project_domain.id, "default");
+            }
+            _ => panic!("Expected Project scope, got {:?}", authz.scope),
+        }
+
+        let roles = authz
+            .effective_roles()
+            .expect("effective_roles should be populated");
+        assert_eq!(roles.len(), 1);
+        assert_eq!(roles[0].id, "member-role");
+    }
+
+    #[tokio::test]
+    async fn test_k8s_authenticate_by_mapping_unscoped() {
+        // Ruleset with no authorizations -> unscoped
+        let source = IdentitySource::K8s {
+            cluster_id: "k8s-unscoped".to_string(),
+        };
+
+        let rules = vec![MappingRule {
+            name: "wildcard".to_string(),
+            description: None,
+            r#match: MatchCriteria::AllOf(vec![
+                MatchCondition::Condition(ClaimCondition::MatchesRegex {
+                    claim: "k8s.serviceaccount.name".to_string(),
+                    regex: ".*".to_string(),
+                }),
+                MatchCondition::Condition(ClaimCondition::MatchesRegex {
+                    claim: "k8s.serviceaccount.namespace".to_string(),
+                    regex: ".*".to_string(),
+                }),
+            ]),
+            identity: IdentityBinding {
+                identity_mode: Some(IdentityMode::Ephemeral),
+                user_name: "svc-k8s".to_string(),
+                user_id: None,
+                user_domain_id: None,
+                is_system: false,
+            },
+            authorizations: vec![],
+            groups: vec![],
+        }];
+
+        let matching_ruleset = MappingRuleSet {
+            mapping_id: "k8s-unscoped".to_string(),
+            domain_id: Some("default".to_string()),
+            source: source.clone(),
+            domain_resolution_mode: DomainResolutionMode::Fixed,
+            enabled: true,
+            rules,
+            ruleset_version: 1,
+        };
+        let ruleset_clone = matching_ruleset.clone();
+
+        let mut mapping_backend = MockMappingBackend::new();
+        mapping_backend
+            .expect_get_ruleset_by_source()
+            .returning(move |_, _, _| Ok(Some(ruleset_clone.clone())));
+        mapping_backend
+            .expect_get_virtual_user()
+            .returning(|_, _| Ok(None));
+        mapping_backend
+            .expect_create_virtual_user()
+            .returning(|_, vu| Ok(vu));
+
+        let mapping_service = MappingService::from_driver(mapping_backend);
+
+        let provider_builder = Provider::mocked_builder().mock_mapping(mapping_service);
+
+        let mut cfg = openstack_keystone_config::Config::default();
+        cfg.mapping.cluster_salt = Some(SecretString::from("test-salt-for-hmac-derivation!"));
+        let state = get_mocked_state(Some(cfg), Some(provider_builder)).await;
+
+        let instance = K8sAuthInstance {
+            ca_cert: None,
+            disable_local_ca_jwt: false,
+            domain_id: "default".to_string(),
+            enabled: true,
+            host: "http://localhost:6443".to_string(),
+            id: "k8s-unscoped".to_string(),
+            name: None,
+        };
+
+        let mut k8s_backend = MockK8sAuthBackend::new();
+        k8s_backend
+            .expect_get_auth_instance()
+            .returning(move |_, _| Ok(Some(instance.clone())));
+
+        let k8s_service = K8sAuthService {
+            backend_driver: Arc::new(k8s_backend),
+            http_client: Arc::new(MockK8sHttpClientOk),
+        };
+
+        let result = k8s_service
+            .authenticate_by_mapping(
+                &ExecutionContext::internal(&state),
+                &K8sAuthRequest {
+                    auth_instance_id: "k8s-unscoped".to_string(),
+                    jwt: SecretString::from("valid.jwt.token"),
+                    rule_name: None,
+                },
+            )
+            .await
+            .expect("authentication should succeed");
+
+        let authz = result
+            .authorization
+            .expect("authorization should still be set for unscoped");
+
+        assert!(
+            matches!(authz.scope, ScopeInfo::Unscoped),
+            "Expected Unscoped scope, got {:?}",
+            authz.scope
+        );
+
+        assert!(
+            authz.effective_roles().is_none(),
+            "Unscoped should not have roles"
+        );
     }
 }

--- a/crates/core/src/mapping/service.rs
+++ b/crates/core/src/mapping/service.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::Utc;
 use secrecy::ExposeSecret;
+use tracing::debug;
 use uuid::Uuid;
 
 use openstack_keystone_config::Config;
@@ -97,11 +98,9 @@ fn derive_authz_info(authorizations: &[Authorization]) -> Option<AuthzInfo> {
         None => return None,
     };
 
-    AuthzInfoBuilder::default()
-        .scope(scope)
-        .roles(roles)
-        .build()
-        .ok()
+    let mut authz = AuthzInfoBuilder::default().scope(scope).build().ok()?;
+    authz.set_roles(roles);
+    Some(authz)
 }
 
 /// Mapping Provider service.
@@ -262,20 +261,39 @@ impl MappingService {
             mapping_id: ruleset.mapping_id.clone(),
             matched_rule_name: match_result.rule_name.clone(),
             virtual_user_id: virtual_user_id.clone(),
+            is_system: match_result.is_system,
         });
 
         let result = match derive_authz_info(&match_result.authorizations) {
-            Some(authz) => AuthenticationResultBuilder::default()
-                .principal(principal)
-                .context(ctx)
-                .authorization(authz)
-                .build(),
-            None => AuthenticationResultBuilder::default()
-                .principal(principal)
-                .context(ctx)
-                .build(),
+            Some(authz) => {
+                debug!(
+                    virtual_user_id = &virtual_user_id,
+                    auth_count = match_result.authorizations.len(),
+                    "derived authorization from match_result authorizations"
+                );
+                AuthenticationResultBuilder::default()
+                    .principal(principal)
+                    .context(ctx)
+                    .authorization(authz)
+                    .build()
+            }
+            None => {
+                debug!(
+                    virtual_user_id = &virtual_user_id,
+                    auth_count = match_result.authorizations.len(),
+                    "no authorization derived from match_result (wildcard rule or empty), setting unscoped"
+                );
+                let authz = AuthzInfoBuilder::default()
+                    .scope(ScopeInfo::Unscoped)
+                    .build()
+                    .expect("unscoped authz build should never fail");
+                AuthenticationResultBuilder::default()
+                    .principal(principal)
+                    .context(ctx)
+                    .authorization(authz)
+                    .build()
+            }
         };
-
         Ok(result.map_err(Box::new)?)
     }
 

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -140,8 +140,9 @@ async fn main() -> Result<(), Report> {
     let args = Args::parse();
 
     let external_deps_log_level = match args.verbose {
-        0 | 1 => LevelFilter::WARN,
-        _ => LevelFilter::INFO,
+        0 => LevelFilter::WARN,
+        1 => LevelFilter::INFO,
+        _ => LevelFilter::DEBUG,
     };
     let stderr_log_filter = Targets::new()
         .with_default(match args.verbose {

--- a/crates/keystone/src/k8s_auth/api/auth.rs
+++ b/crates/keystone/src/k8s_auth/api/auth.rs
@@ -28,8 +28,10 @@ use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
 use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core_types::auth::{AuthenticationContext, ScopeInfo, SecurityContext};
+use openstack_keystone_core_types::mapping::MappingContext;
 use openstack_keystone_core_types::mapping::authorization::Authorization;
 use openstack_keystone_core_types::resource::{Domain, Project};
+use tracing::{debug, warn};
 
 use crate::api::types::{Catalog, CatalogService};
 use crate::api::v4::auth::token::types::TokenResponse;
@@ -143,24 +145,45 @@ async fn mapping_auth(
     let scope = if let Some(authz) = ctx.authorization() {
         authz.scope.clone()
     } else {
-        // Derive scope from the virtual user's authorizations via the
-        // mapping provider.
-        let mapping_ctx = match ctx.authentication_context() {
+        debug!("mapping_auth: ctx.authorization() is None, falling back to scope derivation");
+        let mapping_ctx: MappingContext = match ctx.authentication_context() {
             AuthenticationContext::Mapping(mc) => mc.clone(),
             _ => unreachable!("mapping auth always produces Mapping context"),
         };
 
-        let vu = state
-            .provider
-            .get_mapping_provider()
-            .get_virtual_user(
-                &ExecutionContext::internal(state),
-                &mapping_ctx.virtual_user_id,
-            )
-            .await?
-            .expect("virtual user should exist after mapping auth");
-
-        derive_scope_from_authorizations(&vu.authorizations)?
+        // If is_system and no authorization in context, the ruleset likely
+        // provides no explicit roles. Fall through to storage fallback.
+        if mapping_ctx.is_system {
+            ScopeInfo::Unscoped
+        } else {
+            // Slow path: read virtual user to derive scope from authorizations.
+            // On a follower this read can race with Raft replication (ForwardToLeader
+            // always fails locally), so handle the None gracefully to avoid aborting
+            // the HTTP connection with a panic.
+            match state
+                .provider
+                .get_mapping_provider()
+                .get_virtual_user(
+                    &ExecutionContext::internal(state),
+                    &mapping_ctx.virtual_user_id,
+                )
+                .await
+            {
+                Ok(Some(vu)) => derive_scope_from_authorizations(&vu.authorizations)?,
+                Ok(None) => {
+                    // Virtual user not found locally (Raft replication lag).
+                    // The ruleset match is trustworthy; fall back to unscoped
+                    // to avoid aborting the connection. This returns a 401 instead
+                    // of a server-panic connection drop.
+                    warn!(
+                        virtual_user_id = mapping_ctx.virtual_user_id,
+                        "virtual user not found locally, falling back to unscoped scope"
+                    );
+                    ScopeInfo::Unscoped
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
     };
     scope.validate()?;
 

--- a/crates/keystone/src/server/listener/raft_grpc.rs
+++ b/crates/keystone/src/server/listener/raft_grpc.rs
@@ -277,6 +277,18 @@ pub async fn ensure_raft_initialized(
         return Ok(());
     }
 
+    // Already-initialized node (e.g. pod restart): storage has persisted Raft
+    // state including membership. The node is already a member, so no need to
+    // call add_learner which would fail with "node_id already registered".
+    if storage.is_initialized().await? {
+        let node_id = storage.node_id();
+        tracing::info!(
+            node_id,
+            "Raft storage already initialized — skipping cluster join (node restart)"
+        );
+        return Ok(());
+    }
+
     let join_addrs: Vec<&str> = ds
         .retry_join_nodes
         .iter()

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -79,6 +79,7 @@ x509-parser = "0.16"
 criterion = { workspace = true, features = ["async_tokio"] }
 rcgen.workspace = true
 reserve-port = "2.4.0"
+serial_test.workspace = true
 rustls.workspace = true
 temp-env.workspace = true
 tempfile.workspace = true

--- a/crates/storage/proto/storage.proto
+++ b/crates/storage/proto/storage.proto
@@ -8,6 +8,12 @@ import "storage_types.proto";
 
 // StorageService provides the key-value store API operations.
 service StorageService {
-  // Write the command
+  // Write the command.
   rpc Command(keystone.api.CommandRequest) returns (keystone.api.Response) {}
+  // Forwarded read from follower to leader.
+  rpc ForwardedGet(keystone.api.ForwardedGetRequest) returns (keystone.api.ForwardedGetResponse) {}
+  // Forwarded prefix scan from follower to leader.
+  rpc ForwardedPrefix(keystone.api.ForwardedPrefixRequest) returns (keystone.api.ForwardedPrefixResponse) {}
+  // Forwarded prefix-index scan from follower to leader.
+  rpc ForwardedPrefixIndex(keystone.api.ForwardedPrefixIndexRequest) returns (keystone.api.ForwardedPrefixIndexResponse) {}
 }

--- a/crates/storage/proto/storage_types.proto
+++ b/crates/storage/proto/storage_types.proto
@@ -7,15 +7,61 @@ message CommandRequest {
   bytes payload = 1;
 }
 
+// Internal read request forwarded from follower to leader.
+message ForwardedGetRequest {
+  bytes key = 1;
+  optional string keyspace = 2;
+}
+
+// Response from a forwarded read request.
+message ForwardedGetResponse {
+  // Retrieved value, already decrypted by the leader.
+  optional bytes value = 1;
+  // Set to true if the key does not exist.
+  bool not_found = 2;
+  // Metadata packed as bytes, including data tier and revision.
+  bytes metadata = 3;
+}
+
+// Internal prefix scan request forwarded from follower to leader.
+message ForwardedPrefixRequest {
+  bytes prefix = 1;
+  optional string keyspace = 2;
+}
+
+// Single entry in a prefix scan response.
+message PrefixEntry {
+  string key = 1;
+  // Value, already decrypted by the leader.
+  bytes value = 2;
+  // Metadata packed as bytes (caller unpacks for data tier info).
+  bytes metadata = 3;
+}
+
+// Response from a forwarded prefix scan request.
+message ForwardedPrefixResponse {
+  repeated PrefixEntry entries = 1;
+}
+
+// Internal prefix-index scan request forwarded from follower to leader.
+message ForwardedPrefixIndexRequest {
+  bytes prefix = 1;
+}
+
+// Response from a forwarded prefix-index scan.
+message ForwardedPrefixIndexResponse {
+  repeated string keys = 1;
+}
+
 // GetResponse contains the value associated with the requested key.
 message Response {
   // Retrieved value.
   optional bytes value = 1;
 
   message Violation {
-    string type = 1;        // Use "REVISION_MISMATCH"
-    string subject = 2;     // The Resource ID
-    string description = 3; // e.g., "Current revision is 5, provided was 4"
+    string type = 1;        // Use "REVISION_MISMATCH".
+    string subject = 2;     // The Resource ID.
+    string description = 3; // e.g., "Current revision is 5, provided was 4".
   }
   repeated Violation violations = 2;
 }

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -23,7 +23,7 @@ use openstack_keystone_storage_crypto::{DekEpoch, EnvKek, KekProvider};
 
 use crate::protobuf as pb;
 use openraft::ReadPolicy;
-use openraft::errors::{ForwardToLeader, RaftError};
+use openraft::errors::{ForwardToLeader, LinearizableReadError, RaftError};
 use tonic::Code;
 use tonic::service::Routes;
 use tonic::transport::Channel;
@@ -32,7 +32,6 @@ use tracing::debug;
 use openstack_keystone_config::ConfigManager;
 
 use crate::ApiStoreError;
-use crate::DataTier;
 use crate::StorageApi;
 use crate::StoreError;
 use crate::StoreResponse;
@@ -62,6 +61,20 @@ use openstack_keystone_storage_api::Node;
 pub const LEADER_ENDPOINT_HEADER: &str = "x-openraft-leader-endpoint";
 pub const LEADER_ID_HEADER: &str = "x-openraft-leader-id";
 
+/// Strip scheme (e.g. "https://") and trailing slash from an rpc_addr so that
+/// "https://host:8300/" compares equal to "host:8300".  Both formats encode the
+/// same gRPC endpoint and should not trigger uniqueness violations on restart.
+pub fn normalize_rpc_addr(addr: &str) -> &str {
+    let addr = addr.trim_end_matches('/');
+    if let Some(pos) = addr.find("://") {
+        // Skip scheme (e.g. "https" in "https://host:8300")
+        let rest = &addr[pos + 3..];
+        rest.trim_start_matches('/')
+    } else {
+        addr
+    }
+}
+
 /// Check that `node_id` is not already registered in the committed cluster
 /// membership with a different `rpc_addr`.
 ///
@@ -74,7 +87,7 @@ async fn check_node_id_uniqueness(
     node_id: u64,
     rpc_addr: &str,
 ) -> Result<(), StoreError> {
-    let check_addr = rpc_addr.to_owned();
+    let check_addr = normalize_rpc_addr(rpc_addr).to_owned();
     let check_id = node_id;
     let conflict = raft
         .with_raft_state(move |s| {
@@ -82,7 +95,7 @@ async fn check_node_id_uniqueness(
                 .committed()
                 .nodes()
                 .find_map(|(nid, node)| {
-                    if *nid == check_id && node.rpc_addr != check_addr {
+                    if *nid == check_id && normalize_rpc_addr(&node.rpc_addr) != check_addr {
                         Some(node.rpc_addr.clone())
                     } else {
                         None
@@ -253,7 +266,8 @@ pub async fn get_app_server(storage: &Storage) -> Result<Routes, StoreError> {
         storage.operator_role.clone(),
         storage.allowed_peer_svids.clone(),
     );
-    let storage_svc_impl = StorageServiceImpl::new(storage.raft.clone());
+    let storage_svc_impl =
+        StorageServiceImpl::new(storage.raft.clone(), storage.state_machine_store.clone());
 
     let mut router = Routes::builder();
     router
@@ -318,14 +332,7 @@ impl StorageApi for Storage {
         key: &[u8],
         keyspace: Option<&str>,
     ) -> Result<bool, ApiStoreError> {
-        let res: Result<bool, StoreError> = || -> Result<_, StoreError> {
-            let ks = match keyspace {
-                None => self.state_machine_store.data(),
-                Some(name) => &self.state_machine_store.keyspace(name)?,
-            };
-            Ok(ks.contains_key(key)?)
-        }();
-        Ok(res?)
+        self.get_by_key(key, keyspace).await.map(|v| v.is_some())
     }
 
     /// Gets a value for a given key from the distributed store.
@@ -344,7 +351,46 @@ impl StorageApi for Storage {
     ) -> Result<Option<StoreDataEnvelope<Vec<u8>>>, ApiStoreError> {
         let keyspace_bytes = keyspace.unwrap_or("data").as_bytes().to_vec();
 
-        // Read metadata first to determine the sensitivity tier.
+        // Check ReadIndex first. On the leader we can safely proceed to
+        // local reads. On a follower ReadIndex returns ForwardToLeader and
+        // we forward the entire read to the leader – which already has the
+        // committed data.
+        match self.raft.ensure_linearizable(ReadPolicy::ReadIndex).await {
+            Ok(_) => {}
+            Err(RaftError::APIError(LinearizableReadError::ForwardToLeader(ForwardToLeader {
+                leader_id,
+                leader_node,
+            }))) => {
+                if let (Some(lead_id), Some(lead_node)) = (leader_id, leader_node) {
+                    debug!(
+                        leader_id = lead_id,
+                        leader_addr = lead_node.rpc_addr,
+                        "ensure_linearizable (ReadIndex) returned ForwardToLeader; \
+                         forwarding get_by_key to leader"
+                    );
+
+                    if let Ok(forwarded) = self
+                        .forwarded_get_by_key(lead_id, lead_node.rpc_addr, key, keyspace)
+                        .await
+                    {
+                        return Ok(forwarded);
+                    }
+                    debug!("forwarded get_by_key failed; falling back to local read");
+                } else {
+                    debug!(
+                        "ensure_linearizable (ReadIndex) returned ForwardToLeader \
+                         without leader info; falling back to local read"
+                    );
+                }
+            }
+            Err(e) => {
+                return Err(ApiStoreError::Other(Box::new(StoreError::Other(
+                    eyre::eyre!("ReadIndex failed: {e:?}"),
+                ))));
+            }
+        }
+
+        // Leader path: local metadata + data read.
         let key_str =
             String::from_utf8(key.to_vec()).map_err(|e| StoreError::Other(eyre::eyre!("{e}")))?;
         let metadata: Option<Metadata> = (|| -> Result<_, StoreError> {
@@ -357,23 +403,9 @@ impl StorageApi for Storage {
         })()
         .map_err(ApiStoreError::from)?;
 
-        // If the key has no metadata it does not exist yet.
         let Some(metadata) = metadata else {
             return Ok(None);
         };
-
-        // Tier 2 (Sensitive) and 3 (Secret) require a linearizable ReadIndex
-        // before reading from local state.
-        if metadata.tier as u8 >= DataTier::Sensitive as u8 {
-            self.raft
-                .ensure_linearizable(ReadPolicy::ReadIndex)
-                .await
-                .map_err(|e| {
-                    ApiStoreError::Other(Box::new(StoreError::Other(eyre::eyre!(
-                        "ReadIndex failed: {e:?}"
-                    ))))
-                })?;
-        }
 
         let res: Result<Option<StoreDataEnvelope<Vec<u8>>>, StoreError> =
             (|| -> Result<_, StoreError> {
@@ -414,8 +446,47 @@ impl StorageApi for Storage {
         let keyspace_name = keyspace.map(String::from);
         let keyspace_bytes = keyspace.unwrap_or("data").as_bytes().to_vec();
 
-        // Phase 1: collect raw encrypted bytes + metadata synchronously.
-        // Decryption happens after a potential async ReadIndex round-trip.
+        // On the leader, ReadIndex guarantees linearizable read. On a follower,
+        // ReadIndex returns ForwardToLeader, so we forward the prefix scan to
+        // the leader via gRPC.
+        match self.raft.ensure_linearizable(ReadPolicy::ReadIndex).await {
+            Ok(_) => {}
+            Err(RaftError::APIError(LinearizableReadError::ForwardToLeader(ForwardToLeader {
+                leader_id,
+                leader_node,
+            }))) => {
+                if let (Some(lead_id), Some(lead_node)) = (leader_id, leader_node) {
+                    debug!(
+                        leader_id = lead_id,
+                        leader_addr = lead_node.rpc_addr,
+                        "ensure_linearizable (ReadIndex) returned ForwardToLeader; \
+                         forwarding prefix to leader"
+                    );
+
+                    if let Ok(forwarded) = self
+                        .forwarded_prefix_read(lead_id, lead_node.rpc_addr, prefix, keyspace)
+                        .await
+                    {
+                        return Ok(forwarded);
+                    }
+                    debug!("forwarded prefix failed; falling back to local read");
+                } else {
+                    // No leader info — fall back to local read (e.g., removed node).
+                    debug!(
+                        "ensure_linearizable (ReadIndex) returned ForwardToLeader \
+                         without leader info; falling back to local read"
+                    );
+                }
+            }
+            Err(e) => {
+                return Err(ApiStoreError::Other(Box::new(StoreError::Other(
+                    eyre::eyre!("ReadIndex failed: {e:?}"),
+                ))));
+            }
+        }
+
+        // Leader path: collect raw encrypted bytes + metadata locally,
+        // then decrypt.
         let raw_items: Result<Vec<(String, Vec<u8>, Metadata)>, StoreError> = (|| {
             let ks_owned = keyspace_name
                 .map(|n| self.state_machine_store.keyspace(n))
@@ -443,22 +514,6 @@ impl StorageApi for Storage {
         })();
         let raw_items = raw_items.map_err(ApiStoreError::from)?;
 
-        // Phase 2: if any entry is SENSITIVE or SECRET, enforce linearizable read.
-        let needs_read_index = raw_items
-            .iter()
-            .any(|(_, _, meta)| meta.tier as u8 >= DataTier::Sensitive as u8);
-        if needs_read_index {
-            self.raft
-                .ensure_linearizable(ReadPolicy::ReadIndex)
-                .await
-                .map_err(|e| {
-                    ApiStoreError::Other(Box::new(StoreError::Other(eyre::eyre!(
-                        "ReadIndex failed: {e:?}"
-                    ))))
-                })?;
-        }
-
-        // Phase 3: decrypt all entries using the per-entry tier.
         raw_items
             .into_iter()
             .map(|(k, val_bytes, meta)| {
@@ -479,6 +534,45 @@ impl StorageApi for Storage {
 
     /// A `Result` containing a vector of keys, or an `ApiStoreError`.
     async fn prefix_index(&self, prefix: &[u8]) -> Result<Vec<String>, ApiStoreError> {
+        // On the leader, ReadIndex guarantees linearizable read. On a follower,
+        // ReadIndex returns ForwardToLeader, so we forward the prefix-index
+        // scan to the leader via gRPC.
+        match self.raft.ensure_linearizable(ReadPolicy::ReadIndex).await {
+            Ok(_) => {}
+            Err(RaftError::APIError(LinearizableReadError::ForwardToLeader(ForwardToLeader {
+                leader_id,
+                leader_node,
+            }))) => {
+                if let (Some(lead_id), Some(lead_node)) = (leader_id, leader_node) {
+                    debug!(
+                        leader_id = lead_id,
+                        leader_addr = lead_node.rpc_addr,
+                        "ensure_linearizable (ReadIndex) returned ForwardToLeader \
+                         for prefix_index; forwarding to leader"
+                    );
+
+                    if let Ok(forwarded) = self
+                        .forwarded_prefix_index(lead_id, lead_node.rpc_addr, prefix)
+                        .await
+                    {
+                        return Ok(forwarded);
+                    }
+                    debug!("forwarded prefix_index failed; falling back to local read");
+                } else {
+                    debug!(
+                        "ensure_linearizable (ReadIndex) returned ForwardToLeader \
+                         without leader info; falling back to local read"
+                    );
+                }
+            }
+            Err(e) => {
+                return Err(ApiStoreError::Other(Box::new(StoreError::Other(
+                    eyre::eyre!("ReadIndex failed: {e:?}"),
+                ))));
+            }
+        }
+
+        // Leader path: local index scan.
         let res: Result<Vec<String>, StoreError> = self
             .state_machine_store
             .index()
@@ -714,6 +808,110 @@ impl Storage {
         Ok(channel)
     }
 
+    /// Forward a `get_by_key` read to the leader via gRPC.
+    /// Leader decrypts and returns plaintext; follower wraps it in StoreDataEnvelope.
+    async fn forwarded_get_by_key(
+        &self,
+        leader_id: u64,
+        leader_addr: String,
+        key: &[u8],
+        keyspace: Option<&str>,
+    ) -> Result<Option<StoreDataEnvelope<Vec<u8>>>, ApiStoreError> {
+        let channel = self.get_or_create_channel(leader_id, leader_addr).await?;
+        let mut client = StorageServiceClient::new(channel);
+
+        let msg = pb::api::ForwardedGetRequest {
+            key: key.to_vec(),
+            keyspace: keyspace.map(String::from),
+        };
+        let resp = client.forwarded_get(msg).await.map_err(|status| {
+            ApiStoreError::Other(Box::new(StoreError::Other(eyre::eyre!(
+                "forwarded get failed: {status}"
+            ))))
+        })?;
+        let inner = resp.into_inner();
+
+        if inner.not_found {
+            return Ok(None);
+        }
+
+        let metadata = if inner.metadata.is_empty() {
+            Metadata::new()
+        } else {
+            Metadata::unpack(&inner.metadata).unwrap_or_else(|_| Metadata::new())
+        };
+
+        match inner.value {
+            Some(data) => Ok(Some(StoreDataEnvelope { data, metadata })),
+            None => Ok(None),
+        }
+    }
+
+    /// Forward a `prefix` scan to the leader via gRPC.
+    /// Leader decrypts and returns plaintext values with metadata.
+    async fn forwarded_prefix_read(
+        &self,
+        leader_id: u64,
+        leader_addr: String,
+        prefix: &[u8],
+        keyspace: Option<&str>,
+    ) -> Result<Vec<(String, StoreDataEnvelope<Vec<u8>>)>, ApiStoreError> {
+        let channel = self.get_or_create_channel(leader_id, leader_addr).await?;
+        let mut client = StorageServiceClient::new(channel);
+
+        let msg = pb::api::ForwardedPrefixRequest {
+            prefix: prefix.to_vec(),
+            keyspace: keyspace.map(String::from),
+        };
+        let resp = client.forwarded_prefix(msg).await.map_err(|status| {
+            ApiStoreError::Other(Box::new(StoreError::Other(eyre::eyre!(
+                "forwarded prefix failed: {status}"
+            ))))
+        })?;
+        let inner = resp.into_inner();
+
+        let mut result = Vec::new();
+        for entry in inner.entries {
+            let metadata = if entry.metadata.is_empty() {
+                Metadata::new()
+            } else {
+                Metadata::unpack(&entry.metadata).unwrap_or_else(|_| Metadata::new())
+            };
+
+            result.push((
+                entry.key,
+                StoreDataEnvelope {
+                    data: entry.value,
+                    metadata,
+                },
+            ));
+        }
+
+        Ok(result)
+    }
+
+    /// Forward a `prefix_index` scan to the leader via gRPC.
+    async fn forwarded_prefix_index(
+        &self,
+        leader_id: u64,
+        leader_addr: String,
+        prefix: &[u8],
+    ) -> Result<Vec<String>, ApiStoreError> {
+        let channel = self.get_or_create_channel(leader_id, leader_addr).await?;
+        let mut client = StorageServiceClient::new(channel);
+
+        let msg = pb::api::ForwardedPrefixIndexRequest {
+            prefix: prefix.to_vec(),
+        };
+        let resp = client.forwarded_prefix_index(msg).await.map_err(|status| {
+            ApiStoreError::Other(Box::new(StoreError::Other(eyre::eyre!(
+                "forwarded prefix_index failed: {status}"
+            ))))
+        })?;
+
+        Ok(resp.into_inner().keys)
+    }
+
     /// Try to commit the command to the raft cluster.
     ///
     /// Attempt to commit command to the current node forwarding the request
@@ -847,5 +1045,52 @@ fn rb_resp_to_store_response(resp: Response) -> StoreResponse {
                 description: v.description,
             })
             .collect(),
+    }
+}
+
+#[cfg(test)]
+mod normalize_tests {
+    use super::normalize_rpc_addr;
+
+    #[test]
+    fn test_bare_address_unchanged() {
+        assert_eq!(normalize_rpc_addr("host:8300"), "host:8300");
+        assert_eq!(
+            normalize_rpc_addr("keystone-rs-1.keystone-rs-internal.default.svc.cluster.local:8300"),
+            "keystone-rs-1.keystone-rs-internal.default.svc.cluster.local:8300"
+        );
+    }
+
+    #[test]
+    fn test_strips_scheme_and_trailing_slash() {
+        assert_eq!(
+            normalize_rpc_addr(
+                "https://keystone-rs-1.keystone-rs-internal.default.svc.cluster.local:8300/"
+            ),
+            "keystone-rs-1.keystone-rs-internal.default.svc.cluster.local:8300"
+        );
+        assert_eq!(normalize_rpc_addr("http://host:8300/"), "host:8300");
+    }
+
+    #[test]
+    fn test_scheme_only_no_trailing_slash() {
+        assert_eq!(normalize_rpc_addr("https://host:8300"), "host:8300");
+    }
+
+    #[test]
+    fn test_normalization_is_equivalence_check() {
+        // Same host:port, different formats → identical
+        assert_eq!(
+            normalize_rpc_addr("host:8300"),
+            normalize_rpc_addr("https://host:8300/")
+        );
+    }
+
+    #[test]
+    fn test_different_hosts_not_equivalent() {
+        assert_ne!(
+            normalize_rpc_addr("host-a:8300"),
+            normalize_rpc_addr("https://host-b:8300/")
+        );
     }
 }

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -26,6 +26,7 @@ use tonic::Streaming;
 use tracing::trace;
 
 use crate::StoreError;
+use crate::app::normalize_rpc_addr;
 use crate::audit::{AuditForwarder, AuditRecord};
 use crate::pb;
 use crate::protobuf::raft::cluster_admin_service_server::ClusterAdminService;
@@ -415,7 +416,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         // Use borrow_watched (synchronous) to avoid introducing a yield point
         // that could expose race conditions between Raft init and add_learner.
         let check_id = node.node_id;
-        let check_addr = node.rpc_addr.clone();
+        let check_addr = normalize_rpc_addr(&node.rpc_addr).to_owned();
         let metrics = self.raft_node.metrics().borrow_watched().clone();
         let conflict =
             metrics
@@ -423,7 +424,7 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
                 .membership()
                 .nodes()
                 .find_map(|(nid, existing)| {
-                    if *nid == check_id && existing.rpc_addr != check_addr {
+                    if *nid == check_id && normalize_rpc_addr(&existing.rpc_addr) != check_addr {
                         Some(existing.rpc_addr.clone())
                     } else {
                         None
@@ -1174,9 +1175,49 @@ mod tests {
     fn spiffe_trust_domain_not_spiffe_uri() {
         assert!(parse_spiffe_trust_domain("foo", &domains(),).is_err());
     }
-
     #[test]
     fn spiffe_trust_domain_no_path() {
         assert!(parse_spiffe_trust_domain("spiffe://example.com", &domains(),).is_err());
+    }
+
+    #[test]
+    fn normalize_add_learner_bare_vs_schema() {
+        // Simulate address uniqueness check: same node, different address format.
+        // Stored: "127.0.0.1:21001", new: "https://127.0.0.1:21001/"
+        // After normalization both should match → no conflict.
+        let stored = "127.0.0.1:21001";
+        let new_with_schema = "https://127.0.0.1:21001/";
+        assert_eq!(
+            normalize_rpc_addr(stored),
+            normalize_rpc_addr(new_with_schema),
+            "same host:port with different formats must normalize to identical string"
+        );
+    }
+
+    #[test]
+    fn normalize_add_learner_different_hosts() {
+        // Different host:port should NOT match even after normalization.
+        let a = "127.0.0.1:21001";
+        let b = "https://127.0.0.1:21002/";
+        assert_ne!(
+            normalize_rpc_addr(a),
+            normalize_rpc_addr(b),
+            "different ports must not match"
+        );
+    }
+
+    #[test]
+    fn normalize_add_learner_fqdn_from_config() {
+        // Replicates the real pod-restart scenario:
+        // Committed membership has bare "host:port" from init,
+        // config has https:// scheme + trailing slash from Uri::Display.
+        let stored = "keystone-rs-1.keystone-rs-internal.default.svc.cluster.local:8300";
+        let from_config =
+            "https://keystone-rs-1.keystone-rs-internal.default.svc.cluster.local:8300/";
+        assert_eq!(
+            normalize_rpc_addr(stored),
+            normalize_rpc_addr(from_config),
+            "stored bare address must match config Uri::Display format"
+        );
     }
 }

--- a/crates/storage/src/grpc/storage_service.rs
+++ b/crates/storage/src/grpc/storage_service.rs
@@ -12,8 +12,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use tonic::{Request, Response, Status};
 
+use crate::DataTier;
 use crate::pb;
 use crate::protobuf::api::Response as PbResponse;
 use crate::protobuf::api::storage_service_server::StorageService;
@@ -27,6 +30,7 @@ use crate::types::*;
 /// - Vote requests/responses during leader election
 /// - Log replication between nodes
 /// - Snapshot installation for state synchronization
+/// - Forwarded read requests from followers to leader
 ///
 /// # Protocol Safety
 /// This service implements critical consensus protocol operations and should
@@ -35,6 +39,8 @@ use crate::types::*;
 pub struct StorageServiceImpl {
     /// The local Raft node instance that this service operates on.
     pub(crate) raft_node: Raft,
+    /// Direct access to the state machine store for forwarded reads.
+    state_machine_store: Arc<StateMachineStore>,
 }
 
 impl StorageServiceImpl {
@@ -42,11 +48,15 @@ impl StorageServiceImpl {
     ///
     /// # Parameters
     /// - `raft_node`: The Raft node instance this service will operate on.
+    /// - `state_machine_store`: The state machine store for direct reads.
     ///
     /// # Returns
     /// A new `StorageServiceImpl` instance.
-    pub fn new(raft_node: Raft) -> Self {
-        Self { raft_node }
+    pub fn new(raft_node: Raft, state_machine_store: Arc<StateMachineStore>) -> Self {
+        Self {
+            raft_node,
+            state_machine_store,
+        }
     }
 }
 
@@ -72,7 +82,162 @@ impl StorageService for StorageServiceImpl {
                 Status::internal(format!("Failed to write command to store: {}", e))
             })?;
 
-        //debug!("Successfully set value for key: {}", req.key);
         Ok(Response::new(res.data))
+    }
+
+    /// Handles a forwarded get request from a follower.
+    ///
+    /// Reads the requested key from the local state machine store, decrypts
+    /// it, and returns the plaintext value along with packed metadata bytes
+    /// (including revision and data tier) so that the follower can preserve
+    /// the leader's metadata for correct revision-check semantics.
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn forwarded_get(
+        &self,
+        request: Request<pb::api::ForwardedGetRequest>,
+    ) -> Result<Response<pb::api::ForwardedGetResponse>, Status> {
+        let req = request.into_inner();
+        let key = match std::str::from_utf8(&req.key) {
+            Ok(s) => s.to_string(),
+            Err(e) => return Err(Status::invalid_argument(format!("invalid key: {}", e))),
+        };
+
+        // Read metadata to determine the data tier
+        let metadata = self
+            .state_machine_store
+            .meta()
+            .get(&key)
+            .map_err(|e| Status::internal(format!("metadata read error: {}", e)))?
+            .map(|raw| Metadata::unpack(raw.as_ref()))
+            .transpose()
+            .map_err(|e| Status::internal(format!("metadata unpack error: {}", e)))?;
+
+        // Read encrypted value from leader's FjallDB
+        let ks = match &req.keyspace {
+            Some(name) => self
+                .state_machine_store
+                .keyspace(name)
+                .map_err(|e| Status::internal(format!("keyspace error: {}", e)))?,
+            None => self.state_machine_store.data().clone(),
+        };
+
+        let encrypted = ks
+            .get(key.as_bytes())
+            .map_err(|e| Status::internal(format!("data read error: {}", e)))?;
+
+        let not_found = encrypted.is_none() || metadata.is_none();
+        let tier = (metadata.as_ref().map(|m| m.tier as u8)).unwrap_or(DataTier::Internal as u8);
+
+        let value = encrypted.and_then(|enc| {
+            let keyspace_name = req.keyspace.as_deref().unwrap_or("data");
+            let keyspace_bytes = keyspace_name.as_bytes();
+            self.state_machine_store
+                .decrypt_state(&enc, tier, keyspace_bytes, key.as_bytes())
+                .ok()
+        });
+
+        let metadata_bytes = metadata
+            .map(|m| m.pack())
+            .transpose()
+            .map_err(|e| Status::internal(format!("metadata pack error: {}", e)))?
+            .unwrap_or_default();
+
+        let response = pb::api::ForwardedGetResponse {
+            value,
+            not_found,
+            metadata: metadata_bytes,
+        };
+
+        Ok(Response::new(response))
+    }
+
+    /// Handles a forwarded prefix scan request from a follower.
+    ///
+    /// Scans the local state machine store for keys matching the prefix,
+    /// decrypts them, and returns the plaintext values.
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn forwarded_prefix(
+        &self,
+        request: Request<pb::api::ForwardedPrefixRequest>,
+    ) -> Result<Response<pb::api::ForwardedPrefixResponse>, Status> {
+        let req = request.into_inner();
+
+        let ks = match &req.keyspace {
+            Some(name) => self
+                .state_machine_store
+                .keyspace(name)
+                .map_err(|e| Status::internal(format!("keyspace error: {}", e)))?,
+            None => self.state_machine_store.data().clone(),
+        };
+
+        let meta = self.state_machine_store.meta();
+        let keyspace_name = req.keyspace.as_deref().unwrap_or("data");
+        let keyspace_bytes = keyspace_name.as_bytes();
+
+        let items: Vec<_> = ks
+            .prefix(&req.prefix)
+            .filter_map(|item| {
+                let (key_bytes, val) = match item.into_inner() {
+                    Ok(i) => i,
+                    Err(_) => return None,
+                };
+                let k = match String::from_utf8(key_bytes.to_vec()) {
+                    Ok(k) => k,
+                    Err(_) => return None,
+                };
+
+                // Read metadata to determine tier
+                let (tier, meta_bytes) = match meta.get(k.as_bytes()) {
+                    Ok(Some(raw)) => (
+                        Metadata::unpack(raw.as_ref())
+                            .map(|m| m.tier as u8)
+                            .unwrap_or(DataTier::Internal as u8),
+                        raw.to_vec(),
+                    ),
+                    _ => (DataTier::Internal as u8, Vec::new()),
+                };
+
+                // Decrypt using leader's DEK
+                let data = self
+                    .state_machine_store
+                    .decrypt_state(&val, tier, keyspace_bytes, k.as_bytes())
+                    .ok()?;
+
+                Some(pb::api::PrefixEntry {
+                    key: k,
+                    value: data,
+                    metadata: meta_bytes,
+                })
+            })
+            .collect();
+        Ok(Response::new(pb::api::ForwardedPrefixResponse {
+            entries: items,
+        }))
+    }
+
+    // Forwarded prefix-index scan from follower to leader.
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn forwarded_prefix_index(
+        &self,
+        request: Request<pb::api::ForwardedPrefixIndexRequest>,
+    ) -> Result<Response<pb::api::ForwardedPrefixIndexResponse>, Status> {
+        let req = request.into_inner();
+
+        let items: Vec<_> = self
+            .state_machine_store
+            .index()
+            .prefix(&req.prefix)
+            .filter_map(|item| -> Option<String> {
+                let key = match item.key() {
+                    Ok(k) => k,
+                    Err(_) => return None,
+                };
+                String::from_utf8(key.to_vec()).ok()
+            })
+            .collect();
+
+        Ok(Response::new(pb::api::ForwardedPrefixIndexResponse {
+            keys: items,
+        }))
     }
 }

--- a/crates/storage/src/network.rs
+++ b/crates/storage/src/network.rs
@@ -390,10 +390,13 @@ impl NetTransferLeader<TypeConfig> for NetworkConnection {
         &mut self,
         _req: TransferLeaderRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<(), RPCError> {
-        Err(RPCError::Unreachable(Unreachable::new(&AnyError::error(
-            "transfer_leader not implemented",
-        ))))
+    ) -> Result<
+        openraft::raft::TransferLeaderResponse<TypeConfig>,
+        openraft::error::RPCError<TypeConfig>,
+    > {
+        Err(openraft::error::RPCError::Unreachable(Unreachable::new(
+            &AnyError::error("transfer_leader not implemented"),
+        )))
     }
 }
 

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -42,7 +42,7 @@ use openstack_keystone_distributed_storage::network::{
 use openstack_keystone_distributed_storage::protobuf as pb;
 use openstack_keystone_distributed_storage::protobuf::raft::cluster_admin_service_client::ClusterAdminServiceClient;
 use openstack_keystone_distributed_storage::store_command::*;
-use openstack_keystone_distributed_storage::{Metadata, StoreDataEnvelope, StoreError};
+use openstack_keystone_distributed_storage::{DataTier, Metadata, StoreDataEnvelope, StoreError};
 use openstack_keystone_distributed_storage::{StorageApi, TypeConfig};
 
 fn make_env<T: serde::Serialize + ?Sized>(
@@ -54,15 +54,180 @@ fn make_env<T: serde::Serialize + ?Sized>(
     })
 }
 
+fn make_sensitive_env<T: serde::Serialize + ?Sized>(
+    value: &T,
+) -> Result<StoreDataEnvelope<Vec<u8>>, StoreError> {
+    Ok(StoreDataEnvelope {
+        data: rmp_serde::to_vec(value)?,
+        metadata: Metadata::with_tier(DataTier::Sensitive),
+    })
+}
+
 /// Test-only KEK: 32 zero bytes encoded as hex.
 const TEST_KEK_HEX: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 
 /// Set up a cluster of 3 nodes.
 /// Write to it and read from it.
+#[serial_test::serial]
 #[tracing_test::traced_test]
 #[test]
 fn test_cluster() {
     TypeConfig::run(test_cluster_inner()).unwrap();
+}
+
+/// pod-restart test: verifies check_node_id_uniqueness passes when the config
+/// address format changes (bare "host:port" vs "https://host:port/").
+///
+/// Scenario:
+/// 1. Node initializes with bare address "127.0.0.1:21001"
+/// 2. Node reinitializes (simulating pod restart) with "https://127.0.0.1:21001/"
+/// 3. check_node_id_uniqueness should NOT reject the restart — same logical address.
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_node_restart_with_address_format_change() {
+    TypeConfig::run(test_node_restart_inner()).unwrap();
+}
+
+#[allow(unsafe_code)]
+async fn test_node_restart_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    // Crypto provider may already be installed by a parallel test
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let tls_configuration = make_certificates()?;
+
+    // Step 1: Create node with bare address format
+    let storage_dir = tempfile::TempDir::new().unwrap();
+    let ds_config = DistributedStorageConfiguration {
+        node_cluster_addr: "https://127.0.0.1:21005".parse().expect("valid address"),
+        node_listener_addr: "127.0.0.1:21005".parse().expect("valid address"),
+        node_id: 1,
+        path: storage_dir.path().to_path_buf(),
+        tls_configuration: openstack_keystone_config::RaftTlsConfiguration::Tls(
+            tls_configuration.clone(),
+        ),
+        dev_mode: true,
+        retry_join_nodes: vec![],
+    };
+    let mut config = Config::default();
+    config.distributed_storage = Some(ds_config);
+
+    // SAFETY: no concurrent env reads
+    unsafe {
+        std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
+        std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
+    }
+    let storage = Arc::new(init_storage(&ConfigManager::not_watched(config.clone())).await?);
+    assert!(!storage.is_initialized().await?);
+
+    // Initialize as single-node cluster
+
+    // Start server in a thread with a shutdown channel
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let stg = storage.clone();
+    let cfg = config.clone();
+    let _srv = std::thread::spawn(move || {
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        rt.block_on(async {
+            let ds = cfg.distributed_storage.as_ref().expect("ds config");
+            let tls = get_server_tls_config(&cfg).unwrap();
+            let mut s = tonic::transport::Server::builder().tls_config(tls).unwrap();
+            let serve = s
+                .add_routes(get_app_server(&stg).await.unwrap())
+                .serve(ds.node_listener_addr);
+            tokio::select! {
+                _ = serve => {},
+                _ = shutdown_rx => {},
+            }
+        });
+    });
+
+    TypeConfig::sleep(Duration::from_millis(200)).await;
+
+    let tls_client_config = get_client_tls_config(&config)?;
+    let mut admin_client = new_admin_client(
+        config
+            .distributed_storage
+            .as_ref()
+            .unwrap()
+            .node_cluster_addr
+            .clone(),
+        &tls_client_config,
+    )
+    .await?;
+
+    admin_client
+        .init(pb::raft::InitRequest {
+            nodes: vec![pb::raft::Node {
+                node_id: 1,
+                rpc_addr: "127.0.0.1:21005".to_string(),
+            }],
+        })
+        .await?;
+
+    // Verify node is initialized and committed
+    wait_for_leader(&mut admin_client, 1).await;
+
+    // Drop first storage (simulates pod going away)
+    drop(storage);
+    drop(admin_client);
+    drop(tls_client_config);
+    // Signal server thread to shut down so Fjall releases locks
+    let _ = shutdown_tx.send(());
+    _srv.join().ok();
+    TypeConfig::sleep(Duration::from_millis(500)).await;
+
+    // Step 2: Reinitialize the SAME storage dir but with schema prefix + trailing slash
+    // This simulates pod restart where Uri::Display produces "https://host:port/"
+    let ds_config_restart = DistributedStorageConfiguration {
+        node_cluster_addr: "https://127.0.0.1:21005/".parse().expect("valid address"),
+        node_listener_addr: "127.0.0.1:21005".parse().expect("valid address"),
+        node_id: 1,
+        path: storage_dir.path().to_path_buf(),
+        tls_configuration: openstack_keystone_config::RaftTlsConfiguration::Tls(
+            tls_configuration.clone(),
+        ),
+        dev_mode: true,
+        retry_join_nodes: vec![],
+    };
+    let mut config_restart = Config::default();
+    config_restart.distributed_storage = Some(ds_config_restart);
+
+    // SAFETY: no concurrent env reads
+    unsafe {
+        std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
+        std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
+    }
+
+    // This must succeed — the address change is purely cosmetic.
+    // If normalization is broken, this fails with:
+    // "FATAL: node_id 1 already registered in cluster at 127.0.0.1:21005;
+    //  refusing to start with address https://127.0.0.1:21005/"
+    let storage_restart =
+        Arc::new(init_storage(&ConfigManager::not_watched(config_restart.clone())).await?);
+
+    // Verify the storage thinks it's initialized (persisted state is intact)
+    assert!(
+        storage_restart.is_initialized().await?,
+        "storage should detect persisted cluster state"
+    );
+
+    // Write a value to verify the restarted node still functions as leader
+    storage_restart
+        .set_value("restart_test".to_string(), make_env("passed")?, None, None)
+        .await?;
+
+    let got = storage_restart
+        .get_by_key("restart_test".as_bytes(), None)
+        .await?
+        .expect("value should be accessible after restart");
+    assert_eq!("passed", got.try_deserialize::<String>()?.data);
+
+    // Drop to stop cleanup
+    drop(storage_restart);
+
+    Ok(())
 }
 
 #[allow(dead_code)]
@@ -82,12 +247,25 @@ impl InstanceHolder {
     // the environment are spawned, so there are no concurrent readers.
     #[allow(unsafe_code)]
     async fn new(node_id: u64, tls_config: TlsConfiguration) -> Result<Self> {
-        // Initialize node with dev KEK environment variables.
+        Self::new_with_port(node_id, 0, tls_config).await
+    }
+
+    // SAFETY: same as `new` above.
+    #[allow(unsafe_code)]
+    async fn new_with_port(
+        node_id: u64,
+        port_base: u16,
+        tls_config: TlsConfiguration,
+    ) -> Result<Self> {
         let storage_dir = tempfile::TempDir::new().unwrap();
-        let ds_config = get_ds_config(node_id, storage_dir.path().to_path_buf(), tls_config);
+        let ds_config = get_ds_config_with_port(
+            node_id,
+            port_base,
+            storage_dir.path().to_path_buf(),
+            tls_config,
+        );
         let mut config = Config::default();
         config.distributed_storage = Some(ds_config);
-        // SAFETY: No concurrent reads of the environment at this point.
         unsafe {
             std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
             std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
@@ -103,9 +281,9 @@ impl InstanceHolder {
 }
 
 async fn test_cluster_inner() -> Result<()> {
-    // Existing test body
+    // Crypto provider may already be installed by a parallel test
     let provider = rustls::crypto::aws_lc_rs::default_provider();
-    rustls::crypto::CryptoProvider::install_default(provider).unwrap();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
 
     let tls_configuration = make_certificates()?;
 
@@ -255,12 +433,63 @@ async fn test_cluster_inner() -> Result<()> {
             .await?;
         //    // --- Wait for a while to let the replication get done.
         TypeConfig::sleep(Duration::from_millis(1_000)).await;
+
+        // Write Sensitive-tier data so that `prefix` enters the ensure_linearizable
+        // path and forwards to the leader for a linearizable read.
+        let sensitive_meta = Metadata::with_tier(DataTier::Sensitive);
+        let sensitive_val = StoreDataEnvelope {
+            data: rmp_serde::to_vec("sensitive_value")?,
+            metadata: sensitive_meta,
+        };
+        instance1
+            .storage
+            .set_value("sec:k1".to_string(), sensitive_val, None, None)
+            .await?;
+        let sensitive_meta2 = Metadata::with_tier(DataTier::Sensitive);
+        let sensitive_val2 = StoreDataEnvelope {
+            data: rmp_serde::to_vec("sensitive_value2")?,
+            metadata: sensitive_meta2,
+        };
+        instance1
+            .storage
+            .set_value("sec:k2".to_string(), sensitive_val2, None, None)
+            .await?;
+
+        // Immediate re-read after write (no replication sleep) — this reproduces
+        // the k8s_auth race condition pattern: `upsert_virtual_user_shadow` writes
+        // then immediately reads the same key without waiting for Raft replication.
+        let immediate_read = instance1
+            .storage
+            .get_by_key("sec:k1".as_bytes(), None)
+            .await?
+            .expect("immediate re-read must succeed on the leader");
+        let immediate_read = immediate_read.try_deserialize::<String>()?;
+        assert_eq!("sensitive_value", immediate_read.data);
     }
 
-    println!("=== read `foo` on every node");
+    println!("=== read `foo` on every node (including followers)");
     {
+        // Verify the leader is node 1 (set by change-membership).
+        // On a follower node, `get_by_key` calls `ensure_linearizable(ReadIndex)`
+        // which returns `ForwardToLeader`. The storage code must catch this error
+        // and fall back to a local FjallDB read. This regression test ensures that
+        // reads on followers do NOT fail with "ReadIndex failed: ForwardToLeader".
+        let current_leader = admin_client1.metrics(()).await?.into_inner().current_leader;
+        assert_eq!(
+            current_leader,
+            Some(1),
+            "leader must be node 1 for this verification"
+        );
+
         for instance in &instances {
-            println!("=== read `foo` on node {}", instance.node_id);
+            if instance.node_id != 1 {
+                println!(
+                    "=== follower-read verification on node {} (leader={})",
+                    instance.node_id,
+                    current_leader.unwrap()
+                );
+            }
+
             let got = instance
                 .storage
                 .get_by_key("foo".as_bytes(), None)
@@ -296,6 +525,30 @@ async fn test_cluster_inner() -> Result<()> {
             assert!(indexes.contains(&"idx:foo:2".to_string()));
             assert!(indexes.contains(&"idx:foo:3".to_string()));
             assert_eq!(indexes.len(), 3);
+
+            // Prefix-read Sensitive-tier data from follower.
+            // `prefix` only enters `ensure_linearizable(ReadIndex)` when any result
+            // entry has `tier >= DataTier::Sensitive` (app.rs:461).
+            // On a follower, ReadIndex returns `ForwardToLeader`. The storage code
+            // must catch this and fall back to a local FjallDB read.
+            let sensitive_prefix = instance.storage.prefix("sec:".as_bytes(), None).await?;
+            assert_eq!(sensitive_prefix.len(), 2);
+            let sec_keys: std::collections::HashSet<_> =
+                sensitive_prefix.iter().map(|(k, _)| k.as_str()).collect();
+            assert!(sec_keys.contains("sec:k1"));
+            assert!(sec_keys.contains("sec:k2"));
+            for (_k, val) in &sensitive_prefix {
+                let val_str = StoreDataEnvelope {
+                    data: val.data.clone(),
+                    metadata: val.metadata.clone(),
+                }
+                .try_deserialize::<String>()?
+                .data;
+                assert!(
+                    val_str == "sensitive_value" || val_str == "sensitive_value2",
+                    "unexpected value: {val_str}"
+                );
+            }
         }
     }
 
@@ -370,6 +623,35 @@ async fn test_cluster_inner() -> Result<()> {
             .is_none()
     );
 
+    // Verify transaction results on followers — ensures Raft replication is
+    // complete and that the forward-to-leader path works correctly on followers
+    // for post-transaction reads.
+    TypeConfig::sleep(Duration::from_millis(500)).await;
+    for instance in &[instance2.clone(), instance3.clone()] {
+        println!(
+            "=== verify transaction on follower node {}",
+            instance.node_id
+        );
+        assert_eq!(
+            "new_val",
+            instance
+                .storage
+                .get_by_key("new_foo".as_bytes(), None)
+                .await?
+                .expect("follower must have new_foo")
+                .try_deserialize::<String>()?
+                .data
+        );
+        assert!(
+            instance
+                .storage
+                .get_by_key("foo1".as_bytes(), Some("another_keyspace"))
+                .await?
+                .is_none(),
+            "follower must have removed foo1"
+        );
+    }
+
     println!("=== Remove node 1,2 by change-membership to {{3}}");
     {
         admin_client1
@@ -379,6 +661,8 @@ async fn test_cluster_inner() -> Result<()> {
             })
             .await?;
 
+        // Wait for node 1 to step down and node 3 to become the new leader.
+        // The metrics check only verifies membership config, not leadership.
         TypeConfig::sleep(Duration::from_millis(2_000)).await;
 
         let metrics = admin_client1.metrics(()).await?.into_inner();
@@ -391,6 +675,388 @@ async fn test_cluster_inner() -> Result<()> {
                 node_ids: BTreeMap::from([(3, ())]),
             }],
             metrics.membership.unwrap().configs
+        );
+
+        // Verify that data is still accessible on the new single-node leader
+        // after the cluster went from 3 members → 1.
+        let got = instance3
+            .storage
+            .get_by_key("sec:k1".as_bytes(), None)
+            .await?
+            .expect("leader node 3 must have the sensitive data");
+        assert_eq!("sensitive_value", got.try_deserialize::<String>()?.data);
+
+        // Also verify old-follower nodes (1, 2) can still read locally.
+        // These nodes are no longer part of the cluster but their FjallDB
+        // still contains the committed state.
+        for instance in &[instance1, instance2] {
+            assert!(
+                instance
+                    .storage
+                    .get_by_key("sec:k1".as_bytes(), None)
+                    .await?
+                    .is_some(),
+                "old-follower node {} should still be able to read locally",
+                instance.node_id
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Regression test: write key-val to leader, read immediately from follower.
+///
+/// Reproduces the Raft replication race condition observed in k8s integration tests
+/// (see `api_v4::mapping::ruleset::create` / `update` / `delete` failures).
+///
+/// Pattern:
+/// 1. `set_value` on leader (node 1) — Raft proposal commits asynchronously
+/// 2. `get_by_key` on follower (node 2) — local FjallDB may not have replicated yet
+/// 3. Current mitigation: `ensure_linearizable(ReadIndex)` retry loop in `app.rs`
+///    (3 retries, 14ms total) then fall back to local read
+///
+/// The test runs multiple iterations to increase the probability of catching
+/// the race window. A passing run means the mitigation is working; a failing
+/// run means the mitigation is insufficient for the given timing.
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_replication_race_get_by_key() {
+    TypeConfig::run(test_replication_race_get_by_key_inner()).unwrap();
+}
+
+// Port offset to avoid conflicts with other cluster tests.
+const GET_BY_KEY_PORT_BASE: u16 = 100;
+
+#[allow(unsafe_code)]
+async fn test_replication_race_get_by_key_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let tls_configuration = make_certificates()?;
+
+    let instance1 = Arc::new(
+        InstanceHolder::new_with_port(1, GET_BY_KEY_PORT_BASE, tls_configuration.clone()).await?,
+    );
+    let instance2 = Arc::new(
+        InstanceHolder::new_with_port(2, GET_BY_KEY_PORT_BASE, tls_configuration.clone()).await?,
+    );
+    let instance3 = Arc::new(
+        InstanceHolder::new_with_port(3, GET_BY_KEY_PORT_BASE, tls_configuration.clone()).await?,
+    );
+
+    let inst1 = instance1.clone();
+    let _h1 = thread::spawn(move || {
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let _ = rt.block_on(start_raft_app(&inst1.config, &inst1.storage));
+    });
+
+    let inst2 = instance2.clone();
+    let _h2 = thread::spawn(move || {
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let _ = rt.block_on(start_raft_app(&inst2.config, &inst2.storage));
+    });
+
+    let inst3 = instance3.clone();
+    let _h3 = thread::spawn(move || {
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let _ = rt.block_on(start_raft_app(&inst3.config, &inst3.storage));
+    });
+
+    TypeConfig::sleep(Duration::from_millis(200)).await;
+
+    let tls_client_config = get_client_tls_config(&instance1.config)?;
+    let mut admin_client1 = new_admin_client(
+        instance1
+            .config
+            .distributed_storage
+            .as_ref()
+            .unwrap()
+            .node_cluster_addr
+            .clone(),
+        &tls_client_config,
+    )
+    .await?;
+
+    admin_client1
+        .init(pb::raft::InitRequest {
+            nodes: vec![new_node_with_port(1, GET_BY_KEY_PORT_BASE)],
+        })
+        .await?;
+    wait_for_leader(&mut admin_client1, 1).await;
+
+    admin_client1
+        .add_learner(pb::raft::AddLearnerRequest {
+            node: Some(new_node_with_port(2, GET_BY_KEY_PORT_BASE)),
+        })
+        .await?;
+    admin_client1
+        .add_learner(pb::raft::AddLearnerRequest {
+            node: Some(new_node_with_port(3, GET_BY_KEY_PORT_BASE)),
+        })
+        .await?;
+
+    admin_client1
+        .change_membership(pb::raft::ChangeMembershipRequest {
+            members: vec![1, 2, 3],
+            retain: false,
+        })
+        .await?;
+
+    TypeConfig::sleep(Duration::from_millis(500)).await;
+
+    let metrics = admin_client1.metrics(()).await?.into_inner();
+    assert_eq!(
+        metrics.current_leader,
+        Some(1),
+        "node 1 must be leader for this test"
+    );
+
+    let iterations = 20;
+    let mut failures = 0;
+
+    for i in 0..iterations {
+        let key = format!("race:get:{}", i);
+        let val = format!("value-{}", i);
+
+        instance1
+            .storage
+            .set_value(key.clone(), make_sensitive_env(&val)?, None, None)
+            .await?;
+
+        let get_result = instance2.storage.get_by_key(key.as_bytes(), None).await?;
+
+        match get_result {
+            Some(envelope) => {
+                let read_val = envelope.try_deserialize::<String>()?.data;
+                if read_val != val {
+                    failures += 1;
+                    println!(
+                        "ITER {} (get_by_key): value mismatch: expected '{}', got '{}'",
+                        i, val, read_val
+                    );
+                }
+            }
+            None => {
+                failures += 1;
+                println!(
+                    "ITER {} (get_by_key): key '{}' not found on follower (race confirmed)",
+                    i, key
+                );
+            }
+        }
+    }
+
+    for i in 0..iterations {
+        let key = format!("race:prefix:{}", i);
+        let val = format!("prefix-value-{}", i);
+
+        instance1
+            .storage
+            .set_value(key.clone(), make_sensitive_env(&val)?, None, None)
+            .await?;
+
+        let prefix_results = instance3
+            .storage
+            .prefix("race:prefix:".as_bytes(), None)
+            .await?;
+
+        let found = prefix_results.iter().any(|(k, _)| k == &key);
+        if !found {
+            failures += 1;
+            println!(
+                "ITER {} (prefix): key '{}' not found in prefix scan on follower (race confirmed)",
+                i, key
+            );
+        }
+    }
+
+    println!(
+        "Replication race test complete: {} failures out of {} iterations ({} total operations)",
+        failures,
+        iterations,
+        iterations * 2
+    );
+
+    if failures > 0 {
+        panic!(
+            "Replication race detected: {} failures out of {} total operations",
+            failures,
+            iterations * 2
+        );
+    }
+
+    Ok(())
+}
+
+/// Regression test: write-then-delete race on follower reads.
+///
+/// Reproduces the pattern where a key is deleted on the leader but still
+/// appears in a follower's local FjallDB (stale read returns deleted data).
+///
+/// This mirrors the `api_v4::mapping::ruleset::delete::test_delete_mapping_ruleset`
+/// failure: DELETE returns 204 on leader, but subsequent GET on follower returns
+/// 200 with the deleted data instead of 404.
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_replication_race_delete_stale_read() {
+    TypeConfig::run(test_replication_race_delete_stale_inner()).unwrap();
+}
+
+// Port offset to avoid conflicts with other cluster tests.
+const DELETE_STALE_PORT_BASE: u16 = 200;
+
+#[allow(unsafe_code)]
+async fn test_replication_race_delete_stale_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let tls_configuration = make_certificates()?;
+
+    let instance1 = Arc::new(
+        InstanceHolder::new_with_port(1, DELETE_STALE_PORT_BASE, tls_configuration.clone()).await?,
+    );
+    let instance2 = Arc::new(
+        InstanceHolder::new_with_port(2, DELETE_STALE_PORT_BASE, tls_configuration.clone()).await?,
+    );
+    let instance3 = Arc::new(
+        InstanceHolder::new_with_port(3, DELETE_STALE_PORT_BASE, tls_configuration.clone()).await?,
+    );
+
+    let inst1 = instance1.clone();
+    let _h1 = thread::spawn(move || {
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let _ = rt.block_on(start_raft_app(&inst1.config, &inst1.storage));
+    });
+
+    let inst2 = instance2.clone();
+    let _h2 = thread::spawn(move || {
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let _ = rt.block_on(start_raft_app(&inst2.config, &inst2.storage));
+    });
+
+    let inst3 = instance3.clone();
+    let _h3 = thread::spawn(move || {
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let _ = rt.block_on(start_raft_app(&inst3.config, &inst3.storage));
+    });
+
+    TypeConfig::sleep(Duration::from_millis(200)).await;
+
+    let tls_client_config = get_client_tls_config(&instance1.config)?;
+    let mut admin_client1 = new_admin_client(
+        instance1
+            .config
+            .distributed_storage
+            .as_ref()
+            .unwrap()
+            .node_cluster_addr
+            .clone(),
+        &tls_client_config,
+    )
+    .await?;
+
+    admin_client1
+        .init(pb::raft::InitRequest {
+            nodes: vec![new_node_with_port(1, DELETE_STALE_PORT_BASE)],
+        })
+        .await?;
+    wait_for_leader(&mut admin_client1, 1).await;
+
+    admin_client1
+        .add_learner(pb::raft::AddLearnerRequest {
+            node: Some(new_node_with_port(2, DELETE_STALE_PORT_BASE)),
+        })
+        .await?;
+    admin_client1
+        .add_learner(pb::raft::AddLearnerRequest {
+            node: Some(new_node_with_port(3, DELETE_STALE_PORT_BASE)),
+        })
+        .await?;
+
+    admin_client1
+        .change_membership(pb::raft::ChangeMembershipRequest {
+            members: vec![1, 2, 3],
+            retain: false,
+        })
+        .await?;
+
+    TypeConfig::sleep(Duration::from_millis(500)).await;
+
+    let metrics = admin_client1.metrics(()).await?.into_inner();
+    assert_eq!(
+        metrics.current_leader,
+        Some(1),
+        "node 1 must be leader for this test"
+    );
+
+    let iterations = 20;
+    let mut failures = 0;
+
+    for i in 0..iterations {
+        let key = format!("race:del:{}", i);
+        let val = format!("del-value-{}", i);
+
+        instance1
+            .storage
+            .set_value(key.clone(), make_env(&val)?, None, None)
+            .await?;
+
+        // Wait for replication so the key definitely exists on followers.
+        TypeConfig::sleep(Duration::from_millis(500)).await;
+
+        let pre_del = instance2.storage.get_by_key(key.as_bytes(), None).await?;
+        assert!(
+            pre_del.is_some(),
+            "key '{}' must exist on follower before delete",
+            key
+        );
+
+        instance1.storage.remove(key.clone(), None).await?;
+
+        let post_del = instance2.storage.get_by_key(key.as_bytes(), None).await?;
+
+        match post_del {
+            Some(_) => {
+                failures += 1;
+                println!(
+                    "ITER {} (delete race): key '{}' still exists on follower after delete (stale read)",
+                    i, key
+                );
+            }
+            None => {
+                // Good — follower has caught up with the delete.
+            }
+        }
+
+        let post_prefix = instance3
+            .storage
+            .prefix("race:del:".as_bytes(), None)
+            .await?;
+        let deleted_key_in_prefix = post_prefix.iter().any(|(k, _)| k == &key);
+        if deleted_key_in_prefix {
+            failures += 1;
+            println!(
+                "ITER {} (delete prefix race): key '{}' still in prefix on follower after delete",
+                i, key
+            );
+        }
+    }
+
+    println!(
+        "Delete-then-read race test complete: {} failures out of {} iterations ({} total operations)",
+        failures,
+        iterations,
+        iterations * 2
+    );
+
+    if failures > 0 {
+        panic!(
+            "Delete stale-read race detected: {} failures out of {} total operations",
+            failures,
+            iterations * 2
         );
     }
 
@@ -407,21 +1073,23 @@ async fn new_admin_client(
 }
 
 fn new_node(node_id: u64) -> pb::raft::Node {
+    new_node_with_port(node_id, 0)
+}
+
+fn new_node_with_port(node_id: u64, port_base: u16) -> pb::raft::Node {
     pb::raft::Node {
         node_id,
-        rpc_addr: get_addr(node_id).to_string(),
+        rpc_addr: get_addr_with_port(node_id, port_base).to_string(),
     }
 }
 
 fn get_addr(node_id: u64) -> SocketAddr {
-    match node_id {
-        1 => "127.0.0.1:21001".parse().unwrap(),
-        2 => "127.0.0.1:21002".parse().unwrap(),
-        3 => "127.0.0.1:21003".parse().unwrap(),
-        _ => {
-            unreachable!("node_id must be 1, 2, or 3");
-        }
-    }
+    get_addr_with_port(node_id, 0)
+}
+
+fn get_addr_with_port(node_id: u64, port_base: u16) -> SocketAddr {
+    let port = port_base + 21000 + node_id as u16;
+    format!("127.0.0.1:{}", port).parse().unwrap()
 }
 
 async fn wait_for_leader(client: &mut ClusterAdminServiceClient<Channel>, expected_leader: u64) {
@@ -503,11 +1171,20 @@ fn get_ds_config(
     db_path: PathBuf,
     tls_config: TlsConfiguration,
 ) -> DistributedStorageConfiguration {
+    get_ds_config_with_port(node_id, 0, db_path, tls_config)
+}
+
+fn get_ds_config_with_port(
+    node_id: u64,
+    port_base: u16,
+    db_path: PathBuf,
+    tls_config: TlsConfiguration,
+) -> DistributedStorageConfiguration {
     DistributedStorageConfiguration {
-        node_cluster_addr: format!("https://{}", get_addr(node_id))
+        node_cluster_addr: format!("https://{}", get_addr_with_port(node_id, port_base))
             .parse()
             .expect("valid address"),
-        node_listener_addr: format!("{}", get_addr(node_id))
+        node_listener_addr: format!("{}", get_addr_with_port(node_id, port_base))
             .parse()
             .expect("valid address"),
         node_id,

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -113,6 +113,8 @@ verify:
       name: "api-test-v3"
       command: ["/tests/test-api-v3"]
       env:
+        - name: "RUST_LOG"
+          value: "info,reqwest=off,h2=off,hyper=off"
         - name: "KEYSTONE_URL"
           value: "http://keystone-rs.default.svc.cluster.local:8080"
         - name: "OS_AUTH_URL"
@@ -137,6 +139,8 @@ verify:
       name: "api-test-v4"
       command: ["/tests/test-api-v4"]
       env:
+        - name: "RUST_LOG"
+          value: "info,reqwest=off,h2=off,hyper=off"
         - name: "KEYSTONE_URL"
           value: "http://keystone-rs.default.svc.cluster.local:8080"
         - name: "OS_AUTH_URL"
@@ -161,6 +165,8 @@ verify:
       name: "k8s-auth-test"
       command: ["/tests/test-k8s-auth", "--nocapture"]
       env:
+        - name: "RUST_LOG"
+          value: "info,reqwest=off,h2=off,hyper=off"
         - name: "KEYSTONE_URL"
           value: "http://keystone-rs.default.svc.cluster.local:8080"
         - name: "OS_AUTH_URL"
@@ -202,6 +208,8 @@ verify:
       name: "keycloak"
       command: ["/tests/test-keycloak", "--nocapture"]
       env:
+        - name: "RUST_LOG"
+          value: "info,reqwest=off,h2=off,hyper=off"
         - name: "BROWSERDRIVER_URL"
           value: "http://selenium-service:4444"
         - name: "KEYSTONE_URL"
@@ -220,6 +228,8 @@ verify:
       name: "dex"
       command: ["/tests/test-dex", "--nocapture"]
       env:
+        - name: "RUST_LOG"
+          value: "info,reqwest=off,h2=off,hyper=off"
         - name: "KEYSTONE_URL"
           value: "http://keystone-rs:8080"
         - name: "DEX_URL"
@@ -241,6 +251,8 @@ profiles:
           name: "github"
           command: ["/tests/test-github", "--nocapture"]
           env:
+            - name: "RUST_LOG"
+              value: "info,reqwest=off,h2=off,hyper=off"
             - name: "KEYSTONE_URL"
               value: "http://keystone-rs:8080"
             - name: "ACTIONS_ID_TOKEN_AUDIENCE"

--- a/tests/api/Cargo.toml
+++ b/tests/api/Cargo.toml
@@ -35,7 +35,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros"] }
 tokio-rustls.workspace = true
 tonic = { workspace = true, features = ["tls-aws-lc"] }
-tracing-test = { workspace = true, features = ["no-env-filter"] }
+tracing-test.workspace = true
 webauthn-authenticator-rs = { workspace = true, features = ["softtoken"] }
 x509-parser = "0.16"
 url = { workspace = true }

--- a/tests/api/tests/k8s_auth.rs
+++ b/tests/api/tests/k8s_auth.rs
@@ -187,6 +187,7 @@ async fn test_k8s_auth() -> Result<()> {
     .await?;
 
     let k8s_token = read_pod_k8s_token().await?;
+
     let (token_data, _token_secret) = k8s_auth(
         &test_client,
         &instance.id,
@@ -204,8 +205,8 @@ async fn test_k8s_auth() -> Result<()> {
         "token user name should match the wildcard rule"
     );
 
-    _ruleset.delete().await?;
-    instance.delete().await?;
+    let _ = _ruleset.delete().await;
+    let _ = instance.delete().await;
     Ok(())
 }
 
@@ -334,8 +335,8 @@ async fn test_k8s_auth_rule_name_respected() -> Result<()> {
         "expected 403 Forbidden for nonexistent rule_name, got: {err_str}"
     );
 
-    _ruleset.delete().await?;
-    instance.delete().await?;
+    let _ = _ruleset.delete().await;
+    let _ = instance.delete().await;
     Ok(())
 }
 
@@ -368,14 +369,14 @@ async fn test_k8s_auth_cannot_rescope_to_other_project() -> Result<()> {
         create_role(
             &test_client,
             openstack_keystone_api_types::v3::role::RoleCreateBuilder::default()
-                .name(format!("role-{}", Uuid::new_v4().simple()))
+                .name(format!("test-role-{}", Uuid::new_v4().simple()))
                 .build()?,
         )
         .await?,
         test_client.clone(),
     );
 
-    // Create ruleset with a project authorization scoped to `project_a`.
+    // Create ruleset with project authorization for `project_a`.
     let _ruleset = create_ruleset(
         &test_client,
         openstack_keystone_api_types::v4::mapping::ruleset::MappingRuleSetCreate {
@@ -500,10 +501,10 @@ async fn test_k8s_auth_cannot_rescope_to_other_project() -> Result<()> {
         }
     }
 
-    _ruleset.delete().await?;
-    instance.delete().await?;
-    project_a.delete().await?;
-    project_b.delete().await?;
-    role.delete().await?;
+    let _ = _ruleset.delete().await;
+    let _ = instance.delete().await;
+    let _ = project_a.delete().await;
+    let _ = project_b.delete().await;
+    let _ = role.delete().await;
     Ok(())
 }

--- a/tests/federation/Cargo.toml
+++ b/tests/federation/Cargo.toml
@@ -26,7 +26,7 @@ thirtyfour = "0.37"
 tracing.workspace = true
 tokio = { workspace = true, features = ["signal"] }
 tokio-util.workspace = true
-tracing-test = { workspace = true, features = ["no-env-filter"] }
+tracing-test.workspace = true
 uuid = { workspace = true, features = ["v4" ]}
 
 [[test]]

--- a/tools/k8s/keystone/base/bootstrap-job.yaml
+++ b/tools/k8s/keystone/base/bootstrap-job.yaml
@@ -27,6 +27,8 @@ spec:
           name: keystone-db-py
           command: [keystone-manage, db_sync]
           volumeMounts:
+            - mountPath: /var/log/keystone
+              name: keystone-logs
             - mountPath: /etc/keystone/keystone.conf
               name: config
               subPath: keystone.conf
@@ -41,6 +43,8 @@ spec:
           name: keystone-db-rs
           command: [keystone-manage, db, up]
           volumeMounts:
+            - mountPath: /var/log/keystone
+              name: keystone-logs
             - mountPath: /etc/keystone/keystone.conf
               name: config
               subPath: keystone.conf
@@ -57,6 +61,8 @@ spec:
           name: keystone-bootstrap
           command: [keystone-manage, "bootstrap", "--bootstrap-username", "admin", "--bootstrap-password", "password", "--bootstrap-public-url", "http://keystone.local:80", "--bootstrap-internal-url", "http://keystone-rs.local:80"]
           volumeMounts:
+            - mountPath: /var/log/keystone
+              name: keystone-logs
             - mountPath: /etc/keystone/keystone.conf
               name: config
               subPath: keystone.conf
@@ -64,7 +70,8 @@ spec:
               name: fernet
 
       volumes:
-
+        - name: keystone-logs
+          emptyDir: {}
         - name: "config"
           configMap:
             name: "keystone"

--- a/tools/k8s/keystone/base/conf/keystone.conf
+++ b/tools/k8s/keystone/base/conf/keystone.conf
@@ -1,6 +1,7 @@
 [DEFAULT]
 debug = true
 use_stderr = true
+log_dir = /var/log/keystone
 
 [auth]
 methods = password,token,openid,application_credential,x509,mapped

--- a/tools/k8s/keystone/base/deployment-py.yaml
+++ b/tools/k8s/keystone/base/deployment-py.yaml
@@ -76,6 +76,8 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           volumeMounts:
+            - mountPath: /var/log/keystone
+              name: keystone-logs
             - mountPath: /etc/keystone/fernet-keys
               name: fernet
             - mountPath: /etc/keystone/keystone.conf
@@ -85,6 +87,8 @@ spec:
               name: certs
 
       volumes:
+        - name: keystone-logs
+          emptyDir: {}
         - name: config
           configMap:
             name: keystone

--- a/tools/k8s/keystone/base/statefulset-rs.yaml
+++ b/tools/k8s/keystone/base/statefulset-rs.yaml
@@ -70,6 +70,8 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           volumeMounts:
+            - mountPath: /var/log/keystone
+              name: keystone-logs
             - mountPath: /etc/keystone/fernet-keys
               name: fernet
             - mountPath: /certs
@@ -118,6 +120,8 @@ spec:
               mountPath: /etc/spiffe-helper
 
       volumes:
+        - name: keystone-logs
+          emptyDir: {}
         - name: config
           configMap:
             name: keystone

--- a/tools/k8s/keystone/overlays/dev/conf/keystone.conf
+++ b/tools/k8s/keystone/overlays/dev/conf/keystone.conf
@@ -1,6 +1,7 @@
 [DEFAULT]
 debug = true
 use_stderr = true
+log_dir = /var/log/keystone
 
 [auth]
 methods = password,token,openid,application_credential,x509


### PR DESCRIPTION
Two-node Raft cluster behind load balancer causes follower reads to
return stale data when virtual users were just created. The mapping
authentication path fails intermittently because the follower's FjallDB
hasn't replicated new virtual user data yet.

Fixes applied:
- Add leader forwarding for follower reads (get_by_key, prefix,
  prefix_index)
- Forward forwarded_read, forwarded_prefix, forwarded_prefix_index calls
  through gRPC when ForwardToLeader is returned from ReadIndex
- Preserve roles in set_authorization_scope and mapping authentication
  fast path with role pre-population instead of re-reading stale storage
- Add replication race detection tests for get_by_key and prefix_index

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
