### PR TITLE
feat(storage): Cert validity and SVID TTL enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -4107,6 +4106,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-rustls",
  "tonic",
@@ -6617,7 +6617,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7332,6 +7332,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tempfile",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",
@@ -7435,12 +7436,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -7450,15 +7450,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/crates/core/src/common/password_hashing/bcrypt.rs
+++ b/crates/core/src/common/password_hashing/bcrypt.rs
@@ -12,7 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Bcrypt hasher - mirrors `keystone/common/password_hashers/bcrypt.py::Bcrypt`.
+//! Bcrypt hasher - mirrors
+//! `keystone/common/password_hashers/bcrypt.py::Bcrypt`.
 
 use openstack_keystone_config::Config;
 use tokio::task;

--- a/crates/core/src/common/password_hashing/mod.rs
+++ b/crates/core/src/common/password_hashing/mod.rs
@@ -109,14 +109,15 @@ trait PasswordHasher {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-/// Verify the password length against algorithm constraints and truncate if necessary.
+/// Verify the password length against algorithm constraints and truncate if
+/// necessary.
 ///
-/// Mirrors Keystone's own `password_hashing.py::verify_length_and_trunc_password`:
-/// only `Bcrypt` is capped at 72 bytes (bcrypt's native input limit); every
-/// other algorithm is left at the full `config_max_length`, since
-/// `BcryptSha256`, `Scrypt` and `Pbkdf2Sha512` all first reduce the
-/// password to a fixed-size digest/key and never hit bcrypt's 72-byte
-/// limit directly.
+/// Mirrors Keystone's own
+/// `password_hashing.py::verify_length_and_trunc_password`: only `Bcrypt` is
+/// capped at 72 bytes (bcrypt's native input limit); every other algorithm is
+/// left at the full `config_max_length`, since `BcryptSha256`, `Scrypt` and
+/// `Pbkdf2Sha512` all first reduce the password to a fixed-size digest/key and
+/// never hit bcrypt's 72-byte limit directly.
 fn verify_length_and_trunc_password<'a>(
     password: &'a [u8],
     algo: &PasswordHashingAlgo,
@@ -179,7 +180,8 @@ fn get_dummy_cache() -> &'static DynamicDummyCache {
 }
 
 // ---------------------------------------------------------------------------
-// Public API - signatures unchanged; callers outside this module are unaffected.
+// Public API - signatures unchanged; callers outside this module are
+// unaffected.
 // ---------------------------------------------------------------------------
 
 /// Gets a cached dummy hash matching the precise parameters of the current
@@ -217,8 +219,8 @@ pub async fn get_or_init_dummy_hash(conf: &Config) -> Result<String, PasswordHas
 ///
 /// Call this whenever the Keystone configuration reloads (e.g. via
 /// `ConfigManager::notify_tx`) so that stale `(algorithm, rounds)` entries
-/// are not served after a config change. See `crates/keystone/src/bin/keystone.rs`
-/// for the wiring.
+/// are not served after a config change. See
+/// `crates/keystone/src/bin/keystone.rs` for the wiring.
 pub async fn reset_dummy_hash_cache() {
     get_dummy_cache().map.write().await.clear();
 }
@@ -527,10 +529,10 @@ mod tests {
     //   pip install keystone
     //   cargo test -p openstack-keystone-core -- cross_verify
 
-    /// Run a Rust-produced hash through tools/cross_verify.py against the Python
-    /// hashers. Returns the script's exit code (0 = verified, 1 = rejected,
-    /// 2 = error). Returns `None` when the `keystone` Python package is not
-    /// installed, so the caller can skip.
+    /// Run a Rust-produced hash through tools/cross_verify.py against the
+    /// Python hashers. Returns the script's exit code (0 = verified, 1 =
+    /// rejected, 2 = error). Returns `None` when the `keystone` Python
+    /// package is not installed, so the caller can skip.
     async fn python_cross_verify(algo_name: &str, password: &str, hash: &str) -> Option<i32> {
         // Skip if `import keystone` fails — no Python Keystone installed.
         let importable = tokio::process::Command::new("python")

--- a/crates/core/src/common/password_hashing/pbkdf2.rs
+++ b/crates/core/src/common/password_hashing/pbkdf2.rs
@@ -39,7 +39,8 @@ impl PasswordHasher for Pbkdf2Sha512Hasher {
     async fn hash(&self, conf: &Config, password: &[u8]) -> Result<String, PasswordHashError> {
         // mirrors keystone/common/password_hashers/pbkdf2.py::Sha512.hash()
         // Wire format: $pbkdf2-sha512$<rounds>$<salt_b64>$<digest_b64>
-        // salt and digest are standard base64 no-pad (binascii.b2a_base64().rstrip("=\n")).
+        // salt and digest are standard base64 no-pad
+        // (binascii.b2a_base64().rstrip("=\n")).
         let password_bytes = password.to_vec();
         let rounds = conf.identity.password_hash_rounds.unwrap_or(25000);
         let hash = task::spawn_blocking(move || {
@@ -64,7 +65,8 @@ impl PasswordHasher for Pbkdf2Sha512Hasher {
     ) -> Result<bool, PasswordHashError> {
         // mirrors keystone/common/password_hashers/pbkdf2.py::Sha512.verify()
         // Parses the embedded rounds from the hash string.
-        // replace('.', "+") handles old Passlib-era hashes that used '.' instead of '+'.
+        // replace('.', "+") handles old Passlib-era hashes that used '.' instead of
+        // '+'.
         let password_bytes = password.to_vec();
         let hash_str = hash.to_string();
         let res = task::spawn_blocking(move || {

--- a/crates/core/src/common/password_hashing/plaintext.rs
+++ b/crates/core/src/common/password_hashing/plaintext.rs
@@ -74,7 +74,8 @@ mod tests {
         let conf = mock_config(PasswordHashingAlgo::None, 72);
         let invalid_utf8_password = b"bad\xFFpassword";
 
-        // Ensure our strict UTF-8 validation safely rejects invalid sequence vulnerabilities
+        // Ensure our strict UTF-8 validation safely rejects invalid sequence
+        // vulnerabilities
         let hash_result = hash_password(&conf, invalid_utf8_password).await;
         assert!(
             hash_result.is_err(),

--- a/crates/core/src/common/password_hashing/scrypt.rs
+++ b/crates/core/src/common/password_hashing/scrypt.rs
@@ -12,7 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Scrypt hasher - mirrors `keystone/common/password_hashers/scrypt.py::Scrypt`.
+//! Scrypt hasher - mirrors
+//! `keystone/common/password_hashers/scrypt.py::Scrypt`.
 
 use base64::{Engine as _, engine::general_purpose::STANDARD_NO_PAD};
 use openstack_keystone_config::Config;
@@ -28,7 +29,8 @@ impl PasswordHasher for ScryptHasher {
         // mirrors keystone/common/password_hashers/scrypt.py::Scrypt.hash()
         // Python hardcodes: n=2**16 (ln=16), r=8, p=1, salt_size=16, output=32 bytes.
         // scrypt_block_size / scrypt_parallelism / salt_bytesize config fields are
-        // not yet in IdentityProvider - use Keystone's own defaults until they are added.
+        // not yet in IdentityProvider - use Keystone's own defaults until they are
+        // added.
         let password_bytes = password.to_vec();
         let hash = task::spawn_blocking(move || {
             let salt = generate_salt();
@@ -62,7 +64,8 @@ impl PasswordHasher for ScryptHasher {
         let password_bytes = password.to_vec();
         let hash_str = hash.to_string();
         let res = task::spawn_blocking(move || -> Result<bool, PasswordHashError> {
-            // Strip leading '$', split on '$': ["scrypt", "ln=N,r=R,p=P", salt_b64, digest_b64]
+            // Strip leading '$', split on '$': ["scrypt", "ln=N,r=R,p=P", salt_b64,
+            // digest_b64]
             let parts: Vec<&str> = hash_str[1..].split('$').collect();
             if parts.len() != 4 {
                 return Ok(false);
@@ -87,7 +90,8 @@ impl PasswordHasher for ScryptHasher {
                 }
             }
 
-            // replace('.', "+") handles old Passlib-era hashes that used '.' in place of '+'.
+            // replace('.', "+") handles old Passlib-era hashes that used '.' in place of
+            // '+'.
             let salt = STANDARD_NO_PAD
                 .decode(salt_b64.replace('.', "+").as_bytes())
                 .map_err(|_| PasswordHashError::CryptoHash("Invalid scrypt salt".into()))?;

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -262,7 +262,7 @@ async fn main() -> Result<(), Report> {
             .map_err(|e| KeystoneError::Provider {
                 source: Box::new(e),
             })?;
-        Some(Arc::new(storage))
+        Some(storage)
     } else {
         None
     };

--- a/crates/keystone/src/server/listener/raft_grpc.rs
+++ b/crates/keystone/src/server/listener/raft_grpc.rs
@@ -23,7 +23,7 @@ use tonic::service::InterceptorLayer;
 
 use openstack_keystone_distributed_storage::{
     app::{Storage, get_app_server},
-    network::get_server_tls_config,
+    network::{check_svid_ttl_der, get_server_tls_config, now_unix_secs},
 };
 use openstack_keystone_storage_api::StorageApi;
 
@@ -81,6 +81,14 @@ fn validate_spiffe_id(
             )));
         }
     }
+
+    // Enforce the 5-minute force-renewal window (ADR 0016-v2 §4.1).
+    // This guards ALL Raft gRPC routes including StorageService forwarded
+    // reads. ClusterAdminService handlers additionally re-check this
+    // themselves (`cluster_admin_service::check_svid_ttl`) — that's
+    // intentional defense-in-depth for the RBAC-sensitive admin surface, not
+    // duplicated oversight.
+    check_svid_ttl_der(leaf.as_ref(), now_unix_secs())?;
 
     Ok(())
 }
@@ -432,6 +440,33 @@ mod tests {
         let err = validate_spiffe_id(certs, &trust_domains, &[]).unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
         assert!(err.message().contains("Invalid SPIFFE ID"));
+    }
+
+    #[test]
+    fn test_spiffe_id_svid_in_force_renewal_window() {
+        use rcgen::{CertificateParams, DistinguishedName, KeyPair, SanType, date_time_ymd};
+
+        // Build a cert whose not_after is in the past (expired / force-renewal window).
+        let spiffe_uri = "spiffe://example.org/keystone/storage/node-0"
+            .try_into()
+            .unwrap();
+        let mut params = CertificateParams::default();
+        params.distinguished_name = DistinguishedName::new();
+        params.subject_alt_names = vec![SanType::URI(spiffe_uri)];
+        // not_before < not_after but both in the past → expired.
+        params.not_before = date_time_ymd(2000, 1, 1);
+        params.not_after = date_time_ymd(2001, 1, 1);
+        let key = KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap().der().clone();
+        let certs = Some(Arc::new(vec![cert]));
+        let trust_domains = vec!["example.org".to_string()];
+        let err = validate_spiffe_id(certs, &trust_domains, &[]).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(
+            err.message().contains("expired") || err.message().contains("force-renewal"),
+            "unexpected error: {}",
+            err.message()
+        );
     }
 
     #[test]

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -176,6 +176,14 @@ pub struct Metadata {
     /// this field (e.g. from a previous schema) deserialize to the default.
     #[serde(default)]
     pub tier: DataTier,
+    /// The DEK epoch (`dek_version_u32`) under which the record's value was
+    /// encrypted (ADR 0016-v2 §6 step 6). Set on every write so reads can
+    /// select the correct key deterministically instead of probing multiple
+    /// epochs on a tag-verification failure. `None` only for records written
+    /// before this field existed; such legacy records fall back to a
+    /// try-current-then-probe-retired read path for backward compatibility.
+    #[serde(default)]
+    pub dek_version: Option<u32>,
 }
 
 impl Metadata {
@@ -185,6 +193,7 @@ impl Metadata {
             revision: 0,
             created_at: Utc::now().timestamp(),
             tier: DataTier::Internal,
+            dek_version: None,
         }
     }
 
@@ -194,6 +203,7 @@ impl Metadata {
             revision: 0,
             created_at: Utc::now().timestamp(),
             tier,
+            dek_version: None,
         }
     }
 
@@ -204,6 +214,7 @@ impl Metadata {
             revision: self.revision + 1,
             created_at: self.created_at,
             tier: self.tier,
+            dek_version: self.dek_version,
         }
     }
 

--- a/crates/storage-crypto/Cargo.toml
+++ b/crates/storage-crypto/Cargo.toml
@@ -36,4 +36,4 @@ nix = { workspace = true, features = ["mman", "feature"] }
 rand.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-zeroize = { version = "1", features = ["derive", "zeroize_derive"] }
+zeroize = "1"

--- a/crates/storage-crypto/src/cipher.rs
+++ b/crates/storage-crypto/src/cipher.rs
@@ -34,17 +34,16 @@
 //! All GCM tags are 16 bytes (full-length).  Truncated tags are prohibited
 //! (ADR §2.2).
 
-#[allow(deprecated)]
-use aes_gcm::aead::AeadInPlace;
+use aes_gcm::aead::AeadInOut;
 use aes_gcm::{Aes256Gcm, KeyInit};
 use hkdf::Hkdf;
 use hybrid_array::Array;
 use sha2::Sha256;
-use typenum::{U12, U16, U32};
 use zeroize::Zeroizing;
 
 use crate::dek::{BackupDek, LogDek, StateDek};
 use crate::error::CryptoError;
+use crate::gcm::{GcmKey, GcmNonce, GcmTag};
 
 // Label for snapshot backup AD (ADR §7).
 const BACKUP_AD_LABEL: &[u8] = b"keystone-backup-v1";
@@ -54,24 +53,19 @@ const STATE_MIN_LEN: usize = 32;
 // Minimum bytes in a stored log value: nonce(12) + tag(16) = 28
 const LOG_MIN_LEN: usize = 28;
 
-// Type aliases for array helpers
-type GcmKey = Array<u8, U32>;
-type GcmNonce = Array<u8, U12>;
-type GcmTag = Array<u8, U16>;
-
 /// Convert a slice reference to a typed GCM nonce array reference.
-fn nonce_ref(s: &[u8]) -> &GcmNonce {
-    Array::slice_as_array(s).expect("12-byte nonce")
+fn nonce_ref(s: &[u8]) -> Result<&GcmNonce, CryptoError> {
+    Array::slice_as_array(s).ok_or(CryptoError::InvalidArrayLength)
 }
 
 /// Convert a slice reference to a typed GCM tag array reference.
-fn tag_ref(s: &[u8]) -> &GcmTag {
-    Array::slice_as_array(s).expect("16-byte tag")
+fn tag_ref(s: &[u8]) -> Result<&GcmTag, CryptoError> {
+    Array::slice_as_array(s).ok_or(CryptoError::InvalidArrayLength)
 }
 
 /// Convert a 32-byte slice to a typed GCM key array reference.
-fn key_ref(s: &[u8]) -> &GcmKey {
-    Array::slice_as_array(s).expect("32-byte key")
+fn key_ref(s: &[u8]) -> Result<&GcmKey, CryptoError> {
+    Array::slice_as_array(s).ok_or(CryptoError::InvalidArrayLength)
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +83,6 @@ fn key_ref(s: &[u8]) -> &GcmKey {
 ///
 /// # Returns
 /// `[nonce 12B] ++ [ciphertext] ++ [tag 16B]`.
-#[allow(deprecated)]
 pub fn log_encrypt(
     dek: &LogDek,
     plaintext: &[u8],
@@ -97,13 +90,13 @@ pub fn log_encrypt(
     index: u64,
     nonce: &[u8; 12],
 ) -> Result<Vec<u8>, CryptoError> {
-    let cipher = Aes256Gcm::new(key_ref(&*dek.0));
+    let cipher = Aes256Gcm::new(key_ref(dek.0.as_bytes())?);
     let aad = log_aad(term, index);
-    let gcm_nonce = nonce_ref(nonce);
+    let gcm_nonce = nonce_ref(nonce)?;
 
     let mut buf = plaintext.to_vec();
     let tag = cipher
-        .encrypt_in_place_detached(gcm_nonce, &aad, &mut buf)
+        .encrypt_inout_detached(gcm_nonce, &aad, buf.as_mut_slice().into())
         .map_err(|_| CryptoError::AesEncrypt)?;
 
     let mut out = Vec::with_capacity(12 + plaintext.len() + 16);
@@ -118,7 +111,6 @@ pub fn log_encrypt(
 ///
 /// Returns the plaintext in a zeroing wrapper.  Returns
 /// [`CryptoError::AesDecrypt`] if the GCM tag does not verify.
-#[allow(deprecated)]
 pub fn log_decrypt(
     dek: &LogDek,
     stored: &[u8],
@@ -130,23 +122,19 @@ pub fn log_decrypt(
     }
     let (nonce_bytes, rest) = stored.split_at(12);
     let (ciphertext, tag_bytes) = rest.split_at(rest.len() - 16);
-    let gcm_nonce = nonce_ref(nonce_bytes);
-    let tag = tag_ref(tag_bytes);
+    let gcm_nonce = nonce_ref(nonce_bytes)?;
+    let tag = tag_ref(tag_bytes)?;
     let aad = log_aad(term, index);
-    let cipher = Aes256Gcm::new(key_ref(&*dek.0));
+    let cipher = Aes256Gcm::new(key_ref(dek.0.as_bytes())?);
 
     let mut buf = Zeroizing::new(ciphertext.to_vec());
     cipher
-        .decrypt_in_place_detached(gcm_nonce, &aad, buf.as_mut(), tag)
+        .decrypt_inout_detached(gcm_nonce, &aad, buf.as_mut_slice().into(), tag)
         .map_err(|_| CryptoError::AesDecrypt)?;
     Ok(buf)
 }
 
-// ---------------------------------------------------------------------------
-// State encryption
-// ---------------------------------------------------------------------------
-
-/// Encrypt a Fjall state entry for a given record version.
+/// Encrypt a Fjall state machine record.
 ///
 /// # Parameters
 /// - `dek`        — the state sub-key for this DEK epoch.
@@ -158,7 +146,6 @@ pub fn log_decrypt(
 ///
 /// # Returns
 /// `[nonce 12B] ++ [ciphertext] ++ [tag 16B] ++ [version u32 BE]`.
-#[allow(deprecated)]
 pub fn state_encrypt(
     dek: &StateDek,
     plaintext: &[u8],
@@ -169,12 +156,12 @@ pub fn state_encrypt(
 ) -> Result<Vec<u8>, CryptoError> {
     let nonce_array = state_nonce(dek, pk, version)?;
     let aad = state_aad(tier, domain_id, pk);
-    let cipher = Aes256Gcm::new(key_ref(&*dek.0));
-    let gcm_nonce = nonce_ref(&nonce_array);
+    let cipher = Aes256Gcm::new(key_ref(dek.0.as_bytes())?);
+    let gcm_nonce = nonce_ref(&nonce_array)?;
 
     let mut buf = plaintext.to_vec();
     let tag = cipher
-        .encrypt_in_place_detached(gcm_nonce, &aad, &mut buf)
+        .encrypt_inout_detached(gcm_nonce, &aad, buf.as_mut_slice().into())
         .map_err(|_| CryptoError::AesEncrypt)?;
 
     let mut out = Vec::with_capacity(12 + plaintext.len() + 16 + 4);
@@ -191,7 +178,6 @@ pub fn state_encrypt(
 /// `(plaintext, next_version)` where `next_version = stored_version + 1`.
 /// Returns [`CryptoError::AesDecrypt`] if the GCM tag does not verify —
 /// callers MUST treat this as a quarantine-triggering event.
-#[allow(deprecated)]
 pub fn state_decrypt(
     dek: &StateDek,
     stored: &[u8],
@@ -221,14 +207,14 @@ pub fn state_decrypt(
         return Err(CryptoError::AesDecrypt);
     }
 
-    let gcm_nonce = nonce_ref(nonce_bytes);
-    let tag = tag_ref(tag_bytes);
+    let gcm_nonce = nonce_ref(nonce_bytes)?;
+    let tag = tag_ref(tag_bytes)?;
     let aad = state_aad(tier, domain_id, pk);
-    let cipher = Aes256Gcm::new(key_ref(&*dek.0));
+    let cipher = Aes256Gcm::new(key_ref(dek.0.as_bytes())?);
 
     let mut buf = Zeroizing::new(ciphertext.to_vec());
     cipher
-        .decrypt_in_place_detached(gcm_nonce, &aad, buf.as_mut(), tag)
+        .decrypt_inout_detached(gcm_nonce, &aad, buf.as_mut_slice().into(), tag)
         .map_err(|_| CryptoError::AesDecrypt)?;
 
     let next_version = stored_version.saturating_add(1);
@@ -251,7 +237,6 @@ pub fn state_decrypt(
 ///
 /// # Returns
 /// `[nonce 12B] ++ [ciphertext] ++ [tag 16B]`.
-#[allow(deprecated)]
 #[allow(clippy::disallowed_methods)]
 pub fn backup_encrypt(
     dek: &BackupDek,
@@ -262,12 +247,12 @@ pub fn backup_encrypt(
 ) -> Result<Vec<u8>, CryptoError> {
     let nonce_bytes = backup_nonce(dek, utc_epoch, counter)?;
     let aad = backup_aad(dek_version, utc_epoch, counter);
-    let cipher = Aes256Gcm::new(key_ref(dek.as_bytes()));
-    let gcm_nonce = nonce_ref(&nonce_bytes);
+    let cipher = Aes256Gcm::new(key_ref(dek.as_bytes())?);
+    let gcm_nonce = nonce_ref(&nonce_bytes)?;
 
     let mut buf = plaintext.to_vec();
     let tag = cipher
-        .encrypt_in_place_detached(gcm_nonce, &aad, &mut buf)
+        .encrypt_inout_detached(gcm_nonce, &aad, buf.as_mut_slice().into())
         .map_err(|_| CryptoError::AesEncrypt)?;
 
     let mut out = Vec::with_capacity(12 + plaintext.len() + 16);
@@ -284,7 +269,6 @@ pub fn backup_encrypt(
 /// The stored nonce is re-derived from (`dek`, `utc_epoch`, `counter`) and
 /// verified against the stored bytes to detect accidental epoch/timestamp
 /// confusion.
-#[allow(deprecated)]
 pub fn backup_decrypt(
     dek: &BackupDek,
     stored: &[u8],
@@ -306,13 +290,13 @@ pub fn backup_decrypt(
 
     let (ciphertext, tag_bytes) = rest.split_at(rest.len() - 16);
     let aad = backup_aad(dek_version, utc_epoch, counter);
-    let cipher = Aes256Gcm::new(key_ref(dek.as_bytes()));
-    let gcm_nonce = nonce_ref(nonce_bytes);
-    let tag = tag_ref(tag_bytes);
+    let cipher = Aes256Gcm::new(key_ref(dek.as_bytes())?);
+    let gcm_nonce = nonce_ref(nonce_bytes)?;
+    let tag = tag_ref(tag_bytes)?;
 
     let mut buf = Zeroizing::new(ciphertext.to_vec());
     cipher
-        .decrypt_in_place_detached(gcm_nonce, &aad, buf.as_mut(), tag)
+        .decrypt_inout_detached(gcm_nonce, &aad, buf.as_mut_slice().into(), tag)
         .map_err(|_| CryptoError::AesDecrypt)?;
     Ok(buf)
 }
@@ -333,7 +317,7 @@ fn log_aad(term: u64, index: u64) -> [u8; 16] {
 /// `info = pk ++ version_u32_be` as per ADR §2.2.
 fn state_nonce(dek: &StateDek, pk: &[u8], version: u32) -> Result<[u8; 12], CryptoError> {
     let hkdf =
-        Hkdf::<Sha256>::from_prk(dek.0.as_ref()).map_err(|_| CryptoError::InvalidKeyLength)?;
+        Hkdf::<Sha256>::from_prk(dek.0.as_bytes()).map_err(|_| CryptoError::InvalidKeyLength)?;
 
     let mut info = Vec::with_capacity(pk.len() + 4);
     info.extend_from_slice(pk);
@@ -385,14 +369,14 @@ fn backup_nonce(dek: &BackupDek, utc_epoch: u64, counter: u64) -> Result<[u8; 12
 mod tests {
     use super::*;
     use crate::dek::{LogDek, StateDek};
-    use zeroize::Zeroizing;
+    use crate::mlock::LockedKey;
 
     fn test_log_dek() -> LogDek {
-        LogDek(Zeroizing::new([0x11u8; 32]))
+        LogDek(LockedKey::from_raw([0x11u8; 32]))
     }
 
     fn test_state_dek() -> StateDek {
-        StateDek(Zeroizing::new([0x22u8; 32]))
+        StateDek(LockedKey::from_raw([0x22u8; 32]))
     }
 
     fn test_nonce() -> [u8; 12] {

--- a/crates/storage-crypto/src/dek.rs
+++ b/crates/storage-crypto/src/dek.rs
@@ -31,14 +31,12 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use hkdf::Hkdf;
-use rand::RngExt;
-use sha2::Sha256;
-use zeroize::{Zeroize, Zeroizing};
-
 use crate::audit::AuditHmacKey;
 use crate::error::CryptoError;
 use crate::mlock::LockedKey;
+use hkdf::Hkdf;
+use rand::RngExt;
+use sha2::Sha256;
 
 const LOG_DEK_INFO: &[u8] = b"keystone-raft-log-v1";
 const STATE_DEK_INFO: &[u8] = b"keystone-fjall-state-v1";
@@ -50,10 +48,16 @@ const AUDIT_DEK_INFO_PREFIX: &[u8] = b"keystone-audit-dek-v1";
 // ---------------------------------------------------------------------------
 
 /// Sub-key for encrypting Raft log entries.
-pub struct LogDek(pub(crate) Zeroizing<[u8; 32]>);
+///
+/// Backed by `LockedKey` (mlock'd, guard-paged memory) per ADR §9 ("all keys
+/// — `Dek`, `LogDek`, `StateDek` — ... must be allocated in memory-locked
+/// pages").
+pub struct LogDek(pub(crate) LockedKey);
 
 /// Sub-key for encrypting Fjall state machine entries.
-pub struct StateDek(pub(crate) Zeroizing<[u8; 32]>);
+///
+/// Backed by `LockedKey` (mlock'd, guard-paged memory) per ADR §9.
+pub struct StateDek(pub(crate) LockedKey);
 
 /// Sub-key for encrypting Raft snapshot (backup) data.
 ///
@@ -118,12 +122,14 @@ impl DekEpoch {
         let hkdf = Hkdf::<Sha256>::from_prk(dek.as_bytes().as_ref())
             .map_err(|_| CryptoError::InvalidKeyLength)?;
 
-        let mut log_key = Zeroizing::new([0u8; 32]);
-        hkdf.expand(LOG_DEK_INFO, log_key.as_mut())
+        // Derive sub-keys directly into mlock'd allocations (ADR §9): never
+        // materialise the key in an unlocked buffer first.
+        let mut log_locked = LockedKey::alloc().map_err(|_| CryptoError::InvalidKeyLength)?;
+        hkdf.expand(LOG_DEK_INFO, log_locked.as_mut())
             .map_err(|_| CryptoError::InvalidKeyLength)?;
 
-        let mut state_key = Zeroizing::new([0u8; 32]);
-        hkdf.expand(STATE_DEK_INFO, state_key.as_mut())
+        let mut state_locked = LockedKey::alloc().map_err(|_| CryptoError::InvalidKeyLength)?;
+        hkdf.expand(STATE_DEK_INFO, state_locked.as_mut())
             .map_err(|_| CryptoError::InvalidKeyLength)?;
 
         // BackupDek info is version-bound: prefix ++ version_u32_BE.
@@ -135,8 +141,8 @@ impl DekEpoch {
         Ok(Self {
             version,
             root_dek: dek,
-            log_dek: LogDek(log_key),
-            state_dek: StateDek(state_key),
+            log_dek: LogDek(log_locked),
+            state_dek: StateDek(state_locked),
             backup_dek: BackupDek(backup_locked),
             backup_counter: AtomicU64::new(0),
         })
@@ -196,16 +202,6 @@ pub fn generate_dek() -> LockedKey {
     dek
 }
 
-/// Zeroize sub-keys when `DekEpoch` is dropped (root DEK is handled by
-/// LockedKey).
-impl Drop for DekEpoch {
-    fn drop(&mut self) {
-        self.log_dek.0.zeroize();
-        self.state_dek.0.zeroize();
-        // backup_dek.0 is a LockedKey — it zeroes on drop automatically.
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,9 +216,9 @@ mod tests {
         raw.as_mut().copy_from_slice(&[0x55u8; 32]);
         let epoch = DekEpoch::from_raw(raw, 0).expect("derive");
         // Sub-keys must differ from each other and from raw input.
-        assert_ne!(epoch.log_dek.0.as_ref(), &[0x55u8; 32]);
-        assert_ne!(epoch.state_dek.0.as_ref(), &[0x55u8; 32]);
-        assert_ne!(epoch.log_dek.0.as_ref(), epoch.state_dek.0.as_ref());
+        assert_ne!(epoch.log_dek.0.as_bytes(), &[0x55u8; 32]);
+        assert_ne!(epoch.state_dek.0.as_bytes(), &[0x55u8; 32]);
+        assert_ne!(epoch.log_dek.0.as_bytes(), epoch.state_dek.0.as_bytes());
     }
 
     #[test]
@@ -233,8 +229,8 @@ mod tests {
         let mut raw2 = test_locked_dek();
         raw2.as_mut().copy_from_slice(&[0xAAu8; 32]);
         let e2 = DekEpoch::from_raw(raw2, 1).expect("second");
-        assert_eq!(e1.log_dek.0.as_ref(), e2.log_dek.0.as_ref());
-        assert_eq!(e1.state_dek.0.as_ref(), e2.state_dek.0.as_ref());
+        assert_eq!(e1.log_dek.0.as_bytes(), e2.log_dek.0.as_bytes());
+        assert_eq!(e1.state_dek.0.as_bytes(), e2.state_dek.0.as_bytes());
     }
 
     #[test]

--- a/crates/storage-crypto/src/error.rs
+++ b/crates/storage-crypto/src/error.rs
@@ -68,6 +68,13 @@ pub enum CryptoError {
     #[error("stored ciphertext is too short to be a valid encrypted record")]
     CiphertextTooShort,
 
+    /// A byte slice that should have a fixed AEAD parameter length
+    /// (nonce/tag/key) did not. Should be unreachable in practice — every
+    /// call site passes a statically-sized array — but propagated as an
+    /// error instead of panicking in case that invariant is ever violated.
+    #[error("internal error: fixed-length cryptographic parameter had the wrong size")]
+    InvalidArrayLength,
+
     /// Ciphertext was encrypted under a revoked DEK epoch (ADR 0016-v2 §6.2).
     /// Emergency rotation revokes the compromised DEK; any attempt to decrypt
     /// data with the revoked key is a fatal error.

--- a/crates/storage-crypto/src/gcm.rs
+++ b/crates/storage-crypto/src/gcm.rs
@@ -1,0 +1,25 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Shared AES-256-GCM array type aliases used by [`crate::kek`] and
+//! [`crate::cipher`].
+//!
+//! Kept in one place so the two call sites can't drift apart on the GCM
+//! parameter sizes (key = 32B, nonce = 12B, tag = 16B).
+
+use hybrid_array::Array;
+use typenum::{U12, U16, U32};
+
+pub(crate) type GcmKey = Array<u8, U32>;
+pub(crate) type GcmNonce = Array<u8, U12>;
+pub(crate) type GcmTag = Array<u8, U16>;

--- a/crates/storage-crypto/src/kek.rs
+++ b/crates/storage-crypto/src/kek.rs
@@ -19,9 +19,10 @@
 //! * [`EnvKek`] — reads a hex-encoded 256-bit key from the `KEYSTONE_DEV_KEK`
 //!   environment variable.  Requires `--dev-mode` and
 //!   `KEYSTONE_ALLOW_ENV_KEK=1`.  After reading, the variable is removed from
-//!   the Rust environment map (via `unsafe env::remove_var`) and the underlying
-//!   bytes in `/proc/<pid>/environ` are zeroed on Linux to prevent exposure via
-//!   process inspection tools.
+//!   the Rust environment map (via `unsafe env::remove_var`).  Zeroing the
+//!   underlying bytes in `/proc/<pid>/environ` was attempted but is currently a
+//!   no-op (see [`zero_environ_entry`]) — the raw `environ` bytes are not
+//!   scrubbed, so this is a best-effort dev-mode control, not a guarantee.
 //!
 //! * [`Pkcs11KekStub`] — placeholder that always returns
 //!   [`CryptoError::Pkcs11NotImplemented`].  Reserves the production interface
@@ -29,30 +30,32 @@
 
 use std::env;
 
-#[allow(deprecated)]
-use aes_gcm::aead::AeadInPlace;
+use aes_gcm::aead::AeadInOut;
 use aes_gcm::{Aes256Gcm, KeyInit};
 use hybrid_array::Array;
-use typenum::{U12, U16, U32};
 
-// GCM type aliases
-type GcmKey = Array<u8, U32>;
-type GcmNonce = Array<u8, U12>;
-type GcmTag = Array<u8, U16>;
+use crate::gcm::{GcmKey, GcmNonce, GcmTag};
 
 /// Convert a 12-byte slice reference to a typed GCM nonce array reference.
-fn nonce_ref(s: &[u8]) -> &GcmNonce {
-    Array::slice_as_array(s).expect("12-byte nonce")
+///
+/// `Err(CryptoError::WrappedDekSize)` if `s` is not exactly 12 bytes — never
+/// hit by the call sites in this file (the nonce is always a freshly
+/// generated or length-checked `[u8; 12]`), but propagated rather than
+/// panicked on so a future caller passing an unchecked slice fails cleanly.
+fn nonce_ref(s: &[u8]) -> Result<&GcmNonce, CryptoError> {
+    Array::slice_as_array(s).ok_or(CryptoError::WrappedDekSize)
 }
 
 /// Convert a 16-byte slice reference to a typed GCM tag array reference.
-fn tag_ref(s: &[u8]) -> &GcmTag {
-    Array::slice_as_array(s).expect("16-byte tag")
+/// See [`nonce_ref`] for the error-propagation rationale.
+fn tag_ref(s: &[u8]) -> Result<&GcmTag, CryptoError> {
+    Array::slice_as_array(s).ok_or(CryptoError::WrappedDekSize)
 }
 
 /// Convert a 32-byte slice reference to a typed GCM key array reference.
-fn key_ref(s: &[u8]) -> &GcmKey {
-    Array::slice_as_array(s).expect("32-byte key")
+/// See [`nonce_ref`] for the error-propagation rationale.
+fn key_ref(s: &[u8]) -> Result<&GcmKey, CryptoError> {
+    Array::slice_as_array(s).ok_or(CryptoError::InvalidKeyLength)
 }
 use rand::RngExt;
 use zeroize::{Zeroize, Zeroizing};
@@ -84,9 +87,10 @@ pub trait KekProvider: Send + Sync {
 /// those flags before constructing this type.
 ///
 /// `KEYSTONE_DEV_KEK` is removed from the Rust environment immediately after
-/// reading. On Linux the underlying bytes in `/proc/<pid>/environ` are also
-/// zeroed so that the key cannot be recovered via process memory inspection
-/// tools for the remainder of the process lifetime (ADR 0016-v2 §2.1).
+/// reading (ADR 0016-v2 §2.1).  The raw bytes backing that entry in
+/// `/proc/<pid>/environ` are NOT currently scrubbed — see
+/// [`zero_environ_entry`] — so a process with `/proc` read access could still
+/// recover the key from the original environment block until process exit.
 pub struct EnvKek {
     key: Zeroizing<[u8; 32]>,
 }
@@ -113,14 +117,9 @@ impl EnvKek {
     //    any async tasks that might inspect the environment are spawned.
     // 2. No other thread is spawned before `init_storage` reaches this point, so
     //    there is no concurrent reader of `KEYSTONE_DEV_KEK`.
-    // 3. Removing the variable immediately after reading minimises the window in
-    //    which `/proc/<pid>/environ` exposes the key (ADR 0016-v2 §2.1).
-    //
-    // On Linux, `libc::unsetenv` (called by `std::env::remove_var`) marks the
-    // entry in the `environ` array but does not zero the underlying bytes.
-    // After `remove_var` we iterate the raw environment block and write zeros
-    // over the value portion of the `KEYSTONE_DEV_KEK` entry.  This is safe
-    // because no other thread is reading the environment at this point.
+    // 3. Removing the variable immediately after reading minimises (but, per
+    //    `zero_environ_entry`, does not eliminate) the window in which
+    //    `/proc/<pid>/environ` exposes the key (ADR 0016-v2 §2.1).
     //
     // The workspace sets `unsafe_code = "forbid"` but `storage-crypto` relaxes
     // this to `unsafe_code = "deny"` specifically to permit the mlock
@@ -153,12 +152,12 @@ impl EnvKek {
 impl KekProvider for EnvKek {
     fn wrap_dek(&self, dek: &[u8; 32]) -> Result<Vec<u8>, CryptoError> {
         let nonce_bytes: [u8; 12] = rand::rng().random();
-        let cipher = Aes256Gcm::new(key_ref(&*self.key));
-        let gcm_nonce = nonce_ref(&nonce_bytes);
+        let cipher = Aes256Gcm::new(key_ref(&*self.key)?);
+        let gcm_nonce = nonce_ref(&nonce_bytes)?;
 
         let mut buf = dek.to_vec();
         let tag = cipher
-            .encrypt_in_place_detached(gcm_nonce, DEK_WRAP_AD, &mut buf)
+            .encrypt_inout_detached(gcm_nonce, DEK_WRAP_AD, buf.as_mut_slice().into())
             .map_err(|_| CryptoError::AesEncrypt)?;
 
         let mut out = Vec::with_capacity(12 + 32 + 16);
@@ -173,17 +172,25 @@ impl KekProvider for EnvKek {
         if wrapped.len() != 12 + 32 + 16 {
             return Err(CryptoError::WrappedDekSize);
         }
-        let nonce_arr: [u8; 12] = wrapped[..12].try_into().unwrap();
-        let tag_arr: [u8; 16] = wrapped[44..].try_into().unwrap();
-        let cipher = Aes256Gcm::new(key_ref(&*self.key));
+        // Both slices below are exactly 12/16 bytes given the length check
+        // above (60 = 12 + 32 + 16), so the conversions cannot fail, but
+        // errors are propagated rather than unwrapped in case that
+        // invariant is ever violated by a future edit.
+        let nonce_arr: [u8; 12] = wrapped[..12]
+            .try_into()
+            .map_err(|_| CryptoError::WrappedDekSize)?;
+        let tag_arr: [u8; 16] = wrapped[44..]
+            .try_into()
+            .map_err(|_| CryptoError::WrappedDekSize)?;
+        let cipher = Aes256Gcm::new(key_ref(&*self.key)?);
 
         let mut buf = wrapped[12..44].to_vec();
         cipher
-            .decrypt_in_place_detached(
-                nonce_ref(&nonce_arr),
+            .decrypt_inout_detached(
+                nonce_ref(&nonce_arr)?,
                 DEK_WRAP_AD,
-                &mut buf,
-                tag_ref(&tag_arr),
+                buf.as_mut_slice().into(),
+                tag_ref(&tag_arr)?,
             )
             .map_err(|_| CryptoError::AesDecrypt)?;
 
@@ -231,37 +238,28 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, CryptoError> {
         .collect()
 }
 
-/// Zero the value portion of an environment entry in the raw `environ` block.
+/// No-op placeholder for zeroing the value portion of the `KEYSTONE_DEV_KEK`
+/// entry in the raw `environ` block on Linux.
 ///
 /// On Linux the initial environment is a contiguous array of null-terminated
 /// strings placed on the stack by the kernel.  `libc::unsetenv` (called by
 /// [`std::env::remove_var`]) removes the entry from the internal lookup but
-/// does not zero the bytes of the original string in this block.
-/// `/proc/<pid>/environ` exposes these raw bytes to any process with read
-/// access to `/proc`.
+/// does not zero the bytes of the original string in this block, so
+/// `/proc/<pid>/environ` still exposes the raw key bytes to any process with
+/// `/proc` read access for the remainder of this process's lifetime.
 ///
-/// This function iterates the raw `environ` array, finds the entry matching
-/// `KEYSTONE_DEV_KEK=`, and writes zeros over the value portion (everything
-/// after the `=` until the terminating null).
-///
-/// # Safety
-///
-/// Must only be called when no other thread is reading the environment.  This
-/// invariant holds because `from_env` is the first and only call site and runs
-/// before any async tasks are spawned.
-/// No-op: the original implementation iterated libc `environ` via `unsafe` raw
-/// pointers and attempted to zero the `KEYSTONE_DEV_KEK=` value in-place.  This
-/// turned out to be unreliable (misaligned pointers, corrupted environ arrays
-/// after `std::env::remove_var`, and segfaults in test harnesses).  The primary
-/// protections -- `env::remove_var` and the `Zeroizing<Vec<u8>>` local copy --
-/// already prevent the key from leaking through normal Rust paths.
+/// This function does **not** currently mitigate that: an earlier
+/// implementation iterated the libc `environ` array via raw pointers and
+/// wrote zeros over the value in place, but that approach was unreliable
+/// (misaligned pointers, corrupted `environ` arrays after
+/// `std::env::remove_var`, and segfaults in test harnesses) and was reverted.
+/// The primary protections — `env::remove_var` and copying the key into a
+/// `Zeroizing` buffer rather than holding onto the hex string — still prevent
+/// the key from leaking through normal Rust-level paths; only the raw
+/// `/proc/<pid>/environ` exposure is unaddressed. Reinstating a safe
+/// zeroing implementation is tracked as follow-up work.
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code)]
-fn zero_environ_entry() {
-    // The raw environ bytes in /proc/pid/environ are a best-effort hardening
-    // measure for rootkit-level attacks.  We skip it here due to the inability
-    // to safely traverse the C environ pointer array from Rust.
-}
+fn zero_environ_entry() {}
 
 #[cfg(test)]
 mod tests {
@@ -315,5 +313,74 @@ mod tests {
     #[test]
     fn test_decode_hex_odd_length() {
         assert!(decode_hex("abc").is_err());
+    }
+
+    #[test]
+    fn test_pkcs11_stub_wrap_not_implemented() {
+        let stub = Pkcs11KekStub;
+        assert!(matches!(
+            stub.wrap_dek(&[0u8; 32]),
+            Err(CryptoError::Pkcs11NotImplemented)
+        ));
+    }
+
+    #[test]
+    fn test_pkcs11_stub_unwrap_not_implemented() {
+        let stub = Pkcs11KekStub;
+        assert!(matches!(
+            stub.unwrap_dek(&[0u8; 60]),
+            Err(CryptoError::Pkcs11NotImplemented)
+        ));
+    }
+
+    // `EnvKek::from_env` reads and removes a process-global environment
+    // variable, so tests that touch it must be serialized against each other
+    // to avoid racing on shared state.
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[allow(unsafe_code)]
+    fn with_env_kek<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        match value {
+            Some(v) => unsafe { env::set_var("KEYSTONE_DEV_KEK", v) },
+            None => unsafe { env::remove_var("KEYSTONE_DEV_KEK") },
+        }
+        let result = f();
+        unsafe { env::remove_var("KEYSTONE_DEV_KEK") };
+        result
+    }
+
+    #[test]
+    fn test_from_env_success() {
+        with_env_kek(Some(&"ab".repeat(32)), || {
+            let kek = EnvKek::from_env().expect("from_env");
+            assert_eq!(kek.key.as_ref(), &[0xabu8; 32]);
+            // The variable must be removed after reading.
+            assert!(env::var("KEYSTONE_DEV_KEK").is_err());
+        });
+    }
+
+    #[test]
+    fn test_from_env_missing_var() {
+        with_env_kek(None, || {
+            assert!(matches!(EnvKek::from_env(), Err(CryptoError::KekMissing)));
+        });
+    }
+
+    #[test]
+    fn test_from_env_invalid_hex() {
+        with_env_kek(Some("not-hex!!"), || {
+            assert!(matches!(EnvKek::from_env(), Err(CryptoError::InvalidHex)));
+        });
+    }
+
+    #[test]
+    fn test_from_env_wrong_length() {
+        with_env_kek(Some(&"ab".repeat(16)), || {
+            assert!(matches!(
+                EnvKek::from_env(),
+                Err(CryptoError::InvalidKeyLength)
+            ));
+        });
     }
 }

--- a/crates/storage-crypto/src/lib.rs
+++ b/crates/storage-crypto/src/lib.rs
@@ -44,6 +44,7 @@ pub mod audit;
 pub mod cipher;
 pub mod dek;
 pub mod error;
+mod gcm;
 pub mod kek;
 pub mod mlock;
 pub mod nonce;

--- a/crates/storage-crypto/src/nonce.rs
+++ b/crates/storage-crypto/src/nonce.rs
@@ -256,6 +256,16 @@ mod tests {
     }
 
     #[test]
+    fn test_nonce_exhausted_at_rotation_threshold() {
+        let mut mgr = make_mgr(7);
+        // Drive the counter directly to the rotation threshold rather than
+        // issuing 2^31 nonces.
+        mgr.counter = ROTATION_THRESHOLD;
+        mgr.block_end = ROTATION_THRESHOLD;
+        assert!(matches!(mgr.next_nonce(), Err(CryptoError::NonceExhausted)));
+    }
+
+    #[test]
     fn test_rollback_detection() {
         let store = MemNonce::default();
         // Simulate a previous session that reached counter 2048 (hwm = 2048).

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -83,6 +83,7 @@ rustls.workspace = true
 serial_test.workspace = true
 temp-env.workspace = true
 tempfile.workspace = true
+time = "0.3"
 tracing-subscriber.workspace = true
 tonic = { workspace = true, features = ["tls-aws-lc"] }
 tracing-test.workspace = true

--- a/crates/storage/benches/state_machine.rs
+++ b/crates/storage/benches/state_machine.rs
@@ -32,6 +32,7 @@ fn bench_state_machine(c: &mut Criterion) {
     let revoked_deks: Arc<Mutex<HashSet<u32>>> = Arc::new(Mutex::new(HashSet::new()));
     let kek: Arc<dyn KekProvider> = Arc::new(EnvKek::from_bytes([0x42u8; 32]));
     let (_reencrypt_tx, _reencrypt_rx) = tokio::sync::mpsc::channel::<Arc<DekEpoch>>(16);
+    let (_quarantine_tx, _quarantine_rx) = tokio::sync::mpsc::channel::<(u64, String)>(16);
     let pending_rotations: Arc<
         Mutex<
             HashMap<String, openstack_keystone_distributed_storage::store_command::PendingRotation>,
@@ -42,11 +43,13 @@ fn bench_state_machine(c: &mut Criterion) {
         FjallStateMachine::new(
             db,
             snapshot_dir,
+            1, // node_id
             current_dek,
             old_deks,
             revoked_deks,
             kek,
             _reencrypt_tx,
+            _quarantine_tx,
             pending_rotations,
         )
         .unwrap(),

--- a/crates/storage/benches/write.rs
+++ b/crates/storage/benches/write.rs
@@ -37,7 +37,7 @@ struct InstanceHolder {
     pub node_id: u64,
     pub config: Config,
     storage_dir: TempDir,
-    pub storage: Storage,
+    pub storage: Arc<Storage>,
     pub addr: SocketAddr,
 }
 
@@ -128,6 +128,12 @@ fn make_certificates() -> Result<TlsConfiguration> {
 
     // 2. Generate peer certificate (signed by CA)
     let mut peer_cert_params = CertificateParams::default();
+
+    // Leaf cert validity must not exceed 30 days (ADR 0016-v2 §4.2, enforced
+    // by check_cert_max_validity via get_client_tls_config/get_server_tls_config).
+    let now = time::OffsetDateTime::now_utc();
+    peer_cert_params.not_before = now - time::Duration::days(1);
+    peer_cert_params.not_after = now + time::Duration::days(28);
 
     let client_ip: IpAddr = "127.0.0.1".parse()?;
     peer_cert_params.subject_alt_names = vec![SanType::IpAddress(client_ip)];

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -19,7 +19,7 @@ use dashmap::DashMap;
 use eyre::eyre;
 use openraft::Config;
 use openraft::async_runtime::WatchReceiver;
-use openstack_keystone_storage_crypto::{DekEpoch, EnvKek, KekProvider};
+use openstack_keystone_storage_crypto::{DekEpoch, EnvKek, KekProvider, Pkcs11KekStub};
 
 use crate::protobuf as pb;
 use openraft::ReadPolicy;
@@ -129,7 +129,7 @@ async fn check_node_id_uniqueness(
 ///
 /// # Returns
 /// A `Result` containing the `Storage` instance, or a `StoreError`.
-pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage, StoreError> {
+pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Arc<Storage>, StoreError> {
     // Create a configuration for the raft instance.
     let raft_config = Arc::new(
         Config {
@@ -150,13 +150,31 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
         .ok_or(StoreError::ConfigMissing)?
         .clone();
 
-    // Read and erase the Key Encryption Key from the environment before any
-    // further initialisation (ADR 0016-v2 §2.1).  Erasing it first means core
+    // Select and load the Key Encryption Key before any further
+    // initialisation (ADR 0016-v2 §2.1).  Loading/erasing it first means core
     // dumps triggered during preflight cannot leak the key.
-    let kek: Arc<dyn KekProvider> = Arc::new(
-        EnvKek::from_env()
-            .map_err(|e| StoreError::Other(eyre!("failed to load KEYSTONE_DEV_KEK: {e}")))?,
-    );
+    //
+    // The environment-provided KEK is a dev-mode-only fallback: ADR 0016-v2
+    // §2.1 and invariant 6 require both `--dev-mode` and
+    // `KEYSTONE_ALLOW_ENV_KEK=1` before it may be used. Outside dev-mode there
+    // is currently no production KekProvider implementation (HSM/PKCS#11/KMS
+    // is not yet wired up — see Pkcs11KekStub), so the node refuses to start
+    // rather than silently falling back to an environment-provided key.
+    let kek: Arc<dyn KekProvider> = if ds_config.dev_mode {
+        if std::env::var("KEYSTONE_ALLOW_ENV_KEK").as_deref() != Ok("1") {
+            return Err(StoreError::Other(eyre!(
+                "dev_mode is enabled but KEYSTONE_ALLOW_ENV_KEK=1 is not set; \
+                 refusing to start with an environment-provided KEK \
+                 (ADR 0016-v2 §2.1, invariant 6)"
+            )));
+        }
+        Arc::new(
+            EnvKek::from_env()
+                .map_err(|e| StoreError::Other(eyre!("failed to load KEYSTONE_DEV_KEK: {e}")))?,
+        )
+    } else {
+        Arc::new(Pkcs11KekStub)
+    };
 
     // Run OS-level security pre-flight checks after key material is cleared.
     // In production mode (dev_mode = false) any failure is fatal per ADR
@@ -172,13 +190,17 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
     }
 
     // Create stores and network
-    let (log_store, sm, current_dek, _revoked_deks, pending_rotations) =
+    let (log_store, sm, current_dek, _revoked_deks, pending_rotations, quarantine_rx) =
         crate::new::<crate::TypeConfig, _>(ds_config.path, ds_config.node_id, kek.clone()).await?;
     let state_machine_store = Arc::new(sm);
     let tls_client = init_tls_watcher(config_manager).await?;
     let network = Arc::new(NetworkManager::new(tls_client.clone())?);
 
-    // Spawn TLS cert expiry watchdog for manual-TLS fallback (ADR §4.2).
+    // Spawn expiry watchdog for manual-TLS fallback (ADR §4.2). The 30-day
+    // max-validity cap itself is enforced inside `get_client_tls_config` /
+    // `get_server_tls_config` (network.rs) on every load — including the
+    // `init_tls_watcher` call above — so it's checked here on startup and on
+    // every subsequent hot-reload, not just once.
     if let openstack_keystone_config::RaftTlsConfiguration::Tls(tls) = &ds_config.tls_configuration
         && let Some(cert_content) = tls.tls_cert_content.as_ref()
     {
@@ -204,10 +226,10 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
 
     // Derive the per-node audit HMAC key from the current DEK epoch (ADR §3.1).
     let audit_key = {
-        let guard = current_dek.read().unwrap();
+        let guard = current_dek.read().unwrap_or_else(|p| p.into_inner());
         guard
             .derive_audit_key(ds_config.node_id)
-            .expect("derive audit key from DEK")
+            .map_err(|e| StoreError::Other(eyre!("failed to derive audit HMAC key: {e}")))?
     };
     let (audit_forwarder, _audit_task) = AuditForwarder::spawn(audit_key);
 
@@ -227,7 +249,7 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
             (None, String::new(), String::new(), Vec::new())
         };
 
-    Ok(Storage {
+    let storage = Arc::new(Storage {
         connection_pool: DashMap::new(),
         raft,
         node_id: ds_config.node_id,
@@ -241,7 +263,39 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Storage
         spiffe_path_prefix,
         operator_role,
         allowed_peer_svids,
-    })
+    });
+
+    // Best-effort background forwarding of Raft-committed quarantine events
+    // (ADR 0016-v2 §10 invariant 5). The local, synchronous quarantine
+    // already took effect in FjallStateMachine::decrypt_state before this
+    // channel is signalled; this task only propagates the fact cluster-wide.
+    //
+    // Holds a Weak reference so this task never keeps `Storage` (and the
+    // underlying Fjall database handle) alive on its own — once the last
+    // strong reference is dropped, the next upgrade() fails and the task
+    // exits instead of leaking the node's resources indefinitely.
+    {
+        let storage_weak = Arc::downgrade(&storage);
+        let mut quarantine_rx = quarantine_rx;
+        tokio::spawn(async move {
+            while let Some((node_id, partition)) = quarantine_rx.recv().await {
+                let Some(storage) = storage_weak.upgrade() else {
+                    break;
+                };
+                if let Err(e) = storage.propose_quarantine(node_id, partition.clone()).await {
+                    tracing::warn!(
+                        node_id,
+                        partition,
+                        error = %e,
+                        "failed to propose quarantine via Raft; local quarantine \
+                         remains in effect, cluster-wide visibility delayed"
+                    );
+                }
+            }
+        });
+    }
+
+    Ok(storage)
 }
 
 /// Build a tonic `Server` instance for the raft instance.
@@ -421,6 +475,7 @@ impl StorageApi for Storage {
                     metadata.tier as u8,
                     &keyspace_bytes,
                     key,
+                    metadata.dek_version,
                 )?;
                 Ok(Some(StoreDataEnvelope { data, metadata }))
             })();
@@ -519,7 +574,13 @@ impl StorageApi for Storage {
             .map(|(k, val_bytes, meta)| {
                 let data = self
                     .state_machine_store
-                    .decrypt_state(&val_bytes, meta.tier as u8, &keyspace_bytes, k.as_bytes())
+                    .decrypt_state(
+                        &val_bytes,
+                        meta.tier as u8,
+                        &keyspace_bytes,
+                        k.as_bytes(),
+                        meta.dek_version,
+                    )
                     .map_err(ApiStoreError::from)?;
                 Ok((
                     k,
@@ -809,7 +870,8 @@ impl Storage {
     }
 
     /// Forward a `get_by_key` read to the leader via gRPC.
-    /// Leader decrypts and returns plaintext; follower wraps it in StoreDataEnvelope.
+    /// Leader decrypts and returns plaintext; follower wraps it in
+    /// StoreDataEnvelope.
     async fn forwarded_get_by_key(
         &self,
         leader_id: u64,
@@ -947,6 +1009,22 @@ impl Storage {
             }
             Err(other) => Err(other)?,
         }
+    }
+
+    /// Propose a `Quarantine` mutation via Raft, forwarding to the leader if
+    /// this node is not currently leader (ADR 0016-v2 §10 invariant 5).
+    ///
+    /// Called from the background quarantine-forwarding task in
+    /// [`init_storage`] whenever a local GCM failure threshold is reached.
+    /// Best effort: the local, synchronous quarantine (in-memory block plus
+    /// local Fjall marker) already took effect before this is invoked, so a
+    /// failure here only delays cluster-wide visibility, not local safety.
+    async fn propose_quarantine(&self, node_id: u64, partition: String) -> Result<(), StoreError> {
+        let cmd = StoreCommand::Transaction(vec![MutationInner::Quarantine { node_id, partition }]);
+        let payload = crate::pb::api::CommandRequest::try_from(cmd)
+            .map_err(|e| StoreError::Other(eyre::eyre!("{e}")))?;
+        self.write_command_to_storage(payload).await?;
+        Ok(())
     }
 
     /// Generic retry loop: on `Unavailable` with leader metadata, switch

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -28,6 +28,7 @@ use tracing::trace;
 use crate::StoreError;
 use crate::app::normalize_rpc_addr;
 use crate::audit::{AuditForwarder, AuditRecord};
+use crate::network::{check_svid_ttl_der, now_unix_secs};
 use crate::pb;
 use crate::protobuf::raft::cluster_admin_service_server::ClusterAdminService;
 use crate::store_command::{MutationInner, PendingRotation, StoreCommand};
@@ -153,6 +154,7 @@ fn require_operator<T>(
                     "SPIFFE mode is active; peer must present a SPIFFE URI SAN",
                 ));
             }
+            check_svid_ttl(request)?;
             let role = parse_spiffe_storage_id(&identity, domains, spiffe_path_prefix)?;
             if role != operator_role {
                 return Err(Status::permission_denied(format!(
@@ -191,6 +193,11 @@ fn check_peer_trust_domain<T>(
         return Err(Status::permission_denied(
             "SPIFFE mode is active; peer must present a SPIFFE URI SAN",
         ));
+    }
+
+    // In SPIFFE mode, enforce the 5-minute force-renewal window (ADR 0016-v2 §4.1).
+    if trust_domains.is_some() {
+        check_svid_ttl(request)?;
     }
 
     if allowed_peer_svids.is_empty() {
@@ -233,6 +240,25 @@ fn parse_spiffe_trust_domain(id: &str, trust_domains: &[String]) -> Result<(), S
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// SVID TTL enforcement (ADR 0016-v2 §4.1 — force-renewal window)
+// ---------------------------------------------------------------------------
+
+/// Extracts the peer certificate from `request` and enforces the SVID
+/// force-renewal window (ADR 0016-v2 §4.1). Only called in SPIFFE mode.
+///
+/// Redundant with the `SpiffeIdInterceptor` that already runs this check for
+/// every request reaching this service (`raft_grpc::validate_spiffe_id`) —
+/// kept as defense-in-depth on the RBAC-sensitive admin surface rather than
+/// relying solely on the interceptor layer.
+fn check_svid_ttl<T>(request: &tonic::Request<T>) -> Result<(), Status> {
+    let der = request
+        .peer_certs()
+        .and_then(|certs| certs.first().map(|c| c.as_ref().to_vec()))
+        .ok_or_else(|| Status::permission_denied("no peer certificate presented"))?;
+    check_svid_ttl_der(&der, now_unix_secs())
 }
 
 /// Raft cluster administrative operations.
@@ -868,8 +894,16 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
             tokio::io::AsyncReadExt::read_exact(&mut file, &mut header)
                 .await
                 .map_err(|e| Status::internal(format!("cannot read snapshot header: {e}")))?;
-            let dv = u32::from_be_bytes(header[..4].try_into().unwrap());
-            let ue = u64::from_be_bytes(header[4..12].try_into().unwrap());
+            let dv = u32::from_be_bytes(
+                header[..4]
+                    .try_into()
+                    .map_err(|_| Status::internal("corrupt snapshot header (dek_version)"))?,
+            );
+            let ue = u64::from_be_bytes(
+                header[4..12]
+                    .try_into()
+                    .map_err(|_| Status::internal("corrupt snapshot header (utc_epoch)"))?,
+            );
             (file, header, dv, ue)
         };
 
@@ -1219,5 +1253,50 @@ mod tests {
             normalize_rpc_addr(from_config),
             "stored bare address must match config Uri::Display format"
         );
+    }
+
+    // SVID TTL enforcement (ADR 0016-v2 §4.1 — force-renewal window)
+
+    // Unix timestamp of 2100-01-01 00:00:00 UTC (used as a stable not_after
+    // anchor).
+    const NOT_AFTER_2100_UNIX: i64 = 4_102_444_800;
+
+    fn make_svid_der_not_after_2100() -> Vec<u8> {
+        use rcgen::{CertificateParams, KeyPair, date_time_ymd};
+        let mut params = CertificateParams::default();
+        params.not_before = date_time_ymd(2000, 1, 1);
+        params.not_after = date_time_ymd(2100, 1, 1);
+        let key = KeyPair::generate().expect("keygen");
+        params
+            .self_signed(&key)
+            .expect("self-sign")
+            .der()
+            .as_ref()
+            .to_vec()
+    }
+
+    #[test]
+    fn svid_ttl_ok() {
+        let der = make_svid_der_not_after_2100();
+        // 10 minutes before expiry — well outside the 5-minute window.
+        assert!(check_svid_ttl_der(&der, NOT_AFTER_2100_UNIX - 600).is_ok());
+    }
+
+    #[test]
+    fn svid_ttl_force_renewal_window() {
+        let der = make_svid_der_not_after_2100();
+        // 4 minutes before expiry — inside the 5-minute force-renewal window.
+        let err = check_svid_ttl_der(&der, NOT_AFTER_2100_UNIX - 240)
+            .expect_err("should fail inside force-renewal window");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[test]
+    fn svid_ttl_expired() {
+        let der = make_svid_der_not_after_2100();
+        // 1 second past expiry.
+        let err = check_svid_ttl_der(&der, NOT_AFTER_2100_UNIX + 1)
+            .expect_err("should fail when expired");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
     }
 }

--- a/crates/storage/src/grpc/storage_service.rs
+++ b/crates/storage/src/grpc/storage_service.rs
@@ -127,13 +127,28 @@ impl StorageService for StorageServiceImpl {
 
         let not_found = encrypted.is_none() || metadata.is_none();
         let tier = (metadata.as_ref().map(|m| m.tier as u8)).unwrap_or(DataTier::Internal as u8);
+        let dek_version = metadata.as_ref().and_then(|m| m.dek_version);
 
         let value = encrypted.and_then(|enc| {
             let keyspace_name = req.keyspace.as_deref().unwrap_or("data");
             let keyspace_bytes = keyspace_name.as_bytes();
-            self.state_machine_store
-                .decrypt_state(&enc, tier, keyspace_bytes, key.as_bytes())
-                .ok()
+            match self.state_machine_store.decrypt_state(
+                &enc,
+                tier,
+                keyspace_bytes,
+                key.as_bytes(),
+                dek_version,
+            ) {
+                Ok(plaintext) => Some(plaintext),
+                Err(e) => {
+                    // Collapsed to the same wire response as "not found" below
+                    // (the forwarded-get protocol has no distinct error slot),
+                    // but logged so an operator can tell a quarantined/corrupt
+                    // record apart from a genuinely missing key.
+                    tracing::warn!(key, error = %e, "forwarded_get: decrypt_state failed");
+                    None
+                }
+            }
         });
 
         let metadata_bytes = metadata
@@ -186,22 +201,40 @@ impl StorageService for StorageServiceImpl {
                     Err(_) => return None,
                 };
 
-                // Read metadata to determine tier
-                let (tier, meta_bytes) = match meta.get(k.as_bytes()) {
-                    Ok(Some(raw)) => (
-                        Metadata::unpack(raw.as_ref())
-                            .map(|m| m.tier as u8)
-                            .unwrap_or(DataTier::Internal as u8),
-                        raw.to_vec(),
-                    ),
-                    _ => (DataTier::Internal as u8, Vec::new()),
+                // Read metadata to determine tier and DEK epoch
+                let (tier, dek_version, meta_bytes) = match meta.get(k.as_bytes()) {
+                    Ok(Some(raw)) => {
+                        let parsed = Metadata::unpack(raw.as_ref()).ok();
+                        (
+                            parsed
+                                .as_ref()
+                                .map(|m| m.tier as u8)
+                                .unwrap_or(DataTier::Internal as u8),
+                            parsed.and_then(|m| m.dek_version),
+                            raw.to_vec(),
+                        )
+                    }
+                    _ => (DataTier::Internal as u8, None, Vec::new()),
                 };
 
                 // Decrypt using leader's DEK
-                let data = self
-                    .state_machine_store
-                    .decrypt_state(&val, tier, keyspace_bytes, k.as_bytes())
-                    .ok()?;
+                let data = match self.state_machine_store.decrypt_state(
+                    &val,
+                    tier,
+                    keyspace_bytes,
+                    k.as_bytes(),
+                    dek_version,
+                ) {
+                    Ok(plaintext) => plaintext,
+                    Err(e) => {
+                        // Omitted from results (same as any other filtered-out
+                        // entry) but logged so a quarantined/corrupt record is
+                        // distinguishable from one that simply doesn't match
+                        // the prefix.
+                        tracing::warn!(key = k, error = %e, "forwarded_prefix: decrypt_state failed");
+                        return None;
+                    }
+                };
 
                 Some(pb::api::PrefixEntry {
                     key: k,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -125,7 +125,10 @@ openraft::declare_raft_types!(
 ///
 /// # Returns
 /// `(FjallLogStore, FjallStateMachine, Arc<RwLock<Arc<DekEpoch>>>,
-/// Arc<Mutex<HashSet<u32>>>, Arc<Mutex<HashMap<String, PendingRotation>>>)`.
+/// Arc<Mutex<HashSet<u32>>>, Arc<Mutex<HashMap<String, PendingRotation>>>,
+/// Receiver<(u64, String)>)`. The receiver yields `(node_id, partition)`
+/// quarantine events that the caller should propose via Raft once it has a
+/// handle to the `Raft` instance (see `app::init_storage`).
 pub async fn new<C, P: AsRef<Path>>(
     db_path: P,
     node_id: u64,
@@ -137,6 +140,7 @@ pub async fn new<C, P: AsRef<Path>>(
         Arc<RwLock<Arc<DekEpoch>>>,
         Arc<Mutex<HashSet<u32>>>,
         Arc<Mutex<HashMap<String, store_command::PendingRotation>>>,
+        tokio::sync::mpsc::Receiver<(u64, String)>,
     ),
     io::Error,
 >
@@ -160,7 +164,10 @@ where
     let retired_map =
         load_retired_deks(&db, kek.as_ref()).map_err(|e| io::Error::other(e.to_string()))?;
     let old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>> = Arc::new(Mutex::new(retired_map));
-    let revoked_deks: Arc<Mutex<HashSet<u32>>> = Arc::new(Mutex::new(HashSet::new()));
+    // Load revoked DEK versions from Fjall so an emergency rotation's
+    // containment guarantee survives a restart (ADR 0016-v2 §6.2 step 5).
+    let revoked_set = load_revoked_deks(&db).map_err(|e| io::Error::other(e.to_string()))?;
+    let revoked_deks: Arc<Mutex<HashSet<u32>>> = Arc::new(Mutex::new(revoked_set));
 
     // Load any pending emergency rotations that were staged before a restart.
     let meta_ks = db
@@ -183,6 +190,8 @@ where
         }
     });
 
+    let (quarantine_tx, quarantine_rx) = tokio::sync::mpsc::channel::<(u64, String)>(16);
+
     let log_store = FjallLogStore::new(
         db.clone(),
         node_id,
@@ -195,16 +204,25 @@ where
     let sm = FjallStateMachine::new(
         db,
         snapshot_dir,
+        node_id,
         current_dek.clone(),
         old_deks,
         revoked_deks.clone(),
         kek,
         reencrypt_tx,
+        quarantine_tx,
         pending_rotations.clone(),
     )
     .map_err(|e| io::Error::other(e.to_string()))?;
 
-    Ok((log_store, sm, current_dek, revoked_deks, pending_rotations))
+    Ok((
+        log_store,
+        sm,
+        current_dek,
+        revoked_deks,
+        pending_rotations,
+        quarantine_rx,
+    ))
 }
 
 /// Fjall meta key prefix for retired DEK epochs (mirrors the constant in
@@ -262,6 +280,45 @@ fn load_retired_deks(
         }
     }
     Ok(map)
+}
+
+/// Fjall meta key prefix for revoked DEK epochs (mirrors the constant in
+/// state_machine).
+const DEK_REVOKED_PREFIX: &str = crate::store::state_machine::DEK_REVOKED_PREFIX;
+
+/// Load revoked DEK versions from Fjall meta so an emergency rotation's
+/// containment guarantee survives a restart (ADR 0016-v2 §6.2 step 5).
+///
+/// Only the version is recovered — the stored value is a revocation
+/// timestamp, never key material, since revoked DEKs are discarded
+/// immediately and must never be reconstructable.
+fn load_revoked_deks(db: &Database) -> Result<HashSet<u32>, StoreError> {
+    let meta = db.keyspace("meta", fjall::KeyspaceCreateOptions::default)?;
+    let mut set = HashSet::new();
+    for item in meta.prefix(DEK_REVOKED_PREFIX.as_bytes()) {
+        let (key_bytes, _) = item.into_inner()?;
+        let key_str = match std::str::from_utf8(&key_bytes) {
+            Ok(s) => s.to_owned(),
+            Err(_) => continue,
+        };
+        let version_str = match key_str.strip_prefix(DEK_REVOKED_PREFIX) {
+            Some(s) => s,
+            None => continue,
+        };
+        match version_str.parse::<u32>() {
+            Ok(version) => {
+                tracing::info!(version, "loaded revoked DEK marker");
+                set.insert(version);
+            }
+            Err(_) => {
+                tracing::warn!(
+                    key = key_str,
+                    "revoked DEK key has non-numeric version suffix"
+                );
+            }
+        }
+    }
+    Ok(set)
 }
 
 /// Load the current DEK epoch from Fjall, or generate and persist a new one.
@@ -351,7 +408,7 @@ mod tests {
                 TempDir::new().map_err(|e| StorageError::read(TypeConfig::err_from_error(&e)))?;
             let kek: Arc<dyn openstack_keystone_storage_crypto::KekProvider> =
                 Arc::new(EnvKek::from_bytes([0x42u8; 32]));
-            let (log_store, sm, _current_dek, _revoked, _pending_rotations) =
+            let (log_store, sm, _current_dek, _revoked, _pending_rotations, _quarantine_rx) =
                 crate::new(td.path(), 1, kek)
                     .await
                     .map_err(|e| StorageError::read(TypeConfig::err_from_error(&e)))?;
@@ -364,6 +421,31 @@ mod tests {
     pub fn test_fjall_store() {
         TypeConfig::run(async {
             Suite::test_all(FjallBuilder {}).await.unwrap();
+        });
+    }
+
+    /// Revoked DEK markers persisted to Fjall meta must be picked back up by
+    /// `load_revoked_deks` after a restart (ADR 0016-v2 §6.2 step 5).
+    #[test]
+    #[traced_test]
+    fn revoked_dek_marker_survives_restart() {
+        TypeConfig::run(async {
+            let td = TempDir::new().expect("tempdir");
+            let db = Arc::new(fjall::Database::builder(td.path()).open().expect("open db"));
+            let meta = db
+                .keyspace("meta", fjall::KeyspaceCreateOptions::default)
+                .expect("meta keyspace");
+
+            // Simulate what the InstallDek apply path writes for an emergency
+            // rotation: version + revocation timestamp, never key material.
+            let revoked_key = format!("{}{}", super::DEK_REVOKED_PREFIX, 3u32);
+            meta.insert(revoked_key.as_bytes(), 1_700_000_000u64.to_be_bytes())
+                .expect("insert revoked marker");
+            db.persist(fjall::PersistMode::SyncAll).expect("persist");
+
+            let loaded = super::load_revoked_deks(&db).expect("load revoked deks");
+            assert!(loaded.contains(&3u32));
+            assert_eq!(loaded.len(), 1);
         });
     }
 }

--- a/crates/storage/src/network.rs
+++ b/crates/storage/src/network.rs
@@ -31,6 +31,7 @@ use secrecy::ExposeSecret;
 use spiffe::X509Source;
 use spiffe_rustls::{authorizer, mtls_client};
 use tokio::sync::watch;
+use tonic::Status;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity, ServerTlsConfig};
 use tracing::error;
 
@@ -489,6 +490,87 @@ fn check_cert_expiry(cert_pem: &[u8], shutdown_on_expiry: bool) {
     }
 }
 
+/// Enforces the 30-day maximum leaf certificate validity window (ADR 0016-v2
+/// §4.2).
+///
+/// Returns `Err` if the certificate's total validity window (`not_after −
+/// not_before`) exceeds 30 days. Called at startup before the gRPC listener
+/// accepts connections; the node refuses to start if the cert violates this
+/// invariant.
+pub fn check_cert_max_validity(cert_pem: &[u8]) -> Result<(), StoreError> {
+    use x509_parser::certificate::X509Certificate;
+    use x509_parser::pem::parse_x509_pem;
+    use x509_parser::prelude::FromDer;
+
+    let (_, pem) = parse_x509_pem(cert_pem)
+        .map_err(|e| StoreError::Other(eyre::eyre!("TLS cert PEM parse failed: {e}")))?;
+    let (_, cert) = X509Certificate::from_der(&pem.contents)
+        .map_err(|e| StoreError::Other(eyre::eyre!("TLS cert DER parse failed: {e}")))?;
+
+    let validity = cert.validity();
+    let window_secs = validity
+        .not_after
+        .timestamp()
+        .saturating_sub(validity.not_before.timestamp());
+
+    const MAX_VALIDITY_SECS: i64 = 30 * 24 * 3600;
+
+    if window_secs > MAX_VALIDITY_SECS {
+        return Err(StoreError::Other(eyre::eyre!(
+            "TLS leaf certificate validity ({} days) exceeds the 30-day maximum \
+             enforced by ADR 0016-v2 §4.2; reissue with a shorter validity period",
+            window_secs / 86400
+        )));
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// SVID TTL enforcement (ADR 0016-v2 §4.1 — force-renewal window)
+// ---------------------------------------------------------------------------
+
+/// Minimum remaining SVID validity before refusing an inbound SPIFFE SVID
+/// (ADR 0016-v2 §4.1 — force-renewal window).
+pub const FORCE_RENEWAL_SECS: i64 = 5 * 60;
+
+/// Current Unix timestamp in seconds, saturating to 0 on a pre-epoch clock.
+///
+/// Shared by every `check_svid_ttl_der` call site so the
+/// `SystemTime::now().duration_since(UNIX_EPOCH)...` boilerplate exists in
+/// exactly one place.
+pub fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// Enforces the SVID force-renewal window on a raw DER certificate.
+///
+/// Returns `Err(PERMISSION_DENIED)` if the SVID has fewer than 5 minutes of
+/// remaining validity. `now_secs` is the current Unix timestamp, injected for
+/// testability — pass [`now_unix_secs`] at call sites.
+pub fn check_svid_ttl_der(der: &[u8], now_secs: i64) -> Result<(), Status> {
+    let (_, cert) = x509_parser::parse_x509_certificate(der)
+        .map_err(|_| Status::permission_denied("peer certificate is malformed"))?;
+
+    let not_after = cert.validity().not_after.timestamp();
+    let remaining = not_after.saturating_sub(now_secs);
+
+    if remaining <= 0 {
+        return Err(Status::permission_denied(
+            "peer SVID has expired; refused per ADR 0016-v2 §4.1",
+        ));
+    }
+    if remaining < FORCE_RENEWAL_SECS {
+        return Err(Status::permission_denied(
+            "peer SVID is in the force-renewal window; refused per ADR 0016-v2 §4.1",
+        ));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Static mTLS config helpers (Tls variant of RaftTlsConfiguration)
 // ---------------------------------------------------------------------------
@@ -498,11 +580,18 @@ pub fn get_client_tls_config(config: &Config) -> Result<ClientTlsConfig, StoreEr
     if let Some(ds) = &config.distributed_storage
         && let RaftTlsConfiguration::Tls(tls) = &ds.tls_configuration
     {
+        let cert_pem = tls
+            .tls_cert_content
+            .as_ref()
+            .ok_or(StoreError::TlsConfigMissing)?
+            .expose_secret();
+        // Enforced here (not just once at process startup) so every load of
+        // this shared config — including config-watcher hot-reloads in
+        // `init_tls_watcher` and standalone callers such as `cli-manage` —
+        // rejects an over-long-lived leaf cert (ADR 0016-v2 §4.2).
+        check_cert_max_validity(cert_pem)?;
         let identity = Identity::from_pem(
-            tls.tls_cert_content
-                .as_ref()
-                .ok_or(StoreError::TlsConfigMissing)?
-                .expose_secret(),
+            cert_pem,
             tls.tls_key_content
                 .as_ref()
                 .ok_or(StoreError::TlsConfigMissing)?
@@ -524,11 +613,16 @@ pub fn get_server_tls_config(config: &Config) -> Result<ServerTlsConfig, StoreEr
     if let Some(ds) = &config.distributed_storage
         && let RaftTlsConfiguration::Tls(tls) = &ds.tls_configuration
     {
+        let cert_pem = tls
+            .tls_cert_content
+            .as_ref()
+            .ok_or(StoreError::TlsConfigMissing)?
+            .expose_secret();
+        // See `get_client_tls_config` — same 30-day cap (ADR 0016-v2 §4.2),
+        // enforced on every load of this shared config.
+        check_cert_max_validity(cert_pem)?;
         let identity = Identity::from_pem(
-            tls.tls_cert_content
-                .as_ref()
-                .ok_or(StoreError::TlsConfigMissing)?
-                .expose_secret(),
+            cert_pem,
             tls.tls_key_content
                 .as_ref()
                 .ok_or(StoreError::TlsConfigMissing)?
@@ -674,6 +768,49 @@ pub async fn init_tls_watcher(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---------------------------------------------------------------------------
+    // check_cert_max_validity — P3-A (ADR 0016-v2 §4.2)
+    // ---------------------------------------------------------------------------
+
+    fn make_cert_pem(not_before: (i32, u8, u8), not_after: (i32, u8, u8)) -> Vec<u8> {
+        use rcgen::{CertificateParams, KeyPair, date_time_ymd};
+        let mut params = CertificateParams::default();
+        params.not_before = date_time_ymd(not_before.0, not_before.1, not_before.2);
+        params.not_after = date_time_ymd(not_after.0, not_after.1, not_after.2);
+        let key = KeyPair::generate().expect("keygen");
+        params
+            .self_signed(&key)
+            .expect("self-sign")
+            .pem()
+            .as_bytes()
+            .to_vec()
+    }
+
+    #[test]
+    fn cert_max_validity_ok_29_days() {
+        // June 1 → June 30 = 29 days
+        let pem = make_cert_pem((2026, 6, 1), (2026, 6, 30));
+        assert!(check_cert_max_validity(&pem).is_ok());
+    }
+
+    #[test]
+    fn cert_max_validity_ok_exactly_30_days() {
+        // June 1 → July 1 = exactly 30 days
+        let pem = make_cert_pem((2026, 6, 1), (2026, 7, 1));
+        assert!(check_cert_max_validity(&pem).is_ok());
+    }
+
+    #[test]
+    fn cert_max_validity_rejected_31_days() {
+        // June 1 → July 2 = 31 days
+        let pem = make_cert_pem((2026, 6, 1), (2026, 7, 2));
+        assert!(check_cert_max_validity(&pem).is_err());
+    }
+
+    // ---------------------------------------------------------------------------
+    // strip_scheme
+    // ---------------------------------------------------------------------------
 
     #[test]
     fn test_strip_scheme_https() {

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -61,6 +61,10 @@ const WRITE_RATE_THRESHOLD: u32 = 1u32 << 30;
 const WRITE_RATE_WARN_THRESHOLD: u32 = WRITE_RATE_THRESHOLD / 10 * 9;
 
 /// Fjall meta key prefix for persisted quarantine markers.
+///
+/// Full key layout is `_meta:quarantine:<partition>:<node_id>`: partition
+/// comes first so that `ClearQuarantine` can prefix-scan and remove every
+/// reporting node's entry for a partition in one pass.
 const QUARANTINE_META_PREFIX: &str = "_meta:quarantine:";
 
 /// Sliding window for GCM failure counting.
@@ -69,15 +73,21 @@ const QUARANTINE_WINDOW: Duration = Duration::from_secs(60);
 /// Number of GCM failures within `QUARANTINE_WINDOW` that triggers quarantine.
 const QUARANTINE_THRESHOLD: usize = 3;
 
+/// Builds the Fjall meta key for a quarantine marker.
+fn quarantine_meta_key(partition: &str, node_id: u64) -> String {
+    format!("{QUARANTINE_META_PREFIX}{partition}:{node_id}")
+}
+
 /// Per-partition GCM decryption failure tracker with automatic quarantine.
 ///
 /// A partition accumulates failure `Instant`s in a 60-second sliding window.
-/// At three failures the partition is marked quarantined and the marker is
-/// persisted to Fjall `meta` so it survives restarts.
-///
-/// Quarantine can be cleared by an operator via
-/// `FjallStateMachine::clear_quarantine`.
-#[derive(Default)]
+/// At three failures the partition is marked quarantined locally and — best
+/// effort — the fact is proposed via Raft so it is committed cluster-wide
+/// (ADR 0016-v2 §10 invariant 5). The in-memory `quarantined` set (which
+/// gates local reads) only ever reflects *this* node's own quarantine state;
+/// records reported by other nodes are persisted for audit visibility but
+/// never block local reads, since GCM failures reflect node-local storage
+/// corruption, not a cluster-wide data problem.
 struct QuarantineTracker {
     failures: Mutex<HashMap<String, VecDeque<Instant>>>,
     quarantined: Mutex<HashSet<String>>,
@@ -85,17 +95,67 @@ struct QuarantineTracker {
 
 impl QuarantineTracker {
     /// Initialise from Fjall meta, loading any persisted quarantine markers.
-    fn from_meta(meta: &Keyspace) -> Result<Self, crate::StoreError> {
+    ///
+    /// Only markers reported by `node_id` (this node) are loaded into the
+    /// blocking `quarantined` set; markers from other nodes are logged for
+    /// visibility but otherwise ignored.
+    fn from_meta(meta: &Keyspace, node_id: u64) -> Result<Self, crate::StoreError> {
         let mut quarantined = HashSet::new();
-        for item in meta.prefix(QUARANTINE_META_PREFIX.as_bytes()) {
-            let (key_bytes, _) = item.into_inner()?;
-            if let Ok(key_str) = String::from_utf8(key_bytes.to_vec())
-                && let Some(partition) = key_str.strip_prefix(QUARANTINE_META_PREFIX)
-            {
-                quarantined.insert(partition.to_string());
+
+        // Collect first, then mutate: `insert`/`remove` below (legacy-key
+        // migration) must not run against a live prefix iterator.
+        let entries: Vec<Vec<u8>> = meta
+            .prefix(QUARANTINE_META_PREFIX.as_bytes())
+            .filter_map(|item| item.into_inner().ok())
+            .map(|(k, _)| k.to_vec())
+            .collect();
+
+        for key_bytes in entries {
+            let Ok(key_str) = String::from_utf8(key_bytes.clone()) else {
+                continue;
+            };
+            let Some(rest) = key_str.strip_prefix(QUARANTINE_META_PREFIX) else {
+                continue;
+            };
+
+            let (partition, reporting_node) = match rest.rsplit_once(':') {
+                Some((partition, node_id_str)) => {
+                    let Ok(reporting_node) = node_id_str.parse::<u64>() else {
+                        continue;
+                    };
+                    (partition.to_string(), reporting_node)
+                }
+                None => {
+                    // Pre-migration marker (`_meta:quarantine:<partition>`,
+                    // no node-id suffix). These predate cluster-wide
+                    // quarantine propagation and were always node-local
+                    // (each node owns its own Fjall DB), so treat this as
+                    // this node's own marker and rewrite it to the
+                    // node-scoped key format. Left as-is it would silently
+                    // fail to load on every future restart (no colon to
+                    // split on), quietly ending a quarantine that's still
+                    // supposed to be in effect.
+                    tracing::warn!(
+                        partition = rest,
+                        "migrating pre-upgrade quarantine marker to node-scoped key format"
+                    );
+                    let _ = meta.insert(quarantine_meta_key(rest, node_id), b"1");
+                    let _ = meta.remove(&key_bytes);
+                    (rest.to_string(), node_id)
+                }
+            };
+
+            if reporting_node == node_id {
+                quarantined.insert(partition.clone());
                 tracing::error!(
                     partition,
                     "SECURITY: partition is quarantined (loaded from persistent state)"
+                );
+            } else {
+                tracing::info!(
+                    partition,
+                    reporting_node,
+                    "quarantine record from another cluster node (informational only)"
                 );
             }
         }
@@ -160,6 +220,18 @@ impl QuarantineTracker {
         false
     }
 
+    /// Directly marks a partition quarantined without threshold bookkeeping.
+    ///
+    /// Used when applying a Raft-committed `Quarantine` mutation reported by
+    /// this node itself — idempotent with respect to `record_failure`, which
+    /// already set the same in-memory state synchronously.
+    fn force_quarantine(&self, partition: &str) {
+        self.quarantined
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(partition.to_string());
+    }
+
     /// Clears quarantine state for a partition (operator-initiated recovery).
     fn clear(&self, partition: &str) {
         self.quarantined
@@ -182,6 +254,11 @@ struct SnapshotFile {
 
 /// Fjall meta key prefix for retired DEK epochs.
 const DEK_RETIRED_PREFIX: &str = "_meta:dek:retired:";
+/// Fjall meta key prefix for revoked DEK epochs (emergency rotation).  Only
+/// the version and revocation timestamp are stored here — never the wrapped
+/// key bytes — so the compromised DEK material remains genuinely discarded
+/// (ADR 0016-v2 §6.2 step 5).
+pub(crate) const DEK_REVOKED_PREFIX: &str = "_meta:dek:revoked:";
 /// Fjall meta key for the current wrapped DEK.
 const META_DEK_CURRENT: &[u8] = b"_meta:dek:current";
 /// Fjall meta key prefix for pending emergency rotations.
@@ -246,6 +323,9 @@ pub struct FjallStateMachine {
     data: Keyspace,
     index: Keyspace,
     snapshot_dir: PathBuf,
+    /// This node's Raft ID — tags Quarantine mutations proposed by this node
+    /// and scopes which persisted quarantine markers block local reads.
+    node_id: u64,
     /// Current active DEK epoch (shared with FjallLogStore via Arc).
     dek: Arc<RwLock<Arc<DekEpoch>>>,
     /// Retired DEK epochs held during re-encryption transition (shared with
@@ -258,6 +338,9 @@ pub struct FjallStateMachine {
     kek: Arc<dyn KekProvider>,
     /// Channel to trigger background re-encryption after DEK rotation.
     reencrypt_tx: tokio::sync::mpsc::Sender<Arc<DekEpoch>>,
+    /// Channel signalling `(node_id, partition)` quarantine events for
+    /// best-effort Raft propagation (ADR 0016-v2 §10 invariant 5).
+    quarantine_tx: tokio::sync::mpsc::Sender<(u64, String)>,
     quarantine: Arc<QuarantineTracker>,
     /// Pending emergency DEK rotations awaiting dual-control confirmation.
     /// Shared with `ClusterAdminServiceImpl` so the gRPC handler can inspect
@@ -266,27 +349,32 @@ pub struct FjallStateMachine {
 }
 
 impl FjallStateMachine {
-    #[allow(clippy::result_large_err)]
+    #[allow(clippy::result_large_err, clippy::too_many_arguments)]
     /// Create a new `FjallStateMachine`.
     ///
     /// # Parameters
     /// - `db`: Database instance.
     /// - `snapshot_dir`: Directory to store snapshots.
+    /// - `node_id`: This node's Raft ID.
     /// - `dek`: Shared current DEK epoch (also held by `FjallLogStore`).
     /// - `kek`: Key Encryption Key used to unwrap new DEKs on `InstallDek`.
     /// - `reencrypt_tx`: Channel for signalling the background re-encryption
     ///   task with the old DEK epoch that needs re-encryption.
+    /// - `quarantine_tx`: Channel for signalling the background quarantine
+    ///   forwarding task with `(node_id, partition)` to propose via Raft.
     ///
     /// # Returns
     /// A `Result` containing the `FjallStateMachine`, or a `StoreError`.
     pub fn new(
         db: Arc<Database>,
         snapshot_dir: PathBuf,
+        node_id: u64,
         dek: Arc<RwLock<Arc<DekEpoch>>>,
         old_deks: Arc<Mutex<BTreeMap<u32, Arc<DekEpoch>>>>,
         revoked_deks: Arc<Mutex<HashSet<u32>>>,
         kek: Arc<dyn KekProvider>,
         reencrypt_tx: tokio::sync::mpsc::Sender<Arc<DekEpoch>>,
+        quarantine_tx: tokio::sync::mpsc::Sender<(u64, String)>,
         pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
     ) -> Result<Self, StoreError> {
         let meta = db.keyspace("meta", KeyspaceCreateOptions::default)?;
@@ -295,11 +383,12 @@ impl FjallStateMachine {
 
         fs::create_dir_all(&snapshot_dir)?;
 
-        let quarantine = Arc::new(QuarantineTracker::from_meta(&meta)?);
+        let quarantine = Arc::new(QuarantineTracker::from_meta(&meta, node_id)?);
 
         Ok(Self {
             db,
             snapshot_dir,
+            node_id,
             meta,
             data,
             index,
@@ -308,6 +397,7 @@ impl FjallStateMachine {
             revoked_deks,
             kek,
             reencrypt_tx,
+            quarantine_tx,
             quarantine,
             pending_rotations,
         })
@@ -384,15 +474,21 @@ impl FjallStateMachine {
     /// s quarantine the partition and persist the marker to Fjall meta for
     /// restart durability.
     ///
-    /// During DEK rotation, if decryption with the current DEK fails the method
-    /// transparently retries with the previous epoch (`old_dek`) to serve reads
-    /// of keys not yet re-encrypted.
+    /// `dek_version_hint` should be `Metadata::dek_version` for the record.
+    /// When present, the read selects that exact DEK epoch deterministically
+    /// and never falls back to another key on a tag-verification failure
+    /// (ADR 0016-v2 §6 step 6). `None` indicates a legacy record written
+    /// before per-record DEK version tracking existed; such records fall
+    /// back to the previous try-current-then-probe-retired behavior for
+    /// backward-compatible reads only — every write now populates
+    /// `dek_version`, so this path serves only pre-migration data.
     pub fn decrypt_state(
         &self,
         stored: &[u8],
         tier: u8,
         keyspace: &[u8],
         pk: &[u8],
+        dek_version_hint: Option<u32>,
     ) -> Result<Vec<u8>, StoreError> {
         let partition = String::from_utf8_lossy(keyspace).into_owned();
 
@@ -400,6 +496,79 @@ impl FjallStateMachine {
             return Err(StoreError::Quarantined(partition));
         }
 
+        match dek_version_hint {
+            Some(hint) => {
+                self.decrypt_state_by_version(stored, tier, keyspace, pk, &partition, hint)
+            }
+            None => self.decrypt_state_legacy_probe(stored, tier, keyspace, pk, &partition),
+        }
+    }
+
+    /// Deterministic-epoch decryption: selects the exact DEK epoch named by
+    /// `hint` and never probes another key on failure (ADR 0016-v2 §6 step
+    /// 6). An unknown epoch (already discarded/revoked, or corrupt
+    /// metadata) is treated as ambiguous and quarantined rather than
+    /// silently trying other keys.
+    fn decrypt_state_by_version(
+        &self,
+        stored: &[u8],
+        tier: u8,
+        keyspace: &[u8],
+        pk: &[u8],
+        partition: &str,
+        hint: u32,
+    ) -> Result<Vec<u8>, StoreError> {
+        // Single read of `self.dek`, reused for both the version comparison
+        // and the decrypt call. Reading `.version` and then re-acquiring the
+        // lock in a second `self.dek.read()` would be a TOCTOU race: a DEK
+        // rotation landing between the two reads could swap in a different
+        // epoch than the one `hint` was compared against, causing a
+        // legitimate record to fail GCM verification and spuriously
+        // quarantine the partition.
+        let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
+        let result = if hint == guard.version {
+            state_decrypt(guard.state_dek(), stored, tier, keyspace, pk)
+        } else {
+            drop(guard);
+            let old_map = self.old_deks.lock().unwrap_or_else(|p| p.into_inner());
+            let Some(epoch) = old_map.get(&hint).cloned() else {
+                drop(old_map);
+                self.record_quarantine_failure(partition);
+                return Err(crate::StoreError::Other(eyre::eyre!(
+                    "record references unknown DEK epoch {hint}; treated as corrupt \
+                     per ADR 0016-v2 §6 step 6 (no key-probing fallback) — partition \
+                     '{partition}' quarantined"
+                )));
+            };
+            drop(old_map);
+            state_decrypt(epoch.state_dek(), stored, tier, keyspace, pk)
+        };
+
+        match result {
+            Ok((plaintext, _next_version)) => Ok(plaintext.to_vec()),
+            Err(openstack_keystone_storage_crypto::CryptoError::AesDecrypt) => {
+                self.record_quarantine_failure(partition);
+                Err(StoreError::Crypto {
+                    source: openstack_keystone_storage_crypto::CryptoError::AesDecrypt,
+                })
+            }
+            Err(e) => Err(StoreError::Crypto { source: e }),
+        }
+    }
+
+    /// Legacy fallback for records written before per-record DEK version
+    /// tracking (`Metadata::dek_version == None`). Retained only for
+    /// backward-compatible reads of pre-migration data; every write now
+    /// populates `dek_version`, so new records always use
+    /// `decrypt_state_by_version` instead.
+    fn decrypt_state_legacy_probe(
+        &self,
+        stored: &[u8],
+        tier: u8,
+        keyspace: &[u8],
+        pk: &[u8],
+        partition: &str,
+    ) -> Result<Vec<u8>, StoreError> {
         let result = {
             let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
             state_decrypt(guard.state_dek(), stored, tier, keyspace, pk)
@@ -412,9 +581,10 @@ impl FjallStateMachine {
                 // The retired DEK fallback is only for reading pre-rotation data,
                 // but the GCM failure with the current DEK still counts toward
                 // quarantine threshold.
-                let failed = self.quarantine.record_failure(&partition);
+                let failed = self.quarantine.record_failure(partition);
 
-                // Try retired DEK epochs if in a rotation transition.
+                // Try retired DEK epochs — legacy records have no recorded
+                // dek_version, so this is the only way to locate the right key.
                 let old_map = self.old_deks.lock().unwrap_or_else(|p| p.into_inner());
                 for (_, old) in old_map.iter() {
                     if let Ok((pt, _)) = state_decrypt(old.state_dek(), stored, tier, keyspace, pk)
@@ -422,17 +592,16 @@ impl FjallStateMachine {
                         tracing::warn!(
                             partition,
                             epoch_version = old.version,
-                            "record decrypted with retired DEK epoch — re-encryption required"
+                            "legacy record decrypted with retired DEK epoch — \
+                             re-encryption required"
                         );
                         return Ok(pt.to_vec());
                     }
                 }
                 drop(old_map);
 
-                // Persist quarantine marker if threshold was reached.
                 if failed {
-                    let key = format!("{QUARANTINE_META_PREFIX}{partition}");
-                    let _ = self.meta.insert(key, b"1");
+                    self.persist_and_signal_quarantine(partition);
                 }
                 Err(StoreError::Crypto {
                     source: openstack_keystone_storage_crypto::CryptoError::AesDecrypt,
@@ -442,26 +611,40 @@ impl FjallStateMachine {
         }
     }
 
+    /// Records a GCM tag-verification failure and, if the failure count just
+    /// crossed the quarantine threshold, persists and signals it.
+    fn record_quarantine_failure(&self, partition: &str) {
+        if self.quarantine.record_failure(partition) {
+            self.persist_and_signal_quarantine(partition);
+        }
+    }
+
+    /// Persists the quarantine marker to local Fjall meta (synchronous,
+    /// restart-durable on this node) and signals the background forwarding
+    /// task to propose the same fact via Raft for cluster-wide visibility
+    /// (ADR 0016-v2 §10 invariant 5).
+    fn persist_and_signal_quarantine(&self, partition: &str) {
+        let key = quarantine_meta_key(partition, self.node_id);
+        let _ = self.meta.insert(key, b"1");
+        let _ = self
+            .quarantine_tx
+            .try_send((self.node_id, partition.to_string()));
+    }
+
     /// Returns `true` if the given keyspace partition is currently quarantined.
     pub fn is_quarantined(&self, partition: &str) -> bool {
         self.quarantine.is_quarantined(partition)
-    }
-
-    /// Clears quarantine for a partition (operator-initiated recovery).
-    ///
-    /// Removes the quarantine marker from Fjall meta so the partition becomes
-    /// accessible again after a restart as well.
-    pub fn clear_quarantine(&self, partition: &str) -> Result<(), StoreError> {
-        self.quarantine.clear(partition);
-        let key = format!("{QUARANTINE_META_PREFIX}{partition}");
-        self.meta.remove(key)?;
-        Ok(())
     }
 
     /// Encrypt and write state bytes for a given key.
     ///
     /// Reads the current encrypted record (if present) to extract the stored
     /// version, increments it, then calls `state_encrypt` with the new version.
+    ///
+    /// Returns the ciphertext bytes and the DEK epoch version used, so the
+    /// caller can record it in `Metadata::dek_version` (ADR 0016-v2 §6 step
+    /// 6) — reads select the correct key deterministically instead of
+    /// probing multiple epochs.
     ///
     /// Returns `StoreError::Quarantined` if the keyspace partition is
     /// quarantined.
@@ -472,7 +655,7 @@ impl FjallStateMachine {
         keyspace: &[u8],
         tier: u8,
         plaintext: &[u8],
-    ) -> Result<Vec<u8>, StoreError> {
+    ) -> Result<(Vec<u8>, u32), StoreError> {
         let partition = String::from_utf8_lossy(keyspace).into_owned();
         if self.quarantine.is_quarantined(&partition) {
             return Err(StoreError::Quarantined(partition));
@@ -507,18 +690,19 @@ impl FjallStateMachine {
             );
         }
 
-        let encrypted = {
+        let (encrypted, dek_version) = {
             let guard = self.dek.read().unwrap_or_else(|p| p.into_inner());
-            state_encrypt(
+            let encrypted = state_encrypt(
                 guard.state_dek(),
                 plaintext,
                 tier,
                 keyspace,
                 key,
                 next_version,
-            )?
+            )?;
+            (encrypted, guard.version)
         };
-        Ok(encrypted)
+        Ok((encrypted, dek_version))
     }
 
     #[allow(clippy::result_large_err)]
@@ -976,10 +1160,11 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                         tier,
                                         &cipher,
                                     ) {
-                                        Ok(encrypted) => {
+                                        Ok((encrypted, dek_version)) => {
                                             batch.insert(&ks, key.clone(), encrypted);
                                             let mut meta_with_tier = metadata.clone();
                                             meta_with_tier.tier = DataTier::from(tier);
+                                            meta_with_tier.dek_version = Some(dek_version);
                                             batch.insert(
                                                 &self.meta,
                                                 key.clone(),
@@ -1043,10 +1228,11 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                         tier,
                                         &cipher,
                                     ) {
-                                        Ok(encrypted) => {
+                                        Ok((encrypted, dek_version)) => {
                                             batch.insert(&ks, key.clone(), encrypted);
                                             let mut meta_with_tier = metadata.clone();
                                             meta_with_tier.tier = DataTier::from(tier);
+                                            meta_with_tier.dek_version = Some(dek_version);
                                             batch.insert(
                                                 &self.meta,
                                                 key.clone(),
@@ -1085,10 +1271,50 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                 MutationInner::ClearQuarantine { partition } => {
                                     // Clear in-memory tracker first so reads are
                                     // unblocked as soon as the batch commits.
+                                    // Harmless no-op on nodes that were never
+                                    // quarantined for this partition.
                                     self.quarantine.clear(&partition);
-                                    let key = format!("{QUARANTINE_META_PREFIX}{partition}");
-                                    batch.remove(&self.meta, key.as_bytes());
+                                    // Remove every reporting node's marker for
+                                    // this partition — the operator clears the
+                                    // partition cluster-wide, not just the node
+                                    // they happened to connect to.
+                                    let scan_prefix =
+                                        format!("{QUARANTINE_META_PREFIX}{partition}:");
+                                    let keys_to_remove: Vec<Vec<u8>> = self
+                                        .meta
+                                        .prefix(scan_prefix.as_bytes())
+                                        .filter_map(|item| item.into_inner().ok())
+                                        .map(|(k, _)| k.to_vec())
+                                        .collect();
+                                    for key in &keys_to_remove {
+                                        batch.remove(&self.meta, key.as_slice());
+                                    }
                                     tracing::info!(partition, "quarantine cleared by operator");
+                                }
+                                MutationInner::Quarantine {
+                                    node_id: reporting_node,
+                                    partition,
+                                } => {
+                                    // Applied uniformly on every node. Only
+                                    // the reporting node updates its own
+                                    // blocking in-memory state; other nodes
+                                    // persist the record for audit
+                                    // visibility only (ADR 0016-v2 §10
+                                    // invariant 5).
+                                    let key = quarantine_meta_key(&partition, reporting_node);
+                                    let now = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap_or_default()
+                                        .as_secs();
+                                    batch.insert(&self.meta, key.as_bytes(), now.to_be_bytes());
+                                    if reporting_node == self.node_id {
+                                        self.quarantine.force_quarantine(&partition);
+                                    }
+                                    tracing::info!(
+                                        partition,
+                                        reporting_node,
+                                        "quarantine committed via Raft"
+                                    );
                                 }
                                 MutationInner::InstallDek {
                                     wrapped_dek,
@@ -1134,6 +1360,24 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                                 );
                                             }
                                         }
+                                    } else {
+                                        // Emergency rotation: durably record the revoked
+                                        // marker in the same atomic batch as the DEK swap,
+                                        // so revocation survives a restart (ADR 0016-v2
+                                        // §6.2 step 5). Only the revocation timestamp is
+                                        // stored — never the wrapped key bytes — so the
+                                        // compromised DEK material remains discarded.
+                                        let revoked_key =
+                                            format!("{DEK_REVOKED_PREFIX}{old_version}");
+                                        let now = std::time::SystemTime::now()
+                                            .duration_since(std::time::UNIX_EPOCH)
+                                            .unwrap_or_default()
+                                            .as_secs();
+                                        batch.insert(
+                                            &self.meta,
+                                            revoked_key.as_bytes(),
+                                            now.to_be_bytes(),
+                                        );
                                     }
                                     pending_dek_swap = Some((new_epoch, is_emergency));
                                     tracing::info!(
@@ -1313,7 +1557,15 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                         std::mem::replace(&mut *guard, new_epoch)
                     };
                     if is_emergency_rotation {
-                        // Emergency: old DEK is revoked, not retired
+                        // Emergency: old DEK is revoked, not retired, and —
+                        // unlike a normal rotation — is never forwarded to
+                        // the re-encryption channel below. The point of
+                        // revocation is that this key material must not be
+                        // used again for anything, including internal
+                        // re-encryption of other records (ADR 0016-v2 §6.2
+                        // step 5); `old_epoch` is simply dropped (and
+                        // zeroized by `LockedKey`'s `Drop`) at the end of
+                        // this block.
                         let mut revoked =
                             self.revoked_deks.lock().unwrap_or_else(|p| p.into_inner());
                         if revoked.len() >= MAX_REVOKED_DEKS {
@@ -1335,9 +1587,9 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                             .lock()
                             .unwrap_or_else(|p| p.into_inner())
                             .insert(old_epoch.version, old_epoch.clone());
+                        // Signal background re-encryption task (non-fatal on channel full).
+                        let _ = self.reencrypt_tx.try_send(old_epoch);
                     }
-                    // Signal background re-encryption task (non-fatal on channel full).
-                    let _ = self.reencrypt_tx.try_send(old_epoch);
                     tracing::info!("DEK epoch swapped");
                 }
             }
@@ -1378,5 +1630,255 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
             .persist(PersistMode::SyncAll)
             .map_err(|e| io::Error::other(e.to_string()))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod quarantine_tests {
+    use super::*;
+
+    fn open_meta() -> (fjall::Keyspace, Arc<Database>, tempfile::TempDir) {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let db = Arc::new(Database::builder(td.path()).open().expect("open db"));
+        let meta = db
+            .keyspace("meta", KeyspaceCreateOptions::default)
+            .expect("meta keyspace");
+        (meta, db, td)
+    }
+
+    #[test]
+    fn quarantine_meta_key_puts_partition_before_node_id() {
+        assert_eq!(quarantine_meta_key("data", 7), "_meta:quarantine:data:7");
+    }
+
+    #[test]
+    fn from_meta_only_blocks_matching_node_id() {
+        let (meta, db, _td) = open_meta();
+        // Node 1's own record blocks; node 2's record is informational only.
+        meta.insert(quarantine_meta_key("data", 1), 0u64.to_be_bytes())
+            .expect("insert node 1 marker");
+        meta.insert(quarantine_meta_key("data", 2), 0u64.to_be_bytes())
+            .expect("insert node 2 marker");
+        db.persist(PersistMode::SyncAll).expect("persist");
+
+        let tracker = QuarantineTracker::from_meta(&meta, 1).expect("load tracker");
+        assert!(tracker.is_quarantined("data"));
+
+        let tracker_other = QuarantineTracker::from_meta(&meta, 2).expect("load tracker");
+        assert!(tracker_other.is_quarantined("data"));
+
+        let tracker_uninvolved = QuarantineTracker::from_meta(&meta, 3).expect("load tracker");
+        assert!(!tracker_uninvolved.is_quarantined("data"));
+    }
+
+    /// Pre-upgrade quarantine markers (`_meta:quarantine:<partition>`, no
+    /// node-id suffix) must still block reads after loading, and must be
+    /// migrated to the node-scoped key format so they survive a *second*
+    /// restart too — not just silently dropped on `rsplit_once` failure.
+    #[test]
+    fn from_meta_migrates_legacy_marker_without_node_id() {
+        let (meta, db, _td) = open_meta();
+        let legacy_key = format!("{QUARANTINE_META_PREFIX}data");
+        meta.insert(legacy_key.as_bytes(), b"1")
+            .expect("insert legacy marker");
+        db.persist(PersistMode::SyncAll).expect("persist");
+
+        let tracker = QuarantineTracker::from_meta(&meta, 1).expect("load tracker");
+        assert!(
+            tracker.is_quarantined("data"),
+            "legacy marker must still block reads on the node that owns it"
+        );
+
+        // The legacy key must have been rewritten to the node-scoped format
+        // so a *second* restart doesn't depend on this migration running
+        // again.
+        assert!(
+            meta.get(legacy_key.as_bytes())
+                .expect("read legacy key")
+                .is_none(),
+            "legacy key should have been removed after migration"
+        );
+        assert!(
+            meta.get(quarantine_meta_key("data", 1))
+                .expect("read migrated key")
+                .is_some(),
+            "migrated node-scoped key should now be present"
+        );
+
+        let tracker_again = QuarantineTracker::from_meta(&meta, 1).expect("reload tracker");
+        assert!(
+            tracker_again.is_quarantined("data"),
+            "quarantine must still be in effect on a second restart, via the migrated key"
+        );
+    }
+
+    #[test]
+    fn force_quarantine_is_idempotent_with_record_failure() {
+        let tracker = QuarantineTracker {
+            failures: Mutex::new(HashMap::new()),
+            quarantined: Mutex::new(HashSet::new()),
+        };
+        assert!(!tracker.is_quarantined("data"));
+        tracker.force_quarantine("data");
+        assert!(tracker.is_quarantined("data"));
+        // Calling again is a harmless no-op.
+        tracker.force_quarantine("data");
+        assert!(tracker.is_quarantined("data"));
+    }
+
+    #[test]
+    fn clear_removes_quarantine_state() {
+        let tracker = QuarantineTracker {
+            failures: Mutex::new(HashMap::new()),
+            quarantined: Mutex::new(HashSet::new()),
+        };
+        tracker.force_quarantine("data");
+        assert!(tracker.is_quarantined("data"));
+        tracker.clear("data");
+        assert!(!tracker.is_quarantined("data"));
+    }
+}
+
+#[cfg(test)]
+mod dek_version_tests {
+    use openstack_keystone_storage_crypto::EnvKek;
+
+    use super::*;
+
+    fn test_epoch(seed: u8, version: u32) -> Arc<DekEpoch> {
+        Arc::new(DekEpoch::from_raw(LockedKey::from_raw([seed; 32]), version).expect("epoch"))
+    }
+
+    /// Builds a `FjallStateMachine` with directly controllable `dek` /
+    /// `old_deks` state, so tests can simulate a rotation transition without
+    /// going through the full Raft apply path.
+    fn make_sm(current: Arc<DekEpoch>) -> (FjallStateMachine, tempfile::TempDir) {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let db = Arc::new(Database::builder(td.path()).open().expect("open db"));
+        let kek: Arc<dyn KekProvider> = Arc::new(EnvKek::from_bytes([0x42u8; 32]));
+        let (reencrypt_tx, reencrypt_rx) = tokio::sync::mpsc::channel(1);
+        drop(reencrypt_rx);
+        let (quarantine_tx, quarantine_rx) = tokio::sync::mpsc::channel(1);
+        drop(quarantine_rx);
+
+        let sm = FjallStateMachine::new(
+            db,
+            td.path().join("snapshots"),
+            1, // node_id
+            Arc::new(RwLock::new(current)),
+            Arc::new(Mutex::new(BTreeMap::new())),
+            Arc::new(Mutex::new(HashSet::new())),
+            kek,
+            reencrypt_tx,
+            quarantine_tx,
+            Arc::new(Mutex::new(HashMap::new())),
+        )
+        .expect("construct state machine");
+        (sm, td)
+    }
+
+    #[test]
+    fn decrypt_with_matching_current_version_succeeds() {
+        let epoch = test_epoch(0x01, 1);
+        let (sm, _td) = make_sm(epoch);
+
+        let ks = sm.data().clone();
+        let (ciphertext, version) = sm
+            .encrypt_and_store(&ks, b"k1", b"data", DataTier::Internal as u8, b"hello")
+            .expect("encrypt");
+        assert_eq!(version, 1);
+
+        let plaintext = sm
+            .decrypt_state(
+                &ciphertext,
+                DataTier::Internal as u8,
+                b"data",
+                b"k1",
+                Some(version),
+            )
+            .expect("decrypt with correct hint");
+        assert_eq!(plaintext, b"hello");
+    }
+
+    #[test]
+    fn decrypt_with_retired_epoch_hint_succeeds_without_probing() {
+        let old_epoch = test_epoch(0x02, 1);
+        let (sm, _td) = make_sm(old_epoch.clone());
+
+        let ks = sm.data().clone();
+        let (ciphertext, old_version) = sm
+            .encrypt_and_store(&ks, b"k2", b"data", DataTier::Internal as u8, b"hello")
+            .expect("encrypt under epoch 1");
+        assert_eq!(old_version, 1);
+
+        // Simulate a rotation: swap in a new current epoch, retire the old one.
+        let new_epoch = test_epoch(0x03, 2);
+        *sm.dek.write().unwrap() = new_epoch;
+        sm.old_deks.lock().unwrap().insert(1, old_epoch);
+
+        // Old records still decrypt via the exact retired epoch named by hint.
+        let plaintext = sm
+            .decrypt_state(
+                &ciphertext,
+                DataTier::Internal as u8,
+                b"data",
+                b"k2",
+                Some(old_version),
+            )
+            .expect("decrypt via retired epoch hint");
+        assert_eq!(plaintext, b"hello");
+    }
+
+    #[test]
+    fn decrypt_with_wrong_version_hint_fails_without_probing() {
+        let epoch1 = test_epoch(0x04, 1);
+        let (sm, _td) = make_sm(epoch1.clone());
+
+        let ks = sm.data().clone();
+        let (ciphertext, _version) = sm
+            .encrypt_and_store(&ks, b"k3", b"data", DataTier::Internal as u8, b"hello")
+            .expect("encrypt under epoch 1");
+
+        // Rotate so epoch 1 becomes retired (and decryptable, if probed).
+        let epoch2 = test_epoch(0x05, 2);
+        *sm.dek.write().unwrap() = epoch2;
+        sm.old_deks.lock().unwrap().insert(1, epoch1);
+
+        // A hint naming a version that exists in neither current nor
+        // old_deks must fail outright — never silently fall back to
+        // probing epoch 1, even though epoch 1 would actually decrypt it
+        // (ADR 0016-v2 §6 step 6).
+        let err = sm
+            .decrypt_state(
+                &ciphertext,
+                DataTier::Internal as u8,
+                b"data",
+                b"k3",
+                Some(99),
+            )
+            .expect_err("unknown dek_version hint must not silently probe other keys");
+        assert!(!matches!(err, StoreError::Quarantined(_)));
+    }
+
+    #[test]
+    fn decrypt_legacy_none_hint_still_probes_retired_epochs() {
+        let epoch1 = test_epoch(0x06, 1);
+        let (sm, _td) = make_sm(epoch1.clone());
+
+        let ks = sm.data().clone();
+        let (ciphertext, _version) = sm
+            .encrypt_and_store(&ks, b"k4", b"data", DataTier::Internal as u8, b"hello")
+            .expect("encrypt under epoch 1");
+
+        let epoch2 = test_epoch(0x07, 2);
+        *sm.dek.write().unwrap() = epoch2;
+        sm.old_deks.lock().unwrap().insert(1, epoch1);
+
+        // Legacy records (no dek_version recorded) still fall back to
+        // try-current-then-probe-retired for backward compatibility.
+        let plaintext = sm
+            .decrypt_state(&ciphertext, DataTier::Internal as u8, b"data", b"k4", None)
+            .expect("legacy probe path should still find the retired epoch");
+        assert_eq!(plaintext, b"hello");
     }
 }

--- a/crates/storage/src/store_command.rs
+++ b/crates/storage/src/store_command.rs
@@ -129,11 +129,27 @@ pub enum MutationInner {
 
     /// Clear the quarantine state for a keyspace partition.
     ///
-    /// Removes the `_meta:quarantine:<partition>` persistence marker from Fjall
-    /// and clears the in-memory `QuarantineTracker` entry so the partition
-    /// becomes accessible again.  Propagated via Raft so all nodes are cleared.
+    /// Removes every reporting node's `_meta:quarantine:<partition>:<node_id>`
+    /// persistence marker from Fjall and clears the in-memory
+    /// `QuarantineTracker` entry so the partition becomes accessible again.
+    /// Propagated via Raft so all nodes are cleared.
     ClearQuarantine {
         /// The keyspace partition to un-quarantine (e.g. `"data"`).
+        partition: String,
+    },
+
+    /// Record a GCM-failure quarantine for a partition on a specific node.
+    ///
+    /// Proposed automatically (best effort) when a node's local GCM failure
+    /// threshold is reached, so the fact is committed via Raft and visible
+    /// cluster-wide (ADR 0016-v2 §10 invariant 5). Applied uniformly on every
+    /// node: only the node whose `node_id` matches the local node updates its
+    /// own blocking in-memory state; other nodes persist the record for audit
+    /// visibility only.
+    Quarantine {
+        /// The Raft node ID that detected the GCM failures.
+        node_id: u64,
+        /// The keyspace partition that triggered quarantine.
         partition: String,
     },
 

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -81,12 +81,182 @@ fn test_cluster() {
 /// Scenario:
 /// 1. Node initializes with bare address "127.0.0.1:21001"
 /// 2. Node reinitializes (simulating pod restart) with "https://127.0.0.1:21001/"
-/// 3. check_node_id_uniqueness should NOT reject the restart — same logical address.
+/// 3. check_node_id_uniqueness should NOT reject the restart — same logical
+///    address.
 #[serial_test::serial]
 #[tracing_test::traced_test]
 #[test]
 fn test_node_restart_with_address_format_change() {
     TypeConfig::run(test_node_restart_inner()).unwrap();
+}
+
+/// `init_storage` must refuse to start in production mode (`dev_mode =
+/// false`): there is currently no production `KekProvider` (HSM/PKCS#11/KMS)
+/// wired up, so falling back to an environment-provided KEK would silently
+/// violate ADR 0016-v2 §2.1 / invariant 6.
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_kek_gating_production_mode_rejected() {
+    TypeConfig::run(test_kek_gating_production_mode_rejected_inner()).unwrap();
+}
+
+#[allow(unsafe_code)]
+async fn test_kek_gating_production_mode_rejected_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let storage_dir = tempfile::TempDir::new().unwrap();
+    let tls_configuration = make_certificates()?;
+    let mut ds_config = get_ds_config(101, storage_dir.path().to_path_buf(), tls_configuration);
+    ds_config.dev_mode = false;
+
+    let mut config = Config::default();
+    config.distributed_storage = Some(ds_config);
+
+    // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
+    unsafe {
+        std::env::remove_var("KEYSTONE_DEV_KEK");
+        std::env::remove_var("KEYSTONE_ALLOW_ENV_KEK");
+    }
+
+    let result = init_storage(&ConfigManager::not_watched(config)).await;
+    assert!(
+        result.is_err(),
+        "init_storage must refuse to start with dev_mode=false (no production KekProvider exists)"
+    );
+    Ok(())
+}
+
+/// `init_storage` must refuse to start with `dev_mode = true` unless
+/// `KEYSTONE_ALLOW_ENV_KEK=1` is explicitly set (ADR 0016-v2 §2.1, invariant
+/// 6), even when `KEYSTONE_DEV_KEK` is present.
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_kek_gating_dev_mode_requires_allow_env_kek() {
+    TypeConfig::run(test_kek_gating_dev_mode_requires_allow_env_kek_inner()).unwrap();
+}
+
+#[allow(unsafe_code)]
+async fn test_kek_gating_dev_mode_requires_allow_env_kek_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let storage_dir = tempfile::TempDir::new().unwrap();
+    let tls_configuration = make_certificates()?;
+    let ds_config = get_ds_config(102, storage_dir.path().to_path_buf(), tls_configuration);
+    // dev_mode is true via get_ds_config, but KEYSTONE_ALLOW_ENV_KEK is unset.
+
+    let mut config = Config::default();
+    config.distributed_storage = Some(ds_config);
+
+    // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
+    unsafe {
+        std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
+        std::env::remove_var("KEYSTONE_ALLOW_ENV_KEK");
+    }
+
+    let result = init_storage(&ConfigManager::not_watched(config)).await;
+    assert!(
+        result.is_err(),
+        "init_storage must refuse to start with dev_mode=true but KEYSTONE_ALLOW_ENV_KEK unset"
+    );
+    Ok(())
+}
+
+/// A `Quarantine` mutation committed via Raft blocks reads on the affected
+/// partition, and `ClearQuarantine` restores them — exercising the real
+/// apply() path end-to-end (ADR 0016-v2 §10 invariant 5).
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_quarantine_committed_via_raft() {
+    TypeConfig::run(test_quarantine_committed_via_raft_inner()).unwrap();
+}
+
+#[allow(unsafe_code)]
+async fn test_quarantine_committed_via_raft_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let storage_dir = tempfile::TempDir::new().unwrap();
+    let tls_configuration = make_certificates()?;
+    let ds_config = get_ds_config(103, storage_dir.path().to_path_buf(), tls_configuration);
+
+    let mut config = Config::default();
+    config.distributed_storage = Some(ds_config);
+
+    // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
+    unsafe {
+        std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
+        std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
+    }
+
+    let storage = init_storage(&ConfigManager::not_watched(config)).await?;
+
+    // Bootstrap as a single-node cluster (no gRPC server needed — the Raft
+    // handle is local).
+    storage
+        .initialize(
+            [(
+                103u64,
+                openstack_keystone_storage_api::Node {
+                    node_id: 103,
+                    rpc_addr: "127.0.0.1:0".to_string(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        )
+        .await?;
+    for _ in 0..50 {
+        if storage.current_leader() == Some(103) {
+            break;
+        }
+        TypeConfig::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(storage.current_leader(), Some(103));
+
+    // Write a key so there is something to be blocked from reading.
+    let key = "quarantine-test-key".to_string();
+    storage
+        .set_value(key.clone(), make_env(&"hello")?, None, None)
+        .await?;
+    assert!(storage.get_by_key(key.as_bytes(), None).await?.is_some());
+
+    // Issue a raw Quarantine command for this node's own partition, exactly
+    // as FjallStateMachine::decrypt_state does on GCM failure.
+    let cmd = StoreCommand::Transaction(vec![MutationInner::Quarantine {
+        node_id: 103,
+        partition: "data".to_string(),
+    }]);
+    let payload = pb::api::CommandRequest::try_from(cmd)?;
+    storage.raft.client_write(payload).await?;
+
+    // Reads against the quarantined partition must now fail.
+    let err = storage
+        .get_by_key(key.as_bytes(), None)
+        .await
+        .expect_err("quarantined partition must refuse reads");
+    assert!(
+        format!("{err:?}").to_lowercase().contains("quarantin"),
+        "unexpected error: {err:?}"
+    );
+
+    // ClearQuarantine restores reads.
+    let clear_cmd = StoreCommand::Transaction(vec![MutationInner::ClearQuarantine {
+        partition: "data".to_string(),
+    }]);
+    let clear_payload = pb::api::CommandRequest::try_from(clear_cmd)?;
+    storage.raft.client_write(clear_payload).await?;
+
+    assert!(
+        storage.get_by_key(key.as_bytes(), None).await?.is_some(),
+        "read should succeed again after ClearQuarantine"
+    );
+
+    Ok(())
 }
 
 #[allow(unsafe_code)]
@@ -118,7 +288,7 @@ async fn test_node_restart_inner() -> Result<()> {
         std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
         std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
     }
-    let storage = Arc::new(init_storage(&ConfigManager::not_watched(config.clone())).await?);
+    let storage = init_storage(&ConfigManager::not_watched(config.clone())).await?;
     assert!(!storage.is_initialized().await?);
 
     // Initialize as single-node cluster
@@ -178,8 +348,8 @@ async fn test_node_restart_inner() -> Result<()> {
     _srv.join().ok();
     TypeConfig::sleep(Duration::from_millis(500)).await;
 
-    // Step 2: Reinitialize the SAME storage dir but with schema prefix + trailing slash
-    // This simulates pod restart where Uri::Display produces "https://host:port/"
+    // Step 2: Reinitialize the SAME storage dir but with schema prefix + trailing
+    // slash This simulates pod restart where Uri::Display produces "https://host:port/"
     let ds_config_restart = DistributedStorageConfiguration {
         node_cluster_addr: "https://127.0.0.1:21005/".parse().expect("valid address"),
         node_listener_addr: "127.0.0.1:21005".parse().expect("valid address"),
@@ -204,8 +374,7 @@ async fn test_node_restart_inner() -> Result<()> {
     // If normalization is broken, this fails with:
     // "FATAL: node_id 1 already registered in cluster at 127.0.0.1:21005;
     //  refusing to start with address https://127.0.0.1:21005/"
-    let storage_restart =
-        Arc::new(init_storage(&ConfigManager::not_watched(config_restart.clone())).await?);
+    let storage_restart = init_storage(&ConfigManager::not_watched(config_restart.clone())).await?;
 
     // Verify the storage thinks it's initialized (persisted state is intact)
     assert!(
@@ -235,7 +404,7 @@ struct InstanceHolder {
     pub node_id: u64,
     pub config: Config,
     storage_dir: TempDir,
-    pub storage: Storage,
+    pub storage: Arc<Storage>,
 }
 
 impl InstanceHolder {
@@ -707,14 +876,16 @@ async fn test_cluster_inner() -> Result<()> {
 
 /// Regression test: write key-val to leader, read immediately from follower.
 ///
-/// Reproduces the Raft replication race condition observed in k8s integration tests
-/// (see `api_v4::mapping::ruleset::create` / `update` / `delete` failures).
+/// Reproduces the Raft replication race condition observed in k8s integration
+/// tests (see `api_v4::mapping::ruleset::create` / `update` / `delete`
+/// failures).
 ///
 /// Pattern:
 /// 1. `set_value` on leader (node 1) — Raft proposal commits asynchronously
-/// 2. `get_by_key` on follower (node 2) — local FjallDB may not have replicated yet
-/// 3. Current mitigation: `ensure_linearizable(ReadIndex)` retry loop in `app.rs`
-///    (3 retries, 14ms total) then fall back to local read
+/// 2. `get_by_key` on follower (node 2) — local FjallDB may not have replicated
+///    yet
+/// 3. Current mitigation: `ensure_linearizable(ReadIndex)` retry loop in
+///    `app.rs` (3 retries, 14ms total) then fall back to local read
 ///
 /// The test runs multiple iterations to increase the probability of catching
 /// the race window. A passing run means the mitigation is working; a failing
@@ -895,9 +1066,10 @@ async fn test_replication_race_get_by_key_inner() -> Result<()> {
 /// Reproduces the pattern where a key is deleted on the leader but still
 /// appears in a follower's local FjallDB (stale read returns deleted data).
 ///
-/// This mirrors the `api_v4::mapping::ruleset::delete::test_delete_mapping_ruleset`
-/// failure: DELETE returns 204 on leader, but subsequent GET on follower returns
-/// 200 with the deleted data instead of 404.
+/// This mirrors the
+/// `api_v4::mapping::ruleset::delete::test_delete_mapping_ruleset`
+/// failure: DELETE returns 204 on leader, but subsequent GET on follower
+/// returns 200 with the deleted data instead of 404.
 #[serial_test::serial]
 #[tracing_test::traced_test]
 #[test]
@@ -1148,6 +1320,14 @@ fn make_certificates() -> Result<TlsConfiguration> {
 
     // 2. Generate peer certificate (signed by CA)
     let mut peer_cert_params = CertificateParams::default();
+
+    // Leaf cert validity must not exceed 30 days (ADR 0016-v2 §4.2,
+    // enforced by check_cert_max_validity at storage startup). Bracket the
+    // current time with a 1-day buffer on each side so the cert is valid for
+    // the lifetime of the test run.
+    let now = time::OffsetDateTime::now_utc();
+    peer_cert_params.not_before = now - time::Duration::days(1);
+    peer_cert_params.not_after = now + time::Duration::days(28);
 
     let client_ip: IpAddr = "127.0.0.1".parse()?;
     peer_cert_params.subject_alt_names = vec![SanType::IpAddress(client_ip)];

--- a/doc/src/adr/0016-v2-raft-storage.md
+++ b/doc/src/adr/0016-v2-raft-storage.md
@@ -738,10 +738,15 @@ Any code change violating the following is rejected at review:
    key; 3 distinct key failures within 60 seconds in the same Fjall partition
    trigger read-only quarantine (in-flight Raft proposals are drained, not
    interrupted). **Quarantine state is durable:** it is committed via a Raft
-   proposal to `_meta:quarantine:<node_id>:<partition>` so it persists across
-   node restarts and is visible to all cluster members. A restarted node reads
-   this key at startup and re-enters quarantine if the flag is set, preventing
-   escape via process restart. Recovery requires the operator to run
+   proposal to `_meta:quarantine:<partition>:<node_id>` (partition first, so an
+   operator's `ClearQuarantine` can prefix-scan and remove every reporting
+   node's entry for a partition in one pass) so it persists across node
+   restarts and is visible to all cluster members. GCM failures reflect
+   node-local storage corruption, not a cluster-wide data problem, so
+   blocking is node-scoped: only the reporting node re-enters quarantine (and
+   refuses local reads) for that partition on restart; other nodes persist
+   the record for audit visibility only and continue serving reads. Recovery
+   requires the operator to run
    `keystone-manage storage clear-quarantine` on the affected node, which
    requires `storage-operator` RBAC authorization, is committed via Raft (so
    the flag is cleared cluster-wide), and is audit-logged with caller identity

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -32,6 +32,7 @@ secrecy = { workspace = true, features = ["serde"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
+time = { version = "0.3", default-features = true }
 tempfile.workspace = true
 tracing.workspace = true
 tokio.workspace = true

--- a/tests/integration/src/common.rs
+++ b/tests/integration/src/common.rs
@@ -19,7 +19,7 @@ use std::net::IpAddr;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time;
+use std::time as std_time;
 
 use eyre::{Result, WrapErr};
 use rcgen::{
@@ -31,6 +31,7 @@ use sea_orm::{
 };
 use secrecy::SecretString;
 use tempfile::TempDir;
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use openstack_keystone::plugin_manager::PluginManager;
@@ -129,6 +130,7 @@ pub async fn get_isolated_database() -> Result<DatabaseConnection> {
     Ok(db)
 }
 
+#[allow(unsafe_code)]
 pub async fn get_state() -> Result<(Arc<Service>, TempDir)> {
     let db = get_isolated_database().await?;
 
@@ -175,11 +177,31 @@ pub async fn get_state() -> Result<(Arc<Service>, TempDir)> {
 
     let concrete_storage: Option<Arc<openstack_keystone_distributed_storage::app::Storage>> =
         if cfg.distributed_storage.is_some() {
+            // init_storage requires KEYSTONE_ALLOW_ENV_KEK=1 alongside dev_mode
+            // before it will use an environment-provided KEK. CI sets both
+            // ambiently (tools/raft-env.sh / workflow env), but a bare `cargo
+            // test -p integration` or an IDE test runner skips that setup, so
+            // fall back to setting the same well-known test values here —
+            // only if unset, so CI's own values always win. Multiple test
+            // tasks may race to set these concurrently, but every writer uses
+            // the identical constant value, so the race is benign.
+            // SAFETY: values written are constant across all callers.
+            unsafe {
+                if std::env::var("KEYSTONE_DEV_KEK").is_err() {
+                    std::env::set_var(
+                        "KEYSTONE_DEV_KEK",
+                        "4242424242424242424242424242424242424242424242424242424242424242",
+                    );
+                }
+                if std::env::var("KEYSTONE_ALLOW_ENV_KEK").is_err() {
+                    std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
+                }
+            }
             let cfg_mgr = ConfigManager::not_watched(cfg.clone());
             let storage = openstack_keystone_distributed_storage::app::init_storage(&cfg_mgr)
                 .await
                 .wrap_err("Failed to init storage")?;
-            Some(Arc::new(storage))
+            Some(storage)
         } else {
             None
         };
@@ -211,7 +233,7 @@ pub async fn get_state() -> Result<(Arc<Service>, TempDir)> {
             )]))
             .await?;
     }
-    std::thread::sleep(time::Duration::from_millis(200));
+    std::thread::sleep(std_time::Duration::from_millis(200));
     Ok((state, tmp_dir))
 }
 
@@ -277,8 +299,13 @@ where
 }
 
 fn make_certificates() -> Result<TlsConfiguration> {
+    let now = OffsetDateTime::now_utc();
+    let thirty_days = time::Duration::days(30);
+
     // 1. Generate CA private key and certificate
     let mut ca_params = CertificateParams::default();
+    ca_params.not_before = now;
+    ca_params.not_after = now + thirty_days;
     ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
     ca_params.key_usages = vec![
         KeyUsagePurpose::KeyCertSign,
@@ -296,6 +323,8 @@ fn make_certificates() -> Result<TlsConfiguration> {
 
     // 2. Generate peer certificate (signed by CA)
     let mut peer_cert_params = CertificateParams::default();
+    peer_cert_params.not_before = now;
+    peer_cert_params.not_after = now + thirty_days;
 
     let client_ip: IpAddr = "127.0.0.1".parse()?;
     peer_cert_params.subject_alt_names = vec![SanType::IpAddress(client_ip)];

--- a/tools/start-api.sh
+++ b/tools/start-api.sh
@@ -18,7 +18,7 @@ openssl req -x509 -newkey rsa:4096 -nodes \
     -keyout "${SSL_DIR}/ca.key" \
     -out "${SSL_DIR}/ca.crt" \
     -subj "/CN=Keystone-CA" \
-    -days 365 2>/dev/null
+    -days 30 2>/dev/null
 openssl req -newkey rsa:4096 -nodes \
     -keyout "${SSL_DIR}/ks.key" \
     -out "${SSL_DIR}/ks.csr" \
@@ -27,7 +27,7 @@ openssl req -newkey rsa:4096 -nodes \
 openssl x509 -req -in "${SSL_DIR}/ks.csr" \
     -CA "${SSL_DIR}/ca.crt" -CAkey "${SSL_DIR}/ca.key" \
     -CAcreateserial -out "${SSL_DIR}/ks.pem" \
-    -days 365 -copy_extensions copyall 2>/dev/null
+    -days 30 -copy_extensions copyall 2>/dev/null
 rm -f "${SSL_DIR}/ks.csr"
 
 cleanup() {


### PR DESCRIPTION
TLS fallback (ADR 0016-v2 §4.2): enforce a 30-day maximum leaf cert
validity window. The check now lives inside get_client_tls_config /
get_server_tls_config themselves (network.rs), so it applies uniformly
at startup, on every config-watcher hot-reload, and to any other caller
(e.g. cli-manage) — not just once during init_storage. Covered by three
unit tests (29-day pass, 30-day boundary pass, 31-day fail).

SPIFFE mode (ADR 0016-v2 §4.1): add check_svid_ttl_der (clock-injected
for testability) and check_svid_ttl; both require_operator and
check_peer_trust_domain call check_svid_ttl in SPIFFE mode and return
PERMISSION_DENIED when the peer SVID has expired or has fewer than 5
minutes of remaining validity. This is intentional defense-in-depth on
top of the SpiffeIdInterceptor, which already enforces the same window
for every Raft/admin/storage gRPC route; the duplicated
SystemTime::now()/UNIX_EPOCH boilerplate is now a single shared
now_unix_secs() helper. Covered by three unit tests (10-min remaining
pass, 4-min force-renewal fail, expired fail).

Per-record DEK-epoch tracking (ADR 0016-v2 §6 step 6): every write now
records the DEK epoch used (Metadata::dek_version) so reads can select
the exact key deterministically instead of probing multiple epochs on a
tag-verification failure. Legacy records (dek_version = None) fall back
to the previous try-current-then-probe-retired path. Fixed a TOCTOU race
in decrypt_state_by_version where the current epoch was read via two
separate self.dek.read() calls; a DEK rotation landing between them
could cause a legitimate read to be treated as corrupt and spuriously
quarantine a healthy partition — now a single read is reused for both
the version comparison and the decrypt call.

Cluster-wide quarantine visibility (ADR 0016-v2 §10 invariant 5): a
node that locally quarantines a partition after 3 GCM failures within
60s now also proposes a Quarantine mutation via Raft (best-effort,
forwarded by a background task holding a Weak<Storage>) so the fact is
durably visible to the whole cluster, not just the reporting node.
Blocking remains node-scoped — GCM failures reflect node-local storage
corruption, not a cluster-wide data problem — so only the reporting
node's own reads are blocked; other nodes persist the record for audit
visibility. Fixed QuarantineTracker::from_meta to migrate pre-upgrade
quarantine markers (old `_meta:quarantine:<partition>` key format, no
node-id suffix) to the new node-scoped format instead of silently
dropping them on load, which would have silently un-quarantined any
partition flagged before this upgrade. Updated ADR 0016-v2 §10 to match
the implemented `<partition>:<node_id>` key order (partition first, so
ClearQuarantine can prefix-scan and clear every node's marker for a
partition in one pass) and to document the node-scoped blocking model.

KEK provisioning gating (ADR 0016-v2 §2.1, invariant 6): the
environment-provided KEK is now a dev-mode-only fallback, requiring both
--dev-mode and KEYSTONE_ALLOW_ENV_KEK=1. Outside dev-mode there is no
production KekProvider yet (see Pkcs11KekStub), so the node refuses to
start rather than silently accept an environment-provided key.
init_storage now returns Arc<Storage> (previously callers wrapped it
themselves) so the background quarantine-forwarding task can hold a
Weak reference without an extra indirection.

Other fixes from review:
- benches/state_machine.rs and benches/write.rs updated for
  FjallStateMachine::new's new parameters and bounded cert validity
  (were left on the old signature / unbounded rcgen defaults, breaking
  `cargo bench --features bench_internals` in CI).
- Emergency/revoked DEK epochs are no longer forwarded to the
  re-encryption channel — that key material must never be reused, even
  internally.
- storage_service.rs's forwarded_get/forwarded_prefix now log a warning
  before collapsing a decrypt_state error (quarantined/corrupt epoch) to
  the same "not found" response, instead of swallowing it silently.
- tests/integration/src/common.rs now sets KEYSTONE_DEV_KEK /
  KEYSTONE_ALLOW_ENV_KEK in-process (if unset) so `cargo test -p
  integration` works without the external CI env-setup script.
- Removed unwrap()/expect() from storage-crypto and storage production
  code paths (cipher.rs, kek.rs, app.rs, cluster_admin_service.rs),
  propagating typed errors instead; added CryptoError::InvalidArrayLength
  for the (unreachable but now non-panicking) fixed-length AEAD
  parameter conversions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
