### PR TITLE
feat(audit): Complete ADR-0023 audit implementation

### DIFF
--- a/crates/audit/src/dispatcher.rs
+++ b/crates/audit/src/dispatcher.rs
@@ -217,13 +217,18 @@ impl AuditDispatcher {
 /// Compute HMAC-SHA256 over the JCS-canonical (RFC 8785) serialization of
 /// `payload`.
 ///
-/// JCS requires:
-/// - Object keys sorted lexicographically (Unicode code point order)
-/// - Compact form (no extra whitespace)
-/// - `null` for absent optional fields (we use `skip_serializing_if` on the
-///   struct level, so `None` fields are omitted — this matches the SIEM
-///   verification path which removes the `signature` key and re-serializes the
-///   remainder)
+/// JCS requires object keys sorted lexicographically (Unicode code point
+/// order) and compact form (no extra whitespace).
+///
+/// # Field inclusion
+///
+/// Fields follow their individual `serde` annotations.  Most `Option`-typed
+/// fields (`outcome_reason`, `Initiator.project_id`, `Initiator.domain_id`)
+/// serialize as `null` when `None`.  `Initiator.host` uses
+/// `skip_serializing_if = "Option::is_none"` and is **omitted entirely**
+/// when absent — not set to `null`.  SIEMs MUST reproduce this exact
+/// behavior: re-serialize the received JSON (after removing `signature`)
+/// without inserting absent fields.
 ///
 /// We achieve key ordering by round-tripping through `serde_json::Value`
 /// and sorting object keys recursively before re-serializing. This is
@@ -238,6 +243,8 @@ pub(crate) fn compute_hmac_sha256(payload: &CadfEventPayload, key: &[u8]) -> Str
 
 /// Serialize `payload` to JCS-canonical JSON (RFC 8785 §3.2.3):
 /// object keys sorted lexicographically at every nesting level.
+/// See `compute_hmac_sha256` for the field-inclusion rules (notably
+/// `Initiator.host` is omitted, not null'd, when absent).
 fn jcs_canonical(payload: &CadfEventPayload) -> String {
     let value = serde_json::to_value(payload).expect("CadfEventPayload is always serializable");
     sort_json_keys(value).to_string()

--- a/crates/audit/src/types.rs
+++ b/crates/audit/src/types.rs
@@ -159,12 +159,24 @@ impl CadfEvent {
 /// Human-readable fields (usernames, emails, project names) are excluded by
 /// design. The `host` field carries pre-auth signals; sanitization rules are
 /// enforced at construction time (see `sanitize::sanitize_initiator_host`).
+///
+/// # Serialization note
+///
+/// `project_id` and `domain_id` serialize as JSON `null` when absent.
+/// `host` is **omitted entirely** (not set to `null`) when absent, indicated
+/// by `#[serde(skip_serializing_if = "Option::is_none")]`.  SIEMs that
+/// re-serialize the received JSON to verify the HMAC signature MUST NOT
+/// insert a `"host": null` key for events that do not carry a `host` field;
+/// they must re-serialize the JSON object as received (minus the `signature`
+/// key) without adding absent keys.  See ADR-0023 §"HMAC Signing" for the
+/// full SIEM verification procedure.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Initiator {
     id: String,
     project_id: Option<String>,
     domain_id: Option<String>,
     /// Pre-auth signal (EC2 access key, federation idp_id). No PII.
+    /// Omitted from serialization (not null'd) when absent.
     #[serde(skip_serializing_if = "Option::is_none")]
     host: Option<String>,
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -357,6 +357,20 @@ impl EventDispatcher {
 /// - `on_audit_error` — closure `|AuditDispatchError| -> E` mapping pre-audit
 ///   failures to the outer error type
 ///
+/// # Failure reason extraction (Debug-format contract)
+///
+/// The `Failure` post-audit reason is extracted by formatting the error value
+/// with `{:?}` (the `Debug` trait) and taking characters up to the first `(`,
+/// `{`, or space, capped at 64 characters.  This yields the enum variant name
+/// for typical Rust error enums (e.g. `NotFound`, `Conflict`).  Error types
+/// used with this macro MUST implement `Debug` such that the variant or type
+/// name appears before any delimiter.  In particular:
+/// - Struct-like variants (e.g. `NotFound { .. }`) produce the name before `{`.
+/// - Tuple variants (e.g. `Io(std::io::Error)`) produce the name before `(`.
+/// - Unit variants (e.g. `Unauthorized`) produce the full name unchanged.
+/// - Types that produce multi-word Debug output or leading punctuation will
+///   yield a truncated or empty string — avoid using those as operation errors.
+///
 /// # Cancellation safety
 /// If the future returned by `$op` is dropped before completing, the
 /// post-audit event is never emitted.  Callers that require at-least-once

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -341,22 +341,30 @@ async fn main() -> Result<(), Report> {
     );
 
     // Replay the spool file left by the previous run (at-least-once delivery).
-    struct SingleKeyStore(u64, Arc<[u8]>);
-    impl HmacKeyStore for SingleKeyStore {
+    //
+    // `MultiKeyStore` holds all key versions seen during this process lifetime.
+    // Currently only one version exists; the HashMap is pre-populated with the
+    // current key so that `replay_spool` can verify events signed by it.
+    // When key rotation is implemented, callers MUST insert the new version
+    // before calling `refresh_hmac_key` on the dispatcher — spool events
+    // written before the rotation will still carry the old version number and
+    // must remain verifiable during the drain window (ADR 0023 §"Key Rotation").
+    struct MultiKeyStore(std::collections::HashMap<u64, Arc<[u8]>>);
+    impl HmacKeyStore for MultiKeyStore {
         fn get_key(&self, version: u64) -> Option<Arc<[u8]>> {
-            if version == self.0 {
-                Some(Arc::clone(&self.1))
-            } else {
-                None
-            }
+            self.0.get(&version).map(Arc::clone)
         }
     }
+    let mut key_store = MultiKeyStore(std::collections::HashMap::new());
+    key_store
+        .0
+        .insert(AUDIT_HMAC_KEY_VERSION, Arc::clone(&audit_hmac_key));
     let spool_file = spool_path(&spool_dir, audit_cfg.node_id.as_str());
     replay_spool(
         &spool_file,
         audit_cfg.node_id.as_str(),
         &audit_dispatcher,
-        &SingleKeyStore(AUDIT_HMAC_KEY_VERSION, Arc::clone(&audit_hmac_key)),
+        &key_store,
     )
     .await
     .wrap_err("audit spool replay failed")?;

--- a/crates/keystone/src/federation/api/jwt.rs
+++ b/crates/keystone/src/federation/api/jwt.rs
@@ -24,8 +24,11 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::api::error::KeystoneApiError;
 use crate::api::v4::auth::token::types::TokenResponse as KeystoneTokenResponse;
+use crate::audit::{CorrelationId, emit_perimeter_authenticate_event, error_variant_name};
 use crate::federation::api::error::OidcError;
 use crate::keystone::ServiceState;
+use openstack_keystone_audit::sanitize::{HostKind, sanitize_initiator_host};
+use openstack_keystone_audit::types::Initiator;
 use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
@@ -66,10 +69,31 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
 )]
 #[debug_handler]
 pub async fn login(
+    CorrelationId(cid): CorrelationId,
     State(state): State<ServiceState>,
     headers: HeaderMap,
     Path(idp_id): Path<String>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
+    let result = login_inner(&state, headers, &idp_id).await;
+    // `idp_id` is a pre-auth signal known before any validation happens, so it
+    // is recorded as `Initiator.host` regardless of outcome (ADR 0023 §"Perimeter
+    // Auditing").
+    let host = sanitize_initiator_host(&idp_id, HostKind::FederationIdpUuid)
+        .or_else(|| sanitize_initiator_host(&idp_id, HostKind::FederationIdpNonUuid));
+    let initiator = Initiator::new("unknown".to_string(), None, None, host);
+    let (outcome, reason) = match &result {
+        Ok(_) => ("success", None),
+        Err(e) => ("failure", Some(error_variant_name(e))),
+    };
+    emit_perimeter_authenticate_event(&state.audit_dispatcher, &cid, initiator, outcome, reason);
+    result
+}
+
+async fn login_inner(
+    state: &ServiceState,
+    headers: HeaderMap,
+    idp_id: &str,
+) -> Result<axum::response::Response, KeystoneApiError> {
     state
         .config_manager
         .config
@@ -109,12 +133,12 @@ pub async fn login(
     let idp = state
         .provider
         .get_federation_provider()
-        .get_identity_provider(&ExecutionContext::internal(&state), &idp_id)
+        .get_identity_provider(&ExecutionContext::internal(state), idp_id)
         .await
         .map(|x| {
             x.ok_or_else(|| KeystoneApiError::NotFound {
                 resource: "identity provider".into(),
-                identifier: idp_id,
+                identifier: idp_id.to_string(),
             })
         })??;
 
@@ -198,11 +222,11 @@ pub async fn login(
     let auth_result: AuthenticationResult = state
         .provider
         .get_mapping_provider()
-        .authenticate_by_mapping(&ExecutionContext::internal(&state), &mapping_req)
+        .authenticate_by_mapping(&ExecutionContext::internal(state), &mapping_req)
         .await?;
 
     // No scope is requested in JWT flow, so we resolve unscoped token.
-    let (token_str, api_token) = common::build_token_response(&state, &auth_result, None).await?;
+    let (token_str, api_token) = common::build_token_response(state, &auth_result, None).await?;
 
     tracing::trace!("Token response is {:?}", api_token);
     Ok((

--- a/crates/keystone/src/federation/api/oidc.rs
+++ b/crates/keystone/src/federation/api/oidc.rs
@@ -20,9 +20,14 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::api::error::KeystoneApiError;
 use crate::api::v4::auth::token::types::TokenResponse as KeystoneTokenResponse;
+use crate::audit::{
+    CorrelationId, build_initiator_unknown, emit_perimeter_authenticate_event, error_variant_name,
+};
 use crate::federation::api::error::OidcError;
 use crate::federation::api::types::*;
 use crate::keystone::ServiceState;
+use openstack_keystone_audit::sanitize::{HostKind, sanitize_initiator_host};
+use openstack_keystone_audit::types::Initiator;
 use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
@@ -61,10 +66,39 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
 )]
 #[debug_handler]
 pub async fn callback(
+    CorrelationId(cid): CorrelationId,
     State(state): State<ServiceState>,
     Json(query): Json<AuthCallbackParameters>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
-    let exec = ExecutionContext::internal(&state);
+    // `idp_id` is a pre-auth signal (known as soon as the auth state / idp
+    // lookup resolves, before any token verification happens) so it is
+    // recorded as `Initiator.host` regardless of outcome (ADR 0023 §"Perimeter
+    // Auditing"). `callback_inner` reports it via `idp_id_out` as soon as it
+    // is known, even if a later step in the flow fails.
+    let mut idp_id_out: Option<String> = None;
+    let result = callback_inner(&state, query, &mut idp_id_out).await;
+    let initiator = match &idp_id_out {
+        Some(idp_id) => {
+            let host = sanitize_initiator_host(idp_id, HostKind::FederationIdpUuid)
+                .or_else(|| sanitize_initiator_host(idp_id, HostKind::FederationIdpNonUuid));
+            Initiator::new("unknown".to_string(), None, None, host)
+        }
+        None => build_initiator_unknown(),
+    };
+    let (outcome, reason) = match &result {
+        Ok(_) => ("success", None),
+        Err(e) => ("failure", Some(error_variant_name(e))),
+    };
+    emit_perimeter_authenticate_event(&state.audit_dispatcher, &cid, initiator, outcome, reason);
+    result
+}
+
+async fn callback_inner(
+    state: &ServiceState,
+    query: AuthCallbackParameters,
+    idp_id_out: &mut Option<String>,
+) -> Result<axum::response::Response, KeystoneApiError> {
+    let exec = ExecutionContext::internal(state);
     // Validate auth state
     let auth_state = state
         .provider
@@ -91,6 +125,8 @@ pub async fn callback(
                 identifier: auth_state.idp_id.clone(),
             })
         })??;
+
+    *idp_id_out = Some(idp.id.clone());
 
     if !idp.enabled {
         return Err(OidcError::IdentityProviderDisabled.into());
@@ -204,7 +240,7 @@ pub async fn callback(
     // (unscoped) or a specific project/domain scope that was requested during
     // OIDC auth init.
     let (token_str, api_token) =
-        common::build_token_response(&state, &auth_result, auth_state.scope.as_ref()).await?;
+        common::build_token_response(state, &auth_result, auth_state.scope.as_ref()).await?;
 
     tracing::trace!("Token response is {:?}", api_token);
     Ok((

--- a/doc/src/adr/0023-audit.md
+++ b/doc/src/adr/0023-audit.md
@@ -4,7 +4,7 @@ Date: 2026-06-16
 
 ## Status
 
-Proposed
+Accepted
 
 > **Security review 2026-06-24:** Seven findings applied — HMAC canonicalization
 > (RFC 8785/JCS), `boot_session_id` CSPRNG requirement, `initiator.host`
@@ -176,8 +176,11 @@ pub struct AuditDispatcher {
 impl AuditDispatcher {
     // Signs over unsigned payload. HMAC input is the JCS-canonical (RFC 8785)
     // UTF-8 JSON of all payload fields with keys in lexicographic order, no
-    // extra whitespace, null-valued fields always included. This is the sole
-    // canonical form; SIEMs must reproduce it exactly for verification.
+    // extra whitespace. Most Option-typed fields serialize as `null` when
+    // absent. Exception: `Initiator.host` uses skip_serializing_if and is
+    // **omitted entirely** (not set to `null`) when absent. SIEMs MUST
+    // re-serialize the received JSON (minus `signature`) without inserting
+    // absent keys. This is the sole canonical form for HMAC verification.
     fn finalize_event(&self, partial: CadfEventPayload) -> CadfEvent {
         let (key, version) = self.hmac_key_and_version.load_full().as_ref();
         let completed = CadfEventPayload {


### PR DESCRIPTION
`Initiator.host` uses `skip_serializing_if` and is omitted entirely
(not set to `null`) when absent. Previous comments stated
"null-valued fields always included", which was inaccurate and could
cause SIEMs to insert a spurious `"host": null` key, breaking
HMAC verification.

Add a Serialization note to `Initiator` and a Field inclusion
section to `compute_hmac_sha256` describing per-field behavior.

Replace `SingleKeyStore` with `MultiKeyStore` backed by a `HashMap`,
allowing future key rotation to insert new versions before swapping the
active signing key. Spool events signed by older versions remain
verifiable during the drain window (ADR 0023 §"Key Rotation").

Add `CorrelationId` extraction and perimeter audit emission to the
federation JWT login (`/identity_providers/{idp_id}/jwt`) and OIDC
callback (`/oidc/callback`) handlers.

The sanitized `idp_id` is recorded as `Initiator.host` (UUID form tried
first, then non-UUID alphanumeric). Both handlers now follow the
split-handler pattern: an outer function emits the perimeter event
regardless of outcome, and propagates the result of the inner function.

Document the Debug-format contract for `audited_op!` failure reason
extraction: the macro takes characters from `{:?}` output up to the
first `(`, `{`, or space, yielding the enum variant name. Error types
used with the macro must expose their variant name as the leading token.

Also mark ADR 0023 as Accepted and correct the HMAC signing snippet to
note that `Initiator.host` is omitted (not null'd) when absent.

Assisted-By: Claude Sonnet 4.6 noreply@anthropic.com
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
