### PR TITLE
fix: Fix msgpack decode and auth-method encoding bugs

### DIFF
--- a/crates/token-driver-fernet/src/application_credential.rs
+++ b/crates/token-driver-fernet/src/application_credential.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::ApplicationCredentialPayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for ApplicationCredentialPayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_uuid(wd, &self.project_id)?;
         utils::write_time(wd, self.expires_at)?;
         utils::write_audit_ids(wd, self.audit_ids.clone())?;
@@ -65,7 +63,7 @@ impl MsgPackToken for ApplicationCredentialPayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let project_id = utils::read_uuid(rd)?;

--- a/crates/token-driver-fernet/src/domain_scoped.rs
+++ b/crates/token-driver-fernet/src/domain_scoped.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::DomainScopePayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for DomainScopePayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_uuid(wd, &self.domain_id)?;
         utils::write_time(wd, self.expires_at)?;
         utils::write_audit_ids(wd, self.audit_ids.clone())?;
@@ -64,7 +62,7 @@ impl MsgPackToken for DomainScopePayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let domain_id = utils::read_uuid(rd)?;

--- a/crates/token-driver-fernet/src/federation_domain_scoped.rs
+++ b/crates/token-driver-fernet/src/federation_domain_scoped.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::FederationDomainScopePayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for FederationDomainScopePayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_uuid(wd, &self.domain_id)?;
         utils::write_list_of_uuids(wd, self.group_ids.iter())?;
         utils::write_uuid(wd, &self.idp_id)?;
@@ -67,7 +65,7 @@ impl MsgPackToken for FederationDomainScopePayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let domain_id = utils::read_uuid(rd)?;

--- a/crates/token-driver-fernet/src/federation_project_scoped.rs
+++ b/crates/token-driver-fernet/src/federation_project_scoped.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::FederationProjectScopePayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for FederationProjectScopePayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_uuid(wd, &self.project_id)?;
         utils::write_list_of_uuids(wd, self.group_ids.iter())?;
         utils::write_uuid(wd, &self.idp_id)?;
@@ -67,7 +65,7 @@ impl MsgPackToken for FederationProjectScopePayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let project_id = utils::read_uuid(rd)?;

--- a/crates/token-driver-fernet/src/federation_unscoped.rs
+++ b/crates/token-driver-fernet/src/federation_unscoped.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::FederationUnscopedPayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for FederationUnscopedPayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_list_of_uuids(wd, self.group_ids.iter())?;
         utils::write_uuid(wd, &self.idp_id)?;
         utils::write_str(wd, &self.protocol_id)?;
@@ -66,7 +64,7 @@ impl MsgPackToken for FederationUnscopedPayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let group_ids = utils::read_list_of_uuids(rd)?;

--- a/crates/token-driver-fernet/src/lib.rs
+++ b/crates/token-driver-fernet/src/lib.rs
@@ -29,7 +29,7 @@ use rmp::{
     decode::{ValueReadError, read_marker, read_u8},
     encode::{write_array_len, write_pfix},
 };
-use tracing::trace;
+use tracing::{trace, warn};
 use validator::Validate;
 
 use openstack_keystone_config::Config;
@@ -181,13 +181,27 @@ impl FernetTokenProvider {
 
     /// Reload the provider configuration.
     pub fn reload_config(&mut self) {
+        let methods = &self.config.auth.methods;
+        // The auth methods used by a token are encoded as a single `u8`
+        // bitmask (one bit per configured method), so at most 8 methods can
+        // be represented. `1u8 << k` would overflow (panic in debug, wrap
+        // and collide bits in release) for any method beyond the 8th.
+        if methods.len() > 8 {
+            warn!(
+                configured = methods.len(),
+                usable = ?&methods[..8],
+                dropped = ?&methods[8..],
+                "more than 8 authentication methods are configured; only the \
+                 first 8 can be encoded into a Fernet token, the rest will be \
+                 rejected when used for authentication"
+            );
+        }
         self.auth_map = BTreeMap::from_iter(
-            self.config
-                .auth
-                .methods
+            methods
                 .iter()
+                .take(8)
                 .enumerate()
-                .map(|(k, v)| (1 << k, v.clone())),
+                .map(|(k, v)| (1u8 << k, v.clone())),
         );
         self.set_auth_methods_cache_combinations();
     }
@@ -248,7 +262,14 @@ impl FernetTokenProvider {
             trace!("Auth methods cache miss.");
             let mut results: Vec<String> = Vec::new();
             let mut auth: u8 = value;
-            for (idx, name) in self.auth_map.iter() {
+            // Bits must be tested from the largest to the smallest: after
+            // subtracting a matched bit, the remaining `auth` value is only
+            // guaranteed to be smaller than the next (smaller) bit being
+            // tested. Iterating in ascending order instead would test
+            // `auth / idx == 1` while a larger, not-yet-subtracted bit is
+            // still contributing to `auth`, causing that division to skip
+            // right past 1 and silently drop the smaller method.
+            for (idx, name) in self.auth_map.iter().rev() {
                 // (lbragstad): By dividing the method_int by each key in the
                 // method_map, we know if the division results in an integer of 1, that
                 // key was used in the construction of the total sum of the method_int.
@@ -938,6 +959,68 @@ pub mod tests {
 
         let mut provider = FernetTokenProvider::new(setup_config());
         provider.load_keys().unwrap();
+
+        let encrypted = provider.encrypt(&token).unwrap();
+        let dec_token = discard_issued_at(provider.decrypt(&encrypted).unwrap());
+        assert_eq!(token, dec_token);
+    }
+
+    #[test]
+    fn test_decode_auth_methods_cache_miss_preserves_all_bits() {
+        // setup_config() configures "password,token,openid,application_credential",
+        // so bits are password=1, token=2, openid=4, application_credential=8.
+        let mut provider = FernetTokenProvider::new(setup_config());
+        // Force the fallback bit-decomposition path (normally only hit when a
+        // token's bitmask isn't one of the pre-cached combinations).
+        provider.auth_methods_code_cache.clear();
+
+        let mut methods = provider.decode_auth_methods(0b0101).unwrap(); // password + openid
+        methods.sort();
+        assert_eq!(methods, vec!["openid", "password"]);
+    }
+
+    #[test]
+    fn test_reload_config_caps_more_than_8_auth_methods() {
+        let builder = config::Config::builder()
+            .set_override("auth.methods", "m1,m2,m3,m4,m5,m6,m7,m8,m9")
+            .unwrap()
+            .set_override("database.connection", "dummy")
+            .unwrap();
+        let config: Config = Config::try_from(builder).expect("can build a valid config");
+
+        // Must not panic (shift overflow) despite 9 configured methods.
+        let provider = FernetTokenProvider::new(config);
+        assert_eq!(provider.auth_map.len(), 8);
+        assert!(!provider.auth_map.values().any(|v| v == "m9"));
+    }
+
+    #[tokio::test]
+    async fn test_eighth_auth_method_roundtrip() {
+        // The 8th configured method encodes to bit 128, which the MessagePack
+        // positive-fixint format used for the methods byte cannot represent.
+        let keys_dir = tempdir().unwrap();
+        let file_path = keys_dir.path().join("0");
+        let mut tmp_file = File::create(file_path).unwrap();
+        write!(tmp_file, "BFTs1CIVIBLTP4GOrQ26VETrJ7Zwz1O4wbEcCQ966eM=").unwrap();
+
+        let builder = config::Config::builder()
+            .set_override("auth.methods", "m1,m2,m3,m4,m5,m6,m7,m8")
+            .unwrap()
+            .set_override("database.connection", "dummy")
+            .unwrap();
+        let mut config: Config = Config::try_from(builder).expect("can build a valid config");
+        config.fernet_tokens.key_repository = keys_dir.keep();
+
+        let mut provider = FernetTokenProvider::new(config);
+        provider.load_keys().unwrap();
+
+        let token = FernetToken::Unscoped(UnscopedPayload {
+            user_id: Uuid::new_v4().simple().to_string(),
+            methods: vec!["m8".into()],
+            audit_ids: vec!["Zm9vCg".into()],
+            expires_at: Local::now().trunc_subsecs(0).into(),
+            ..Default::default()
+        });
 
         let encrypted = provider.encrypt(&token).unwrap();
         let dec_token = discard_issued_at(provider.decrypt(&encrypted).unwrap());

--- a/crates/token-driver-fernet/src/project_scoped.rs
+++ b/crates/token-driver-fernet/src/project_scoped.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::ProjectScopePayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for ProjectScopePayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_uuid(wd, &self.project_id)?;
         utils::write_time(wd, self.expires_at)?;
         utils::write_audit_ids(wd, self.audit_ids.clone())?;
@@ -64,7 +62,7 @@ impl MsgPackToken for ProjectScopePayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let project_id = utils::read_uuid(rd)?;

--- a/crates/token-driver-fernet/src/restricted.rs
+++ b/crates/token-driver-fernet/src/restricted.rs
@@ -13,7 +13,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Restricted token Fernet implementation.
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::RestrictedPayload;
@@ -37,11 +36,10 @@ impl MsgPackToken for RestrictedPayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_uuid(wd, &self.token_restriction_id)?;
         utils::write_time(wd, self.expires_at)?;
         utils::write_uuid(wd, &self.project_id)?;
@@ -68,7 +66,7 @@ impl MsgPackToken for RestrictedPayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let token_restriction_id = utils::read_uuid(rd)?;

--- a/crates/token-driver-fernet/src/system_scoped.rs
+++ b/crates/token-driver-fernet/src/system_scoped.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::SystemScopePayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for SystemScopePayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_str(wd, &self.system_id)?;
         utils::write_time(wd, self.expires_at)?;
         utils::write_audit_ids(wd, self.audit_ids.clone())?;
@@ -64,7 +62,7 @@ impl MsgPackToken for SystemScopePayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let system_id = utils::read_str(rd)?;

--- a/crates/token-driver-fernet/src/trust.rs
+++ b/crates/token-driver-fernet/src/trust.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::TrustPayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for TrustPayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_uuid(wd, &self.project_id)?;
         utils::write_time(wd, self.expires_at)?;
         utils::write_audit_ids(wd, self.audit_ids.clone())?;
@@ -65,7 +63,7 @@ impl MsgPackToken for TrustPayload {
         // Order of reading is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let project_id = utils::read_uuid(rd)?;

--- a/crates/token-driver-fernet/src/unscoped.rs
+++ b/crates/token-driver-fernet/src/unscoped.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use rmp::{decode::read_pfix, encode::write_pfix};
 use std::io::Write;
 
 use openstack_keystone_core_types::token::UnscopedPayload;
@@ -36,11 +35,10 @@ impl MsgPackToken for UnscopedPayload {
         fernet_provider: &FernetTokenProvider,
     ) -> Result<(), FernetDriverError> {
         utils::write_uuid(wd, &self.user_id)?;
-        write_pfix(
+        utils::write_auth_methods_code(
             wd,
             fernet_provider.encode_auth_methods(self.methods.clone())?,
-        )
-        .map_err(|x| FernetDriverError::RmpEncode(x.to_string()))?;
+        )?;
         utils::write_time(wd, self.expires_at)?;
         utils::write_audit_ids(wd, self.audit_ids.clone())?;
 
@@ -63,7 +61,7 @@ impl MsgPackToken for UnscopedPayload {
         // Order of writing is important
         let user_id = utils::read_uuid(rd)?;
         let methods: Vec<String> = fernet_provider
-            .decode_auth_methods(read_pfix(rd)?)?
+            .decode_auth_methods(utils::read_auth_methods_code(rd)?)?
             .into_iter()
             .collect();
         let expires_at = utils::read_time(rd)?;

--- a/crates/token-driver-fernet/src/utils.rs
+++ b/crates/token-driver-fernet/src/utils.rs
@@ -86,16 +86,21 @@ impl FernetUtils {
                 context: "setting effective process GID".into(),
                 source: e,
             })?;
-            seteuid(Uid::from_raw(uid)).map_err(|e| FernetDriverError::NixErrno {
-                context: "setting effective process UID".into(),
-                source: e,
-            })?;
 
-            // This guard ensures IDs are restored even if the function returns early
+            // Install the restore guard immediately after the first privilege
+            // transition succeeds, so a failure in the second transition below
+            // still restores the original ids via `?` instead of leaving the
+            // process running with a half-dropped privilege state (egid
+            // changed, euid not).
             let _id_guard = scopeguard::guard((old_euid, old_egid), |(u, g)| {
                 let _ = seteuid(u);
                 let _ = setegid(g);
             });
+
+            seteuid(Uid::from_raw(uid)).map_err(|e| FernetDriverError::NixErrno {
+                context: "setting effective process UID".into(),
+                source: e,
+            })?;
         }
 
         // 3. Atomic Write: Create a temp file in the same directory
@@ -236,6 +241,97 @@ impl FernetUtils {
     }
 }
 
+/// Read the length that follows an already-consumed `Bin8`/`Bin16`/`Bin32`
+/// marker.
+///
+/// MessagePack stores this length as a raw big-endian integer immediately
+/// after the marker byte, not as another MessagePack-encoded value, so it
+/// must not be decoded with a marker-aware reader such as `read_pfix`.
+///
+/// # Parameters
+/// - `marker`: The already-consumed marker (`Bin8`, `Bin16` or `Bin32`).
+/// - `rd`: The reader to read from.
+///
+/// # Returns
+/// A `Result` containing the length if successful, or a `FernetDriverError`.
+fn read_bin_len_for_marker<R: Read>(marker: Marker, rd: &mut R) -> Result<u32, FernetDriverError> {
+    match marker {
+        Marker::Bin8 => Ok(u32::from(byteorder::ReadBytesExt::read_u8(rd)?)),
+        Marker::Bin16 => Ok(u32::from(byteorder::ReadBytesExt::read_u16::<
+            byteorder::BigEndian,
+        >(rd)?)),
+        Marker::Bin32 => Ok(byteorder::ReadBytesExt::read_u32::<byteorder::BigEndian>(
+            rd,
+        )?),
+        other => Err(FernetDriverError::InvalidTokenUuidMarker(other)),
+    }
+}
+
+/// Read the length that follows an already-consumed `FixStr`/`Str8`/`Str16`/
+/// `Str32` marker. See [`read_bin_len_for_marker`] for why this cannot be
+/// decoded with a marker-aware reader.
+///
+/// # Parameters
+/// - `marker`: The already-consumed marker.
+/// - `rd`: The reader to read from.
+///
+/// # Returns
+/// A `Result` containing the length if successful, or a `FernetDriverError`.
+fn read_str_len_for_marker<R: Read>(marker: Marker, rd: &mut R) -> Result<u32, FernetDriverError> {
+    match marker {
+        Marker::FixStr(len) => Ok(len.into()),
+        Marker::Str8 => Ok(u32::from(byteorder::ReadBytesExt::read_u8(rd)?)),
+        Marker::Str16 => Ok(u32::from(byteorder::ReadBytesExt::read_u16::<
+            byteorder::BigEndian,
+        >(rd)?)),
+        Marker::Str32 => Ok(byteorder::ReadBytesExt::read_u32::<byteorder::BigEndian>(
+            rd,
+        )?),
+        other => Err(FernetDriverError::InvalidTokenUuidMarker(other)),
+    }
+}
+
+/// Read the encoded authentication methods bitmask.
+///
+/// Values below 128 are encoded as a MessagePack positive fixint (the
+/// historical, compact representation). Values using bit 7 (the 8th
+/// configured auth method) no longer fit that format and are encoded as a
+/// MessagePack `uint8` instead; both are accepted here.
+///
+/// # Parameters
+/// - `rd`: The reader to read from.
+///
+/// # Returns
+/// A `Result` containing the encoded byte if successful, or a
+/// `FernetDriverError`.
+pub fn read_auth_methods_code<R: Read>(rd: &mut R) -> Result<u8, FernetDriverError> {
+    match read_marker(rd).map_err(ValueReadError::from)? {
+        Marker::FixPos(val) => Ok(val),
+        Marker::U8 => Ok(byteorder::ReadBytesExt::read_u8(rd)?),
+        other => Err(FernetDriverError::InvalidTokenUuidMarker(other)),
+    }
+}
+
+/// Write the encoded authentication methods bitmask.
+///
+/// Uses a positive fixint for values below 128 (compact, and compatible with
+/// every token written so far), falling back to a `uint8` for values that
+/// need the full byte range (`write_pfix` would panic on those).
+///
+/// # Parameters
+/// - `wd`: The writer to write to.
+/// - `code`: The encoded authentication methods byte.
+///
+/// # Returns
+/// A `Result` indicating success or a `FernetDriverError`.
+pub fn write_auth_methods_code<W: RmpWrite>(wd: &mut W, code: u8) -> Result<(), FernetDriverError> {
+    if code < 128 {
+        write_pfix(wd, code).map_err(|x| FernetDriverError::RmpEncode(x.to_string()))
+    } else {
+        write_u8(wd, code).map_err(|x| FernetDriverError::RmpEncode(x.to_string()))
+    }
+}
+
 /// Read binary data from the payload.
 ///
 /// # Parameters
@@ -288,10 +384,14 @@ pub fn write_str<W: RmpWrite>(wd: &mut W, data: &str) -> Result<(), FernetDriver
 /// `FernetDriverError`.
 pub fn read_str<R: Read>(rd: &mut R) -> Result<String, FernetDriverError> {
     match read_marker(rd).map_err(ValueReadError::from)? {
-        Marker::Bin8 => {
-            Ok(String::from_utf8_lossy(&read_bin_data(read_pfix(rd)?.into(), rd)?).to_string())
+        marker @ (Marker::Bin8 | Marker::Bin16 | Marker::Bin32) => {
+            let len = read_bin_len_for_marker(marker, rd)?;
+            Ok(String::from_utf8_lossy(&read_bin_data(len, rd)?).to_string())
         }
-        Marker::FixStr(len) => Ok(read_str_data(len.into(), rd)?),
+        marker @ (Marker::FixStr(_) | Marker::Str8 | Marker::Str16 | Marker::Str32) => {
+            let len = read_str_len_for_marker(marker, rd)?;
+            Ok(read_str_data(len, rd)?)
+        }
         other => Err(FernetDriverError::InvalidTokenUuidMarker(other)),
     }
 }
@@ -316,8 +416,10 @@ pub fn read_uuid(rd: &mut &[u8]) -> Result<String, FernetDriverError> {
                     // This is uuid as bytes
                     // Technically we may fail reading it into bytes, but python part is
                     // responsible that it doesn not happen
-                    if let Marker::Bin8 = read_marker(rd).map_err(ValueReadError::from)? {
-                        return Ok(Uuid::try_from(read_bin_data(read_pfix(rd)?.into(), rd)?)?
+                    let marker = read_marker(rd).map_err(ValueReadError::from)?;
+                    if let Marker::Bin8 | Marker::Bin16 | Marker::Bin32 = marker {
+                        let len = read_bin_len_for_marker(marker, rd)?;
+                        return Ok(Uuid::try_from(read_bin_data(len, rd)?)?
                             .as_simple()
                             .to_string());
                     }
@@ -325,15 +427,18 @@ pub fn read_uuid(rd: &mut &[u8]) -> Result<String, FernetDriverError> {
                 Marker::False => {
                     // This is not uuid
                     match read_marker(rd).map_err(ValueReadError::from)? {
-                        Marker::Bin8 => {
-                            return Ok(String::from_utf8_lossy(&read_bin_data(
-                                read_pfix(rd)?.into(),
-                                rd,
-                            )?)
-                            .to_string());
+                        marker @ (Marker::Bin8 | Marker::Bin16 | Marker::Bin32) => {
+                            let len = read_bin_len_for_marker(marker, rd)?;
+                            return Ok(
+                                String::from_utf8_lossy(&read_bin_data(len, rd)?).to_string()
+                            );
                         }
-                        Marker::FixStr(len) => {
-                            return Ok(read_str_data(len.into(), rd)?);
+                        marker @ (Marker::FixStr(_)
+                        | Marker::Str8
+                        | Marker::Str16
+                        | Marker::Str32) => {
+                            let len = read_str_len_for_marker(marker, rd)?;
+                            return Ok(read_str_data(len, rd)?);
                         }
                         other => {
                             return Err(FernetDriverError::InvalidTokenUuidMarker(other));
@@ -425,8 +530,10 @@ pub fn read_audit_ids(
     if let Marker::FixArray(len) = read_marker(rd).map_err(ValueReadError::from)? {
         let mut result: Vec<String> = Vec::new();
         for _ in 0..len {
-            if let Marker::Bin8 = read_marker(rd).map_err(ValueReadError::from)? {
-                let dt = read_bin_data(read_pfix(rd)?.into(), rd)?;
+            let marker = read_marker(rd).map_err(ValueReadError::from)?;
+            if let Marker::Bin8 | Marker::Bin16 | Marker::Bin32 = marker {
+                let bin_len = read_bin_len_for_marker(marker, rd)?;
+                let dt = read_bin_data(bin_len, rd)?;
                 let audit_id: String = URL_SAFE_NO_PAD.encode(dt);
                 result.push(audit_id);
             } else {
@@ -655,5 +762,46 @@ mod tests {
         let mut decode_data = msg.as_slice();
         let decoded = read_bool(&mut decode_data).unwrap();
         assert_eq!(test, decoded);
+    }
+
+    #[test]
+    fn test_write_read_uuid_long_non_uuid_str() {
+        // Non-UUID ids are written as raw bytes (`write_bin`), which switches
+        // from a `Bin8` to a `Bin16` marker at 256 bytes and uses a raw
+        // (non-MessagePack) length byte/word either way. Exercise both the
+        // >=128 (still Bin8) and >=256 (Bin16) boundaries.
+        for len in [150, 300] {
+            let long_id = "a".repeat(len);
+            let mut buf = Vec::new();
+            write_uuid(&mut buf, &long_id).unwrap();
+            let mut decode_data = buf.as_slice();
+            let decoded = read_uuid(&mut decode_data).unwrap();
+            assert_eq!(long_id, decoded);
+        }
+    }
+
+    #[test]
+    fn test_write_read_str_long() {
+        // `write_str` switches from `FixStr` to `Str8`/`Str16` at 32/256
+        // bytes; `read_str` must understand all of them.
+        for len in [10, 32, 100, 300] {
+            let long_str = "a".repeat(len);
+            let mut buf = Vec::new();
+            write_str(&mut buf, &long_str).unwrap();
+            let mut decode_data = buf.as_slice();
+            let decoded = read_str(&mut decode_data).unwrap();
+            assert_eq!(long_str, decoded);
+        }
+    }
+
+    #[test]
+    fn test_write_read_auth_methods_code_full_range() {
+        for code in [1u8, 64, 127, 128, 200, 255] {
+            let mut buf = Vec::new();
+            write_auth_methods_code(&mut buf, code).unwrap();
+            let mut decode_data = buf.as_slice();
+            let decoded = read_auth_methods_code(&mut decode_data).unwrap();
+            assert_eq!(code, decoded);
+        }
     }
 }


### PR DESCRIPTION
Fixes several correctness/security bugs found while reviewing the Fernet
token driver:

- read_str/read_uuid/read_audit_ids used read_pfix (a marker-aware
  positive-fixint reader) to read the raw length byte that follows a
  Bin8 marker, and read_str didn't handle the Str8/Str16/Str32 markers
  that write_str actually emits for strings >=32 bytes. Any non-UUID
  identifier >=128 bytes or string field >=32 bytes (system_id,
  protocol_id, long federated user/group ids, etc.) failed to decode.
  Both readers now correctly parse the raw (non-MessagePack) length that
  follows Bin8/16/32 and Str8/16/32 markers.

- The auth-methods bitmask byte was written with write_pfix, which
  asserts val < 128 and panics for any combination using the 8th
  configured auth method (bit 128). Added write_auth_methods_code /
  read_auth_methods_code helpers that use a positive fixint for values
  <128 (unchanged wire format, still fully backward compatible) and a
  MessagePack uint8 for values >=128, and switched all ten token payload
  modules to use them.

- FernetTokenProvider::reload_config computed 1u8 << k for each
  configured auth method by index; with more than 8 methods configured
  this shift-overflows (panics in debug, silently collides bits in
  release). Now caps the bitmask to the first 8 methods and warns if
  more are configured.

- FernetTokenProvider::decode_auth_methods's cache-miss fallback walked
  the bit->name map in ascending order, but the "auth / idx == 1" bit
  test is only valid from the largest bit down to the smallest;
  ascending order silently dropped smaller bits whenever a larger bit
  was also set, under-reporting the auth methods used for a token.
  Fixed to iterate in descending order.

- FernetUtils::create_tmp_new_key installed the scopeguard that restores
  the original euid/egid only after both setegid and seteuid succeeded,
  so a seteuid failure after a successful setegid left the process with
  its effective group permanently changed. The guard is now installed
  right after setegid succeeds, before seteuid is attempted.

Added regression tests for each of the above.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
