### PR TITLE
fix(webauthn): rotate raft ceremony-state keyspaces and reclaim expired ones

### DIFF
--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -472,4 +472,45 @@ pub trait StorageApi: Send + Sync {
     /// `Some(id)`, because without a leader writes will return
     /// `ForwardToLeader(None, None)` (ADR 0016-v2 §4.2).
     async fn current_leader(&self) -> Option<u64>;
+
+    /// Returns `true` if `keyspace` has been created, without creating it as
+    /// a side effect.
+    ///
+    /// Callers that maintain a rotating/time-bucketed set of keyspaces (e.g.
+    /// TTL'd session or ceremony state, to avoid unbounded growth and
+    /// tombstone buildup in a single ever-growing keyspace) use this to skip
+    /// garbage-collecting buckets that were never written to — every other
+    /// read/write method on this trait auto-creates the named keyspace on
+    /// first access, which would otherwise turn a GC sweep into a generator
+    /// of empty partitions.
+    async fn keyspace_exists(&self, keyspace: &str) -> Result<bool, StoreError>;
+
+    /// Permanently deletes an empty keyspace/partition.
+    ///
+    /// This is local storage housekeeping, not a Raft-replicated mutation: an
+    /// empty keyspace has no content observable through this trait, so
+    /// reclaiming the (now unused) partition does not itself change
+    /// state-machine output. That said, callers driving deletion off
+    /// wall-clock buckets (rather than a value already agreed on via Raft)
+    /// should not fire this from every node independently: clock skew means
+    /// a fast node can consider a bucket expired while a correctly-clocked
+    /// peer still needs to read it, and this call has no way to detect that.
+    /// Restrict such sweeps to the current leader (see
+    /// [`Self::current_leader`]) to bound the blast radius to one node at a
+    /// time.
+    ///
+    /// Implementations must reject the call — returning an error without
+    /// deleting anything — if the keyspace still contains entries, and must
+    /// never allow deletion of the core `"data"`, `"meta"`, or `"index"`
+    /// keyspaces.
+    async fn drop_keyspace(&self, keyspace: &str) -> Result<(), StoreError>;
+
+    /// Returns this node's own Raft node id.
+    ///
+    /// Combine with [`Self::current_leader`] (`current_leader().await ==
+    /// Some(node_id().await)`) to check leadership before running
+    /// node-local housekeeping — such as [`Self::drop_keyspace`] sweeps
+    /// driven by wall-clock time — that should only run on one cluster
+    /// member at a time.
+    async fn node_id(&self) -> u64;
 }

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -768,6 +768,20 @@ impl StorageApi for Storage {
         self.raft.metrics().borrow_watched().current_leader
     }
 
+    async fn keyspace_exists(&self, keyspace: &str) -> Result<bool, ApiStoreError> {
+        Ok(self.state_machine_store.keyspace_exists(keyspace))
+    }
+
+    async fn drop_keyspace(&self, keyspace: &str) -> Result<(), ApiStoreError> {
+        self.state_machine_store
+            .drop_keyspace(keyspace)
+            .map_err(ApiStoreError::from)
+    }
+
+    async fn node_id(&self) -> u64 {
+        self.node_id
+    }
+
     async fn initialize(&self, nodes: HashMap<u64, Node>) -> Result<(), ApiStoreError> {
         let pb_nodes: HashMap<u64, pb::raft::Node> = nodes
             .into_iter()

--- a/crates/storage/src/mock.rs
+++ b/crates/storage/src/mock.rs
@@ -41,6 +41,11 @@ pub struct MockStorage {
     metadata: Mutex<HashMap<String, Vec<u8>>>,
     /// index_key -> ()  (flat, no keyspace).
     indexes: Mutex<HashMap<Vec<u8>, ()>>,
+    /// This node's simulated Raft node id. Defaults to `0`.
+    node_id: Mutex<u64>,
+    /// The simulated current Raft leader id. Defaults to `None` (no
+    /// leader), matching `current_leader()`'s prior hardcoded behavior.
+    leader_id: Mutex<Option<u64>>,
 }
 
 fn lock<'a, T>(m: &'a Mutex<T>) -> Result<std::sync::MutexGuard<'a, T>, StoreError> {
@@ -50,6 +55,18 @@ fn lock<'a, T>(m: &'a Mutex<T>) -> Result<std::sync::MutexGuard<'a, T>, StoreErr
 }
 
 impl MockStorage {
+    /// Sets this node's simulated Raft node id, for tests exercising
+    /// leader-only logic (`current_leader() == Some(node_id())`).
+    pub fn set_node_id(&self, id: u64) {
+        *self.node_id.lock().unwrap_or_else(|p| p.into_inner()) = id;
+    }
+
+    /// Sets the simulated current Raft leader id, for tests exercising
+    /// leader-only logic.
+    pub fn set_current_leader(&self, leader: Option<u64>) {
+        *self.leader_id.lock().unwrap_or_else(|p| p.into_inner()) = leader;
+    }
+
     /// Store a value under `key` in `keyspace`, recording `metadata`.
     /// Returns a `Violation` when `expected_revision` mismatches.
     /// When a violation occurs, the write is skipped (true CAS behavior).
@@ -387,7 +404,31 @@ impl StorageApi for MockStorage {
     }
 
     async fn current_leader(&self) -> Option<u64> {
-        None
+        *self.leader_id.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    async fn keyspace_exists(&self, keyspace: &str) -> Result<bool, ApiStoreError> {
+        Ok(lock(&self.data)?.contains_key(keyspace))
+    }
+
+    async fn drop_keyspace(&self, keyspace: &str) -> Result<(), ApiStoreError> {
+        if matches!(keyspace, "data" | "meta" | "index") {
+            return Err(ApiStoreError::other(format!(
+                "refusing to drop core keyspace '{keyspace}'"
+            )));
+        }
+        let mut data = lock(&self.data)?;
+        if data.get(keyspace).is_some_and(|m| !m.is_empty()) {
+            return Err(ApiStoreError::other(format!(
+                "refusing to drop non-empty keyspace '{keyspace}'"
+            )));
+        }
+        data.remove(keyspace);
+        Ok(())
+    }
+
+    async fn node_id(&self) -> u64 {
+        *self.node_id.lock().unwrap_or_else(|p| p.into_inner())
     }
 
     async fn initialize(

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -346,6 +346,20 @@ pub struct FjallStateMachine {
     /// Shared with `ClusterAdminServiceImpl` so the gRPC handler can inspect
     /// the map without going through Raft.
     pub pending_rotations: Arc<Mutex<HashMap<String, PendingRotation>>>,
+    /// Serializes non-core keyspace lifecycle changes (`drop_keyspace`)
+    /// against `apply()`'s writes.
+    ///
+    /// `apply()` holds the read side for its whole call (writes are
+    /// inherently sequential per node, so this never contends against
+    /// itself); `drop_keyspace` takes the write side for its
+    /// exists/is-empty/delete sequence. Without this, a keyspace's
+    /// emptiness check and physical deletion race a concurrent, still
+    /// in-flight `apply()` write to that same keyspace: Fjall's batch
+    /// commit path writes directly to the tree and does not consult the
+    /// `is_deleted` flag the single-item API checks, so the write would
+    /// silently land in an already-deregistered, soon-to-be-discarded
+    /// partition — applied per Raft, invisible to every future read.
+    keyspace_lifecycle: Arc<RwLock<()>>,
 }
 
 impl FjallStateMachine {
@@ -400,6 +414,7 @@ impl FjallStateMachine {
             quarantine_tx,
             quarantine,
             pending_rotations,
+            keyspace_lifecycle: Arc::new(RwLock::new(())),
         })
     }
 
@@ -462,6 +477,54 @@ impl FjallStateMachine {
                 .db
                 .keyspace(other.as_ref(), KeyspaceCreateOptions::default)?,
         })
+    }
+
+    /// Returns `true` if `name` names a keyspace that currently exists.
+    ///
+    /// Unlike [`Self::keyspace`], this never auto-vivifies an empty
+    /// partition — safe to call speculatively when probing for
+    /// garbage-collection candidates.
+    pub fn keyspace_exists<S: AsRef<str>>(&self, name: S) -> bool {
+        matches!(name.as_ref(), "data" | "meta" | "index") || self.db.keyspace_exists(name.as_ref())
+    }
+
+    /// Permanently deletes an empty, non-core keyspace/partition.
+    ///
+    /// Returns an error, without deleting anything, if the keyspace still
+    /// has entries or if it names one of the core `"data"` / `"meta"` /
+    /// `"index"` keyspaces. A no-op if the keyspace does not exist.
+    ///
+    /// Not part of the replicated Raft log: dropping an already-empty
+    /// partition has no effect observable through `StorageApi`, so every
+    /// node may reclaim it independently once it locally observes the
+    /// keyspace is drained (analogous to local LSM compaction).
+    pub fn drop_keyspace<S: AsRef<str>>(&self, name: S) -> Result<(), StoreError> {
+        let name = name.as_ref();
+        if matches!(name, "data" | "meta" | "index") {
+            return Err(StoreError::Other(eyre::eyre!(
+                "refusing to drop core keyspace '{name}'"
+            )));
+        }
+        // Excludes any concurrent `apply()` call for the whole
+        // exists/is-empty/delete sequence, so a write that `apply()` is
+        // mid-way through queuing into this keyspace's batch can't be
+        // silently discarded by a delete that lands between the emptiness
+        // check and the physical drop.
+        let _lifecycle_guard = self
+            .keyspace_lifecycle
+            .write()
+            .unwrap_or_else(|p| p.into_inner());
+        if !self.db.keyspace_exists(name) {
+            return Ok(());
+        }
+        let ks = self.db.keyspace(name, KeyspaceCreateOptions::default)?;
+        if !ks.is_empty()? {
+            return Err(StoreError::Other(eyre::eyre!(
+                "refusing to drop non-empty keyspace '{name}'"
+            )));
+        }
+        self.db.delete_keyspace(ks)?;
+        Ok(())
     }
 
     /// Decrypt state bytes previously written by [`state_encrypt`].
@@ -1055,6 +1118,14 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
         let mut entries = entries;
 
         while let Some((entry, responder)) = entries.try_next().await? {
+            // Held for this entry's whole processing+commit (there is no
+            // further `.await` in this loop body until the next iteration),
+            // so a concurrent `drop_keyspace` can't observe a keyspace as
+            // empty mid-write and delete it out from under this commit.
+            let _lifecycle_guard = self
+                .keyspace_lifecycle
+                .read()
+                .unwrap_or_else(|p| p.into_inner());
             let last_applied_log = entry.log_id();
             let mut batch = self.db.batch();
             let mut has_violations = false;
@@ -1880,5 +1951,134 @@ mod dek_version_tests {
             .decrypt_state(&ciphertext, DataTier::Internal as u8, b"data", b"k4", None)
             .expect("legacy probe path should still find the retired epoch");
         assert_eq!(plaintext, b"hello");
+    }
+}
+
+#[cfg(test)]
+mod keyspace_gc_tests {
+    use openstack_keystone_storage_crypto::EnvKek;
+
+    use super::*;
+
+    /// Builds a `FjallStateMachine` for exercising `keyspace_exists` /
+    /// `drop_keyspace` against the real Fjall backend (as opposed to
+    /// `mock::MockStorage`, which models the same contract in-memory for
+    /// driver-level tests).
+    fn make_sm() -> (FjallStateMachine, tempfile::TempDir) {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let db = Arc::new(Database::builder(td.path()).open().expect("open db"));
+        let kek: Arc<dyn KekProvider> = Arc::new(EnvKek::from_bytes([0x42u8; 32]));
+        let epoch =
+            Arc::new(DekEpoch::from_raw(LockedKey::from_raw([0x09; 32]), 1).expect("epoch"));
+        let (reencrypt_tx, reencrypt_rx) = tokio::sync::mpsc::channel(1);
+        drop(reencrypt_rx);
+        let (quarantine_tx, quarantine_rx) = tokio::sync::mpsc::channel(1);
+        drop(quarantine_rx);
+
+        let sm = FjallStateMachine::new(
+            db,
+            td.path().join("snapshots"),
+            1,
+            Arc::new(RwLock::new(epoch)),
+            Arc::new(Mutex::new(BTreeMap::new())),
+            Arc::new(Mutex::new(HashSet::new())),
+            kek,
+            reencrypt_tx,
+            quarantine_tx,
+            Arc::new(Mutex::new(HashMap::new())),
+        )
+        .expect("construct state machine");
+        (sm, td)
+    }
+
+    #[test]
+    fn keyspace_exists_is_false_until_first_access_and_never_auto_vivifies() {
+        let (sm, _td) = make_sm();
+        assert!(!sm.keyspace_exists("rotating_bucket_1"));
+        // Checking existence must not have created it as a side effect.
+        assert!(!sm.keyspace_exists("rotating_bucket_1"));
+
+        let _ks = sm.keyspace("rotating_bucket_1").expect("create keyspace");
+        assert!(sm.keyspace_exists("rotating_bucket_1"));
+    }
+
+    #[test]
+    fn keyspace_exists_is_always_true_for_core_keyspaces() {
+        let (sm, _td) = make_sm();
+        assert!(sm.keyspace_exists("data"));
+        assert!(sm.keyspace_exists("meta"));
+        assert!(sm.keyspace_exists("index"));
+    }
+
+    #[test]
+    fn drop_keyspace_is_noop_when_never_created() {
+        let (sm, _td) = make_sm();
+        sm.drop_keyspace("never_created").expect("no-op drop");
+        assert!(!sm.keyspace_exists("never_created"));
+    }
+
+    #[test]
+    fn drop_keyspace_reclaims_an_empty_partition() {
+        let (sm, _td) = make_sm();
+        sm.keyspace("rotating_bucket_2").expect("create keyspace");
+        assert!(sm.keyspace_exists("rotating_bucket_2"));
+
+        sm.drop_keyspace("rotating_bucket_2")
+            .expect("drop empty keyspace");
+        assert!(!sm.keyspace_exists("rotating_bucket_2"));
+    }
+
+    #[test]
+    fn drop_keyspace_refuses_non_empty_partition() {
+        let (sm, _td) = make_sm();
+        let ks = sm.keyspace("rotating_bucket_3").expect("create keyspace");
+        ks.insert(b"leftover-key", b"leftover-value")
+            .expect("insert");
+
+        let err = sm
+            .drop_keyspace("rotating_bucket_3")
+            .expect_err("must refuse to drop a non-empty keyspace");
+        assert!(matches!(err, StoreError::Other(_)));
+        assert!(sm.keyspace_exists("rotating_bucket_3"));
+    }
+
+    #[test]
+    fn drop_keyspace_refuses_core_keyspaces() {
+        let (sm, _td) = make_sm();
+        for core in ["data", "meta", "index"] {
+            let err = sm
+                .drop_keyspace(core)
+                .expect_err("must refuse to drop a core keyspace");
+            assert!(matches!(err, StoreError::Other(_)));
+            assert!(sm.keyspace_exists(core));
+        }
+    }
+
+    /// Regression test for the TOCTOU race between `drop_keyspace` and a
+    /// concurrent `apply()` write: `apply()` holds `keyspace_lifecycle`'s
+    /// read side for an entry's whole processing+commit, so `drop_keyspace`
+    /// (which takes the write side) must not be able to proceed while any
+    /// such read guard is outstanding — otherwise a keyspace could be
+    /// deleted mid-write, and Fjall's batch-commit path would silently
+    /// write into the now-deregistered, soon-to-be-discarded partition
+    /// (it does not consult the `is_deleted` flag the single-item API
+    /// checks).
+    #[test]
+    fn keyspace_lifecycle_lock_excludes_concurrent_readers_and_writer() {
+        let (sm, _td) = make_sm();
+        sm.keyspace("rotating_bucket_race")
+            .expect("create keyspace");
+
+        // Simulate an in-flight apply() holding the read guard for the
+        // duration of a batch commit.
+        let _apply_guard = sm.keyspace_lifecycle.read().expect("acquire read guard");
+
+        // A concurrent drop_keyspace call must be excluded, not race the
+        // in-flight write — try_write proves it would block rather than
+        // proceed and silently discard that write.
+        assert!(
+            sm.keyspace_lifecycle.try_write().is_err(),
+            "drop_keyspace's write lock must not be obtainable while apply() holds the read side"
+        );
     }
 }

--- a/crates/webauthn/src/driver/raft.rs
+++ b/crates/webauthn/src/driver/raft.rs
@@ -28,58 +28,78 @@ use crate::{
 };
 
 static DATA_KEYSPACE: &str = "data";
-static KEY_CURRENT_STATE: &str = "webauthn:state:current";
+
+/// Prefix for the rotating, time-bucketed keyspaces that hold in-flight
+/// WebAuthn ceremony state (registration/authentication challenges).
+///
+/// Ceremony state is inherently short-lived — a browser has only a few
+/// minutes to complete a passkey ceremony before the challenge goes stale —
+/// but a naive implementation that keeps writing to a single, never-rotated
+/// keyspace lets abandoned ceremonies accumulate forever, interleaved on
+/// disk with fresh writes (the classic segmentation problem for an
+/// LSM-backed store: live keys and long-dead tombstones end up mixed in the
+/// same compaction unit, and compaction can never fully reclaim the dead
+/// space because it keeps getting new neighbors). Bucketing writes by a
+/// coarse wall-clock window instead confines each ceremony's data to one of
+/// a small, bounded set of keyspaces that age out together and can be
+/// reclaimed as a whole once expired (see `cleanup`).
+static STATE_KEYSPACE_PREFIX: &str = "webauthn_state";
+
+/// Width of a single rotating state-keyspace time bucket, in seconds.
+///
+/// Matches the SQL driver's ceremony TTL (`driver::sql::state::delete_expired`,
+/// 5 minutes) so ceremony-state lifetime is consistent across backends.
+const STATE_BUCKET_WIDTH_SECS: i64 = 300;
+
+/// Number of buckets *before* the current one that reads/deletes still
+/// consult, so a ceremony started just before a bucket boundary is not
+/// orphaned when it completes just after it.
+const STATE_BUCKET_LOOKBACK: i64 = 1;
+
+/// Number of already-expired buckets (past the lookback window) that
+/// `cleanup` inspects on every tick.
+///
+/// This bounds GC cost to a handful of cheap `keyspace_exists` checks per
+/// tick regardless of how long the process has been running: most of those
+/// checks are `false` (nothing was ever written there, or the bucket was
+/// already reclaimed on an earlier tick) and complete without touching
+/// storage. A bucket found non-empty is drained via ordinary Raft-replicated
+/// removes; the now-empty partition is physically reclaimed on a later tick
+/// once every node has applied those removes.
+const STATE_BUCKET_GC_HORIZON: i64 = 6;
 
 /// Raft driver for the K8s Auth module.
 #[derive(Default)]
 pub struct RaftDriver {}
 
 impl RaftDriver {
-    /// Generate the keyspace name for storing temporary states using the
-    /// last_log_index.
+    /// The rotating state-keyspace time bucket for `now`.
     ///
-    /// # Parameters
-    /// - `storage`: The storage instance.
-    ///
-    /// # Returns
-    /// The generated keyspace name.
-    fn generate_state_keyspace_name(&self) -> String {
-        format!("webauth_state_{}", Utc::now().timestamp())
+    /// A pure function of wall-clock time: every cluster node derives the
+    /// same "current" bucket independently, with no persisted pointer or
+    /// coordination required (unlike the previous scheme, which cached a
+    /// single keyspace name on first use and then reused it forever).
+    fn state_bucket_for(&self, timestamp: i64) -> i64 {
+        timestamp.div_euclid(STATE_BUCKET_WIDTH_SECS)
     }
 
-    /// Get the name of the keyspace containing current (not expired) states.
-    ///
-    /// # Parameters
-    /// - `storage`: The storage instance.
-    ///
-    /// # Returns
-    /// A `Result` containing the keyspace name, or an `Error`.
-    async fn get_current_state_keyspace_name(
-        &self,
-        storage: &dyn StorageApi,
-    ) -> Result<String, ApiStoreError> {
-        let res = match storage
-            .get_by_key(KEY_CURRENT_STATE.as_bytes(), Some(DATA_KEYSPACE))
-            .await?
-        {
-            Some(val) => rmp_serde::from_slice(&val.data)?,
-            None => {
-                let ks_name = self.generate_state_keyspace_name();
-                storage
-                    .set_value(
-                        KEY_CURRENT_STATE.to_string(),
-                        StoreDataEnvelope {
-                            metadata: Metadata::new(),
-                            data: rmp_serde::to_vec(&ks_name)?,
-                        },
-                        Some(DATA_KEYSPACE.to_string()),
-                        None,
-                    )
-                    .await?;
-                ks_name
-            }
-        };
-        Ok(res)
+    /// The current rotating state-keyspace time bucket.
+    fn current_state_bucket(&self) -> i64 {
+        self.state_bucket_for(Utc::now().timestamp())
+    }
+
+    /// Keyspace name for a given time bucket.
+    fn state_keyspace_name(&self, bucket: i64) -> String {
+        format!("{STATE_KEYSPACE_PREFIX}_{bucket}")
+    }
+
+    /// Candidate keyspaces for a state read/delete, most-recent first: the
+    /// current bucket followed by `STATE_BUCKET_LOOKBACK` older ones.
+    fn state_keyspace_read_candidates(&self) -> Vec<String> {
+        let current = self.current_state_bucket();
+        (0..=STATE_BUCKET_LOOKBACK)
+            .map(|back| self.state_keyspace_name(current - back))
+            .collect()
     }
 
     /// Get the key name for the credential registration.
@@ -224,8 +244,8 @@ impl RaftDriver {
         storage: &dyn StorageApi,
         user_id: &str,
         auth_state: &PasskeyAuthentication,
-        state_keyspace: &str,
     ) -> Result<(), ApiStoreError> {
+        let keyspace = self.state_keyspace_name(self.current_state_bucket());
         storage
             .set_value(
                 self.get_user_cred_auth_state_key_name(user_id),
@@ -233,7 +253,7 @@ impl RaftDriver {
                     metadata: Metadata::new(),
                     data: rmp_serde::to_vec(auth_state)?,
                 },
-                Some(state_keyspace.to_string()),
+                Some(keyspace),
                 None,
             )
             .await?;
@@ -244,27 +264,32 @@ impl RaftDriver {
         &self,
         storage: &dyn StorageApi,
         user_id: &str,
-        state_keyspace: &str,
     ) -> Result<Option<PasskeyAuthentication>, ApiStoreError> {
         let key = self.get_user_cred_auth_state_key_name(user_id);
-        Ok(storage
-            .get_by_key(key.as_bytes(), Some(state_keyspace))
-            .await?
-            .map(|env| env.try_deserialize())
-            .transpose()?
-            .map(|x| x.data))
+        for keyspace in self.state_keyspace_read_candidates() {
+            if let Some(env) = storage.get_by_key(key.as_bytes(), Some(&keyspace)).await? {
+                return Ok(Some(env.try_deserialize()?.data));
+            }
+        }
+        Ok(None)
     }
 
     async fn delete_user_webauthn_credential_authentication_state_impl(
         &self,
         storage: &dyn StorageApi,
         user_id: &str,
-        state_keyspace: &str,
     ) -> Result<(), ApiStoreError> {
         let key = self.get_user_cred_auth_state_key_name(user_id);
-        storage
-            .remove(key, Some(state_keyspace.to_string()))
-            .await?;
+        for keyspace in self.state_keyspace_read_candidates() {
+            // Skip keyspaces that were never written to: `remove()` against
+            // a nonexistent keyspace auto-creates an empty partition as a
+            // side effect on the real backend, which would defeat the
+            // point of rotating (every ceremony completion would otherwise
+            // vivify the lookback bucket even when it was never used).
+            if storage.keyspace_exists(&keyspace).await? {
+                storage.remove(key.clone(), Some(keyspace)).await?;
+            }
+        }
         Ok(())
     }
 
@@ -273,8 +298,8 @@ impl RaftDriver {
         storage: &dyn StorageApi,
         user_id: &str,
         reg_state: &PasskeyRegistration,
-        state_keyspace: &str,
     ) -> Result<(), ApiStoreError> {
+        let keyspace = self.state_keyspace_name(self.current_state_bucket());
         storage
             .set_value(
                 self.get_user_cred_registration_state_key_name(user_id),
@@ -282,7 +307,7 @@ impl RaftDriver {
                     metadata: Metadata::new(),
                     data: rmp_serde::to_vec(reg_state)?,
                 },
-                Some(state_keyspace.to_string()),
+                Some(keyspace),
                 None,
             )
             .await?;
@@ -293,36 +318,95 @@ impl RaftDriver {
         &self,
         storage: &dyn StorageApi,
         user_id: &str,
-        state_keyspace: &str,
     ) -> Result<Option<PasskeyRegistration>, ApiStoreError> {
         let key = self.get_user_cred_registration_state_key_name(user_id);
-        Ok(storage
-            .get_by_key(key.as_bytes(), Some(state_keyspace))
-            .await?
-            .map(|env| env.try_deserialize())
-            .transpose()?
-            .map(|x| x.data))
+        for keyspace in self.state_keyspace_read_candidates() {
+            if let Some(env) = storage.get_by_key(key.as_bytes(), Some(&keyspace)).await? {
+                return Ok(Some(env.try_deserialize()?.data));
+            }
+        }
+        Ok(None)
     }
 
     async fn delete_user_webauthn_credential_registration_state_impl(
         &self,
         storage: &dyn StorageApi,
         user_id: &str,
-        state_keyspace: &str,
     ) -> Result<(), ApiStoreError> {
         let key = self.get_user_cred_registration_state_key_name(user_id);
-        storage
-            .remove(key, Some(state_keyspace.to_string()))
-            .await?;
+        for keyspace in self.state_keyspace_read_candidates() {
+            // See the auth-state variant above: skip keyspaces that were
+            // never created to avoid vivifying an empty lookback-bucket
+            // partition on every ceremony completion.
+            if storage.keyspace_exists(&keyspace).await? {
+                storage.remove(key.clone(), Some(keyspace)).await?;
+            }
+        }
         Ok(())
+    }
+
+    /// Reclaims rotating state keyspaces that have aged out of the read
+    /// lookback window (`STATE_BUCKET_LOOKBACK`).
+    ///
+    /// For each candidate bucket (checked oldest-affected-first, bounded by
+    /// `STATE_BUCKET_GC_HORIZON`): skip it cheaply if it was never created;
+    /// otherwise drain any leftover keys via ordinary Raft-replicated
+    /// removes (abandoned ceremonies that never called the corresponding
+    /// `delete_*` method), then reclaim the partition itself once empty.
+    /// Draining and dropping are split across ticks on purpose — a bucket
+    /// found non-empty this tick is guaranteed empty on read the next tick,
+    /// once every node has applied the removes — so this never races a
+    /// write against a delete.
+    async fn cleanup_expired_state_keyspaces_impl(
+        &self,
+        storage: &dyn StorageApi,
+    ) -> Result<(), ApiStoreError> {
+        let oldest_readable = self.current_state_bucket() - STATE_BUCKET_LOOKBACK;
+        for bucket in (oldest_readable - STATE_BUCKET_GC_HORIZON)..oldest_readable {
+            let keyspace = self.state_keyspace_name(bucket);
+            if !storage.keyspace_exists(&keyspace).await? {
+                continue;
+            }
+            let stale = storage.prefix(b"", Some(&keyspace)).await?;
+            if stale.is_empty() {
+                storage.drop_keyspace(&keyspace).await?;
+            } else {
+                for (key, _) in stale {
+                    storage.remove(key, Some(keyspace.clone())).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether this node is the current Raft leader.
+    ///
+    /// `cleanup_expired_state_keyspaces_impl` decides which buckets are
+    /// expired from this node's own wall clock, then calls `drop_keyspace`
+    /// directly — not through Raft. Calling it from every node
+    /// independently would let a fast-clocked node drop a bucket a
+    /// correctly-clocked peer still needs. Gating on leadership bounds the
+    /// sweep to one node at a time.
+    async fn is_current_leader(&self, storage: &dyn StorageApi) -> bool {
+        storage.current_leader().await == Some(storage.node_id().await)
     }
 }
 
 #[async_trait]
 impl WebauthnApi for RaftDriver {
     #[tracing::instrument(level = "debug", skip_all())]
-    async fn cleanup<'a>(&self, _exec: &ExecutionContext<'a>) -> Result<(), WebauthnError> {
-        Ok(())
+    async fn cleanup<'a>(&self, exec: &ExecutionContext<'a>) -> Result<(), WebauthnError> {
+        let raft = exec
+            .state()
+            .storage
+            .as_deref()
+            .ok_or(WebauthnError::RaftNotAvailable)?;
+        if !self.is_current_leader(raft).await {
+            return Ok(());
+        }
+        self.cleanup_expired_state_keyspaces_impl(raft)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Create webauthn credential for the user.
@@ -390,14 +474,9 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        let state_keyspace = self.get_current_state_keyspace_name(raft).await?;
-        self.delete_user_webauthn_credential_authentication_state_impl(
-            raft,
-            user_id,
-            &state_keyspace,
-        )
-        .await
-        .map_err(|e| e.into())
+        self.delete_user_webauthn_credential_authentication_state_impl(raft, user_id)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Delete webauthn credential registration state for the user.
@@ -412,8 +491,7 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        let state_keyspace = self.get_current_state_keyspace_name(raft).await?;
-        self.delete_user_webauthn_credential_registration_state_impl(raft, user_id, &state_keyspace)
+        self.delete_user_webauthn_credential_registration_state_impl(raft, user_id)
             .await
             .map_err(|e| e.into())
     }
@@ -430,8 +508,7 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        let state_keyspace = self.get_current_state_keyspace_name(raft).await?;
-        self.get_user_webauthn_credential_authentication_state_impl(raft, user_id, &state_keyspace)
+        self.get_user_webauthn_credential_authentication_state_impl(raft, user_id)
             .await
             .map_err(|e| e.into())
     }
@@ -448,8 +525,7 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        let state_keyspace = self.get_current_state_keyspace_name(raft).await?;
-        self.get_user_webauthn_credential_registration_state_impl(raft, user_id, &state_keyspace)
+        self.get_user_webauthn_credential_registration_state_impl(raft, user_id)
             .await
             .map_err(|e| e.into())
     }
@@ -484,15 +560,9 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        let state_keyspace = self.get_current_state_keyspace_name(raft).await?;
-        self.save_user_webauthn_credential_authentication_state_impl(
-            raft,
-            user_id,
-            auth_state,
-            &state_keyspace,
-        )
-        .await
-        .map_err(|e| e.into())
+        self.save_user_webauthn_credential_authentication_state_impl(raft, user_id, auth_state)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Save webauthn credential registration state.
@@ -508,15 +578,9 @@ impl WebauthnApi for RaftDriver {
             .storage
             .as_deref()
             .ok_or(WebauthnError::RaftNotAvailable)?;
-        let state_keyspace = self.get_current_state_keyspace_name(raft).await?;
-        self.save_user_webauthn_credential_registration_state_impl(
-            raft,
-            user_id,
-            reg_state,
-            &state_keyspace,
-        )
-        .await
-        .map_err(|e| e.into())
+        self.save_user_webauthn_credential_registration_state_impl(raft, user_id, reg_state)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Update credential data.
@@ -552,6 +616,121 @@ mod tests {
 
     const DATA_KEYSPACE_TEST: &str = "data";
     const STATE_KEYSPACE: &str = "webauth_state_test";
+
+    /// Wraps `MockStorage`, recording every keyspace passed to `remove()`.
+    ///
+    /// Used to prove `delete_*_impl` skips `remove()` entirely for
+    /// candidate keyspaces that were never written to — on the real Fjall
+    /// backend, calling `remove()` against a nonexistent keyspace silently
+    /// creates it, which `MockStorage` alone does not reproduce.
+    #[derive(Default)]
+    struct RecordingStorage {
+        inner: MockStorage,
+        removed_keyspaces: std::sync::Mutex<Vec<Option<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl StorageApi for RecordingStorage {
+        async fn contains_key(
+            &self,
+            key: &[u8],
+            keyspace: Option<&str>,
+        ) -> Result<bool, ApiStoreError> {
+            self.inner.contains_key(key, keyspace).await
+        }
+
+        async fn get_by_key(
+            &self,
+            key: &[u8],
+            keyspace: Option<&str>,
+        ) -> Result<Option<StoreDataEnvelope<Vec<u8>>>, ApiStoreError> {
+            self.inner.get_by_key(key, keyspace).await
+        }
+
+        async fn prefix(
+            &self,
+            prefix: &[u8],
+            keyspace: Option<&str>,
+        ) -> Result<Vec<(String, StoreDataEnvelope<Vec<u8>>)>, ApiStoreError> {
+            self.inner.prefix(prefix, keyspace).await
+        }
+
+        async fn prefix_index(&self, prefix: &[u8]) -> Result<Vec<String>, ApiStoreError> {
+            self.inner.prefix_index(prefix).await
+        }
+
+        async fn remove(
+            &self,
+            key: String,
+            keyspace: Option<String>,
+        ) -> Result<openstack_keystone_distributed_storage::StoreResponse, ApiStoreError> {
+            self.removed_keyspaces
+                .lock()
+                .unwrap()
+                .push(keyspace.clone());
+            self.inner.remove(key, keyspace).await
+        }
+
+        async fn remove_index(
+            &self,
+            key: String,
+        ) -> Result<openstack_keystone_distributed_storage::StoreResponse, ApiStoreError> {
+            self.inner.remove_index(key).await
+        }
+
+        async fn set_value(
+            &self,
+            key: String,
+            value: StoreDataEnvelope<Vec<u8>>,
+            keyspace: Option<String>,
+            expected_revision: Option<u64>,
+        ) -> Result<openstack_keystone_distributed_storage::StoreResponse, ApiStoreError> {
+            self.inner
+                .set_value(key, value, keyspace, expected_revision)
+                .await
+        }
+
+        async fn set_index_key(
+            &self,
+            key: String,
+        ) -> Result<openstack_keystone_distributed_storage::StoreResponse, ApiStoreError> {
+            self.inner.set_index_key(key).await
+        }
+
+        async fn transaction(
+            &self,
+            mutations: Vec<openstack_keystone_distributed_storage::Mutation>,
+        ) -> Result<openstack_keystone_distributed_storage::StoreResponse, ApiStoreError> {
+            self.inner.transaction(mutations).await
+        }
+
+        async fn is_initialized(&self) -> Result<bool, ApiStoreError> {
+            self.inner.is_initialized().await
+        }
+
+        async fn initialize(
+            &self,
+            nodes: std::collections::HashMap<u64, openstack_keystone_distributed_storage::Node>,
+        ) -> Result<(), ApiStoreError> {
+            self.inner.initialize(nodes).await
+        }
+
+        async fn current_leader(&self) -> Option<u64> {
+            self.inner.current_leader().await
+        }
+
+        async fn keyspace_exists(&self, keyspace: &str) -> Result<bool, ApiStoreError> {
+            self.inner.keyspace_exists(keyspace).await
+        }
+
+        async fn drop_keyspace(&self, keyspace: &str) -> Result<(), ApiStoreError> {
+            self.inner.drop_keyspace(keyspace).await
+        }
+
+        async fn node_id(&self) -> u64 {
+            self.inner.node_id().await
+        }
+    }
 
     #[tokio::test]
     async fn test_credential_storage<'a>() {
@@ -734,5 +913,288 @@ mod tests {
             .await
             .unwrap();
         assert!(found.is_none());
+    }
+
+    // PasskeyAuthentication wraps AuthenticationState under "ast"; same
+    // fixture shape used by the SQL driver's state tests.
+    fn sample_auth_state() -> PasskeyAuthentication {
+        serde_json::from_str(
+            r#"{"ast": {"credentials": [], "policy": "preferred", "challenge": "dGVzdC1jaGFsbGVuZ2U", "appid": null, "allow_backup_eligible_upgrade": false}}"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_state_bucket_is_pure_function_of_time() {
+        let driver = RaftDriver::default();
+        assert_eq!(driver.state_bucket_for(0), 0);
+        assert_eq!(driver.state_bucket_for(STATE_BUCKET_WIDTH_SECS - 1), 0);
+        assert_eq!(driver.state_bucket_for(STATE_BUCKET_WIDTH_SECS), 1);
+        assert_eq!(
+            driver.state_keyspace_name(42),
+            format!("{STATE_KEYSPACE_PREFIX}_42")
+        );
+        // Two independent calls agree — no persisted pointer is consulted.
+        assert_eq!(driver.current_state_bucket(), driver.current_state_bucket());
+    }
+
+    #[tokio::test]
+    async fn test_auth_state_roundtrip_via_impl_rotates_into_current_bucket() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+        let auth_state = sample_auth_state();
+
+        driver
+            .save_user_webauthn_credential_authentication_state_impl(
+                &storage,
+                "user-1",
+                &auth_state,
+            )
+            .await
+            .unwrap();
+
+        // Written straight into the current bucket's keyspace, not a
+        // cached/static one.
+        let current_ks = driver.state_keyspace_name(driver.current_state_bucket());
+        assert!(
+            storage
+                .get_by_key(
+                    driver
+                        .get_user_cred_auth_state_key_name("user-1")
+                        .as_bytes(),
+                    Some(&current_ks)
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        assert!(
+            driver
+                .get_user_webauthn_credential_authentication_state_impl(&storage, "user-1")
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        driver
+            .delete_user_webauthn_credential_authentication_state_impl(&storage, "user-1")
+            .await
+            .unwrap();
+        assert!(
+            driver
+                .get_user_webauthn_credential_authentication_state_impl(&storage, "user-1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_auth_state_skips_remove_on_never_written_lookback_bucket() {
+        let driver = RaftDriver::default();
+        let storage = RecordingStorage::default();
+        let auth_state = sample_auth_state();
+
+        // Only the current bucket ever receives a write; the previous
+        // (lookback) bucket's keyspace was never created.
+        driver
+            .save_user_webauthn_credential_authentication_state_impl(
+                &storage,
+                "user-1",
+                &auth_state,
+            )
+            .await
+            .unwrap();
+
+        driver
+            .delete_user_webauthn_credential_authentication_state_impl(&storage, "user-1")
+            .await
+            .unwrap();
+
+        // `remove()` must only be issued for the bucket that actually
+        // exists — calling it against the never-written lookback bucket
+        // would auto-vivify an empty partition on the real backend.
+        let removed = storage.removed_keyspaces.lock().unwrap();
+        let current_ks = driver.state_keyspace_name(driver.current_state_bucket());
+        assert_eq!(removed.as_slice(), [Some(current_ks)]);
+    }
+
+    #[tokio::test]
+    async fn test_get_auth_state_falls_back_to_previous_bucket() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+        let auth_state = sample_auth_state();
+
+        // Simulate a ceremony that started just before a bucket boundary:
+        // its state lives in the *previous* bucket's keyspace, not the
+        // current one.
+        let previous_ks = driver.state_keyspace_name(driver.current_state_bucket() - 1);
+        storage
+            .set_value(
+                driver.get_user_cred_auth_state_key_name("user-1"),
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: rmp_serde::to_vec(&auth_state).unwrap(),
+                },
+                Some(previous_ks),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let found = driver
+            .get_user_webauthn_credential_authentication_state_impl(&storage, "user-1")
+            .await
+            .unwrap();
+        assert!(found.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_auth_state_beyond_lookback_is_not_found() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+        let auth_state = sample_auth_state();
+
+        // A bucket older than the lookback window is treated as expired,
+        // even if a stale entry still physically exists there.
+        let ancient_ks =
+            driver.state_keyspace_name(driver.current_state_bucket() - STATE_BUCKET_LOOKBACK - 1);
+        storage
+            .set_value(
+                driver.get_user_cred_auth_state_key_name("user-1"),
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: rmp_serde::to_vec(&auth_state).unwrap(),
+                },
+                Some(ancient_ks),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let found = driver
+            .get_user_webauthn_credential_authentication_state_impl(&storage, "user-1")
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_is_a_noop_when_nothing_ever_written() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+        driver
+            .cleanup_expired_state_keyspaces_impl(&storage)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_is_current_leader_true_when_leader_matches_self() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+        storage.set_node_id(7);
+        storage.set_current_leader(Some(7));
+        assert!(driver.is_current_leader(&storage).await);
+    }
+
+    #[tokio::test]
+    async fn test_is_current_leader_false_when_another_node_leads() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+        storage.set_node_id(7);
+        storage.set_current_leader(Some(3));
+        assert!(!driver.is_current_leader(&storage).await);
+    }
+
+    #[tokio::test]
+    async fn test_is_current_leader_false_when_no_leader_elected() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+        storage.set_node_id(7);
+        assert!(!driver.is_current_leader(&storage).await);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_drains_then_drops_expired_keyspace() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+
+        // Well past the read lookback window and inside the GC horizon:
+        // eligible for reclamation this tick.
+        let stale_bucket = driver.current_state_bucket() - STATE_BUCKET_LOOKBACK - 2;
+        let stale_ks = driver.state_keyspace_name(stale_bucket);
+        storage
+            .set_value(
+                "abandoned-user:auth".to_string(),
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: rmp_serde::to_vec(&sample_auth_state()).unwrap(),
+                },
+                Some(stale_ks.clone()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(storage.keyspace_exists(&stale_ks).await.unwrap());
+
+        // First tick: drains the leftover key but leaves the (now empty)
+        // partition in place.
+        driver
+            .cleanup_expired_state_keyspaces_impl(&storage)
+            .await
+            .unwrap();
+        assert!(
+            storage
+                .get_by_key(b"abandoned-user:auth", Some(&stale_ks))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(storage.keyspace_exists(&stale_ks).await.unwrap());
+
+        // Second tick: finds it empty and reclaims the partition itself.
+        driver
+            .cleanup_expired_state_keyspaces_impl(&storage)
+            .await
+            .unwrap();
+        assert!(!storage.keyspace_exists(&stale_ks).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_does_not_touch_buckets_still_within_lookback() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+
+        let live_ks =
+            driver.state_keyspace_name(driver.current_state_bucket() - STATE_BUCKET_LOOKBACK);
+        storage
+            .set_value(
+                "active-user:auth".to_string(),
+                StoreDataEnvelope {
+                    metadata: Metadata::new(),
+                    data: rmp_serde::to_vec(&sample_auth_state()).unwrap(),
+                },
+                Some(live_ks.clone()),
+                None,
+            )
+            .await
+            .unwrap();
+
+        driver
+            .cleanup_expired_state_keyspaces_impl(&storage)
+            .await
+            .unwrap();
+
+        // Still readable — a ceremony started at the edge of the lookback
+        // window must not be garbage collected out from under it.
+        assert!(
+            storage
+                .get_by_key(b"active-user:auth", Some(&live_ks))
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 }


### PR DESCRIPTION
The raft driver's "state_keyspace" naming was never actually rotating:
get_current_state_keyspace_name() generated a timestamped name once,
then cached and reused it forever, so every WebAuthn ceremony
(registration/authentication challenge) ever attempted piled up in a
single keyspace with no way to reclaim it — cleanup() was a no-op stub,
unlike the SQL driver which deletes rows past a 5-minute TTL.

Replace the cached pointer with a keyspace name derived purely from a
5-minute wall-clock bucket, so every cluster node computes the same
"current" bucket independently with no coordination. Reads/deletes
check the current bucket plus one lookback bucket so a ceremony
started near a boundary isn't orphaned. cleanup() now drains and then
physically reclaims aged-out bucket keyspaces via two new StorageApi
primitives (keyspace_exists/drop_keyspace) added alongside their Fjall
and mock implementations, so abandoned ceremonies no longer accumulate
indefinitely in a single ever-growing keyspace.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
