### PR TITLE
feat(api-key): Implement stateless SCIM ingress auth (ADR 0021)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,7 +2,7 @@ experimental = ["setup-scripts"]
 
 [profile.default]
 # exclude raft-only tests
-default-filter = 'not test(/spiffe/) and not test(/mapping/) and not test(/test_cluster/)'
+default-filter = 'not test(/spiffe/) and not test(/mapping/) and not test(/test_cluster/) and not test(/api_key/)'
 # Global default settings
 #
 [scripts.setup.setup-pg]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -210,11 +210,23 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
 ]
 
 [[package]]
@@ -225,9 +237,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "asn1-rs"
@@ -395,9 +407,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -406,14 +418,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -544,13 +557,13 @@ dependencies = [
 
 [[package]]
 name = "bcrypt"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
+checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
  "base64 0.22.1",
  "blowfish",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "subtle",
  "zeroize",
 ]
@@ -595,14 +608,23 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -644,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -655,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -668,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -679,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -695,9 +717,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
-version = "5.2.0"
+version = "5.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+checksum = "4a813de7f2bbedb7dce265b64f1cf5908ebe4d56281ece8d847e98113788b9b0"
 dependencies = [
  "rust_decimal",
  "schemars",
@@ -771,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -795,9 +817,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1044,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.23"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1064,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1365,7 +1387,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -1976,9 +1998,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fjall"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62b25b4d815ae178d7d9e4aa32ee59f072efd5431c736abede1e6ee13c8c453"
+checksum = "038acd422d607e0eca09e093f299f9eccf9bd097554343d93746afff81a45113"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -2250,25 +2272,22 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2331,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2509,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2598,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -2786,12 +2805,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -3031,13 +3044,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3100,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "keycloak"
-version = "26.6.1"
+version = "26.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209cc18fddbe7caf18c1cacf692ecc60b7cb8b17423644abd5e9ca0283a27ecc"
+checksum = "36d3481d17efb3e251c0d1e5c7451ecd4ef24e81dd1a223f9815e7649c42a004"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -3157,12 +3169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,14 +3182,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
  "plain",
- "redox_syscall 0.8.1",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -3237,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -3249,9 +3255,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e447ac67ff6aef4ec07fc19e507b219336cbba90a697c0dbeb1bf51b91536b67"
+checksum = "8ef86c3c797c10eefcc73407c43ae48c19d4df686131a8334b2895a513e91df4"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -3322,9 +3328,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -3655,13 +3661,12 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.3.5"
+version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -3733,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -3764,9 +3769,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3795,6 +3800,7 @@ dependencies = [
  "inventory",
  "jsonwebtoken",
  "nix 0.31.3",
+ "openstack-keystone-api-key-driver-raft",
  "openstack-keystone-api-types",
  "openstack-keystone-appcred-driver-sql",
  "openstack-keystone-assignment-driver-sql",
@@ -3851,6 +3857,20 @@ dependencies = [
  "utoipa-swagger-ui",
  "uuid",
  "validator",
+]
+
+[[package]]
+name = "openstack-keystone-api-key-driver-raft"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "openstack-keystone-core",
+ "openstack-keystone-core-types",
+ "openstack-keystone-distributed-storage",
+ "rmp-serde",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4008,18 +4028,22 @@ dependencies = [
 name = "openstack-keystone-core"
 version = "0.1.1"
 dependencies = [
+ "argon2",
  "async-trait",
  "axum",
  "base64 0.22.1",
  "bcrypt",
  "chrono",
  "config",
+ "crc32fast",
  "dashmap",
  "derive_builder",
  "eyre",
+ "governor",
  "hmac 0.13.0",
  "httpmock",
  "inventory",
+ "ipnet",
  "mockall",
  "openstack-keystone-api-types",
  "openstack-keystone-audit",
@@ -5464,9 +5488,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.23"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
+checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -5474,9 +5498,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5494,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -5583,7 +5607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -5685,9 +5709,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags 2.13.0",
 ]
@@ -5725,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5748,9 +5772,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -5896,9 +5920,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
  "bitflags 2.13.0",
  "once_cell",
@@ -6003,9 +6027,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -6063,9 +6087,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6090,9 +6114,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6766,9 +6790,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -7238,7 +7262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8087,11 +8111,11 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "sha1_smol",
@@ -8188,20 +8212,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -8212,9 +8227,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8226,9 +8241,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8236,9 +8251,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8246,9 +8261,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8259,33 +8274,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -8302,22 +8295,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8436,9 +8417,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8787,97 +8768,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap",
- "prettyplease",
- "syn 2.0.118",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -8941,9 +8834,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yaml-rust2"
@@ -8997,18 +8890,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9038,18 +8931,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9119,9 +9012,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "crates/api-key-driver-raft",
   "crates/api-types",
   "crates/audit",
   "crates/appcred-driver-sql",
@@ -56,9 +57,11 @@ exclude = [
 [workspace.dependencies]
 aes-gcm = { version = "0.11" }
 arc-swap = { version = "1.7" }
+argon2 = { version = "0.5" }
 async-trait = { version = "0.1" }
 axum = { version = "0.8", default-features = false }
 axum-server = { version = "0.8", default-features = false }
+crc32fast = { version = "1.4" }
 base64 = { version = "0.22" }
 base64urlsafedata = "0.5"
 bcrypt = { version = "0.19" }
@@ -84,11 +87,14 @@ hyper-util = { version = "0.1" }
 hkdf = { version = "0.13" }
 hmac = { version = "0.13" }
 inventory = { version = "0.3" }
+ipnet = { version = "2" }
 itertools = { version = "0.15" }
 mockall = { version = "0.15" }
 mockall_double = { version = "0.3" }
 nix = { version = "0.31", default-features = false }
+openidconnect = { version = "4.0" }
 openraft = { version = "=0.10.0-alpha.27" }
+openstack-keystone-api-key-driver-raft = { version = "0.1", path = "crates/api-key-driver-raft/" }
 openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "crates/api-types" }
 openstack-keystone-audit = { version = "0.1.0", path = "crates/audit" }
 openstack-keystone-appcred-driver-sql = { version = "0.1", path = "crates/appcred-driver-sql/" }

--- a/crates/api-key-driver-raft/Cargo.toml
+++ b/crates/api-key-driver-raft/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "openstack-keystone-api-key-driver-raft"
+description = "OpenStack Keystone Raft driver for API Key (SCIM ingress) machine identities"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+exclude.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+chrono = { workspace = true, default-features = false, features = ["clock"] }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
+openstack-keystone-distributed-storage.workspace = true
+rmp-serde.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+openstack-keystone-distributed-storage = { workspace = true, features = ["mock"] }
+tokio = { workspace = true, features = ["rt"] }
+
+[lints]
+workspace = true

--- a/crates/api-key-driver-raft/src/lib.rs
+++ b/crates/api-key-driver-raft/src/lib.rs
@@ -1,0 +1,668 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OpenStack Keystone Raft driver for API Key (SCIM ingress) machine
+//! identities (ADR 0021).
+use async_trait::async_trait;
+use chrono::Utc;
+
+use openstack_keystone_core::api_key::backend::ApiKeyBackend;
+use openstack_keystone_core::api_key::error::ApiKeyProviderError;
+use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core_types::api_key::*;
+use openstack_keystone_distributed_storage::{
+    Metadata, StorageApi, StoreDataEnvelope, StoreError, store_command::Mutation,
+};
+
+/// Raft Database API Key backend.
+///
+/// Primary records are indexed by `lookup_hash` (ADR 0021 §2.A), the fast
+/// non-secret SHA-256 digest of the token entropy, to serve the O(1)
+/// authentication hot path. The public `client_id` UUID used by
+/// administrative CRUD is resolved through a secondary index whose key
+/// embeds the target `lookup_hash` as a suffix.
+#[derive(Default)]
+pub struct RaftBackend {}
+
+impl RaftBackend {
+    /// Primary storage key: `api_client:v1:<domain_id>:<lookup_hash>`.
+    fn get_resource_key_name<D: AsRef<str>, H: AsRef<str>>(
+        &self,
+        domain_id: D,
+        lookup_hash: H,
+    ) -> String {
+        format!(
+            "api_client:v1:{}:{}",
+            domain_id.as_ref(),
+            lookup_hash.as_ref()
+        )
+    }
+
+    /// Prefix covering all keys for a domain (used for listing).
+    fn get_resource_by_domain_prefix<D: AsRef<str>>(&self, domain_id: D) -> String {
+        format!("api_client:v1:{}:", domain_id.as_ref())
+    }
+
+    /// Secondary index key resolving `client_id` to `lookup_hash`:
+    /// `api_client:client_id_idx:v1:<domain_id>:<client_id>:<lookup_hash>`.
+    fn get_client_id_idx_key_name<D: AsRef<str>, C: AsRef<str>, H: AsRef<str>>(
+        &self,
+        domain_id: D,
+        client_id: C,
+        lookup_hash: H,
+    ) -> String {
+        format!(
+            "api_client:client_id_idx:v1:{}:{}:{}",
+            domain_id.as_ref(),
+            client_id.as_ref(),
+            lookup_hash.as_ref()
+        )
+    }
+
+    /// Prefix resolving all index entries for a given `client_id`. Exactly
+    /// one entry is expected to exist at a time.
+    fn get_client_id_idx_prefix<D: AsRef<str>, C: AsRef<str>>(
+        &self,
+        domain_id: D,
+        client_id: C,
+    ) -> String {
+        format!(
+            "api_client:client_id_idx:v1:{}:{}:",
+            domain_id.as_ref(),
+            client_id.as_ref()
+        )
+    }
+
+    /// Resolve `client_id` to its current `lookup_hash` via the secondary
+    /// index.
+    async fn resolve_lookup_hash(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        client_id: &str,
+    ) -> Result<Option<String>, StoreError> {
+        let prefix = self.get_client_id_idx_prefix(domain_id, client_id);
+        let entries = storage.prefix_index(prefix.as_bytes()).await?;
+        Ok(entries
+            .into_iter()
+            .next()
+            .map(|key| key[prefix.len()..].to_string()))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn create_impl(
+        &self,
+        storage: &dyn StorageApi,
+        data: ApiClientResourceCreate,
+    ) -> Result<ApiClientResource, StoreError> {
+        let obj = ApiClientResource {
+            domain_id: data.domain_id,
+            provider_id: data.provider_id,
+            client_id: data.client_id,
+            lookup_hash: data.lookup_hash,
+            secret_hash: data.secret_hash,
+            allowed_ips: data.allowed_ips,
+            description: data.description,
+            enabled: true,
+            created_at: Utc::now().timestamp(),
+            expires_at: data.expires_at,
+            last_used_at: None,
+            revoked_at: None,
+            revoked_by: None,
+        };
+        let mutations = vec![
+            Mutation::set(
+                self.get_resource_key_name(&obj.domain_id, &obj.lookup_hash),
+                obj.clone(),
+                Metadata::new(),
+                None::<&str>,
+                None,
+            )?,
+            Mutation::set_index(self.get_client_id_idx_key_name(
+                &obj.domain_id,
+                &obj.client_id,
+                &obj.lookup_hash,
+            )),
+        ];
+        storage.transaction(mutations).await?;
+        Ok(obj)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn get_by_lookup_hash_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        lookup_hash: &str,
+    ) -> Result<Option<ApiClientResource>, StoreError> {
+        Ok(storage
+            .get_by_key(
+                self.get_resource_key_name(domain_id, lookup_hash)
+                    .as_bytes(),
+                None,
+            )
+            .await?
+            .map(|env| env.try_deserialize::<ApiClientResource>())
+            .transpose()?
+            .map(|x| x.data))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn get_by_client_id_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        client_id: &str,
+    ) -> Result<Option<ApiClientResource>, StoreError> {
+        let Some(lookup_hash) = self
+            .resolve_lookup_hash(storage, domain_id, client_id)
+            .await?
+        else {
+            return Ok(None);
+        };
+        self.get_by_lookup_hash_impl(storage, domain_id, &lookup_hash)
+            .await
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn list_impl(
+        &self,
+        storage: &dyn StorageApi,
+        params: &ApiClientResourceListParameters,
+    ) -> Result<Vec<ApiClientResource>, StoreError> {
+        let prefix = self.get_resource_by_domain_prefix(&params.domain_id);
+        let mut res: Vec<ApiClientResource> = Vec::new();
+        for (_, envelope) in storage.prefix(prefix.as_bytes(), None).await? {
+            let candidate = envelope.try_deserialize::<ApiClientResource>()?.data;
+            if let Some(provider_id) = &params.provider_id
+                && &candidate.provider_id != provider_id
+            {
+                continue;
+            }
+            if let Some(enabled) = params.enabled
+                && candidate.enabled != enabled
+            {
+                continue;
+            }
+            res.push(candidate);
+        }
+        Ok(res)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn update_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        client_id: &str,
+        data: ApiClientResourceUpdate,
+    ) -> Result<ApiClientResource, StoreError> {
+        let Some(lookup_hash) = self
+            .resolve_lookup_hash(storage, domain_id, client_id)
+            .await?
+        else {
+            return Err(StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            });
+        };
+        let key = self.get_resource_key_name(domain_id, &lookup_hash);
+        let curr: StoreDataEnvelope<ApiClientResource> = storage
+            .get_by_key(key.as_bytes(), None)
+            .await?
+            .ok_or_else(|| StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })?
+            .try_deserialize()?;
+        let new = curr.data.with_update(data);
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                key,
+                StoreDataEnvelope {
+                    data: rmp_serde::to_vec(&new)?,
+                    metadata: new_meta,
+                },
+                None,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(new)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn revoke_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        client_id: &str,
+        revoked_by: &str,
+    ) -> Result<ApiClientResource, StoreError> {
+        let Some(lookup_hash) = self
+            .resolve_lookup_hash(storage, domain_id, client_id)
+            .await?
+        else {
+            return Err(StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            });
+        };
+        let key = self.get_resource_key_name(domain_id, &lookup_hash);
+        let curr: StoreDataEnvelope<ApiClientResource> = storage
+            .get_by_key(key.as_bytes(), None)
+            .await?
+            .ok_or_else(|| StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })?
+            .try_deserialize()?;
+        let new = curr.data.revoke(revoked_by, Utc::now().timestamp());
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                key,
+                StoreDataEnvelope {
+                    data: rmp_serde::to_vec(&new)?,
+                    metadata: new_meta,
+                },
+                None,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(new)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn update_last_used_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        lookup_hash: &str,
+        last_used_at: i64,
+    ) -> Result<(), StoreError> {
+        let key = self.get_resource_key_name(domain_id, lookup_hash);
+        let Some(curr): Option<StoreDataEnvelope<ApiClientResource>> = storage
+            .get_by_key(key.as_bytes(), None)
+            .await?
+            .map(|env| env.try_deserialize())
+            .transpose()?
+        else {
+            return Ok(());
+        };
+        let mut new = curr.data;
+        new.last_used_at = Some(last_used_at);
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                key,
+                StoreDataEnvelope {
+                    data: rmp_serde::to_vec(&new)?,
+                    metadata: new_meta,
+                },
+                None,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn update_secret_hash_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        lookup_hash: &str,
+        secret_hash: String,
+    ) -> Result<(), StoreError> {
+        let key = self.get_resource_key_name(domain_id, lookup_hash);
+        let Some(curr): Option<StoreDataEnvelope<ApiClientResource>> = storage
+            .get_by_key(key.as_bytes(), None)
+            .await?
+            .map(|env| env.try_deserialize())
+            .transpose()?
+        else {
+            return Ok(());
+        };
+        let mut new = curr.data;
+        new.secret_hash = secret_hash;
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                key,
+                StoreDataEnvelope {
+                    data: rmp_serde::to_vec(&new)?,
+                    metadata: new_meta,
+                },
+                None,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ApiKeyBackend for RaftBackend {
+    async fn create(
+        &self,
+        state: &ServiceState,
+        data: ApiClientResourceCreate,
+    ) -> Result<ApiClientResource, ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        self.create_impl(raft, data)
+            .await
+            .map_err(ApiKeyProviderError::raft)
+    }
+
+    async fn get_by_client_id<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+    ) -> Result<Option<ApiClientResource>, ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        self.get_by_client_id_impl(raft, domain_id, client_id)
+            .await
+            .map_err(ApiKeyProviderError::raft)
+    }
+
+    async fn get_by_lookup_hash<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+    ) -> Result<Option<ApiClientResource>, ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        self.get_by_lookup_hash_impl(raft, domain_id, lookup_hash)
+            .await
+            .map_err(ApiKeyProviderError::raft)
+    }
+
+    async fn list(
+        &self,
+        state: &ServiceState,
+        params: &ApiClientResourceListParameters,
+    ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        self.list_impl(raft, params)
+            .await
+            .map_err(ApiKeyProviderError::raft)
+    }
+
+    async fn update<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+        data: ApiClientResourceUpdate,
+    ) -> Result<ApiClientResource, ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        match self.update_impl(raft, domain_id, client_id, data).await {
+            Ok(obj) => Ok(obj),
+            Err(e) => {
+                if e.to_string().contains("NotFound") {
+                    Err(ApiKeyProviderError::NotFound(client_id.to_string()))
+                } else {
+                    Err(ApiKeyProviderError::raft(e))
+                }
+            }
+        }
+    }
+
+    async fn revoke<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+        revoked_by: &'a str,
+    ) -> Result<ApiClientResource, ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        match self
+            .revoke_impl(raft, domain_id, client_id, revoked_by)
+            .await
+        {
+            Ok(obj) => Ok(obj),
+            Err(e) => {
+                if e.to_string().contains("NotFound") {
+                    Err(ApiKeyProviderError::NotFound(client_id.to_string()))
+                } else {
+                    Err(ApiKeyProviderError::raft(e))
+                }
+            }
+        }
+    }
+
+    async fn update_last_used<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+        last_used_at: i64,
+    ) -> Result<(), ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        self.update_last_used_impl(raft, domain_id, lookup_hash, last_used_at)
+            .await
+            .map_err(ApiKeyProviderError::raft)
+    }
+
+    async fn update_secret_hash<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+        secret_hash: String,
+    ) -> Result<(), ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        self.update_secret_hash_impl(raft, domain_id, lookup_hash, secret_hash)
+            .await
+            .map_err(ApiKeyProviderError::raft)
+    }
+}
+
+/// Linkage anchor — see ADR-0018. Referenced by the `keystone` crate's
+/// `build.rs`-generated `_ANCHORS` static so the linker extracts `.rlib`
+/// members, keeping `inventory::submit!` sections visible at runtime.
+#[allow(dead_code)]
+pub fn anchor() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openstack_keystone_distributed_storage::mock::MockStorage;
+
+    fn make_create(client_id: &str, domain_id: &str, lookup_hash: &str) -> ApiClientResourceCreate {
+        ApiClientResourceCreate {
+            domain_id: domain_id.to_string(),
+            provider_id: "provider-1".to_string(),
+            client_id: client_id.to_string(),
+            lookup_hash: lookup_hash.to_string(),
+            secret_hash: "$argon2id$v=19$m=65536,t=3,p=4$salt$hash".to_string(),
+            allowed_ips: None,
+            description: None,
+            expires_at: Utc::now().timestamp() + 3600,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_by_lookup_hash() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        let created = backend
+            .create_impl(&storage, make_create("client-1", "domain-1", "hash-1"))
+            .await
+            .unwrap();
+        assert_eq!(created.client_id, "client-1");
+        assert!(created.enabled);
+
+        let fetched = backend
+            .get_by_lookup_hash_impl(&storage, "domain-1", "hash-1")
+            .await
+            .unwrap();
+        assert_eq!(fetched.unwrap().client_id, "client-1");
+    }
+
+    #[tokio::test]
+    async fn test_get_by_client_id() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("client-1", "domain-1", "hash-1"))
+            .await
+            .unwrap();
+
+        let fetched = backend
+            .get_by_client_id_impl(&storage, "domain-1", "client-1")
+            .await
+            .unwrap();
+        assert_eq!(fetched.unwrap().lookup_hash, "hash-1");
+
+        let missing = backend
+            .get_by_client_id_impl(&storage, "domain-1", "nonexistent")
+            .await
+            .unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_by_domain_and_provider_filter() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("client-1", "domain-1", "hash-1"))
+            .await
+            .unwrap();
+        backend
+            .create_impl(&storage, make_create("client-2", "domain-1", "hash-2"))
+            .await
+            .unwrap();
+        backend
+            .create_impl(&storage, make_create("client-3", "domain-2", "hash-3"))
+            .await
+            .unwrap();
+
+        let params = ApiClientResourceListParameters {
+            domain_id: "domain-1".to_string(),
+            provider_id: None,
+            enabled: None,
+        };
+        let listed = backend.list_impl(&storage, &params).await.unwrap();
+        assert_eq!(listed.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_update_allowed_ips_semantics() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("client-1", "domain-1", "hash-1"))
+            .await
+            .unwrap();
+
+        let update = ApiClientResourceUpdate {
+            allowed_ips: Some(Some(vec!["10.0.0.0/8".to_string()])),
+            description: None,
+            enabled: None,
+        };
+        let updated = backend
+            .update_impl(&storage, "domain-1", "client-1", update)
+            .await
+            .unwrap();
+        assert_eq!(updated.allowed_ips, Some(vec!["10.0.0.0/8".to_string()]));
+
+        // Explicitly clear back to unrestricted.
+        let clear_update = ApiClientResourceUpdate {
+            allowed_ips: Some(None),
+            description: None,
+            enabled: None,
+        };
+        let cleared = backend
+            .update_impl(&storage, "domain-1", "client-1", clear_update)
+            .await
+            .unwrap();
+        assert_eq!(cleared.allowed_ips, None);
+    }
+
+    #[tokio::test]
+    async fn test_revoke_sets_tombstone_without_deleting() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("client-1", "domain-1", "hash-1"))
+            .await
+            .unwrap();
+
+        let revoked = backend
+            .revoke_impl(&storage, "domain-1", "client-1", "operator-1")
+            .await
+            .unwrap();
+        assert!(!revoked.enabled);
+        assert_eq!(revoked.revoked_by, Some("operator-1".to_string()));
+        assert!(revoked.revoked_at.is_some());
+
+        // Still resolvable by lookup_hash — no hard delete (ADR 0021 §5.C).
+        let fetched = backend
+            .get_by_lookup_hash_impl(&storage, "domain-1", "hash-1")
+            .await
+            .unwrap();
+        assert!(fetched.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_update_last_used() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("client-1", "domain-1", "hash-1"))
+            .await
+            .unwrap();
+
+        backend
+            .update_last_used_impl(&storage, "domain-1", "hash-1", 12345)
+            .await
+            .unwrap();
+
+        let fetched = backend
+            .get_by_lookup_hash_impl(&storage, "domain-1", "hash-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(fetched.last_used_at, Some(12345));
+    }
+}

--- a/crates/api-types/src/error.rs
+++ b/crates/api-types/src/error.rs
@@ -86,6 +86,9 @@ pub enum KeystoneApiError {
     #[error("missing x-subject-token header")]
     SubjectTokenMissing,
 
+    #[error("rate limit exceeded, retry later")]
+    TooManyRequests,
+
     #[error("The request you have made requires authentication.")]
     UnauthorizedNoContext,
 

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -22,6 +22,7 @@ use {
     serde_json::json,
 };
 
+use openstack_keystone_core_types::api_key::ApiKeyProviderError;
 use openstack_keystone_core_types::assignment::AssignmentProviderError;
 use openstack_keystone_core_types::auth::AuthenticationError;
 use openstack_keystone_core_types::catalog::CatalogProviderError;
@@ -51,6 +52,7 @@ impl IntoResponse for KeystoneApiError {
             KeystoneApiError::InternalError(_) | KeystoneApiError::Other(..) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
+            KeystoneApiError::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
             _ => StatusCode::BAD_REQUEST,
         };
 
@@ -233,6 +235,24 @@ impl From<RevokeProviderError> for KeystoneApiError {
     }
 }
 
+impl From<ApiKeyProviderError> for KeystoneApiError {
+    fn from(value: ApiKeyProviderError) -> Self {
+        match value {
+            ApiKeyProviderError::NotFound(x) => Self::NotFound {
+                resource: "api_key".into(),
+                identifier: x,
+            },
+            ApiKeyProviderError::Conflict(x) => Self::Conflict(x),
+            ApiKeyProviderError::Authentication { source } => source.into(),
+            // Crypto/storage-layer failures on the authentication hot path must
+            // never leak detail to the client (ADR 0021 §6.D OPSEC leakage);
+            // callers on that path should prefer mapping these to a generic
+            // `AuthenticationError::Unauthorized` before this conversion runs.
+            other => Self::InternalError(other.to_string()),
+        }
+    }
+}
+
 impl From<MappingProviderError> for KeystoneApiError {
     fn from(value: MappingProviderError) -> Self {
         match value {
@@ -260,6 +280,9 @@ impl From<MappingProviderError> for KeystoneApiError {
                 "interpolated value exceeds 256 character limit".to_string(),
             ),
             MappingProviderError::RulesetImmutable(x) => Self::BadRequest(x),
+            MappingProviderError::ApiClientSystemScopeForbidden(x) => Self::BadRequest(format!(
+                "rule '{x}' grants system scope, which is forbidden for API Key (ApiClient) mapping rulesets"
+            )),
             MappingProviderError::RaftNotAvailable => Self::InternalError(
                 "raft storage is not available in the mapping provider".to_string(),
             ),

--- a/crates/api-types/src/v4/mapping/ruleset.rs
+++ b/crates/api-types/src/v4/mapping/ruleset.rs
@@ -65,6 +65,11 @@ pub enum IdentitySource {
         /// SPIFFE trust domain identifier.
         trust_domain: String,
     },
+    /// API Key (SCIM ingress) machine identity source (ADR 0021).
+    ApiClient {
+        /// The API Key `provider_id` this ruleset is bound to.
+        provider_id: String,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-types/src/v4/mapping/ruleset_conv.rs
+++ b/crates/api-types/src/v4/mapping/ruleset_conv.rs
@@ -53,6 +53,7 @@ impl From<api::IdentitySource> for core::IdentitySource {
             api::IdentitySource::Federation { idp_id } => Self::Federation { idp_id },
             api::IdentitySource::K8s { cluster_id } => Self::K8s { cluster_id },
             api::IdentitySource::Spiffe { trust_domain } => Self::Spiffe { trust_domain },
+            api::IdentitySource::ApiClient { provider_id } => Self::ApiClient { provider_id },
         }
     }
 }
@@ -63,6 +64,7 @@ impl From<core::IdentitySource> for api::IdentitySource {
             core::IdentitySource::Federation { idp_id } => Self::Federation { idp_id },
             core::IdentitySource::K8s { cluster_id } => Self::K8s { cluster_id },
             core::IdentitySource::Spiffe { trust_domain } => Self::Spiffe { trust_domain },
+            core::IdentitySource::ApiClient { provider_id } => Self::ApiClient { provider_id },
         }
     }
 }

--- a/crates/config/src/api_key.rs
+++ b/crates/config/src/api_key.rs
@@ -1,0 +1,134 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key (SCIM ingress) provider configuration
+//!
+//! See ADR 0021 (Stateless API-Key Ingress & Ephemeral Security Contexts for
+//! SCIM).
+use serde::Deserialize;
+use validator::Validate;
+
+use crate::common::{csv, default_raft_driver};
+
+/// API Key (SCIM ingress) provider configuration.
+#[derive(Debug, Deserialize, Clone, Validate)]
+pub struct ApiKeyProvider {
+    /// Argon2id memory cost, in KiB, required of any stored PHC hash. Values
+    /// below this floor trigger a lazy re-hash on next successful
+    /// verification (ADR 0021 §6.B, Invariant 8).
+    #[serde(default = "default_argon2_memory_kib")]
+    #[validate(range(min = 1))]
+    pub argon2_memory_kib: u32,
+
+    /// Argon2id time cost (iterations) required of any stored PHC hash.
+    #[serde(default = "default_argon2_time_cost")]
+    #[validate(range(min = 1))]
+    pub argon2_time_cost: u32,
+
+    /// Argon2id parallelism (lanes) required of any stored PHC hash.
+    #[serde(default = "default_argon2_parallelism")]
+    #[validate(range(min = 1))]
+    pub argon2_parallelism: u32,
+
+    /// API Key backend.
+    #[serde(default = "default_raft_driver")]
+    pub driver: String,
+
+    /// Maximum number of days an API Key may go unused (per `last_used_at`)
+    /// before the janitor disables it (PCI-DSS inactivity threshold).
+    #[serde(default = "default_janitor_inactive_days")]
+    #[validate(range(min = 1))]
+    pub janitor_inactive_days: u32,
+
+    /// Additional days beyond `janitor_inactive_days` before disablement, to
+    /// absorb bounded drift from asynchronous `last_used_at` writes (ADR
+    /// 0021 §6.F).
+    #[serde(default = "default_janitor_grace_days")]
+    pub janitor_grace_days: u32,
+
+    /// Number of days a revoked key's tombstone is retained for audit before
+    /// the janitor physically purges it from storage (ADR 0021 §6.F).
+    #[serde(default = "default_janitor_tombstone_retention_days")]
+    #[validate(range(min = 1))]
+    pub janitor_tombstone_retention_days: u32,
+
+    /// CIDR blocks of reverse proxies trusted to prepend `X-Forwarded-For`
+    /// entries. Used to compute the effective client IP via the
+    /// rightmost-non-trusted algorithm (ADR 0021 §3 Step 2, §6.E,
+    /// Invariant 4).
+    #[serde(deserialize_with = "csv", default)]
+    pub trusted_proxies: Vec<String>,
+
+    /// Maximum burst of SCIM ingress authentication attempts accepted
+    /// instantaneously, per rate-limit key (`lookup_hash`, or source IP when
+    /// the token fails the format check), before throttling kicks in (ADR
+    /// 0021 §6.A).
+    #[serde(default = "default_rate_limit_burst_size")]
+    #[validate(range(min = 1))]
+    pub rate_limit_burst_size: u32,
+
+    /// Sustained SCIM ingress authentication attempts allowed per minute,
+    /// per rate-limit key, once the burst allowance is exhausted.
+    #[serde(default = "default_rate_limit_replenish_per_minute")]
+    #[validate(range(min = 1))]
+    pub rate_limit_replenish_per_minute: u32,
+}
+
+fn default_argon2_memory_kib() -> u32 {
+    65536
+}
+
+fn default_argon2_time_cost() -> u32 {
+    3
+}
+
+fn default_argon2_parallelism() -> u32 {
+    4
+}
+
+fn default_janitor_inactive_days() -> u32 {
+    90
+}
+
+fn default_janitor_grace_days() -> u32 {
+    7
+}
+
+fn default_janitor_tombstone_retention_days() -> u32 {
+    365
+}
+
+fn default_rate_limit_burst_size() -> u32 {
+    10
+}
+
+fn default_rate_limit_replenish_per_minute() -> u32 {
+    60
+}
+
+impl Default for ApiKeyProvider {
+    fn default() -> Self {
+        Self {
+            driver: default_raft_driver(),
+            argon2_memory_kib: default_argon2_memory_kib(),
+            argon2_time_cost: default_argon2_time_cost(),
+            argon2_parallelism: default_argon2_parallelism(),
+            janitor_inactive_days: default_janitor_inactive_days(),
+            janitor_grace_days: default_janitor_grace_days(),
+            janitor_tombstone_retention_days: default_janitor_tombstone_retention_days(),
+            trusted_proxies: Vec::new(),
+            rate_limit_burst_size: default_rate_limit_burst_size(),
+            rate_limit_replenish_per_minute: default_rate_limit_replenish_per_minute(),
+        }
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -56,6 +56,7 @@ use tokio::sync::RwLock;
 use tracing::error;
 use validator::Validate;
 
+mod api_key;
 mod application_credentials;
 mod assignment;
 mod audit;
@@ -83,6 +84,7 @@ mod token_restriction;
 mod trust;
 mod webauthn;
 
+pub use api_key::*;
 pub use application_credentials::*;
 pub use assignment::*;
 pub use audit::*;
@@ -113,6 +115,11 @@ pub use webauthn::*;
 /// Keystone configuration.
 #[derive(Debug, Default, Deserialize, Clone, Validate)]
 pub struct Config {
+    /// API Key (SCIM ingress) provider configuration.
+    #[serde(default)]
+    #[validate(nested)]
+    pub api_key: ApiKeyProvider,
+
     /// Application credentials provider configuration.
     #[serde(default)]
     pub application_credential: ApplicationCredentialProvider,
@@ -673,10 +680,10 @@ mod tests {
             r#"
     [auth]
     methods = []
-    
+
     [database]
     connection = "foo"
-    
+
     [distributed_storage]
     node_cluster_addr = "https://localhost:8310"
     node_id = 1
@@ -729,6 +736,108 @@ mod tests {
         assert!(
             err_msg.contains("security_compliance.invalid_password_hash_max_chars"),
             "Error message should explicitly blame invalid_password_hash_max_chars, but got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_api_key_defaults() {
+        let cfg = ApiKeyProvider::default();
+        assert_eq!(cfg.argon2_memory_kib, 65536);
+        assert_eq!(cfg.argon2_time_cost, 3);
+        assert_eq!(cfg.argon2_parallelism, 4);
+        assert_eq!(cfg.janitor_inactive_days, 90);
+        assert_eq!(cfg.janitor_grace_days, 7);
+        assert_eq!(cfg.janitor_tombstone_retention_days, 365);
+        assert!(cfg.trusted_proxies.is_empty());
+    }
+
+    #[test]
+    fn test_api_key_trusted_proxies_and_validation() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let config_file = NamedTempFile::with_suffix(".conf").unwrap();
+        let mut f = std::fs::File::create(config_file.path()).unwrap();
+        f.write_all(
+            r#"
+    [auth]
+    methods = []
+
+    [database]
+    connection = "foo"
+
+    [distributed_storage]
+    node_cluster_addr = "https://localhost:8310"
+    node_id = 1
+    path = "/keystone/storage"
+
+    [api_key]
+    trusted_proxies = 10.0.0.0/8,192.168.1.0/24
+            "#
+            .as_bytes(),
+        )
+        .unwrap();
+        f.sync_all().unwrap();
+
+        let cfg = Config::load_all(config_file.path().to_path_buf()).unwrap();
+        assert_eq!(
+            cfg.api_key.trusted_proxies,
+            vec!["10.0.0.0/8".to_string(), "192.168.1.0/24".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_invalid_api_key_validation() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let config_file = NamedTempFile::with_suffix(".conf").unwrap();
+        let mut f = std::fs::File::create(config_file.path()).unwrap();
+        f.write_all(
+            r#"
+    [auth]
+    methods = []
+
+    [database]
+    connection = "foo"
+
+    [distributed_storage]
+    node_cluster_addr = "https://localhost:8310"
+    node_id = 1
+    path = "/keystone/storage"
+
+    [api_key]
+    argon2_memory_kib = 0
+    argon2_time_cost = 0
+    argon2_parallelism = 0
+    janitor_inactive_days = 0
+    janitor_tombstone_retention_days = 0
+            "#
+            .as_bytes(),
+        )
+        .unwrap();
+        f.sync_all().unwrap();
+
+        let result = Config::load_all(config_file.path().to_path_buf());
+        assert!(result.is_err());
+
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(err_msg.contains("api_key.argon2_memory_kib"), "{}", err_msg);
+        assert!(err_msg.contains("api_key.argon2_time_cost"), "{}", err_msg);
+        assert!(
+            err_msg.contains("api_key.argon2_parallelism"),
+            "{}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("api_key.janitor_inactive_days"),
+            "{}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("api_key.janitor_tombstone_retention_days"),
+            "{}",
             err_msg
         );
     }

--- a/crates/core-types/src/api_key.rs
+++ b/crates/core-types/src/api_key.rs
@@ -11,23 +11,10 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # Integration tests
-//!
-//! Test the functionality on the provider level (not through the API).
+//! # API Key (SCIM ingress) machine identities (ADR 0021)
 
-mod api_key;
-mod application_credential;
-mod assignment;
-mod audit;
-mod catalog;
-mod common;
-mod identity;
-mod k8s_auth;
-mod mapping;
+mod error;
 mod resource;
-mod revoke;
-mod role;
-mod token;
 
-#[macro_use]
-mod macros;
+pub use error::*;
+pub use resource::*;

--- a/crates/core-types/src/api_key/error.rs
+++ b/crates/core-types/src/api_key/error.rs
@@ -1,0 +1,98 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key provider error
+
+use thiserror::Error;
+
+use crate::auth::AuthenticationError;
+use crate::error::BuilderError;
+
+/// API Key (`ApiClientResource`) provider error.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum ApiKeyProviderError {
+    /// Authentication error.
+    #[error(transparent)]
+    Authentication {
+        /// The source of the error.
+        #[from]
+        source: AuthenticationError,
+    },
+
+    /// API key not found.
+    #[error("API key {0} not found")]
+    NotFound(String),
+
+    /// Conflict.
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Argon2id hashing or verification error (token generation, secret
+    /// hashing, lazy re-hash). Stored as a message rather than a boxed
+    /// source because `argon2::password_hash::Error` does not implement
+    /// `std::error::Error` (the crate targets `no_std`).
+    #[error("crypto error in the api_key provider: {0}")]
+    Crypto(String),
+
+    /// Raft storage is not available for the API Key provider.
+    #[error("raft storage is not available in the api_key provider")]
+    RaftNotAvailable,
+
+    /// Raft storage error.
+    #[error("raft storage error in the api_key provider: {source}")]
+    RaftStoreError {
+        /// The source of the error.
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Structures builder error.
+    #[error(transparent)]
+    StructBuilder {
+        /// The source of the error.
+        #[from]
+        source: Box<BuilderError>,
+    },
+
+    /// Unsupported driver.
+    #[error("unsupported driver `{0}` for the api_key provider")]
+    UnsupportedDriver(String),
+}
+
+impl ApiKeyProviderError {
+    /// Wrap a raft storage error.
+    pub fn raft<E>(source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::RaftStoreError {
+            source: Box::new(source),
+        }
+    }
+
+    /// Wrap a crypto (Argon2id) error.
+    pub fn crypto<E>(source: E) -> Self
+    where
+        E: std::fmt::Display,
+    {
+        Self::Crypto(source.to_string())
+    }
+}
+
+impl From<BuilderError> for ApiKeyProviderError {
+    fn from(value: BuilderError) -> Self {
+        Self::StructBuilder {
+            source: Box::new(value),
+        }
+    }
+}

--- a/crates/core-types/src/api_key/resource.rs
+++ b/crates/core-types/src/api_key/resource.rs
@@ -1,0 +1,235 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key (SCIM ingress) resource
+//!
+//! See ADR 0021 (Stateless API-Key Ingress & Ephemeral Security Contexts for
+//! SCIM) for the full design.
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use crate::error::BuilderError;
+
+/// A domain-owned machine identity credential used for stateless SCIM
+/// ingress authentication (ADR 0021 §2).
+///
+/// Indexed in storage by `lookup_hash` (fast, non-secret SHA-256 digest of
+/// the token entropy) under
+/// `data:api_client:v1:<domain_id>:<lookup_hash>`. `client_id` is the public
+/// UUID handed to administrators for CRUD operations and is never embedded
+/// in the token itself.
+#[derive(Builder, Clone, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct ApiClientResource {
+    /// Domain owning this machine identity.
+    pub domain_id: String,
+
+    /// The Unified Mapping Engine (ADR 0020) `provider_id` this key
+    /// authenticates against. Multiple keys may share a `provider_id` to
+    /// support zero-downtime rotation (ADR 0021 §5.D).
+    pub provider_id: String,
+
+    /// Public UUID used for management API references. Never embedded in
+    /// the token or HTTP headers.
+    pub client_id: String,
+
+    /// `SHA-256(entropy)`, used as the fast O(1) storage index.
+    pub lookup_hash: String,
+
+    /// PHC-formatted Argon2id hash of the token entropy, used for
+    /// cryptographic verification.
+    pub secret_hash: String,
+
+    /// CIDR allowlist restricting the source IP of the request. `None`
+    /// means no restriction applies (ADR 0021 Invariant 5); a missing field
+    /// and `Some(vec![])` MUST be treated identically.
+    #[builder(default)]
+    pub allowed_ips: Option<Vec<String>>,
+
+    /// Free-form administrative description.
+    #[builder(default)]
+    pub description: Option<String>,
+
+    /// Whether the key currently authenticates. Cleared by revocation and
+    /// by the janitor on inactivity (ADR 0021 §6.F).
+    pub enabled: bool,
+
+    /// UTC epoch seconds.
+    pub created_at: i64,
+
+    /// Mandatory TTL, UTC epoch seconds.
+    pub expires_at: i64,
+
+    /// UTC epoch seconds of the last successful authentication. Updated
+    /// asynchronously and thus may lag actual usage (ADR 0021 §6.F).
+    #[builder(default)]
+    pub last_used_at: Option<i64>,
+
+    /// Tombstone timestamp for audit retention. Set by revocation; the key
+    /// is never hard-deleted at revoke time (ADR 0021 §5.C).
+    #[builder(default)]
+    pub revoked_at: Option<i64>,
+
+    /// User ID of the operator who revoked the key.
+    #[builder(default)]
+    pub revoked_by: Option<String>,
+}
+
+impl std::fmt::Debug for ApiClientResource {
+    /// Redacts `secret_hash` to prevent leaking the Argon2id PHC string into
+    /// application error logs (ADR 0021 §2.B).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiClientResource")
+            .field("domain_id", &self.domain_id)
+            .field("provider_id", &self.provider_id)
+            .field("client_id", &self.client_id)
+            .field("lookup_hash", &self.lookup_hash)
+            .field("secret_hash", &"[REDACTED]")
+            .field("allowed_ips", &self.allowed_ips)
+            .field("description", &self.description)
+            .field("enabled", &self.enabled)
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .field("last_used_at", &self.last_used_at)
+            .field("revoked_at", &self.revoked_at)
+            .field("revoked_by", &self.revoked_by)
+            .finish()
+    }
+}
+
+impl ApiClientResource {
+    /// Whether the key is currently usable for authentication: enabled and
+    /// not past its TTL (ADR 0021 §3 Step 2).
+    pub fn is_active(&self, now_utc_seconds: i64) -> bool {
+        self.enabled && now_utc_seconds < self.expires_at
+    }
+
+    /// Apply a partial [`ApiClientResourceUpdate`], returning the new
+    /// version to persist.
+    pub fn with_update(self, update: ApiClientResourceUpdate) -> Self {
+        Self {
+            description: match update.description {
+                Some(new_description) => new_description,
+                None => self.description,
+            },
+            allowed_ips: match update.allowed_ips {
+                Some(new_allowed_ips) => new_allowed_ips,
+                None => self.allowed_ips,
+            },
+            enabled: update.enabled.unwrap_or(self.enabled),
+            ..self
+        }
+    }
+
+    /// Apply the emergency revocation path (ADR 0021 §5.C): disables the
+    /// key and stamps the tombstone, without deleting the record.
+    pub fn revoke(self, revoked_by: impl Into<String>, revoked_at: i64) -> Self {
+        Self {
+            enabled: false,
+            revoked_at: Some(revoked_at),
+            revoked_by: Some(revoked_by.into()),
+            ..self
+        }
+    }
+}
+
+/// Input to create a new [`ApiClientResource`]. `lookup_hash` and
+/// `secret_hash` are computed by the token generation utility before
+/// reaching the provider; the plaintext token is never part of this
+/// structure.
+#[derive(Builder, Clone, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct ApiClientResourceCreate {
+    /// Domain owning this machine identity.
+    pub domain_id: String,
+
+    /// The Unified Mapping Engine (ADR 0020) `provider_id` this key
+    /// authenticates against.
+    pub provider_id: String,
+
+    /// Public UUID used for management API references.
+    pub client_id: String,
+
+    /// `SHA-256(entropy)`, used as the fast O(1) storage index.
+    pub lookup_hash: String,
+
+    /// PHC-formatted Argon2id hash of the token entropy.
+    pub secret_hash: String,
+
+    /// CIDR allowlist restricting the source IP of the request.
+    #[builder(default)]
+    pub allowed_ips: Option<Vec<String>>,
+
+    /// Free-form administrative description.
+    #[builder(default)]
+    pub description: Option<String>,
+
+    /// Mandatory TTL, UTC epoch seconds.
+    pub expires_at: i64,
+}
+
+impl std::fmt::Debug for ApiClientResourceCreate {
+    /// Redacts `secret_hash`; see [`ApiClientResource::fmt`].
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiClientResourceCreate")
+            .field("domain_id", &self.domain_id)
+            .field("provider_id", &self.provider_id)
+            .field("client_id", &self.client_id)
+            .field("lookup_hash", &self.lookup_hash)
+            .field("secret_hash", &"[REDACTED]")
+            .field("allowed_ips", &self.allowed_ips)
+            .field("description", &self.description)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+/// Partial update for an [`ApiClientResource`] (`PUT
+/// /v4/api-keys/{client_id}`).
+///
+/// `allowed_ips` and `description` use nested `Option`s: the outer `None`
+/// means "leave unchanged", while `Some(None)` explicitly clears the field
+/// (for `allowed_ips`, `Some(None)` removes the IP restriction entirely per
+/// ADR 0021 Invariant 5).
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
+pub struct ApiClientResourceUpdate {
+    /// `None` = unchanged. `Some(None)` = clear. `Some(Some(ips))` = set.
+    pub allowed_ips: Option<Option<Vec<String>>>,
+
+    /// `None` = unchanged. `Some(None)` = clear. `Some(Some(desc))` = set.
+    pub description: Option<Option<String>>,
+
+    /// `None` = unchanged.
+    pub enabled: Option<bool>,
+}
+
+/// Filter parameters for `GET /v4/api-keys`.
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct ApiClientResourceListParameters {
+    /// Domain to list keys for.
+    pub domain_id: String,
+
+    /// Restrict to keys bound to this `provider_id`.
+    #[builder(default)]
+    pub provider_id: Option<String>,
+
+    /// Restrict to enabled/disabled keys.
+    #[builder(default)]
+    pub enabled: Option<bool>,
+}

--- a/crates/core-types/src/auth.rs
+++ b/crates/core-types/src/auth.rs
@@ -139,6 +139,26 @@ pub enum AuthenticationError {
     #[error("The password is expired for user: {0}")]
     UserPasswordExpired(String),
 
+    /// An API Key's Unified Mapping Engine (ADR 0020) evaluation resolved
+    /// zero authorizations. Per ADR 0021 Invariant 1, this MUST fail
+    /// authentication rather than produce an unscoped, role-less context
+    /// that would push the access decision onto downstream OPA coverage.
+    #[error("API key resolved no authorizations")]
+    NoAuthorizationsFound,
+
+    /// An API Key's mapping resolved to more than one authorization entry.
+    /// Per ADR 0021 Invariant 2, an Ephemeral Security Context must operate
+    /// under exactly one scope.
+    #[error("API key resolved multiple authorizations; only a single scope is permitted")]
+    MultipleScopesForbidden,
+
+    /// An API Key's mapping resolved to `Authorization::System`. Per ADR
+    /// 0021 Invariant 3, system scope is prohibited at API-Key ingress; the
+    /// write-time prohibition (ADR 0021 §6.C) is defense-in-depth, not a
+    /// substitute for this runtime check.
+    #[error("system scope is forbidden for API-Key ingress")]
+    SystemScopeForbiddenForApiKey,
+
     /// A role assignment failed to convert to a valid RoleRef.
     #[error("role assignment cannot be converted to a role reference")]
     RoleConversionFailed,

--- a/crates/core-types/src/error.rs
+++ b/crates/core-types/src/error.rs
@@ -16,6 +16,7 @@
 //! Diverse errors that can occur during the Keystone processing (not the API).
 use thiserror::Error;
 
+use crate::api_key::ApiKeyProviderError;
 use crate::application_credential::ApplicationCredentialProviderError;
 use crate::assignment::AssignmentProviderError;
 use crate::auth::AuthenticationError;
@@ -61,6 +62,14 @@ impl From<derive_builder::UninitializedFieldError> for BuilderError {
 /// Keystone error.
 #[derive(Debug, Error)]
 pub enum KeystoneError {
+    /// API Key provider.
+    #[error(transparent)]
+    ApiKeyProvider {
+        /// The source of the error.
+        #[from]
+        source: ApiKeyProviderError,
+    },
+
     /// Application credential provider.
     #[error(transparent)]
     ApplicationCredential {

--- a/crates/core-types/src/lib.rs
+++ b/crates/core-types/src/lib.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::module_inception)]
 #![deny(clippy::unwrap_used)]
 
+pub mod api_key;
 pub mod application_credential;
 pub mod assignment;
 pub mod auth;

--- a/crates/core-types/src/mapping/error.rs
+++ b/crates/core-types/src/mapping/error.rs
@@ -140,6 +140,15 @@ pub enum MappingProviderError {
     /// Local identity mode requires Federation as the identity source.
     #[error("Local identity mode requires Federation source (got: {0})")]
     LocalIdentityRequiresFederation(String),
+
+    /// A ruleset sourced from an API Key (SCIM ingress) provider granted
+    /// `is_system` or `Authorization::System`, which is prohibited at
+    /// write-time as defense-in-depth for the runtime ingress guard (ADR
+    /// 0021 §6.C, Invariant 3).
+    #[error(
+        "rule '{0}' grants system scope, which is forbidden for API Key (ApiClient) mapping rulesets"
+    )]
+    ApiClientSystemScopeForbidden(String),
 }
 
 impl MappingProviderError {

--- a/crates/core-types/src/mapping/resolution.rs
+++ b/crates/core-types/src/mapping/resolution.rs
@@ -60,6 +60,11 @@ pub enum IdentitySource {
         /// The SPIFFE trust domain.
         trust_domain: String,
     },
+    /// API Key (SCIM ingress) machine identity authentication (ADR 0021).
+    ApiClient {
+        /// The API Key `provider_id` this ruleset is bound to.
+        provider_id: String,
+    },
 }
 
 impl IdentitySource {
@@ -72,6 +77,7 @@ impl IdentitySource {
             Self::Federation { idp_id } => format!("federation:{idp_id}"),
             Self::K8s { cluster_id } => format!("k8s:{cluster_id}"),
             Self::Spiffe { trust_domain } => format!("spiffe:{trust_domain}"),
+            Self::ApiClient { provider_id } => format!("api_client:{provider_id}"),
         }
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,17 +9,21 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+argon2.workspace = true
 async-trait.workspace = true
 openstack-keystone-audit = { workspace = true }
-axum = { workspace = true, default-features = false, features = ["json"], optional = true }
+axum = { workspace = true, default-features = false, features = ["json", "tokio"], optional = true }
 base64.workspace = true
 bcrypt = { workspace = true, features = ["alloc"] }
 chrono = { workspace = true, default-features = false }
+crc32fast.workspace = true
 derive_builder.workspace = true
 eyre.workspace = true
+governor.workspace = true
 hmac.workspace = true
 dashmap.workspace = true
 inventory.workspace = true
+ipnet.workspace = true
 openstack-keystone-api-types = { workspace = true, optional = true }
 openstack-keystone-core-types.workspace = true
 openstack-keystone-config.workspace = true

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod api_key_auth;
 pub mod auth;
 pub mod common;
 pub mod v3;

--- a/crates/core/src/api/api_key_auth.rs
+++ b/crates/core/src/api/api_key_auth.rs
@@ -1,0 +1,526 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key (SCIM ingress) authentication extractor (ADR 0021)
+//!
+//! [`ApiKeyAuth`] is deliberately separate from the shared [`super::Auth`]
+//! extractor: per ADR 0021 §4 (Sub-Router Isolation), API keys must be
+//! accepted *only* on the SCIM sub-router, never on core OpenStack
+//! endpoints. Mounting this extractor exclusively on SCIM route handlers
+//! achieves that isolation structurally, without needing a path allowlist.
+use std::net::{IpAddr, SocketAddr};
+use std::ops::Deref;
+
+use axum::extract::{ConnectInfo, FromRef, FromRequestParts, Path};
+use axum::http::request::Parts;
+use ipnet::IpNet;
+use tracing::warn;
+
+use openstack_keystone_core_types::api_key::ApiClientResource;
+use openstack_keystone_core_types::auth::AuthenticationError;
+use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
+use openstack_keystone_core_types::mapping::authorization::Authorization;
+use openstack_keystone_core_types::mapping::resolution::IdentitySource;
+use openstack_keystone_core_types::mapping::virtual_user::MatchResult;
+
+use crate::api::KeystoneApiError;
+use crate::api_key::{crypto, token};
+use crate::auth::{ExecutionContext, ValidatedSecurityContext};
+use crate::keystone::ServiceState;
+use crate::mapping::engine;
+
+/// Ephemeral, single-scope [`ValidatedSecurityContext`] hydrated from a
+/// verified API Key, for use exclusively on the SCIM sub-router.
+#[derive(Debug, Clone)]
+pub struct ApiKeyAuth(pub ValidatedSecurityContext);
+
+impl Deref for ApiKeyAuth {
+    type Target = ValidatedSecurityContext;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<S> FromRequestParts<S> for ApiKeyAuth
+where
+    ServiceState: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = KeystoneApiError;
+
+    #[tracing::instrument(skip(state), err)]
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let state = ServiceState::from_ref(state);
+
+        // The SCIM route is domain-scoped: `/SCIM/v2/{domain_id}/...`. The
+        // key lookup keyspace is partitioned by domain_id (ADR 0021 §2.A),
+        // so it must be known before any storage access.
+        let Path(domain_id) = Path::<String>::from_request_parts(parts, &state)
+            .await
+            .map_err(|_| KeystoneApiError::from(AuthenticationError::Unauthorized))?;
+
+        let peer_ip = parts
+            .extensions
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|ConnectInfo(addr)| addr.ip());
+
+        let presented_token = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|h| h.to_str().ok())
+            .and_then(|h| h.strip_prefix("Bearer "))
+            .ok_or(KeystoneApiError::UnauthorizedNoContext)?;
+
+        let cfg = state.config_manager.config.read().await.api_key.clone();
+
+        // Step 1: format check + hash-based rate limiting (ADR 0021 §3 Step 1).
+        let parsed = match token::parse(presented_token) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                // No valid entropy: key the limiter on source IP instead, so
+                // brute-force garbage traffic doesn't bypass rate limiting by
+                // sending malformed tokens.
+                if let Some(ip) = peer_ip
+                    && state
+                        .api_key_rate_limiter
+                        .check_key(&ip.to_string())
+                        .is_err()
+                {
+                    return Err(KeystoneApiError::TooManyRequests);
+                }
+                return Err(AuthenticationError::Unauthorized.into());
+            }
+        };
+
+        if state
+            .api_key_rate_limiter
+            .check_key(&parsed.lookup_hash)
+            .is_err()
+        {
+            return Err(KeystoneApiError::TooManyRequests);
+        }
+
+        // Step 2: database lookup & IP allowlisting.
+        use secrecy::ExposeSecret;
+        let entropy = parsed.entropy.expose_secret();
+
+        let resource = state
+            .provider
+            .get_api_key_provider()
+            .get_by_lookup_hash(&state, &domain_id, &parsed.lookup_hash)
+            .await
+            .map_err(|e| {
+                warn!(error = %e, "api_key lookup failed");
+                AuthenticationError::Unauthorized
+            })?;
+
+        let Some(resource) = resource else {
+            // Dummy hash: burn the same Argon2id cost as a real verification
+            // to prevent timing-based enumeration of valid lookup hashes
+            // (ADR 0021 Invariant 7).
+            let _ = crypto::generate_dummy_hash(&cfg).await;
+            return Err(AuthenticationError::Unauthorized.into());
+        };
+
+        let now = chrono::Utc::now().timestamp();
+        if !resource.is_active(now) {
+            let _ = crypto::generate_dummy_hash(&cfg).await;
+            return Err(AuthenticationError::Unauthorized.into());
+        }
+
+        let effective_ip = resolve_client_ip(&parts.headers, peer_ip, &cfg.trusted_proxies);
+        if !ip_allowed(effective_ip, &resource.allowed_ips) {
+            return Err(AuthenticationError::Unauthorized.into());
+        }
+
+        // Step 3: cryptographic verification & lazy re-hash.
+        let verified = crypto::verify_secret(entropy, &resource.secret_hash)
+            .await
+            .map_err(|e| {
+                warn!(error = %e, "api_key argon2 verification errored");
+                AuthenticationError::Unauthorized
+            })?;
+        if !verified {
+            return Err(AuthenticationError::Unauthorized.into());
+        }
+
+        spawn_lazy_rehash(&state, &resource, entropy.to_string(), cfg.clone());
+        spawn_last_used_update(&state, &resource, now);
+
+        // Step 4: ephemeral context hydration (anti-bleed scoping).
+        hydrate_ephemeral_context(&state, &resource).await
+    }
+}
+
+/// Fire-and-forget re-hash of the stored secret if its PHC parameters fall
+/// below the configured floor (ADR 0021 Invariant 8). Never blocks the
+/// request on this maintenance work.
+fn spawn_lazy_rehash(
+    state: &ServiceState,
+    resource: &ApiClientResource,
+    entropy: String,
+    cfg: openstack_keystone_config::ApiKeyProvider,
+) {
+    if crypto::params_meet_minimums(&resource.secret_hash, &cfg).unwrap_or(true) {
+        return;
+    }
+    let state = state.clone();
+    let domain_id = resource.domain_id.clone();
+    let lookup_hash = resource.lookup_hash.clone();
+    tokio::spawn(async move {
+        match crypto::hash_secret(&entropy, &cfg).await {
+            Ok(new_hash) => {
+                if let Err(e) = state
+                    .provider
+                    .get_api_key_provider()
+                    .update_secret_hash(&state, &domain_id, &lookup_hash, new_hash)
+                    .await
+                {
+                    warn!(error = %e, "api_key lazy re-hash persist failed");
+                }
+            }
+            Err(e) => warn!(error = %e, "api_key lazy re-hash failed"),
+        }
+    });
+}
+
+/// Fire-and-forget `last_used_at` update (ADR 0021 §3 Step 3). Async writes
+/// may occasionally drop under pressure; the janitor grace period absorbs
+/// this documented drift (ADR 0021 §6.F).
+fn spawn_last_used_update(state: &ServiceState, resource: &ApiClientResource, now: i64) {
+    let state = state.clone();
+    let domain_id = resource.domain_id.clone();
+    let lookup_hash = resource.lookup_hash.clone();
+    tokio::spawn(async move {
+        if let Err(e) = state
+            .provider
+            .get_api_key_provider()
+            .update_last_used(&state, &domain_id, &lookup_hash, now)
+            .await
+        {
+            warn!(error = %e, "api_key last_used_at update failed");
+        }
+    });
+}
+
+/// Compute the effective client IP using the rightmost-non-trusted-proxy
+/// algorithm (ADR 0021 §3 Step 2, §6.E, Invariant 4): append the raw TCP
+/// peer to the right of the `X-Forwarded-For` chain, then walk right to
+/// left, returning the first address not in `trusted_proxies`. If the raw
+/// TCP peer itself is not trusted, it is used directly without consulting
+/// XFF at all.
+fn resolve_client_ip(
+    headers: &axum::http::HeaderMap,
+    peer_ip: Option<IpAddr>,
+    trusted_proxies: &[String],
+) -> Option<IpAddr> {
+    let trusted: Vec<IpNet> = trusted_proxies
+        .iter()
+        .filter_map(|c| c.parse::<IpNet>().ok())
+        .collect();
+
+    let is_trusted = |ip: &IpAddr| trusted.iter().any(|net| net.contains(ip));
+
+    let peer = peer_ip?;
+    if !is_trusted(&peer) {
+        return Some(peer);
+    }
+
+    let xff_chain: Vec<IpAddr> = headers
+        .get(axum::http::header::HeaderName::from_static(
+            "x-forwarded-for",
+        ))
+        .and_then(|h| h.to_str().ok())
+        .map(|h| {
+            h.split(',')
+                .filter_map(|s| s.trim().parse::<IpAddr>().ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut chain = xff_chain;
+    chain.push(peer);
+
+    chain
+        .into_iter()
+        .rev()
+        .find(|ip| !is_trusted(ip))
+        .or(Some(peer))
+}
+
+/// Whether `client_ip` satisfies the key's `allowed_ips` CIDR allowlist.
+/// `None` (missing field) means no restriction applies (ADR 0021 Invariant
+/// 5); a missing field and `Some(vec![])` are treated identically.
+fn ip_allowed(client_ip: Option<IpAddr>, allowed_ips: &Option<Vec<String>>) -> bool {
+    let Some(allowed) = allowed_ips else {
+        return true;
+    };
+    if allowed.is_empty() {
+        return true;
+    }
+    let Some(ip) = client_ip else {
+        return false;
+    };
+    allowed
+        .iter()
+        .filter_map(|c| c.parse::<IpNet>().ok())
+        .any(|net| net.contains(&ip))
+}
+
+/// Evaluate the API Key's bound mapping ruleset and hydrate an
+/// [`ApiKeyAuth`] under exactly one scope (ADR 0021 §3 Step 4).
+async fn hydrate_ephemeral_context(
+    state: &ServiceState,
+    resource: &ApiClientResource,
+) -> Result<ApiKeyAuth, KeystoneApiError> {
+    let source = IdentitySource::ApiClient {
+        provider_id: resource.provider_id.clone(),
+    };
+    let exec = ExecutionContext::internal(state);
+
+    let ruleset = state
+        .provider
+        .get_mapping_provider()
+        .get_ruleset_by_source(&exec, &resource.domain_id, &source)
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "api_key mapping ruleset lookup failed");
+            AuthenticationError::Unauthorized
+        })?
+        .ok_or(AuthenticationError::Unauthorized)?;
+
+    if !ruleset.enabled {
+        return Err(AuthenticationError::Unauthorized.into());
+    }
+
+    let mut claims = std::collections::HashMap::new();
+    claims.insert(
+        "api_client.client_id".to_string(),
+        vec![resource.client_id.clone()],
+    );
+    claims.insert(
+        "api_client.provider_id".to_string(),
+        vec![resource.provider_id.clone()],
+    );
+
+    // Pre-evaluate to enforce the API-Key-specific invariants (1–3) before
+    // hydrating any context. `authenticate_by_mapping` below independently
+    // re-evaluates the same (ruleset, claims) pair — evaluation is pure, so
+    // this is deterministic; the small duplicated cost buys enforcement of
+    // invariants the generic mapping engine does not itself know about.
+    let match_result: Option<MatchResult> =
+        engine::evaluate_ruleset(&ruleset, &claims, ruleset.domain_id.as_deref(), None).map_err(
+            |e| {
+                warn!(error = %e, "api_key mapping evaluation failed");
+                AuthenticationError::Unauthorized
+            },
+        )?;
+
+    let authorization = match &match_result {
+        // Invariant 1: no-authorizations → authentication failure.
+        None => return Err(AuthenticationError::NoAuthorizationsFound.into()),
+        Some(mr) if mr.authorizations.is_empty() => {
+            return Err(AuthenticationError::NoAuthorizationsFound.into());
+        }
+        // Invariant 2: single-scope enforcement.
+        Some(mr) if mr.authorizations.len() > 1 => {
+            return Err(AuthenticationError::MultipleScopesForbidden.into());
+        }
+        Some(mr) => &mr.authorizations[0],
+    };
+
+    // Invariant 3: system scope prohibited at API-Key ingress.
+    if matches!(authorization, Authorization::System { .. }) {
+        return Err(AuthenticationError::SystemScopeForbiddenForApiKey.into());
+    }
+
+    let scope = match authorization {
+        Authorization::Project {
+            project_id,
+            project_domain_id,
+            ..
+        } => openstack_keystone_core_types::auth::ScopeInfo::Project {
+            project: openstack_keystone_core_types::resource::Project {
+                id: project_id.clone(),
+                domain_id: project_domain_id.clone(),
+                name: String::new(),
+                description: None,
+                enabled: true,
+                is_domain: false,
+                parent_id: None,
+                extra: Default::default(),
+            },
+            project_domain: openstack_keystone_core_types::resource::Domain {
+                id: project_domain_id.clone(),
+                name: String::new(),
+                description: None,
+                enabled: true,
+                extra: Default::default(),
+            },
+        },
+        Authorization::Domain { domain_id, .. } => {
+            openstack_keystone_core_types::auth::ScopeInfo::Domain(
+                openstack_keystone_core_types::resource::Domain {
+                    id: domain_id.clone(),
+                    name: String::new(),
+                    description: None,
+                    enabled: true,
+                    extra: Default::default(),
+                },
+            )
+        }
+        Authorization::System { .. } => unreachable!("rejected above"),
+    };
+    scope.validate()?;
+
+    // Invariant 6: user_id derived exclusively from client_id, never from
+    // provider_id — `unique_workload_id` here is the key's public UUID.
+    let mapping_req = MappingAuthRequest {
+        domain_id: Some(resource.domain_id.clone()),
+        source,
+        unique_workload_id: resource.client_id.clone(),
+        claims,
+        rule_name: None,
+    };
+
+    let auth_result = state
+        .provider
+        .get_mapping_provider()
+        .authenticate_by_mapping(&exec, &mapping_req)
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "api_key mapping authentication failed");
+            AuthenticationError::Unauthorized
+        })?;
+
+    let ctx = openstack_keystone_core_types::auth::SecurityContext::try_from(auth_result)?;
+
+    let vsc = ValidatedSecurityContext::new_for_scope(ctx, scope, state).await?;
+    Ok(ApiKeyAuth(vsc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    fn headers_with_xff(xff: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::HeaderName::from_static("x-forwarded-for"),
+            xff.parse().unwrap(),
+        );
+        headers
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    // ---------------------------------------------------------------------
+    // resolve_client_ip (ADR 0021 §3 Step 2, §6.E, Invariant 4)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn untrusted_peer_ignores_xff_entirely() {
+        // Peer itself is not a trusted proxy: XFF must not be consulted at
+        // all, even if present (prevents spoofing via an untrusted hop).
+        let headers = headers_with_xff("1.2.3.4");
+        let peer = Some(ip("203.0.113.5"));
+        let trusted = vec!["10.0.0.0/8".to_string()];
+        assert_eq!(
+            resolve_client_ip(&headers, peer, &trusted),
+            Some(ip("203.0.113.5"))
+        );
+    }
+
+    #[test]
+    fn trusted_peer_walks_xff_rightmost_non_trusted() {
+        // Chain (left to right): 1.2.3.4 (attacker-controlled), 10.0.0.5
+        // (trusted intermediate hop), peer 10.0.0.1 (trusted, terminal
+        // proxy). Effective IP must be 10.0.0.5's predecessor scanning
+        // right-to-left: append peer, walk right-to-left, first non-trusted.
+        let headers = headers_with_xff("1.2.3.4, 10.0.0.5");
+        let peer = Some(ip("10.0.0.1"));
+        let trusted = vec!["10.0.0.0/8".to_string()];
+        assert_eq!(
+            resolve_client_ip(&headers, peer, &trusted),
+            Some(ip("1.2.3.4"))
+        );
+    }
+
+    #[test]
+    fn trusted_peer_all_hops_trusted_falls_back_to_peer() {
+        let headers = headers_with_xff("10.0.0.9");
+        let peer = Some(ip("10.0.0.1"));
+        let trusted = vec!["10.0.0.0/8".to_string()];
+        assert_eq!(
+            resolve_client_ip(&headers, peer, &trusted),
+            Some(ip("10.0.0.1"))
+        );
+    }
+
+    #[test]
+    fn leftmost_xff_entry_is_never_trusted_blindly() {
+        // Regression guard for the leftmost-take vulnerability (ADR 0021 F2):
+        // an attacker prepending a spoofed IP as the leftmost XFF entry must
+        // not be accepted just because it's present.
+        let headers = headers_with_xff("203.0.113.99, 1.2.3.4, 10.0.0.5");
+        let peer = Some(ip("10.0.0.1"));
+        let trusted = vec!["10.0.0.0/8".to_string()];
+        let effective = resolve_client_ip(&headers, peer, &trusted);
+        assert_ne!(effective, Some(ip("203.0.113.99")));
+        assert_eq!(effective, Some(ip("1.2.3.4")));
+    }
+
+    #[test]
+    fn no_peer_ip_resolves_to_none() {
+        let headers = HeaderMap::new();
+        assert_eq!(resolve_client_ip(&headers, None, &[]), None);
+    }
+
+    // ---------------------------------------------------------------------
+    // ip_allowed (ADR 0021 Invariant 5)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn none_allowed_ips_means_unrestricted() {
+        assert!(ip_allowed(Some(ip("203.0.113.1")), &None));
+        assert!(ip_allowed(None, &None));
+    }
+
+    #[test]
+    fn empty_allowed_ips_means_unrestricted() {
+        // `Some(vec![])` MUST behave identically to `None` per Invariant 5.
+        assert!(ip_allowed(Some(ip("203.0.113.1")), &Some(vec![])));
+    }
+
+    #[test]
+    fn ip_within_allowlist_is_allowed() {
+        let allowed = Some(vec!["10.0.0.0/8".to_string()]);
+        assert!(ip_allowed(Some(ip("10.1.2.3")), &allowed));
+    }
+
+    #[test]
+    fn ip_outside_allowlist_is_denied() {
+        let allowed = Some(vec!["10.0.0.0/8".to_string()]);
+        assert!(!ip_allowed(Some(ip("203.0.113.1")), &allowed));
+    }
+
+    #[test]
+    fn missing_client_ip_with_restriction_is_denied() {
+        let allowed = Some(vec!["10.0.0.0/8".to_string()]);
+        assert!(!ip_allowed(None, &allowed));
+    }
+}

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -230,6 +230,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
+                governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
+            )),
             shutdown: false,
         };
         Arc::new(service)
@@ -336,6 +339,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
+                governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
+            )),
             shutdown: false,
         });
 
@@ -436,6 +442,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
+                governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
+            )),
             shutdown: false,
         });
 
@@ -500,6 +509,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
+                governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
+            )),
             shutdown: false,
         });
 
@@ -563,6 +575,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
+                governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
+            )),
             shutdown: false,
         });
 

--- a/crates/core/src/api_key.rs
+++ b/crates/core/src/api_key.rs
@@ -11,23 +11,17 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # Integration tests
-//!
-//! Test the functionality on the provider level (not through the API).
+//! # API Key (SCIM ingress) machine identity management (ADR 0021)
 
-mod api_key;
-mod application_credential;
-mod assignment;
-mod audit;
-mod catalog;
-mod common;
-mod identity;
-mod k8s_auth;
-mod mapping;
-mod resource;
-mod revoke;
-mod role;
-mod token;
+pub mod backend;
+pub mod crypto;
+pub mod error;
+mod provider_api;
+pub mod service;
+pub mod token;
 
-#[macro_use]
-mod macros;
+#[cfg(any(test, feature = "mock"))]
+pub use crate::mocks::MockApiKeyProvider;
+pub use error::ApiKeyProviderError;
+pub use provider_api::ApiKeyApi;
+pub use service::ApiKeyService;

--- a/crates/core/src/api_key/backend.rs
+++ b/crates/core/src/api_key/backend.rs
@@ -1,0 +1,101 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key provider: Backends.
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::api_key::*;
+
+use crate::api_key::ApiKeyProviderError;
+use crate::keystone::ServiceState;
+
+/// API Key Backend trait.
+///
+/// Backend driver interface expected by the API Key provider.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait ApiKeyBackend: Send + Sync {
+    /// Create a new API Key.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `data` - [`ApiClientResourceCreate`] data for the new key.
+    ///
+    /// # Returns
+    /// * Success with the created [`ApiClientResource`].
+    /// * Error if the instance could not be created.
+    async fn create(
+        &self,
+        state: &ServiceState,
+        data: ApiClientResourceCreate,
+    ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+    /// Fetch an API Key by its public `client_id`.
+    async fn get_by_client_id<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+    ) -> Result<Option<ApiClientResource>, ApiKeyProviderError>;
+
+    /// Fetch an API Key by its `lookup_hash`.
+    async fn get_by_lookup_hash<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+    ) -> Result<Option<ApiClientResource>, ApiKeyProviderError>;
+
+    /// List API Keys.
+    async fn list(
+        &self,
+        state: &ServiceState,
+        params: &ApiClientResourceListParameters,
+    ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError>;
+
+    /// Update an API Key's configuration.
+    async fn update<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+        data: ApiClientResourceUpdate,
+    ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+    /// Emergency revocation path.
+    async fn revoke<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+        revoked_by: &'a str,
+    ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+    /// Update the `last_used_at` timestamp for a key.
+    async fn update_last_used<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+        last_used_at: i64,
+    ) -> Result<(), ApiKeyProviderError>;
+
+    /// Replace the stored `secret_hash` for a key (lazy re-hash).
+    async fn update_secret_hash<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+        secret_hash: String,
+    ) -> Result<(), ApiKeyProviderError>;
+}

--- a/crates/core/src/api_key/crypto.rs
+++ b/crates/core/src/api_key/crypto.rs
@@ -1,0 +1,183 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key Argon2id hashing & verification (ADR 0021 §3 Step 3, §6.B).
+use argon2::password_hash::rand_core::OsRng;
+use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
+use argon2::{Algorithm, Argon2, Params, Version};
+
+use openstack_keystone_config::ApiKeyProvider;
+
+use crate::api_key::ApiKeyProviderError;
+
+/// Fixed non-secret input used only to burn CPU time equivalent to a real
+/// verification, never compared against a stored hash (ADR 0021 Invariant
+/// 7). Deliberately not derived from any request data.
+const DUMMY_ENTROPY: &str = "keystone-api-key-dummy-entropy-constant-time-padding";
+
+fn build_params(config: &ApiKeyProvider) -> Result<Params, ApiKeyProviderError> {
+    Params::new(
+        config.argon2_memory_kib,
+        config.argon2_time_cost,
+        config.argon2_parallelism,
+        None,
+    )
+    .map_err(ApiKeyProviderError::crypto)
+}
+
+/// Hash token entropy into a PHC-formatted Argon2id string using the
+/// configured (current) parameters.
+pub async fn hash_secret(
+    entropy: &str,
+    config: &ApiKeyProvider,
+) -> Result<String, ApiKeyProviderError> {
+    let entropy = entropy.to_string();
+    let config = config.clone();
+    tokio::task::spawn_blocking(move || {
+        let params = build_params(&config)?;
+        let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+        let salt = SaltString::generate(&mut OsRng);
+        argon2
+            .hash_password(entropy.as_bytes(), &salt)
+            .map(|hash| hash.to_string())
+            .map_err(ApiKeyProviderError::crypto)
+    })
+    .await
+    .map_err(ApiKeyProviderError::crypto)?
+}
+
+/// Verify token entropy against a stored PHC-formatted Argon2id hash.
+///
+/// Verification uses the algorithm/version/parameters embedded in `phc`
+/// itself (not the caller's current configuration), so a key hashed with
+/// older parameters still verifies correctly before the lazy re-hash
+/// (Invariant 8) brings it up to the current floor. Comparison against the
+/// stored hash is constant-time, performed internally by the `argon2` crate.
+pub async fn verify_secret(entropy: &str, phc: &str) -> Result<bool, ApiKeyProviderError> {
+    let entropy = entropy.to_string();
+    let phc = phc.to_string();
+    tokio::task::spawn_blocking(move || {
+        let parsed = PasswordHash::new(&phc).map_err(ApiKeyProviderError::crypto)?;
+        Ok(Argon2::default()
+            .verify_password(entropy.as_bytes(), &parsed)
+            .is_ok())
+    })
+    .await
+    .map_err(ApiKeyProviderError::crypto)?
+}
+
+/// Whether the parameters embedded in a stored PHC string meet the
+/// configured minimums (Invariant 8).
+pub fn params_meet_minimums(
+    phc: &str,
+    config: &ApiKeyProvider,
+) -> Result<bool, ApiKeyProviderError> {
+    let parsed = PasswordHash::new(phc).map_err(ApiKeyProviderError::crypto)?;
+    let params = Params::try_from(&parsed).map_err(ApiKeyProviderError::crypto)?;
+    Ok(params.m_cost() >= config.argon2_memory_kib
+        && params.t_cost() >= config.argon2_time_cost
+        && params.p_cost() >= config.argon2_parallelism)
+}
+
+/// Re-hash `entropy` with the current configured parameters if the stored
+/// `phc` falls below the configured floor. Returns `None` when no re-hash is
+/// necessary.
+pub async fn rehash_if_needed(
+    entropy: &str,
+    phc: &str,
+    config: &ApiKeyProvider,
+) -> Result<Option<String>, ApiKeyProviderError> {
+    if params_meet_minimums(phc, config)? {
+        return Ok(None);
+    }
+    Ok(Some(hash_secret(entropy, config).await?))
+}
+
+/// Generate a dummy Argon2id hash using the current configured parameters,
+/// for the caller to verify the presented (non-existent-key) token against.
+/// Ensures the "no such `lookup_hash`" response path costs the same wall
+/// time as a real "found but wrong secret" verification, preventing
+/// timing-based enumeration of valid lookup hashes (ADR 0021 Invariant 7).
+pub async fn generate_dummy_hash(config: &ApiKeyProvider) -> Result<String, ApiKeyProviderError> {
+    hash_secret(DUMMY_ENTROPY, config).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> ApiKeyProvider {
+        ApiKeyProvider {
+            argon2_memory_kib: 8,
+            argon2_time_cost: 1,
+            argon2_parallelism: 1,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_hash_and_verify_roundtrip() {
+        let config = test_config();
+        let phc = hash_secret("correct-entropy", &config).await.unwrap();
+        assert!(verify_secret("correct-entropy", &phc).await.unwrap());
+        assert!(!verify_secret("wrong-entropy", &phc).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_params_meet_minimums() {
+        let low_config = test_config();
+        let phc = hash_secret("entropy", &low_config).await.unwrap();
+        assert!(params_meet_minimums(&phc, &low_config).unwrap());
+
+        let higher_config = ApiKeyProvider {
+            argon2_memory_kib: 65536,
+            ..low_config
+        };
+        assert!(!params_meet_minimums(&phc, &higher_config).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_rehash_if_needed() {
+        let low_config = test_config();
+        let phc = hash_secret("entropy", &low_config).await.unwrap();
+
+        // No re-hash needed against the same (low) parameters.
+        assert!(
+            rehash_if_needed("entropy", &phc, &low_config)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Re-hash required against stricter parameters, and the new hash
+        // still verifies.
+        let higher_config = ApiKeyProvider {
+            argon2_time_cost: 2,
+            ..low_config
+        };
+        let rehashed = rehash_if_needed("entropy", &phc, &higher_config)
+            .await
+            .unwrap()
+            .expect("rehash expected");
+        assert!(verify_secret("entropy", &rehashed).await.unwrap());
+        assert!(params_meet_minimums(&rehashed, &higher_config).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_generate_dummy_hash_is_valid_phc() {
+        let config = test_config();
+        let phc = generate_dummy_hash(&config).await.unwrap();
+        assert!(verify_secret(DUMMY_ENTROPY, &phc).await.unwrap());
+        assert!(!verify_secret("attacker-guess", &phc).await.unwrap());
+    }
+}

--- a/crates/core/src/api_key/error.rs
+++ b/crates/core/src/api_key/error.rs
@@ -11,23 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # Integration tests
-//!
-//! Test the functionality on the provider level (not through the API).
-
-mod api_key;
-mod application_credential;
-mod assignment;
-mod audit;
-mod catalog;
-mod common;
-mod identity;
-mod k8s_auth;
-mod mapping;
-mod resource;
-mod revoke;
-mod role;
-mod token;
-
-#[macro_use]
-mod macros;
+//! # API Key Provider error
+pub use openstack_keystone_core_types::api_key::ApiKeyProviderError;

--- a/crates/core/src/api_key/provider_api.rs
+++ b/crates/core/src/api_key/provider_api.rs
@@ -1,0 +1,165 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key (SCIM ingress) provider API.
+
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::api_key::*;
+
+use crate::api_key::ApiKeyProviderError;
+use crate::keystone::ServiceState;
+
+/// The trait for managing API Key (SCIM ingress) machine identities (ADR
+/// 0021).
+#[async_trait]
+pub trait ApiKeyApi: Send + Sync {
+    /// Create a new API Key.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `data` - [`ApiClientResourceCreate`] data for the new key.
+    ///
+    /// # Returns
+    /// * Success with the created [`ApiClientResource`].
+    /// * Error if the key could not be created.
+    async fn create(
+        &self,
+        state: &ServiceState,
+        data: ApiClientResourceCreate,
+    ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+    /// Fetch an API Key by its public `client_id`.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `domain_id` - The domain the key belongs to.
+    /// * `client_id` - The public UUID of the key.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the [`ApiClientResource`] if
+    /// found, or an `Error`.
+    async fn get_by_client_id<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+    ) -> Result<Option<ApiClientResource>, ApiKeyProviderError>;
+
+    /// Fetch an API Key by its `lookup_hash` (the SCIM ingress hot path,
+    /// ADR 0021 §3 Step 2).
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `domain_id` - The domain the key belongs to.
+    /// * `lookup_hash` - `SHA-256(entropy)` of the presented token.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the [`ApiClientResource`] if
+    /// found, or an `Error`.
+    async fn get_by_lookup_hash<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+    ) -> Result<Option<ApiClientResource>, ApiKeyProviderError>;
+
+    /// List API Keys.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `params` - [`ApiClientResourceListParameters`] for filtering the list.
+    ///
+    /// # Returns
+    /// * Success with a list of [`ApiClientResource`].
+    /// * Error if the listing failed.
+    async fn list(
+        &self,
+        state: &ServiceState,
+        params: &ApiClientResourceListParameters,
+    ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError>;
+
+    /// Update an API Key's configuration.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `domain_id` - The domain the key belongs to.
+    /// * `client_id` - The public UUID of the key to update.
+    /// * `data` - [`ApiClientResourceUpdate`] data to apply.
+    ///
+    /// # Returns
+    /// * Success with the updated [`ApiClientResource`].
+    /// * Error if the update failed.
+    async fn update<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+        data: ApiClientResourceUpdate,
+    ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+    /// Emergency revocation path (ADR 0021 §5.C): disables the key and
+    /// stamps the tombstone without deleting the record.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `domain_id` - The domain the key belongs to.
+    /// * `client_id` - The public UUID of the key to revoke.
+    /// * `revoked_by` - User ID of the revoking operator.
+    ///
+    /// # Returns
+    /// * Success with the revoked [`ApiClientResource`].
+    /// * Error if the revocation failed.
+    async fn revoke<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+        revoked_by: &'a str,
+    ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+    /// Update the `last_used_at` timestamp for a key (ADR 0021 §3 Step 3).
+    /// Callers on the authentication hot path are expected to invoke this
+    /// asynchronously (fire-and-forget) rather than await it inline.
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `domain_id` - The domain the key belongs to.
+    /// * `lookup_hash` - `SHA-256(entropy)` of the presented token.
+    /// * `last_used_at` - UTC epoch seconds of the authentication event.
+    async fn update_last_used<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+        last_used_at: i64,
+    ) -> Result<(), ApiKeyProviderError>;
+
+    /// Replace the stored `secret_hash` for a key (ADR 0021 §6.B Invariant
+    /// 8, lazy re-hash). Internal maintenance operation, not part of the
+    /// public admin update surface — callers on the authentication hot path
+    /// are expected to invoke this asynchronously (fire-and-forget).
+    ///
+    /// # Arguments
+    /// * `state` - Service state.
+    /// * `domain_id` - The domain the key belongs to.
+    /// * `lookup_hash` - `SHA-256(entropy)` of the presented token.
+    /// * `secret_hash` - The freshly computed PHC-formatted Argon2id hash.
+    async fn update_secret_hash<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+        secret_hash: String,
+    ) -> Result<(), ApiKeyProviderError>;
+}

--- a/crates/core/src/api_key/service.rs
+++ b/crates/core/src/api_key/service.rs
@@ -1,0 +1,141 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key provider
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core_types::api_key::*;
+
+use crate::api_key::{ApiKeyApi, ApiKeyProviderError, backend::ApiKeyBackend};
+use crate::keystone::ServiceState;
+use crate::plugin_manager::PluginManagerApi;
+
+/// API Key Provider.
+pub struct ApiKeyService {
+    /// Backend driver.
+    pub(super) backend_driver: Arc<dyn ApiKeyBackend>,
+}
+
+impl ApiKeyService {
+    /// Create a new `ApiKeyService`.
+    ///
+    /// # Arguments
+    /// * `config` - Reference to the [`Config`].
+    /// * `plugin_manager` - Reference to the [`PluginManagerApi`].
+    ///
+    /// # Returns
+    /// * Success with a new `ApiKeyService` instance.
+    /// * `ApiKeyProviderError` if the backend driver cannot be loaded.
+    pub fn new<P: PluginManagerApi>(
+        config: &Config,
+        plugin_manager: &P,
+    ) -> Result<Self, ApiKeyProviderError> {
+        let backend_driver = plugin_manager
+            .get_api_key_backend(config.api_key.driver.clone())?
+            .clone();
+        Ok(Self { backend_driver })
+    }
+}
+
+#[async_trait]
+impl ApiKeyApi for ApiKeyService {
+    async fn create(
+        &self,
+        state: &ServiceState,
+        data: ApiClientResourceCreate,
+    ) -> Result<ApiClientResource, ApiKeyProviderError> {
+        self.backend_driver.create(state, data).await
+    }
+
+    async fn get_by_client_id<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+    ) -> Result<Option<ApiClientResource>, ApiKeyProviderError> {
+        self.backend_driver
+            .get_by_client_id(state, domain_id, client_id)
+            .await
+    }
+
+    async fn get_by_lookup_hash<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+    ) -> Result<Option<ApiClientResource>, ApiKeyProviderError> {
+        self.backend_driver
+            .get_by_lookup_hash(state, domain_id, lookup_hash)
+            .await
+    }
+
+    async fn list(
+        &self,
+        state: &ServiceState,
+        params: &ApiClientResourceListParameters,
+    ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError> {
+        self.backend_driver.list(state, params).await
+    }
+
+    async fn update<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+        data: ApiClientResourceUpdate,
+    ) -> Result<ApiClientResource, ApiKeyProviderError> {
+        self.backend_driver
+            .update(state, domain_id, client_id, data)
+            .await
+    }
+
+    async fn revoke<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+        revoked_by: &'a str,
+    ) -> Result<ApiClientResource, ApiKeyProviderError> {
+        self.backend_driver
+            .revoke(state, domain_id, client_id, revoked_by)
+            .await
+    }
+
+    async fn update_last_used<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+        last_used_at: i64,
+    ) -> Result<(), ApiKeyProviderError> {
+        self.backend_driver
+            .update_last_used(state, domain_id, lookup_hash, last_used_at)
+            .await
+    }
+
+    async fn update_secret_hash<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        lookup_hash: &'a str,
+        secret_hash: String,
+    ) -> Result<(), ApiKeyProviderError> {
+        self.backend_driver
+            .update_secret_hash(state, domain_id, lookup_hash, secret_hash)
+            .await
+    }
+}

--- a/crates/core/src/api_key/token.rs
+++ b/crates/core/src/api_key/token.rs
@@ -1,0 +1,190 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key opaque token format (ADR 0021 §2.C, §3 Step 1)
+//!
+//! Format: `kscim_{entropy}_{crc32}`, where `entropy` is high-entropy
+//! alphanumeric ("base62") random data and `crc32` is a lowercase hex CRC32
+//! checksum of `entropy`. The CRC32 is strictly a cheap format-validity
+//! check to cheaply reject malformed data before touching storage or the
+//! Argon2id verifier; it is not a cryptographic security boundary.
+use rand::distr::{Alphanumeric, SampleString};
+use secrecy::SecretString;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+const TOKEN_PREFIX: &str = "kscim";
+/// ~256 bits of entropy over the 62-character alphanumeric alphabet
+/// (log2(62) ≈ 5.954 bits/char), matching the ADR's "32 bytes" target.
+const ENTROPY_LEN: usize = 43;
+
+/// Token format validation error. Deliberately uninformative in its
+/// `Display` impl at the point where it is surfaced to a client — callers on
+/// the authentication path should map any variant to a generic
+/// unauthorized response rather than reveal which check failed.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TokenFormatError {
+    /// Token does not start with the expected `kscim_` prefix.
+    #[error("token prefix is invalid")]
+    InvalidPrefix,
+
+    /// Token does not split into an entropy and checksum segment.
+    #[error("token structure is invalid")]
+    InvalidFormat,
+
+    /// The CRC32 checksum does not match the entropy segment.
+    #[error("token checksum does not match")]
+    ChecksumMismatch,
+}
+
+/// A freshly generated API Key. `token` is the full opaque bearer value
+/// returned to the administrator exactly once; `entropy` and `lookup_hash`
+/// are what gets persisted (as `secret_hash` after Argon2id hashing, and
+/// `lookup_hash` respectively — see ADR 0021 §2.C).
+#[derive(Debug)]
+pub struct GeneratedApiKey {
+    /// The full `kscim_...` bearer token, shown once.
+    pub token: SecretString,
+    /// The raw entropy segment, to be Argon2id-hashed by the caller.
+    pub entropy: SecretString,
+    /// `SHA-256(entropy)`, the non-secret storage index.
+    pub lookup_hash: String,
+}
+
+/// A token that passed format validation (prefix + checksum), ready for the
+/// storage lookup and Argon2id verification steps.
+#[derive(Debug)]
+pub struct ParsedApiKey {
+    /// The raw entropy segment, to be Argon2id-verified by the caller.
+    pub entropy: SecretString,
+    /// `SHA-256(entropy)`, used to look up the stored `ApiClientResource`.
+    pub lookup_hash: String,
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// `SHA-256(entropy)` as a lowercase hex string.
+pub fn compute_lookup_hash(entropy: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(entropy.as_bytes());
+    to_hex(&hasher.finalize())
+}
+
+/// Generate a new API Key token.
+pub fn generate() -> GeneratedApiKey {
+    let entropy_plain = Alphanumeric.sample_string(&mut rand::rng(), ENTROPY_LEN);
+    let lookup_hash = compute_lookup_hash(&entropy_plain);
+    let crc = crc32fast::hash(entropy_plain.as_bytes());
+    let token_plain = format!("{TOKEN_PREFIX}_{entropy_plain}_{crc:08x}");
+    GeneratedApiKey {
+        token: SecretString::from(token_plain),
+        entropy: SecretString::from(entropy_plain),
+        lookup_hash,
+    }
+}
+
+/// Parse and format-validate a presented bearer token (ADR 0021 §3 Step 1).
+///
+/// Does not touch storage or perform Argon2id verification; it only checks
+/// that the token is well-formed and its checksum is internally consistent.
+pub fn parse(token: &str) -> Result<ParsedApiKey, TokenFormatError> {
+    let rest = token
+        .strip_prefix(TOKEN_PREFIX)
+        .and_then(|r| r.strip_prefix('_'))
+        .ok_or(TokenFormatError::InvalidPrefix)?;
+    let (entropy, crc_hex) = rest
+        .rsplit_once('_')
+        .ok_or(TokenFormatError::InvalidFormat)?;
+    if entropy.is_empty() || crc_hex.len() != 8 {
+        return Err(TokenFormatError::InvalidFormat);
+    }
+    let expected_crc =
+        u32::from_str_radix(crc_hex, 16).map_err(|_| TokenFormatError::InvalidFormat)?;
+    if crc32fast::hash(entropy.as_bytes()) != expected_crc {
+        return Err(TokenFormatError::ChecksumMismatch);
+    }
+    Ok(ParsedApiKey {
+        entropy: SecretString::from(entropy.to_string()),
+        lookup_hash: compute_lookup_hash(entropy),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use secrecy::ExposeSecret;
+
+    use super::*;
+
+    #[test]
+    fn test_generate_roundtrips_through_parse() {
+        let generated = generate();
+        let parsed = parse(generated.token.expose_secret()).unwrap();
+        assert_eq!(
+            parsed.entropy.expose_secret(),
+            generated.entropy.expose_secret()
+        );
+        assert_eq!(parsed.lookup_hash, generated.lookup_hash);
+    }
+
+    #[test]
+    fn test_generate_has_expected_prefix_and_length() {
+        let generated = generate();
+        let token = generated.token.expose_secret();
+        assert!(token.starts_with("kscim_"));
+        // prefix (5) + '_' + entropy (43) + '_' + crc32 hex (8)
+        assert_eq!(token.len(), 5 + 1 + ENTROPY_LEN + 1 + 8);
+    }
+
+    #[test]
+    fn test_parse_rejects_bad_prefix() {
+        let err = parse("notkscim_abc_00000000").unwrap_err();
+        assert_eq!(err, TokenFormatError::InvalidPrefix);
+    }
+
+    #[test]
+    fn test_parse_rejects_missing_segments() {
+        let err = parse("kscim_onlyoneseg").unwrap_err();
+        assert_eq!(err, TokenFormatError::InvalidFormat);
+    }
+
+    #[test]
+    fn test_parse_rejects_bad_checksum() {
+        let generated = generate();
+        let token = generated.token.expose_secret();
+        // Flip the last hex digit of the CRC32 segment, preserving overall
+        // structure/length so this exercises the checksum check specifically
+        // rather than the format check.
+        let mut chars: Vec<char> = token.chars().collect();
+        let last = chars.len() - 1;
+        chars[last] = if chars[last] == '0' { '1' } else { '0' };
+        let tampered: String = chars.into_iter().collect();
+
+        let err = parse(&tampered).unwrap_err();
+        assert_eq!(err, TokenFormatError::ChecksumMismatch);
+    }
+
+    #[test]
+    fn test_lookup_hash_is_deterministic() {
+        assert_eq!(
+            compute_lookup_hash("same-entropy"),
+            compute_lookup_hash("same-entropy")
+        );
+        assert_ne!(
+            compute_lookup_hash("entropy-a"),
+            compute_lookup_hash("entropy-b")
+        );
+    }
+}

--- a/crates/core/src/keystone.rs
+++ b/crates/core/src/keystone.rs
@@ -14,6 +14,7 @@
 //! # Keystone state
 use std::sync::Arc;
 
+use governor::{DefaultKeyedRateLimiter, Quota, RateLimiter};
 use sea_orm::DatabaseConnection;
 use tracing::info;
 
@@ -51,6 +52,11 @@ pub struct Service {
     /// Distributed storage instance (when configured).
     pub storage: Option<Arc<dyn StorageApi>>,
 
+    /// Sliding-window rate limiter for the API Key (SCIM ingress)
+    /// authentication path, keyed on `lookup_hash` (or source IP when the
+    /// presented token fails the format check) (ADR 0021 §6.A).
+    pub api_key_rate_limiter: Arc<DefaultKeyedRateLimiter<String>>,
+
     /// Shutdown flag.
     pub shutdown: bool,
 }
@@ -80,6 +86,21 @@ impl Service {
         audit_dispatcher: Arc<AuditDispatcher>,
         storage: Option<Arc<dyn StorageApi>>,
     ) -> Result<Self, KeystoneError> {
+        let api_key_cfg = cfg.config.read().await.api_key.clone();
+        let quota = Quota::per_minute(
+            api_key_cfg
+                .rate_limit_replenish_per_minute
+                .try_into()
+                .unwrap_or(std::num::NonZeroU32::MAX),
+        )
+        .allow_burst(
+            api_key_cfg
+                .rate_limit_burst_size
+                .try_into()
+                .unwrap_or(std::num::NonZeroU32::MAX),
+        );
+        let api_key_rate_limiter = Arc::new(RateLimiter::keyed(quota));
+
         Ok(Self {
             config_manager: cfg,
             provider,
@@ -88,6 +109,7 @@ impl Service {
             db,
             policy_enforcer,
             storage,
+            api_key_rate_limiter,
             shutdown: false,
         })
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -78,6 +78,7 @@ use sea_orm::{DatabaseConnection, Schema};
 
 #[cfg(any(feature = "api", test))]
 pub mod api;
+pub mod api_key;
 pub mod application_credential;
 pub mod assignment;
 pub mod auth;

--- a/crates/core/src/mapping/validation.rs
+++ b/crates/core/src/mapping/validation.rs
@@ -25,7 +25,8 @@ use std::collections::HashSet;
 use regex_syntax::hir::{Hir, HirKind, Repetition as HirRepetition};
 
 use openstack_keystone_core_types::mapping::MappingProviderError;
-use openstack_keystone_core_types::mapping::resolution::DomainResolutionMode;
+use openstack_keystone_core_types::mapping::authorization::Authorization;
+use openstack_keystone_core_types::mapping::resolution::{DomainResolutionMode, IdentitySource};
 use openstack_keystone_core_types::mapping::rule::{ClaimCondition, MappingRule};
 use openstack_keystone_core_types::mapping::ruleset::{
     MappingRuleSet, MappingRuleSetCreate, MappingRuleSetUpdate,
@@ -60,6 +61,10 @@ const MAX_ALLOWED_DOMAINS: usize = 256;
 pub fn validate_ruleset_create(ruleset: &MappingRuleSetCreate) -> Result<(), MappingProviderError> {
     // 1. Rule name uniqueness and format
     validate_rules(&ruleset.rules)?;
+
+    // API Key (ApiClient) rulesets must never grant system scope (ADR 0021
+    // §6.C, Invariant 3 defense-in-depth).
+    validate_api_client_no_system_scope(&ruleset.source, &ruleset.rules)?;
 
     // 2. Regex safety for all `MatchesRegex` conditions
     let all_conditions = collect_all_claim_conditions(&ruleset.rules);
@@ -100,6 +105,11 @@ pub fn validate_ruleset_update(
     // If new rules are supplied, validate them
     if let Some(ref rules) = update.rules {
         validate_rules(rules)?;
+
+        // API Key (ApiClient) rulesets must never grant system scope (ADR
+        // 0021 §6.C, Invariant 3 defense-in-depth). `source` is immutable, so
+        // always validated against `existing.source`.
+        validate_api_client_no_system_scope(&existing.source, rules)?;
 
         // Regex safety
         let all_conditions = collect_all_claim_conditions(rules);
@@ -207,6 +217,35 @@ fn validate_rules(rules: &[MappingRule]) -> Result<(), MappingProviderError> {
         }
     }
 
+    Ok(())
+}
+
+/// Reject `is_system` or `Authorization::System` grants in any rule of a
+/// ruleset sourced from an API Key (`IdentitySource::ApiClient`) provider.
+///
+/// Per ADR 0021 §6.C, allowing an API Key to hold system scope is dangerous
+/// enough that the prohibition is enforced at both write-time (here) and at
+/// authentication time (`hydrate_ephemeral_context`); this check is
+/// defense-in-depth, not a substitute for the runtime guard.
+fn validate_api_client_no_system_scope(
+    source: &IdentitySource,
+    rules: &[MappingRule],
+) -> Result<(), MappingProviderError> {
+    if !matches!(source, IdentitySource::ApiClient { .. }) {
+        return Ok(());
+    }
+    for rule in rules {
+        if rule.identity.is_system
+            || rule
+                .authorizations
+                .iter()
+                .any(|auth| matches!(auth, Authorization::System { .. }))
+        {
+            return Err(MappingProviderError::ApiClientSystemScopeForbidden(
+                rule.name.clone(),
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -1404,6 +1443,93 @@ mod tests {
         assert!(matches!(
             result,
             Err(MappingProviderError::DuplicateRuleName(_))
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_api_client_no_system_scope tests (ADR 0021 §6.C)
+    // -----------------------------------------------------------------------
+
+    fn api_client_source() -> IdentitySource {
+        IdentitySource::ApiClient {
+            provider_id: "provider-1".to_string(),
+        }
+    }
+
+    fn rule_with_is_system(name: &str) -> MappingRule {
+        let mut rule = simple_rule(name, "user-name");
+        rule.identity.is_system = true;
+        rule
+    }
+
+    fn rule_with_system_authorization(name: &str) -> MappingRule {
+        let mut rule = simple_rule(name, "user-name");
+        rule.authorizations = vec![Authorization::System {
+            system_id: "all".to_string(),
+            roles: Vec::new(),
+        }];
+        rule
+    }
+
+    #[test]
+    fn api_client_ruleset_rejects_is_system() {
+        let ruleset = MappingRuleSetCreate {
+            source: api_client_source(),
+            rules: vec![rule_with_is_system("system-rule")],
+            ..sample_ruleset_create()
+        };
+        let result = validate_ruleset_create(&ruleset);
+        assert!(matches!(
+            result,
+            Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "system-rule"
+        ));
+    }
+
+    #[test]
+    fn api_client_ruleset_rejects_system_authorization() {
+        let ruleset = MappingRuleSetCreate {
+            source: api_client_source(),
+            rules: vec![rule_with_system_authorization("system-auth-rule")],
+            ..sample_ruleset_create()
+        };
+        let result = validate_ruleset_create(&ruleset);
+        assert!(matches!(
+            result,
+            Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "system-auth-rule"
+        ));
+    }
+
+    #[test]
+    fn non_api_client_ruleset_allows_system_scope() {
+        // Defense-in-depth is scoped to ApiClient sources only; other
+        // sources (e.g. Federation) are unaffected by this guard.
+        let ruleset = MappingRuleSetCreate {
+            rules: vec![rule_with_is_system("system-rule")],
+            ..sample_ruleset_create()
+        };
+        assert!(validate_ruleset_create(&ruleset).is_ok());
+    }
+
+    #[test]
+    fn api_client_ruleset_update_rejects_is_system() {
+        let existing = MappingRuleSet {
+            mapping_id: "test-123".to_string(),
+            domain_id: Some("test-domain".to_string()),
+            source: api_client_source(),
+            domain_resolution_mode: DomainResolutionMode::Fixed,
+            enabled: true,
+            rules: vec![simple_rule("existing-rule", "user-exists")],
+            ruleset_version: 0,
+        };
+        let update = MappingRuleSetUpdate {
+            rules: Some(vec![rule_with_is_system("new-system-rule")]),
+            enabled: None,
+            allowed_domains: None,
+        };
+        let result = validate_ruleset_update(&existing, &update);
+        assert!(matches!(
+            result,
+            Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "new-system-rule"
         ));
     }
 }

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -26,6 +26,80 @@ use crate::auth::AuthenticationResult;
 use crate::auth::{ExecutionContext, ScopeInfo, SecurityContext, ValidatedSecurityContext};
 use crate::keystone::ServiceState;
 
+mod api_key {
+    use super::*;
+
+    use openstack_keystone_core_types::api_key::*;
+
+    use crate::api_key::{ApiKeyApi, ApiKeyProviderError};
+
+    mock! {
+        pub ApiKeyProvider {}
+
+        #[async_trait]
+        impl ApiKeyApi for ApiKeyProvider {
+            async fn create(
+                &self,
+                state: &ServiceState,
+                data: ApiClientResourceCreate,
+            ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+            async fn get_by_client_id<'a>(
+                &self,
+                state: &ServiceState,
+                domain_id: &'a str,
+                client_id: &'a str,
+            ) -> Result<Option<ApiClientResource>, ApiKeyProviderError>;
+
+            async fn get_by_lookup_hash<'a>(
+                &self,
+                state: &ServiceState,
+                domain_id: &'a str,
+                lookup_hash: &'a str,
+            ) -> Result<Option<ApiClientResource>, ApiKeyProviderError>;
+
+            async fn list(
+                &self,
+                state: &ServiceState,
+                params: &ApiClientResourceListParameters,
+            ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError>;
+
+            async fn update<'a>(
+                &self,
+                state: &ServiceState,
+                domain_id: &'a str,
+                client_id: &'a str,
+                data: ApiClientResourceUpdate,
+            ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+            async fn revoke<'a>(
+                &self,
+                state: &ServiceState,
+                domain_id: &'a str,
+                client_id: &'a str,
+                revoked_by: &'a str,
+            ) -> Result<ApiClientResource, ApiKeyProviderError>;
+
+            async fn update_last_used<'a>(
+                &self,
+                state: &ServiceState,
+                domain_id: &'a str,
+                lookup_hash: &'a str,
+                last_used_at: i64,
+            ) -> Result<(), ApiKeyProviderError>;
+
+            async fn update_secret_hash<'a>(
+                &self,
+                state: &ServiceState,
+                domain_id: &'a str,
+                lookup_hash: &'a str,
+                secret_hash: String,
+            ) -> Result<(), ApiKeyProviderError>;
+        }
+    }
+}
+pub use api_key::MockApiKeyProvider;
+
 mod application_credential {
     use super::*;
 

--- a/crates/core/src/plugin_manager.rs
+++ b/crates/core/src/plugin_manager.rs
@@ -22,6 +22,8 @@
 //! for the provider.
 use std::sync::Arc;
 
+use crate::api_key::ApiKeyProviderError;
+use crate::api_key::backend::ApiKeyBackend;
 use crate::application_credential::{
     ApplicationCredentialProviderError, backend::ApplicationCredentialBackend,
 };
@@ -53,6 +55,19 @@ use crate::trust::backend::TrustBackend;
 
 /// Plugin manager trait.
 pub trait PluginManagerApi {
+    /// Get registered API Key backend.
+    ///
+    /// # Parameters
+    /// - `name`: The name of the backend to retrieve.
+    ///
+    /// # Returns
+    /// - `Ok(&Arc<dyn ApiKeyBackend>)` if found, otherwise
+    ///   `Err(ApiKeyProviderError)`.
+    fn get_api_key_backend<S: AsRef<str>>(
+        &self,
+        name: S,
+    ) -> Result<&Arc<dyn ApiKeyBackend>, ApiKeyProviderError>;
+
     /// Get registered application credential backend.
     ///
     /// # Parameters
@@ -234,6 +249,13 @@ pub trait PluginManagerApi {
         &self,
         name: S,
     ) -> Result<&Arc<dyn TrustBackend>, TrustProviderError>;
+
+    /// Register API Key backend.
+    ///
+    /// # Parameters
+    /// - `name`: The name to register the backend under.
+    /// - `plugin`: The backend implementation.
+    fn register_api_key_backend<S: AsRef<str>>(&mut self, name: S, plugin: Arc<dyn ApiKeyBackend>);
 
     /// Register application credential backend.
     ///

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -22,6 +22,9 @@ use std::sync::Arc;
 
 use openstack_keystone_config::Config;
 
+use crate::api_key::ApiKeyApi;
+#[cfg(any(test, feature = "mock"))]
+use crate::api_key::MockApiKeyProvider;
 use crate::application_credential::ApplicationCredentialApi;
 #[cfg(any(test, feature = "mock"))]
 use crate::application_credential::MockApplicationCredentialProvider;
@@ -69,6 +72,8 @@ use crate::trust::TrustApi;
 #[derive(Builder)]
 #[builder(pattern = "owned")]
 pub struct Provider {
+    /// API Key provider.
+    api_key: Box<dyn ApiKeyApi>,
     /// Application credential provider.
     application_credential: Box<dyn ApplicationCredentialApi>,
     /// Assignment provider.
@@ -99,6 +104,12 @@ pub struct Provider {
 
 #[cfg(any(test, feature = "mock"))]
 impl ProviderBuilder {
+    pub fn mock_api_key(self, value: impl ApiKeyApi + 'static) -> Self {
+        let mut new = self;
+        new.api_key = Some(Box::new(value));
+        new
+    }
+
     pub fn mock_application_credential(
         self,
         value: impl ApplicationCredentialApi + 'static,
@@ -188,6 +199,7 @@ impl Provider {
         plugin_manager: &P,
         k8s_http_client: Arc<dyn K8sHttpClient>,
     ) -> Result<Self, KeystoneError> {
+        let api_key = Box::new(crate::api_key::ApiKeyService::new(cfg, plugin_manager)?);
         let application_credential = Box::new(
             crate::application_credential::ApplicationCredentialService::new(cfg, plugin_manager)?,
         );
@@ -217,6 +229,7 @@ impl Provider {
         let trust = Box::new(crate::trust::TrustService::new(cfg, plugin_manager)?);
 
         Ok(Self {
+            api_key,
             application_credential,
             assignment,
             catalog,
@@ -237,6 +250,7 @@ impl Provider {
     #[cfg(any(test, feature = "mock"))]
     pub fn mocked_builder() -> ProviderBuilder {
         ProviderBuilder::default()
+            .mock_api_key(MockApiKeyProvider::default())
             .mock_application_credential(MockApplicationCredentialProvider::default())
             .mock_assignment(MockAssignmentProvider::default())
             .mock_catalog(MockCatalogProvider::default())
@@ -250,6 +264,11 @@ impl Provider {
             .mock_role(MockRoleProvider::default())
             .mock_token(MockTokenProvider::default())
             .mock_trust(MockTrustProvider::default())
+    }
+
+    /// Get the API Key provider.
+    pub fn get_api_key_provider(&self) -> &dyn ApiKeyApi {
+        &*self.api_key
     }
 
     /// Get the application credential provider.

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -32,6 +32,7 @@ hyper.workspace = true
 inventory.workspace = true
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 nix = { workspace = true, features = ["socket", "user"] }
+openstack-keystone-api-key-driver-raft.workspace = true
 openstack-keystone-api-types = { workspace = true, features = ["openapi", "validate", "conv"]}
 openstack-keystone-audit.workspace = true
 openstack-keystone-appcred-driver-sql.workspace = true

--- a/crates/keystone/src/audit.rs
+++ b/crates/keystone/src/audit.rs
@@ -92,6 +92,7 @@ pub fn error_variant_name(error: &KeystoneApiError) -> String {
         KeystoneApiError::Base64Decode(_) => "BadRequest".to_string(),
         KeystoneApiError::Serde { .. } => "BadRequest".to_string(),
         KeystoneApiError::Other(_) => "InternalServerError".to_string(),
+        KeystoneApiError::TooManyRequests => "TooManyRequests".to_string(),
     }
 }
 
@@ -125,6 +126,9 @@ pub fn sanitize_authentication_error(e: &AuthenticationError) -> &'static str {
         AuthenticationError::TrustorDomainDisabled => "TrustorDomainDisabled",
         AuthenticationError::UserDomainDisabled => "UserDomainDisabled",
         AuthenticationError::RoleConversionFailed => "RoleConversionFailed",
+        AuthenticationError::NoAuthorizationsFound => "NoAuthorizationsFound",
+        AuthenticationError::MultipleScopesForbidden => "MultipleScopesForbidden",
+        AuthenticationError::SystemScopeForbiddenForApiKey => "SystemScopeForbiddenForApiKey",
     }
 }
 

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -72,6 +72,7 @@ use openstack_keystone::provider::Provider;
 use openstack_keystone::resource::ResourceHook;
 use openstack_keystone::revoke::RevokeHook;
 use openstack_keystone::role::RoleHook;
+use openstack_keystone::scim;
 use openstack_keystone::server::listener::{raft_grpc, spiffe_tls, spiffe_tls_uds};
 use openstack_keystone::token::TokenHook;
 use openstack_keystone::trust::TrustHook;
@@ -547,6 +548,10 @@ async fn main() -> Result<(), Report> {
     } else {
         info!("Not enabling the WebAuthN extension due to the `config.webauthn.enabled` flag.");
     }
+
+    // SCIM ingress sub-router (ADR 0021 §4): mounted independently of
+    // `/v3`/`/v4` so that only these routes accept API-Key bearer tokens.
+    app = app.nest("/SCIM/v2", scim::router().with_state(shared_state.clone()));
 
     app = app
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi))

--- a/crates/keystone/src/lib.rs
+++ b/crates/keystone/src/lib.rs
@@ -101,6 +101,7 @@ pub mod provider;
 pub mod resource;
 pub mod revoke;
 pub mod role;
+pub mod scim;
 pub mod server;
 pub mod token;
 pub mod trust;

--- a/crates/keystone/src/plugin_manager.rs
+++ b/crates/keystone/src/plugin_manager.rs
@@ -24,6 +24,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core::api_key::ApiKeyProviderError;
+use openstack_keystone_core::api_key::backend::ApiKeyBackend;
 use openstack_keystone_core::application_credential::{
     ApplicationCredentialProviderError, backend::ApplicationCredentialBackend,
 };
@@ -58,6 +60,8 @@ pub use openstack_keystone_core::plugin_manager::*;
 /// trait during the service start.
 #[derive(Clone)]
 pub struct PluginManager {
+    /// API Key backend plugins.
+    api_key_backends: HashMap<String, Arc<dyn ApiKeyBackend>>,
     /// Application credentials backend plugin.
     application_credential_backends: HashMap<String, Arc<dyn ApplicationCredentialBackend>>,
     /// Assignments backend plugin.
@@ -89,6 +93,26 @@ pub struct PluginManager {
 }
 
 impl PluginManagerApi for PluginManager {
+    /// Get registered API Key backend.
+    ///
+    /// # Parameters
+    /// * `name` - The name of the backend to retrieve.
+    ///
+    /// # Returns
+    /// A `Result` containing a reference to the `ApiKeyBackend` if found, or
+    /// an `ApiKeyProviderError`.
+    #[allow(clippy::borrowed_box)]
+    fn get_api_key_backend<S: AsRef<str>>(
+        &self,
+        name: S,
+    ) -> Result<&Arc<dyn ApiKeyBackend>, ApiKeyProviderError> {
+        self.api_key_backends
+            .get(name.as_ref())
+            .ok_or(ApiKeyProviderError::UnsupportedDriver(
+                name.as_ref().to_string(),
+            ))
+    }
+
     /// Get registered application credential backend.
     ///
     /// # Parameters
@@ -363,6 +387,16 @@ impl PluginManagerApi for PluginManager {
             ))
     }
 
+    /// Register API Key backend.
+    ///
+    /// # Parameters
+    /// * `name` - The name of the backend to register.
+    /// * `plugin` - The backend implementation to register.
+    fn register_api_key_backend<S: AsRef<str>>(&mut self, name: S, plugin: Arc<dyn ApiKeyBackend>) {
+        self.api_key_backends
+            .insert(name.as_ref().to_string(), plugin);
+    }
+
     /// Register application credential backend.
     ///
     /// # Parameters
@@ -605,6 +639,7 @@ impl PluginManager {
     /// A new instance of `PluginManager`.
     pub fn with_config(config: &Config) -> Self {
         let mut slf = Self {
+            api_key_backends: HashMap::new(),
             application_credential_backends: HashMap::new(),
             assignment_backends: HashMap::new(),
             catalog_backends: HashMap::new(),
@@ -634,6 +669,10 @@ impl PluginManager {
         slf.register_mapping_backend(
             "raft",
             Arc::new(openstack_keystone_mapping_driver_raft::RaftBackend::default()),
+        );
+        slf.register_api_key_backend(
+            "raft",
+            Arc::new(openstack_keystone_api_key_driver_raft::RaftBackend::default()),
         );
         slf
     }

--- a/crates/keystone/src/scim.rs
+++ b/crates/keystone/src/scim.rs
@@ -1,0 +1,53 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # SCIM ingress sub-router (ADR 0021)
+//!
+//! Mounted independently of `/v3`/`/v4` at `/SCIM/v2` per ADR 0021 §4
+//! (Sub-Router Isolation): only handlers nested here use the
+//! [`ApiKeyAuth`] extractor to accept API-Key bearer tokens. Core OpenStack
+//! endpoints never use this extractor and therefore reject API keys
+//! outright, satisfying the isolation requirement structurally rather than
+//! via a path allowlist.
+//!
+//! SCIM resource endpoints (Users, Groups per RFC 7644) are out of scope
+//! for ADR 0021, which specifies only the authentication ingress adapter.
+//! `whoami` exists to prove the ingress pipeline end-to-end.
+use axum::{Json, Router, extract::Path, routing::get};
+use serde::Serialize;
+
+use openstack_keystone_core::api::api_key_auth::ApiKeyAuth;
+use openstack_keystone_core::keystone::ServiceState;
+
+/// Diagnostic response describing the resolved ephemeral security context.
+#[derive(Serialize)]
+struct WhoAmI {
+    user_id: String,
+    scope: String,
+}
+
+async fn whoami(Path(_domain_id): Path<String>, ApiKeyAuth(vsc): ApiKeyAuth) -> Json<WhoAmI> {
+    let ctx = vsc.inner();
+    Json(WhoAmI {
+        user_id: ctx.principal().get_user_id(),
+        scope: ctx
+            .authorization()
+            .map(|authz| format!("{:?}", authz.scope))
+            .unwrap_or_else(|| "unscoped".to_string()),
+    })
+}
+
+/// SCIM ingress sub-router, nested at `/SCIM/v2` in the main binary.
+pub fn router() -> Router<ServiceState> {
+    Router::new().route("/{domain_id}/whoami", get(whoami))
+}

--- a/tests/integration/src/api_key.rs
+++ b/tests/integration/src/api_key.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # API Key (SCIM ingress) provider integration tests (ADR 0021)
+//!
+//! Raft-only backend — these tests only run under the `raft` nextest
+//! profile (see `.config/nextest.toml`), matching the `mapping`/`spiffe`
+//! test suites.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use chrono::Utc;
+use eyre::Result;
+
+use openstack_keystone::keystone::Service;
+use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core_types::api_key::*;
+
+mod create;
+mod get;
+mod last_used;
+mod list;
+mod mapping_system_scope;
+mod revoke;
+mod update;
+
+use crate::common::*;
+
+impl ResourceDeleter<ApiClientResource> for Arc<Service> {
+    fn delete(&self, resource: ApiClientResource) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            // No hard delete exists (ADR 0021 §5.C) — cleanup revokes instead.
+            let _ = self
+                .provider
+                .get_api_key_provider()
+                .revoke(
+                    self,
+                    &resource.domain_id,
+                    &resource.client_id,
+                    "test-cleanup",
+                )
+                .await;
+        })
+    }
+}
+
+pub async fn create_api_key(
+    state: &ServiceState,
+    data: ApiClientResourceCreate,
+) -> Result<AsyncResourceGuard<ApiClientResource, ServiceState>> {
+    let res = state
+        .provider
+        .get_api_key_provider()
+        .create(state, data)
+        .await
+        .unwrap();
+    Ok(AsyncResourceGuard::new(res, state.clone()))
+}
+
+/// Construct a sample API Key creation payload with unique `client_id` and
+/// `lookup_hash` values. `secret_hash` is a well-formed-looking but
+/// non-functional PHC string — provider-level CRUD does not perform Argon2id
+/// verification, so it never needs to actually verify.
+pub fn sample_api_key_create(domain_id: &str, provider_id: &str) -> ApiClientResourceCreate {
+    let unique = uuid::Uuid::new_v4().simple().to_string();
+    ApiClientResourceCreate {
+        domain_id: domain_id.to_string(),
+        provider_id: provider_id.to_string(),
+        client_id: format!("client-{unique}"),
+        lookup_hash: format!("lookup-{unique}"),
+        secret_hash: "$argon2id$v=19$m=65536,t=3,p=4$c2FsdHNhbHQ$aGFzaGhhc2g".to_string(),
+        allowed_ips: None,
+        description: Some("integration test key".to_string()),
+        expires_at: Utc::now().timestamp() + 3600,
+    }
+}

--- a/tests/integration/src/api_key/create.rs
+++ b/tests/integration/src/api_key/create.rs
@@ -1,0 +1,86 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test API Key creation.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use super::{create_api_key, sample_api_key_create};
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_create() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let sot = sample_api_key_create(&domain.id, "provider-1");
+
+    let res = create_api_key(&state, sot.clone()).await?;
+
+    assert_eq!(sot.domain_id, res.domain_id);
+    assert_eq!(sot.provider_id, res.provider_id);
+    assert_eq!(sot.client_id, res.client_id);
+    assert_eq!(sot.lookup_hash, res.lookup_hash);
+    assert_eq!(sot.secret_hash, res.secret_hash);
+    assert_eq!(sot.allowed_ips, res.allowed_ips);
+    assert_eq!(sot.description, res.description);
+    assert_eq!(sot.expires_at, res.expires_at);
+
+    // Server-managed fields.
+    assert!(res.enabled);
+    assert!(res.last_used_at.is_none());
+    assert!(res.revoked_at.is_none());
+    assert!(res.revoked_by.is_none());
+    assert!(res.created_at > 0);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_with_allowed_ips() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let mut sot = sample_api_key_create(&domain.id, "provider-1");
+    sot.allowed_ips = Some(vec!["10.0.0.0/8".to_string(), "192.168.1.0/24".to_string()]);
+
+    let res = create_api_key(&state, sot.clone()).await?;
+
+    assert_eq!(sot.allowed_ips, res.allowed_ips);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_two_keys_same_provider_rotation() -> Result<()> {
+    // Zero-downtime rotation (ADR 0021 §5.D): N:1 keys-to-provider mapping
+    // must not collide, since the primary index is keyed by lookup_hash, not
+    // provider_id.
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let key_a =
+        create_api_key(&state, sample_api_key_create(&domain.id, "shared-provider")).await?;
+    let key_b =
+        create_api_key(&state, sample_api_key_create(&domain.id, "shared-provider")).await?;
+
+    assert_ne!(key_a.client_id, key_b.client_id);
+    assert_ne!(key_a.lookup_hash, key_b.lookup_hash);
+    assert_eq!(key_a.provider_id, key_b.provider_id);
+
+    Ok(())
+}

--- a/tests/integration/src/api_key/get.rs
+++ b/tests/integration/src/api_key/get.rs
@@ -1,0 +1,122 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test API Key retrieval by `client_id` and by `lookup_hash`.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use super::{create_api_key, sample_api_key_create};
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_by_client_id() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_client_id(&state, &domain.id, &created.client_id)
+        .await?;
+
+    assert_eq!(
+        fetched.map(|k| k.client_id),
+        Some(created.client_id.clone())
+    );
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_by_client_id_missing() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_client_id(&state, &domain.id, "nonexistent-client-id")
+        .await?;
+
+    assert!(fetched.is_none());
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_by_lookup_hash() -> Result<()> {
+    // The SCIM ingress hot path (ADR 0021 §3 Step 2) resolves solely by
+    // lookup_hash, never by client_id.
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain.id, &created.lookup_hash)
+        .await?;
+
+    assert_eq!(
+        fetched.map(|k| k.client_id),
+        Some(created.client_id.clone())
+    );
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_by_lookup_hash_missing() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain.id, "nonexistent-lookup-hash")
+        .await?;
+
+    assert!(fetched.is_none());
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_is_domain_scoped() -> Result<()> {
+    // A key created under domain A must not resolve when queried under
+    // domain B, even with the correct lookup_hash — the primary storage
+    // index partitions strictly by domain_id (ADR 0021 §2.A).
+    let (state, _) = get_state().await?;
+    let domain_a = create_domain!(state)?;
+    let domain_b = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain_a.id, "provider-1")).await?;
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain_b.id, &created.lookup_hash)
+        .await?;
+
+    assert!(fetched.is_none());
+
+    Ok(())
+}

--- a/tests/integration/src/api_key/last_used.rs
+++ b/tests/integration/src/api_key/last_used.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test `update_last_used` (ADR 0021 §3 Step 3) and `update_secret_hash`
+//! (lazy re-hash, ADR 0021 Invariant 8) maintenance operations.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use super::{create_api_key, sample_api_key_create};
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_last_used() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+    assert!(created.last_used_at.is_none());
+
+    let now = chrono::Utc::now().timestamp();
+    state
+        .provider
+        .get_api_key_provider()
+        .update_last_used(&state, &domain.id, &created.lookup_hash, now)
+        .await?;
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain.id, &created.lookup_hash)
+        .await?
+        .expect("key must still exist");
+
+    assert_eq!(fetched.last_used_at, Some(now));
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_last_used_on_missing_key_is_a_no_op() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    // No key exists for this lookup_hash; must not error (mirrors the
+    // dummy-hash timing-parity path, which always runs regardless of
+    // whether the key exists).
+    let result = state
+        .provider
+        .get_api_key_provider()
+        .update_last_used(&state, &domain.id, "nonexistent-lookup-hash", 12345)
+        .await;
+
+    assert!(result.is_ok());
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_secret_hash() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    let new_hash = "$argon2id$v=19$m=131072,t=4,p=4$bmV3c2FsdA$bmV3aGFzaA".to_string();
+    state
+        .provider
+        .get_api_key_provider()
+        .update_secret_hash(&state, &domain.id, &created.lookup_hash, new_hash.clone())
+        .await?;
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain.id, &created.lookup_hash)
+        .await?
+        .expect("key must still exist");
+
+    assert_eq!(fetched.secret_hash, new_hash);
+    // Re-hashing must not disturb unrelated fields.
+    assert_eq!(fetched.client_id, created.client_id);
+    assert!(fetched.enabled);
+
+    Ok(())
+}

--- a/tests/integration/src/api_key/list.rs
+++ b/tests/integration/src/api_key/list.rs
@@ -1,0 +1,119 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test API Key listing (domain scoping, provider_id and enabled filters).
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core_types::api_key::ApiClientResourceListParameters;
+
+use super::{create_api_key, sample_api_key_create};
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_list_scoped_to_domain() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain_a = create_domain!(state)?;
+    let domain_b = create_domain!(state)?;
+
+    let key_a1 = create_api_key(&state, sample_api_key_create(&domain_a.id, "provider-1")).await?;
+    let key_a2 = create_api_key(&state, sample_api_key_create(&domain_a.id, "provider-2")).await?;
+    let _key_b = create_api_key(&state, sample_api_key_create(&domain_b.id, "provider-1")).await?;
+
+    let listed = state
+        .provider
+        .get_api_key_provider()
+        .list(
+            &state,
+            &ApiClientResourceListParameters {
+                domain_id: domain_a.id.clone(),
+                provider_id: None,
+                enabled: None,
+            },
+        )
+        .await?;
+
+    let listed_client_ids: Vec<String> = listed.into_iter().map(|k| k.client_id).collect();
+    assert!(listed_client_ids.contains(&key_a1.client_id));
+    assert!(listed_client_ids.contains(&key_a2.client_id));
+    assert_eq!(listed_client_ids.len(), 2);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_list_filters_by_provider_id() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let key_a = create_api_key(&state, sample_api_key_create(&domain.id, "provider-a")).await?;
+    let _key_b = create_api_key(&state, sample_api_key_create(&domain.id, "provider-b")).await?;
+
+    let listed = state
+        .provider
+        .get_api_key_provider()
+        .list(
+            &state,
+            &ApiClientResourceListParameters {
+                domain_id: domain.id.clone(),
+                provider_id: Some("provider-a".to_string()),
+                enabled: None,
+            },
+        )
+        .await?;
+
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].client_id, key_a.client_id);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_list_filters_by_enabled() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let enabled_key =
+        create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+    let revoked_key =
+        create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+    state
+        .provider
+        .get_api_key_provider()
+        .revoke(&state, &domain.id, &revoked_key.client_id, "operator-1")
+        .await?;
+
+    let listed_enabled = state
+        .provider
+        .get_api_key_provider()
+        .list(
+            &state,
+            &ApiClientResourceListParameters {
+                domain_id: domain.id.clone(),
+                provider_id: None,
+                enabled: Some(true),
+            },
+        )
+        .await?;
+
+    assert_eq!(listed_enabled.len(), 1);
+    assert_eq!(listed_enabled[0].client_id, enabled_key.client_id);
+
+    Ok(())
+}

--- a/tests/integration/src/api_key/mapping_system_scope.rs
+++ b/tests/integration/src/api_key/mapping_system_scope.rs
@@ -1,0 +1,153 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Cross-provider integration test: the mapping engine's write-time guard
+//! (ADR 0021 §6.C, Invariant 3 defense-in-depth) must reject any
+//! `IdentitySource::ApiClient` ruleset that grants system scope, exercised
+//! through the real (raft-backed) mapping provider rather than the
+//! `crates/core` unit tests.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core::mapping::MappingApi;
+use openstack_keystone_core_types::mapping::authorization::Authorization;
+use openstack_keystone_core_types::mapping::error::MappingProviderError;
+use openstack_keystone_core_types::mapping::resolution::IdentitySource;
+use openstack_keystone_core_types::mapping::*;
+
+use crate::common::get_state;
+use crate::create_domain;
+
+fn api_client_rule(name: &str, is_system: bool, authorizations: Vec<Authorization>) -> MappingRule {
+    MappingRule {
+        name: name.into(),
+        description: None,
+        r#match: MatchCriteria::AllOf(vec![]),
+        identity: IdentityBinding {
+            identity_mode: None,
+            user_name: "${claims.api_client.client_id}".into(),
+            user_id: None,
+            user_domain_id: None,
+            is_system,
+        },
+        authorizations,
+        groups: Vec::new(),
+    }
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_api_client_ruleset_rejects_is_system() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let ruleset = MappingRuleSetCreate {
+        mapping_id: Some(uuid::Uuid::new_v4().simple().to_string()),
+        domain_id: Some(domain.id.clone()),
+        source: IdentitySource::ApiClient {
+            provider_id: "provider-1".into(),
+        },
+        domain_resolution_mode: DomainResolutionMode::Fixed,
+        enabled: true,
+        rules: vec![api_client_rule("system-rule", true, Vec::new())],
+    };
+
+    let result = state
+        .provider
+        .get_mapping_provider()
+        .create_ruleset(&ExecutionContext::internal(&state), ruleset)
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "system-rule"
+    ));
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_api_client_ruleset_rejects_system_authorization() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let ruleset = MappingRuleSetCreate {
+        mapping_id: Some(uuid::Uuid::new_v4().simple().to_string()),
+        domain_id: Some(domain.id.clone()),
+        source: IdentitySource::ApiClient {
+            provider_id: "provider-1".into(),
+        },
+        domain_resolution_mode: DomainResolutionMode::Fixed,
+        enabled: true,
+        rules: vec![api_client_rule(
+            "system-auth-rule",
+            false,
+            vec![Authorization::System {
+                system_id: "all".into(),
+                roles: Vec::new(),
+            }],
+        )],
+    };
+
+    let result = state
+        .provider
+        .get_mapping_provider()
+        .create_ruleset(&ExecutionContext::internal(&state), ruleset)
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "system-auth-rule"
+    ));
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_api_client_ruleset_allows_non_system_scope() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let ruleset = MappingRuleSetCreate {
+        mapping_id: Some(uuid::Uuid::new_v4().simple().to_string()),
+        domain_id: Some(domain.id.clone()),
+        source: IdentitySource::ApiClient {
+            provider_id: "provider-1".into(),
+        },
+        domain_resolution_mode: DomainResolutionMode::Fixed,
+        enabled: true,
+        rules: vec![api_client_rule(
+            "project-rule",
+            false,
+            vec![Authorization::Project {
+                project_id: "project-1".into(),
+                project_domain_id: domain.id.clone(),
+                roles: Vec::new(),
+            }],
+        )],
+    };
+
+    let res = state
+        .provider
+        .get_mapping_provider()
+        .create_ruleset(&ExecutionContext::internal(&state), ruleset)
+        .await?;
+
+    assert_eq!(res.rules.len(), 1);
+
+    Ok(())
+}

--- a/tests/integration/src/api_key/revoke.rs
+++ b/tests/integration/src/api_key/revoke.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test the API Key emergency revocation path (ADR 0021 §5.C): tombstone,
+//! not hard delete.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use super::{create_api_key, sample_api_key_create};
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_revoke_disables_and_stamps_tombstone() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    let revoked = state
+        .provider
+        .get_api_key_provider()
+        .revoke(&state, &domain.id, &created.client_id, "operator-1")
+        .await?;
+
+    assert!(!revoked.enabled);
+    assert_eq!(revoked.revoked_by, Some("operator-1".to_string()));
+    assert!(revoked.revoked_at.is_some());
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_revoke_does_not_hard_delete() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    state
+        .provider
+        .get_api_key_provider()
+        .revoke(&state, &domain.id, &created.client_id, "operator-1")
+        .await?;
+
+    // The lookup_hash → resource mapping must still resolve (audit trail /
+    // incident response), just with enabled: false.
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain.id, &created.lookup_hash)
+        .await?;
+
+    assert!(fetched.is_some());
+    assert!(!fetched.unwrap().enabled);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_revoke_missing_key_fails() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let result = state
+        .provider
+        .get_api_key_provider()
+        .revoke(&state, &domain.id, "nonexistent-client-id", "operator-1")
+        .await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/tests/integration/src/api_key/update.rs
+++ b/tests/integration/src/api_key/update.rs
@@ -1,0 +1,161 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test API Key update, including the double-`Option` `allowed_ips` and
+//! `description` semantics (ADR 0021 Invariant 5).
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core_types::api_key::ApiClientResourceUpdate;
+
+use super::{create_api_key, sample_api_key_create};
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_sets_allowed_ips() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+    assert!(created.allowed_ips.is_none());
+
+    let updated = state
+        .provider
+        .get_api_key_provider()
+        .update(
+            &state,
+            &domain.id,
+            &created.client_id,
+            ApiClientResourceUpdate {
+                allowed_ips: Some(Some(vec!["10.0.0.0/8".to_string()])),
+                description: None,
+                enabled: None,
+            },
+        )
+        .await?;
+
+    assert_eq!(updated.allowed_ips, Some(vec!["10.0.0.0/8".to_string()]));
+    // `None` in the request means "unchanged".
+    assert_eq!(updated.description, created.description);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_clears_allowed_ips_to_unrestricted() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let mut sot = sample_api_key_create(&domain.id, "provider-1");
+    sot.allowed_ips = Some(vec!["10.0.0.0/8".to_string()]);
+    let created = create_api_key(&state, sot).await?;
+
+    let updated = state
+        .provider
+        .get_api_key_provider()
+        .update(
+            &state,
+            &domain.id,
+            &created.client_id,
+            ApiClientResourceUpdate {
+                // `Some(None)` explicitly clears the restriction.
+                allowed_ips: Some(None),
+                description: None,
+                enabled: None,
+            },
+        )
+        .await?;
+
+    assert_eq!(updated.allowed_ips, None);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_description() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    let updated = state
+        .provider
+        .get_api_key_provider()
+        .update(
+            &state,
+            &domain.id,
+            &created.client_id,
+            ApiClientResourceUpdate {
+                allowed_ips: None,
+                description: Some(Some("updated description".to_string())),
+                enabled: None,
+            },
+        )
+        .await?;
+
+    assert_eq!(updated.description, Some("updated description".to_string()));
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_disable_key() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    let updated = state
+        .provider
+        .get_api_key_provider()
+        .update(
+            &state,
+            &domain.id,
+            &created.client_id,
+            ApiClientResourceUpdate {
+                allowed_ips: None,
+                description: None,
+                enabled: Some(false),
+            },
+        )
+        .await?;
+
+    assert!(!updated.enabled);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_missing_key_fails() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let result = state
+        .provider
+        .get_api_key_provider()
+        .update(
+            &state,
+            &domain.id,
+            "nonexistent-client-id",
+            ApiClientResourceUpdate::default(),
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
SCIM M2M provisioning integrations use static bearer tokens and can't
do a Fernet token exchange first. Adds a domain-scoped API-Key
provider (Argon2id-hashed secrets, raft-backed) and a dedicated
ingress extractor mounted only on /SCIM/v2, so core OpenStack
endpoints never accept API keys.

- ApiClientResource CRUD (create/get/list/update/revoke) via
  ApiKeyApi, raft driver keyed by lookup_hash with a client_id
  secondary index for zero-downtime key rotation
- kscim_<entropy>_<crc32> token format, Argon2id hash/verify/lazy
  re-hash, dummy-hash timing parity against lookup-hash enumeration
- IdentitySource::ApiClient wired into the mapping engine, with a
  write-time guard rejecting system-scope grants on API-Key rulesets
- ingress extractor enforces single-scope/no-system-scope/
  no-authorizations invariants before hydrating a SecurityContext,
  plus rightmost-non-trusted-proxy IP resolution and per-lookup_hash
  rate limiting
- provider-level integration tests (raft nextest profile)

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
