### PR TITLE
fix: Further polish storage crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4118,6 +4118,7 @@ dependencies = [
  "tracing-test",
  "uuid",
  "x509-parser 0.18.1",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -67,6 +67,7 @@ spiffe-rustls.workspace = true
 thiserror.workspace = true
 tokio-rustls.workspace = true
 tonic = { workspace = true, features = ["router", "_tls-any"] }
+zeroize = "1"
 tonic-prost.workspace = true
 tower.workspace = true
 tracing.workspace = true

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -36,12 +36,11 @@ use crate::StorageApi;
 use crate::StoreError;
 use crate::StoreResponse;
 use crate::Violation;
-use crate::audit::AuditForwarder;
+use crate::audit::{AuditForwarder, AuditRecord};
 use crate::grpc::cluster_admin_service::ClusterAdminServiceImpl;
 use crate::grpc::raft_service::RaftServiceImpl;
 use crate::grpc::storage_service::StorageServiceImpl;
 use crate::network::{CertExpiryWatchdog, NetworkManager, RaftTlsClient, init_tls_watcher};
-use crate::pb::api::Response;
 use crate::pb::raft::cluster_admin_service_server::ClusterAdminServiceServer;
 use crate::pb::raft::raft_service_server::RaftServiceServer;
 use crate::protobuf::api::storage_service_client::StorageServiceClient;
@@ -120,6 +119,98 @@ async fn check_node_id_uniqueness(
 
     tracing::debug!(node_id, rpc_addr, "node_id uniqueness check passed");
     Ok(())
+}
+
+/// Best-effort live verification of node_id uniqueness against a reachable
+/// cluster peer's *current* membership (ADR 0016-v2 §4.3 / F7).
+///
+/// `check_node_id_uniqueness` only reads this node's own persisted Raft
+/// state, which cannot detect a conflict that appeared on the live cluster
+/// while this node was offline (e.g. its old `(node_id, rpc_addr)` was
+/// reused by a misconfigured or impersonating node during an outage).
+///
+/// Returns:
+/// - `Ok(true)` if at least one configured peer was reached and its live
+///   membership confirms no conflict.
+/// - `Ok(false)` if no configured peer could be reached at all —
+///   verification is inconclusive. The caller should log a prominent
+///   warning but proceed rather than refuse to start: treating "no peer
+///   reachable" as fail-closed would make it impossible to recover from a
+///   full-cluster outage where every node restarts simultaneously with no
+///   live peer to ask (the ADR's literal fail-closed wording does not
+///   distinguish that case from an active network partition, so this is a
+///   deliberate, documented deviation in favor of cluster recoverability).
+/// - `Err` if a reachable peer's live membership shows an actual
+///   `(node_id, rpc_addr)` conflict — a real, actionable signal, so this
+///   remains fail-closed.
+async fn verify_node_id_uniqueness_live(
+    tls_client: &RaftTlsClient,
+    node_id: u64,
+    rpc_addr: &str,
+    peers: &[(u64, String)],
+) -> Result<bool, StoreError> {
+    const PEER_CONTACT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    let check_addr = normalize_rpc_addr(rpc_addr);
+
+    for (_peer_id, peer_addr) in peers {
+        // Skip only entries that are literally our own address — NOT
+        // entries that share our node_id, since a peer advertising our
+        // node_id at a *different* address is exactly the conflict this
+        // check must detect (skipping on node_id would defeat the purpose
+        // whenever a misconfigured node's own retry_join_nodes list still
+        // contains the entry for the id it is impersonating).
+        if normalize_rpc_addr(peer_addr) == check_addr {
+            continue;
+        }
+
+        let attempt = async {
+            let channel = tls_client.connect(peer_addr).await?;
+            let mut client = ClusterAdminServiceClient::new(channel);
+            client
+                .metrics(())
+                .await
+                .map(|resp| resp.into_inner())
+                .map_err(|s| StoreError::Other(eyre!("metrics RPC failed: {s}")))
+        };
+
+        let metrics = match tokio::time::timeout(PEER_CONTACT_TIMEOUT, attempt).await {
+            Ok(Ok(metrics)) => metrics,
+            Ok(Err(e)) => {
+                tracing::debug!(peer_addr, error = %e, "peer unreachable during live uniqueness check");
+                continue;
+            }
+            Err(_) => {
+                tracing::debug!(peer_addr, "peer live uniqueness check timed out");
+                continue;
+            }
+        };
+
+        if let Some(membership) = metrics.membership {
+            for (nid, node) in &membership.nodes {
+                if *nid == node_id && normalize_rpc_addr(&node.rpc_addr) != check_addr {
+                    tracing::error!(
+                        node_id,
+                        rpc_addr,
+                        existing_addr = node.rpc_addr,
+                        peer_addr,
+                        "FATAL: live peer reports node_id already registered at a \
+                         different address"
+                    );
+                    return Err(StoreError::Other(eyre!(
+                        "FATAL: node_id {node_id} is registered at {} per live peer {peer_addr}; \
+                         refusing to start with address {rpc_addr}",
+                        node.rpc_addr
+                    )));
+                }
+            }
+        }
+
+        // Reached a peer and found no conflict — verification complete;
+        // no need to contact additional peers.
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 /// Initialize storage services backed by the raft.
@@ -224,6 +315,34 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Arc<Sto
     let rpc_addr = ds_config.node_cluster_addr.to_string();
     check_node_id_uniqueness(&raft, ds_config.node_id, &rpc_addr).await?;
 
+    // Additionally verify against a live peer's current membership, since
+    // the local check above cannot detect a conflict that appeared while
+    // this node was offline (ADR 0016-v2 §4.3 / F7).
+    if !ds_config.retry_join_nodes.is_empty() {
+        match verify_node_id_uniqueness_live(
+            &tls_client,
+            ds_config.node_id,
+            &rpc_addr,
+            &ds_config.retry_join_nodes,
+        )
+        .await
+        {
+            Ok(true) => {
+                tracing::debug!("node_id uniqueness verified against a live cluster peer");
+            }
+            Ok(false) => {
+                tracing::warn!(
+                    node_id = ds_config.node_id,
+                    "SECURITY: could not verify node_id uniqueness against any live peer \
+                     (ADR 0016-v2 §4.3); proceeding on local state only. If this is a \
+                     network partition rather than a full-cluster restart, a duplicate \
+                     node_id may go undetected until Raft consensus surfaces it."
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
     // Derive the per-node audit HMAC key from the current DEK epoch (ADR §3.1).
     let audit_key = {
         let guard = current_dek.read().unwrap_or_else(|p| p.into_inner());
@@ -290,6 +409,84 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Arc<Sto
                         "failed to propose quarantine via Raft; local quarantine \
                          remains in effect, cluster-wide visibility delayed"
                     );
+                }
+            }
+        });
+    }
+
+    // Emergency-rotation confirmation-timeout sweeper (ADR 0016-v2 §6.2
+    // step 1): only the current leader proactively aborts pending
+    // emergency rotations whose 5-minute confirmation window has elapsed
+    // with no ConfirmRotateDek, so the abort and its audit trail don't
+    // depend on some future RPC happening to touch the same rotation_id.
+    // Runs on every node but is a no-op unless that node is leader, so
+    // exactly one abort (and one audit record) is produced per timeout.
+    {
+        let storage_weak = Arc::downgrade(&storage);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                let Some(storage) = storage_weak.upgrade() else {
+                    break;
+                };
+                if storage.current_leader() != Some(storage.node_id()) {
+                    continue;
+                }
+
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                let expired: Vec<crate::store_command::PendingRotation> = {
+                    let pending = storage
+                        .pending_rotations
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner());
+                    pending
+                        .values()
+                        .filter(|e| e.expires_at <= now)
+                        .cloned()
+                        .collect()
+                };
+
+                for entry in expired {
+                    let cmd =
+                        StoreCommand::Transaction(vec![MutationInner::AbortPendingRotation {
+                            rotation_id: entry.rotation_id.clone(),
+                        }]);
+                    let Ok(payload) = crate::pb::api::CommandRequest::try_from(cmd) else {
+                        continue;
+                    };
+                    match storage.write_command_to_storage(payload).await {
+                        Ok(_) => {
+                            storage.audit_forwarder.emit(AuditRecord::now(
+                                "DEK_ROTATION_EMERGENCY_ABORTED",
+                                &entry.initiator,
+                                storage.node_id(),
+                                entry.dek_version,
+                                serde_json::json!({
+                                    "rotation_id": entry.rotation_id,
+                                    "expires_at": entry.expires_at,
+                                    "reason": "confirmation window expired with no \
+                                               ConfirmRotateDek",
+                                }),
+                            ));
+                            tracing::warn!(
+                                rotation_id = entry.rotation_id,
+                                initiator = entry.initiator,
+                                "SECURITY: emergency DEK rotation confirmation window \
+                                 expired; automatically aborted"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                rotation_id = entry.rotation_id,
+                                error = %e,
+                                "failed to propose AbortPendingRotation via Raft"
+                            );
+                        }
+                    }
                 }
             }
         });
@@ -659,7 +856,7 @@ impl StorageApi for Storage {
         key: String,
         keyspace: Option<String>,
     ) -> Result<StoreResponse, ApiStoreError> {
-        let response: Response = {
+        let response: crate::ZeroizingResponse = {
             let inner =
                 MutationInner::convert(Mutation::remove(key.into_bytes(), keyspace.clone(), None))?;
             let request = StoreCommand::Transaction(vec![inner]);
@@ -677,7 +874,7 @@ impl StorageApi for Storage {
     /// # Returns
     /// A `Result` containing the `StoreResponse`, or an `ApiStoreError`.
     async fn remove_index(&self, key: String) -> Result<StoreResponse, ApiStoreError> {
-        let response: Response = {
+        let response: crate::ZeroizingResponse = {
             let request = StoreCommand::Transaction(vec![MutationInner::RemoveIndex {
                 key: key.into_bytes(),
             }]);
@@ -997,11 +1194,11 @@ impl Storage {
     /// - `command`: A command to apply to the cluster.
     ///
     /// # Returns
-    /// A `Result` containing the `Response`, or a `StoreError`.
+    /// A `Result` containing the `ZeroizingResponse`, or a `StoreError`.
     async fn write_command_to_storage(
         &self,
         command: crate::pb::api::CommandRequest,
-    ) -> Result<Response, StoreError> {
+    ) -> Result<crate::ZeroizingResponse, StoreError> {
         match self.raft.client_write(command.clone()).await {
             Ok(rsp) => {
                 let rsp = rsp.data;
@@ -1054,13 +1251,13 @@ impl Storage {
     /// - `node_addr`: The cluster node address.
     ///
     /// # Returns
-    /// A `Result` containing the `Response`, or a `StoreError`.
+    /// A `Result` containing the `ZeroizingResponse`, or a `StoreError`.
     async fn command_with_forwarding(
         &self,
         command: crate::pb::api::CommandRequest,
         node_id: u64,
         node_addr: String,
-    ) -> Result<Response, StoreError> {
+    ) -> Result<crate::ZeroizingResponse, StoreError> {
         let max_retries = 3;
 
         let mut node_addr = node_addr;
@@ -1084,7 +1281,13 @@ impl Storage {
                             description: v.description.clone(),
                         });
                     }
-                    return Ok(resp);
+                    // Wrap the deserialized wire response in the zeroizing
+                    // type so it's scrubbed on drop for the rest of its
+                    // lifetime in this process (ADR 0016-v2 §8).
+                    return Ok(crate::ZeroizingResponse {
+                        value: resp.value.map(zeroize::Zeroizing::new),
+                        violations: resp.violations,
+                    });
                 }
                 Err(status) if status.code() == Code::Unavailable => {
                     // Extract leader endpoint from gRPC metadata
@@ -1124,10 +1327,14 @@ impl Storage {
     }
 }
 
-/// Convert protobuf `Response` to lightweight `StoreResponse`.
-fn rb_resp_to_store_response(resp: Response) -> StoreResponse {
+/// Convert the internal `ZeroizingResponse` to the public `StoreResponse`.
+///
+/// This is the legitimate hand-off point to the caller: the plaintext
+/// leaves the zeroizing wrapper here because the caller needs an owned,
+/// ordinary `Vec<u8>` to use (e.g. deserialize into a typed struct).
+fn rb_resp_to_store_response(resp: crate::ZeroizingResponse) -> StoreResponse {
     StoreResponse {
-        value: resp.value,
+        value: resp.value.map(|v| v.to_vec()),
         violations: resp
             .violations
             .into_iter()

--- a/crates/storage/src/grpc/storage_service.rs
+++ b/crates/storage/src/grpc/storage_service.rs
@@ -82,7 +82,9 @@ impl StorageService for StorageServiceImpl {
                 Status::internal(format!("Failed to write command to store: {}", e))
             })?;
 
-        Ok(Response::new(res.data))
+        // Convert right before the wire boundary, so the zeroizing wrapper
+        // is held as long as possible (ADR 0016-v2 §8).
+        Ok(Response::new(res.data.into()))
     }
 
     /// Handles a forwarded get request from a follower.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -97,11 +97,97 @@ pub mod protobuf {
 }
 pub use crate::protobuf as pb;
 
+/// Application response returned by the state machine on `apply()` (ADR
+/// 0016-v2 §8: `RaftResponse` — "Ephemeral plaintext response, transmitted
+/// only over mTLS. Zeroized by the sender immediately after gRPC send.").
+///
+/// `value` holds decrypted plaintext for reads served through the Raft
+/// write path (e.g. `CreateIfAbsent` echoing back the stored value); it is
+/// wrapped in `Zeroizing` so the buffer is scrubbed as soon as the last
+/// clone/owner drops, rather than lingering in freed heap memory until
+/// reused. This narrows, but does not eliminate, the exposure window: gRPC
+/// implementations (tonic/prost) may still buffer or copy bytes internally
+/// during transmission, which this wrapper cannot reach — the compensating
+/// controls for that residual risk are `RLIMIT_CORE = 0` and
+/// `PR_SET_DUMPABLE = 0`, enforced at startup (see `preflight.rs`).
+#[derive(Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ZeroizingResponse {
+    /// Decrypted plaintext value, when the operation returns one.
+    #[serde(with = "zeroizing_bytes_serde")]
+    pub value: Option<zeroize::Zeroizing<Vec<u8>>>,
+    /// Violations detected during the operation (e.g. CAS conflicts).
+    pub violations: Vec<pb::api::response::Violation>,
+}
+
+/// Redacts `value` instead of deriving `Debug`, so an accidental `{:?}` in a
+/// log line or error message never prints plaintext. `openraft`'s own
+/// testing harness requires `C::R: Debug`, so this can't simply be omitted.
+impl std::fmt::Debug for ZeroizingResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZeroizingResponse")
+            .field(
+                "value",
+                &self
+                    .value
+                    .as_ref()
+                    .map(|v| format!("<redacted {} bytes>", v.len())),
+            )
+            .field("violations", &self.violations)
+            .finish()
+    }
+}
+
+/// The `zeroize` crate does not implement `serde::{Serialize, Deserialize}`
+/// for `Zeroizing<T>`, so this shim (de)serializes the value as a plain
+/// `Option<Vec<u8>>` and wraps/unwraps `Zeroizing` at the boundary. Note
+/// this shim is only exercised in the (rare) `AppendEntries`/snapshot
+/// replay path — normal client responses never leave the local process.
+mod zeroizing_bytes_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use zeroize::Zeroizing;
+
+    pub fn serialize<S>(
+        value: &Option<Zeroizing<Vec<u8>>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.as_deref().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Zeroizing<Vec<u8>>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v: Option<Vec<u8>> = Option::deserialize(deserializer)?;
+        Ok(v.map(Zeroizing::new))
+    }
+}
+
+impl From<ZeroizingResponse> for pb::api::Response {
+    fn from(r: ZeroizingResponse) -> Self {
+        Self {
+            value: r.value.map(|v| v.to_vec()),
+            violations: r.violations,
+        }
+    }
+}
+
+impl From<pb::api::Response> for ZeroizingResponse {
+    fn from(r: pb::api::Response) -> Self {
+        Self {
+            value: r.value.map(zeroize::Zeroizing::new),
+            violations: r.violations,
+        }
+    }
+}
+
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
     pub TypeConfig:
         D = pb::api::CommandRequest,
-        R = pb::api::Response,
+        R = ZeroizingResponse,
         LeaderId = pb::raft::LeaderId,
         Vote = pb::raft::Vote,
         Entry = pb::raft::Entry,
@@ -447,5 +533,41 @@ mod tests {
             assert!(loaded.contains(&3u32));
             assert_eq!(loaded.len(), 1);
         });
+    }
+
+    /// `ZeroizingResponse` must round-trip losslessly through the
+    /// `pb::api::Response` wire type in both directions (ADR 0016-v2 §8).
+    #[test]
+    fn zeroizing_response_round_trips_through_wire_type() {
+        let original = super::ZeroizingResponse {
+            value: Some(zeroize::Zeroizing::new(b"top secret".to_vec())),
+            violations: vec![crate::pb::api::response::Violation {
+                r#type: "CONFLICT".to_string(),
+                subject: "some-key".to_string(),
+                description: "revision mismatch".to_string(),
+            }],
+        };
+
+        let wire: crate::pb::api::Response = original.clone().into();
+        assert_eq!(wire.value.as_deref(), Some(b"top secret".as_slice()));
+        assert_eq!(wire.violations.len(), 1);
+
+        let back: super::ZeroizingResponse = wire.into();
+        assert_eq!(back.value.as_deref(), original.value.as_deref());
+        assert_eq!(back.violations, original.violations);
+    }
+
+    /// `Debug` must redact the plaintext value rather than deriving it, so
+    /// an accidental `{:?}` never leaks the response payload (ADR 0016-v2
+    /// §9 spirit — don't format secrets).
+    #[test]
+    fn zeroizing_response_debug_redacts_value() {
+        let resp = super::ZeroizingResponse {
+            value: Some(zeroize::Zeroizing::new(b"top secret".to_vec())),
+            violations: vec![],
+        };
+        let debug_str = format!("{resp:?}");
+        assert!(!debug_str.contains("top secret"));
+        assert!(debug_str.contains("redacted"));
     }
 }

--- a/crates/storage/src/network.rs
+++ b/crates/storage/src/network.rs
@@ -138,9 +138,15 @@ impl tower::Service<http::Uri> for SpiffeConnector {
             let connector = tokio_rustls::TlsConnector::from(tls);
             // `SpiffeServerCertVerifier` validates the peer's SPIFFE URI SAN and
             // ignores the DNS server name, so any valid constant name is fine here.
-            let server_name =
-                rustls::pki_types::ServerName::try_from("keystone-raft-peer.internal")
-                    .expect("constant DNS name is valid");
+            let server_name = rustls::pki_types::ServerName::try_from(
+                "keystone-raft-peer.internal",
+            )
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("constant DNS name invalid: {e}"),
+                )
+            })?;
             let tls_stream = connector.connect(server_name, tcp).await?;
             Ok(hyper_util::rt::TokioIo::new(tls_stream))
         })

--- a/crates/storage/src/proto_impl/impl_admin_response.rs
+++ b/crates/storage/src/proto_impl/impl_admin_response.rs
@@ -22,7 +22,7 @@ impl TryFrom<pb::raft::AdminResponse> for ClientWriteResponse {
                 .log_id
                 .ok_or_else(|| StoreError::RaftMissingParameter("AdminResponse.LogId".into()))?
                 .into(),
-            data: r.data.unwrap_or_default(),
+            data: r.data.map(Into::into).unwrap_or_default(),
             membership: r.membership.map(|mem| mem.try_into()).transpose()?,
         })
     }
@@ -32,7 +32,7 @@ impl From<ClientWriteResponse> for pb::raft::AdminResponse {
     fn from(r: ClientWriteResponse) -> Self {
         pb::raft::AdminResponse {
             log_id: Some(r.log_id.into()),
-            data: Some(r.data),
+            data: Some(r.data.into()),
             membership: r.membership.map(|mem| mem.into()),
             pending_rotation_id: String::new(),
         }

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -46,7 +46,6 @@ use serde::Serialize;
 use crate::DataTier;
 use crate::StoreError;
 use crate::TypeConfig;
-use crate::protobuf as pb;
 use crate::protobuf::api::response::Violation;
 use crate::store_command::*;
 use crate::types::Metadata;
@@ -1600,6 +1599,40 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                         }
                                     }
                                 }
+                                MutationInner::AbortPendingRotation { rotation_id } => {
+                                    let now = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap_or_default()
+                                        .as_secs();
+                                    let mut pending = self
+                                        .pending_rotations
+                                        .lock()
+                                        .unwrap_or_else(|p| p.into_inner());
+                                    // Defensive re-check: only remove if still present and
+                                    // actually expired. A ConfirmRotateDek may have raced
+                                    // ahead of the sweeper and already resolved this entry,
+                                    // or the sweeper's read may have been stale — either
+                                    // way this is a silent no-op, not a violation.
+                                    if let Some(entry) = pending.get(&rotation_id)
+                                        && entry.expires_at <= now
+                                    {
+                                        let removed = pending.remove(&rotation_id);
+                                        drop(pending);
+                                        if let Some(entry) = removed {
+                                            let meta_key =
+                                                format!("{PENDING_ROTATION_PREFIX}{rotation_id}");
+                                            batch.remove(&self.meta, meta_key.as_bytes());
+                                            tracing::warn!(
+                                                rotation_id,
+                                                initiator = entry.initiator,
+                                                expires_at = entry.expires_at,
+                                                "SECURITY: emergency DEK rotation confirmation \
+                                                 window expired with no confirmation — \
+                                                 automatically aborted (ADR 0016-v2 §6.2 step 1)"
+                                            );
+                                        }
+                                    }
+                                }
                             }
                         }
                         has_violations = !violations.is_empty();
@@ -1678,8 +1711,8 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                 .map_err(|e| io::Error::other(e.to_string()))?;
 
             if let Some(responder) = responder {
-                responder.send(pb::api::Response {
-                    value: response.0,
+                responder.send(crate::ZeroizingResponse {
+                    value: response.0.map(zeroize::Zeroizing::new),
                     violations: response.1,
                 });
             }

--- a/crates/storage/src/store_command.rs
+++ b/crates/storage/src/store_command.rs
@@ -206,6 +206,22 @@ pub enum MutationInner {
         /// Peer TLS identity of the confirming operator.
         confirmer: String,
     },
+
+    /// Automatic confirmation-timeout abort for an emergency DEK rotation
+    /// (ADR §6.2 step 1).
+    ///
+    /// Proposed by the leader's background sweeper when a pending rotation's
+    /// 5-minute confirmation window elapses with no `ConfirmRotateDek` call.
+    /// On apply: removes the entry from `_meta:rotation:pending:<id>` and the
+    /// in-memory map only if it is still present and actually expired —
+    /// defensive re-check since the proposal may have been built from a
+    /// stale sweep read. No-op (not a violation) if the entry is missing or
+    /// not yet expired, since a `ConfirmRotateDek` may have raced ahead of
+    /// the sweep and already resolved it.
+    AbortPendingRotation {
+        /// UUID v4 identifier from `CreatePendingRotation`.
+        rotation_id: String,
+    },
 }
 
 impl MutationInner {

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -259,6 +259,265 @@ async fn test_quarantine_committed_via_raft_inner() -> Result<()> {
     Ok(())
 }
 
+/// An `AbortPendingRotation` mutation committed via Raft removes an expired
+/// pending emergency rotation so it can no longer be confirmed — exercising
+/// the real apply() path for the confirmation-timeout sweeper (ADR 0016-v2
+/// §6.2 step 1).
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_abort_pending_rotation_via_raft() {
+    TypeConfig::run(test_abort_pending_rotation_via_raft_inner()).unwrap();
+}
+
+#[allow(unsafe_code)]
+async fn test_abort_pending_rotation_via_raft_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let storage_dir = tempfile::TempDir::new().unwrap();
+    let tls_configuration = make_certificates()?;
+    let ds_config = get_ds_config(104, storage_dir.path().to_path_buf(), tls_configuration);
+
+    let mut config = Config::default();
+    config.distributed_storage = Some(ds_config);
+
+    // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
+    unsafe {
+        std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
+        std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
+    }
+
+    let storage = init_storage(&ConfigManager::not_watched(config)).await?;
+
+    storage
+        .initialize(
+            [(
+                104u64,
+                openstack_keystone_storage_api::Node {
+                    node_id: 104,
+                    rpc_addr: "127.0.0.1:0".to_string(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        )
+        .await?;
+    for _ in 0..50 {
+        if storage.current_leader() == Some(104) {
+            break;
+        }
+        TypeConfig::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(storage.current_leader(), Some(104));
+
+    // Stage an emergency rotation whose confirmation window has already
+    // elapsed, exactly as the sweeper would find on its next tick.
+    let rotation_id = "test-rotation-abort".to_string();
+    let expires_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .saturating_sub(10);
+    let create_cmd = StoreCommand::Transaction(vec![MutationInner::CreatePendingRotation {
+        rotation_id: rotation_id.clone(),
+        wrapped_dek: vec![0u8; 60],
+        dek_version: 99,
+        expires_at,
+        initiator: "spiffe://example.org/keystone/storage/operator-a".to_string(),
+    }]);
+    let create_payload = pb::api::CommandRequest::try_from(create_cmd)?;
+    storage.raft.client_write(create_payload).await?;
+
+    // The sweeper proposes exactly this mutation once the window elapses.
+    let abort_cmd = StoreCommand::Transaction(vec![MutationInner::AbortPendingRotation {
+        rotation_id: rotation_id.clone(),
+    }]);
+    let abort_payload = pb::api::CommandRequest::try_from(abort_cmd)?;
+    storage.raft.client_write(abort_payload).await?;
+
+    // The aborted rotation can no longer be confirmed.
+    let confirm_cmd = StoreCommand::Transaction(vec![MutationInner::ConfirmPendingRotation {
+        rotation_id: rotation_id.clone(),
+        confirmer: "spiffe://example.org/keystone/storage/operator-b".to_string(),
+    }]);
+    let confirm_payload = pb::api::CommandRequest::try_from(confirm_cmd)?;
+    let resp = storage.raft.client_write(confirm_payload).await?;
+    assert_eq!(
+        resp.data.violations.first().map(|v| v.r#type.as_str()),
+        Some("NOT_FOUND"),
+        "confirming an aborted rotation must fail with NOT_FOUND, got: {:?}",
+        resp.data.violations
+    );
+
+    Ok(())
+}
+
+/// A node whose `node_id` is already live on a reachable peer under a
+/// different address must refuse to start, even though its own local
+/// (empty) Raft state has no record of the conflict — exercising
+/// `verify_node_id_uniqueness_live` (ADR 0016-v2 §4.3 / F7).
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_live_uniqueness_check_detects_conflict() {
+    TypeConfig::run(test_live_uniqueness_check_detects_conflict_inner()).unwrap();
+}
+
+#[allow(unsafe_code)]
+async fn test_live_uniqueness_check_detects_conflict_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let tls_configuration = make_certificates()?;
+
+    // SAFETY: no concurrent env reads; test is `#[serial_test::serial]`.
+    unsafe {
+        std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
+        std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
+    }
+
+    // Node A: bootstraps as a single-node cluster and stays live.
+    let storage_dir_a = tempfile::TempDir::new().unwrap();
+    let ds_config_a = get_ds_config(
+        200,
+        storage_dir_a.path().to_path_buf(),
+        tls_configuration.clone(),
+    );
+    let mut config_a = Config::default();
+    config_a.distributed_storage = Some(ds_config_a);
+
+    let storage_a = init_storage(&ConfigManager::not_watched(config_a.clone())).await?;
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let stg_a = storage_a.clone();
+    let cfg_a = config_a.clone();
+    let _srv = std::thread::spawn(move || {
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        rt.block_on(async {
+            let ds = cfg_a.distributed_storage.as_ref().expect("ds config");
+            let tls = get_server_tls_config(&cfg_a).unwrap();
+            let mut s = tonic::transport::Server::builder().tls_config(tls).unwrap();
+            let serve = s
+                .add_routes(get_app_server(&stg_a).await.unwrap())
+                .serve(ds.node_listener_addr);
+            tokio::select! {
+                _ = serve => {},
+                _ = shutdown_rx => {},
+            }
+        });
+    });
+    TypeConfig::sleep(Duration::from_millis(200)).await;
+
+    let tls_client_config = get_client_tls_config(&config_a)?;
+    let mut admin_client = new_admin_client(
+        config_a
+            .distributed_storage
+            .as_ref()
+            .unwrap()
+            .node_cluster_addr
+            .clone(),
+        &tls_client_config,
+    )
+    .await?;
+    admin_client
+        .init(pb::raft::InitRequest {
+            nodes: vec![new_node(200)],
+        })
+        .await?;
+    wait_for_leader(&mut admin_client, 200).await;
+
+    // Node B: same node_id (200), different address, fresh (empty) local
+    // storage — its own local check has nothing to compare against, but
+    // retry_join_nodes points at node A's live, reachable address.
+    let storage_dir_b = tempfile::TempDir::new().unwrap();
+    let mut ds_config_b = get_ds_config_with_port(
+        200,
+        50,
+        storage_dir_b.path().to_path_buf(),
+        tls_configuration,
+    );
+    ds_config_b.retry_join_nodes = vec![(200, get_addr(200).to_string())];
+    let mut config_b = Config::default();
+    config_b.distributed_storage = Some(ds_config_b);
+
+    // from_env() removes KEYSTONE_DEV_KEK after reading it, so it must be
+    // re-set before every init_storage call in this process.
+    unsafe {
+        std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
+        std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
+    }
+    let result = init_storage(&ConfigManager::not_watched(config_b)).await;
+
+    // Clean up node A's server before asserting, so a failure doesn't leak
+    // the thread/port into subsequent tests.
+    drop(admin_client);
+    drop(tls_client_config);
+    drop(storage_a);
+    let _ = shutdown_tx.send(());
+    _srv.join().ok();
+
+    let Err(err) = result else {
+        panic!(
+            "init_storage must refuse to start when a live peer reports the same \
+             node_id at a different address"
+        );
+    };
+    assert!(
+        format!("{err:?}").contains("already registered")
+            || format!("{err:?}").contains("is registered at"),
+        "unexpected error: {err:?}"
+    );
+
+    Ok(())
+}
+
+/// When `retry_join_nodes` is configured but every listed peer is
+/// unreachable, `init_storage` must still start rather than refuse — a
+/// strict fail-closed policy here would make it impossible to recover from
+/// a full-cluster outage where every node restarts simultaneously with no
+/// live peer to ask (ADR 0016-v2 §4.3 / F7, deliberate deviation
+/// documented on `verify_node_id_uniqueness_live`).
+#[serial_test::serial]
+#[tracing_test::traced_test]
+#[test]
+fn test_live_uniqueness_check_proceeds_when_no_peer_reachable() {
+    TypeConfig::run(test_live_uniqueness_check_proceeds_when_no_peer_reachable_inner()).unwrap();
+}
+
+#[allow(unsafe_code)]
+async fn test_live_uniqueness_check_proceeds_when_no_peer_reachable_inner() -> Result<()> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+
+    let storage_dir = tempfile::TempDir::new().unwrap();
+    let tls_configuration = make_certificates()?;
+    let mut ds_config = get_ds_config(210, storage_dir.path().to_path_buf(), tls_configuration);
+    // Points at an address with nothing listening — every contact attempt
+    // must fail, exercising the "no peer reachable" branch.
+    ds_config.retry_join_nodes = vec![(210, "127.0.0.1:21999".to_string())];
+
+    let mut config = Config::default();
+    config.distributed_storage = Some(ds_config);
+
+    // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
+    unsafe {
+        std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
+        std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
+    }
+
+    init_storage(&ConfigManager::not_watched(config))
+        .await
+        .map_err(|e| {
+            eyre::eyre!(
+                "init_storage must proceed (with a warning) when no configured peer is \
+                 reachable, not refuse to start: {e}"
+            )
+        })?;
+
+    Ok(())
+}
+
 #[allow(unsafe_code)]
 async fn test_node_restart_inner() -> Result<()> {
     let provider = rustls::crypto::aws_lc_rs::default_provider();


### PR DESCRIPTION
ADR 0016-v2 §6.2 step 1 requires a pending emergency DEK rotation
whose 5-minute confirmation window elapses with no ConfirmRotateDek
to be automatically aborted -- a Raft proposal removing the pending
entry, with an audit record capturing the initiator identity, expiry
timestamp, and the fact that no confirmation arrived. The previous
implementation only detected expiry lazily, when some other RPC
(CreatePendingRotation or ConfirmPendingRotation) happened to touch
the same rotation_id later; if no such call ever came, the pending
entry -- and its risk window -- sat there indefinitely with no
abort and no audit trail.

Add MutationInner::AbortPendingRotation, applied uniformly on every
node: removes the entry from the in-memory map and Fjall meta only
if it is still present and actually expired (defensive re-check,
since the proposal may be built from a stale sweep read -- a
ConfirmRotateDek racing ahead of the sweep is not an error). A
background task in init_storage ticks every 30 seconds and, only on
the current leader, scans pending_rotations for expired entries and
proposes the abort, emitting a DEK_ROTATION_EMERGENCY_ABORTED audit
record on success. Gating on leadership keeps this to one abort (and
one audit record) per timeout, since every node's tick would
otherwise race to propose the same abort.

Also fixes the crate's one remaining unwrap_used/expect_used clippy
violation (network.rs's SpiffeConnector), propagating a real
std::io::Error instead of expecting a constant DNS name is always
valid.

check_node_id_uniqueness only reads this node's own persisted Raft
membership state, which cannot detect a conflict that appeared on
the live cluster while this node was offline -- e.g. its old
(node_id, rpc_addr) reused by a misconfigured or impersonating node
during an outage (ADR 0016-v2 §4.3 / F7).

Add verify_node_id_uniqueness_live: when retry_join_nodes is
configured, contact each peer (5s timeout each, stopping at the
first reachable one) via the existing ClusterAdminService Metrics
RPC and cross-check node_id/rpc_addr against that peer's live
membership.

The ADR's literal wording says refusing to start if no peer is
reachable should be treated the same as a detected collision. That
would make a full-cluster outage unrecoverable: if every node
restarts at once, none has a live peer to ask, so all would refuse
to start together. This implementation deliberately deviates: an
actual conflict reported by a reachable peer remains fail-closed
(refuses to start), but "no peer reachable at all" only logs a
CRITICAL warning and proceeds on local state.

Filters the peer list by matching rpc_addr, not node_id -- an
earlier version of this check filtered by node_id, which meant a
peer entry sharing our own claimed node_id (the exact conflict
scenario the check exists to catch) was silently skipped as
"self". Caught by test_live_uniqueness_check_detects_conflict,
which bootstraps a real peer, points a second node's
retry_join_nodes at it under the same node_id but a different
address, and confirms init_storage refuses to start.
test_live_uniqueness_check_proceeds_when_no_peer_reachable covers
the complementary warn-and-proceed path.

ADR 0016-v2 §8 specifies RaftResponse.payload as "Ephemeral plaintext
response... Zeroized by the sender immediately after gRPC send," with
a Rust type ZeroizingResponse. The type never existed -- the actual R
in declare_raft_types! was a plain pb::api::Response carrying
Option<Vec<u8>>, which sits in ordinary (non-zeroizing) heap memory
from the moment the state machine constructs it in apply() until
it's dropped and the allocator reclaims the page, unscrubbed.

Add ZeroizingResponse { value: Option<Zeroizing<Vec<u8>>>, violations
} as R. Every call site is either the state machine constructing it
directly (state_machine.rs's apply(), now wraps the plaintext at
construction) or an internal hop (app.rs's write_command_to_storage /
command_with_forwarding) that stays in the zeroizing type as long as
possible; the one place it must leave the process as
pb::api::Response -- storage_service.rs's command() handler, sent
over the wire to a follower that forwarded a write to the leader --
converts right at the tonic Response::new(...) boundary, and
rb_resp_to_store_response does the same at the point where it hands
off to the public (non-zeroizing) StoreResponse API.

zeroize doesn't provide serde impls for Zeroizing<T>, so
ZeroizingResponse (de)serializes value through a small shim module
that round-trips it as a plain Option<Vec<u8>> at the wire boundary.
Debug is hand-implemented to redact the value field instead of being
derived, so an accidental {:?} in a log line can't leak the payload;
openraft's own black-box test harness (Suite, exercised by
test_fjall_store) requires R: Debug, so this couldn't just be
omitted.

This narrows, but does not eliminate, the exposure window the ADR
describes: tonic/prost may still copy bytes internally during
transmission, unreachable by any application-level wrapper. The
compensating controls named in the ADR (RLIMIT_CORE=0,
PR_SET_DUMPABLE=0) are already enforced at startup and are what
actually cover that residual risk.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
