### PR TITLE
feat: ADR 0021 admin surface, simulate-access, and janitor

### DIFF
--- a/crates/api-key-driver-raft/src/lib.rs
+++ b/crates/api-key-driver-raft/src/lib.rs
@@ -99,7 +99,7 @@ impl RaftBackend {
             .map(|key| key[prefix.len()..].to_string()))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    //#[cfg_attr(not(test), allow(dead_code))]
     async fn create_impl(
         &self,
         storage: &dyn StorageApi,
@@ -138,7 +138,6 @@ impl RaftBackend {
         Ok(obj)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn get_by_lookup_hash_impl(
         &self,
         storage: &dyn StorageApi,
@@ -157,7 +156,6 @@ impl RaftBackend {
             .map(|x| x.data))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn get_by_client_id_impl(
         &self,
         storage: &dyn StorageApi,
@@ -174,7 +172,6 @@ impl RaftBackend {
             .await
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn list_impl(
         &self,
         storage: &dyn StorageApi,
@@ -199,7 +196,53 @@ impl RaftBackend {
         Ok(res)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Cross-domain prefix scan over every `ApiClientResource`, for the
+    /// janitor sweep (ADR 0021 §6.F). `"api_client:v1:"` matches only primary
+    /// resource keys -- the secondary `client_id_idx` keys live under
+    /// `"api_client:client_id_idx:v1:..."`, a disjoint prefix, and in the
+    /// separate index keyspace besides.
+    async fn list_all_impl(
+        &self,
+        storage: &dyn StorageApi,
+    ) -> Result<Vec<ApiClientResource>, StoreError> {
+        let mut res: Vec<ApiClientResource> = Vec::new();
+        for (_, envelope) in storage.prefix(b"api_client:v1:", None).await? {
+            res.push(envelope.try_deserialize::<ApiClientResource>()?.data);
+        }
+        Ok(res)
+    }
+
+    /// Hard-delete a tombstoned record (ADR 0021 §6.F physical reclamation):
+    /// removes both the primary resource key and its `client_id_idx` entry.
+    /// A no-op (not an error) if the record is already gone.
+    async fn purge_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        client_id: &str,
+    ) -> Result<(), StoreError> {
+        let Some(lookup_hash) = self
+            .resolve_lookup_hash(storage, domain_id, client_id)
+            .await?
+        else {
+            return Ok(());
+        };
+        let mutations = vec![
+            Mutation::remove(
+                self.get_resource_key_name(domain_id, &lookup_hash),
+                None::<&str>,
+                None,
+            ),
+            Mutation::remove_index(self.get_client_id_idx_key_name(
+                domain_id,
+                client_id,
+                &lookup_hash,
+            )),
+        ];
+        storage.transaction(mutations).await?;
+        Ok(())
+    }
+
     async fn update_impl(
         &self,
         storage: &dyn StorageApi,
@@ -239,7 +282,6 @@ impl RaftBackend {
         Ok(new)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn revoke_impl(
         &self,
         storage: &dyn StorageApi,
@@ -279,7 +321,6 @@ impl RaftBackend {
         Ok(new)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn update_last_used_impl(
         &self,
         storage: &dyn StorageApi,
@@ -313,7 +354,6 @@ impl RaftBackend {
         Ok(())
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn update_secret_hash_impl(
         &self,
         storage: &dyn StorageApi,
@@ -488,6 +528,34 @@ impl ApiKeyBackend for RaftBackend {
             .await
             .map_err(ApiKeyProviderError::raft)
     }
+
+    async fn list_all(
+        &self,
+        state: &ServiceState,
+    ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        self.list_all_impl(raft)
+            .await
+            .map_err(ApiKeyProviderError::raft)
+    }
+
+    async fn purge<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+    ) -> Result<(), ApiKeyProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(ApiKeyProviderError::RaftNotAvailable)?;
+        self.purge_impl(raft, domain_id, client_id)
+            .await
+            .map_err(ApiKeyProviderError::raft)
+    }
 }
 
 /// Linkage anchor — see ADR-0018. Referenced by the `keystone` crate's
@@ -641,6 +709,68 @@ mod tests {
             .await
             .unwrap();
         assert!(fetched.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_list_all_spans_domains() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("client-1", "domain-1", "hash-1"))
+            .await
+            .unwrap();
+        backend
+            .create_impl(&storage, make_create("client-2", "domain-2", "hash-2"))
+            .await
+            .unwrap();
+
+        let all = backend.list_all_impl(&storage).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_purge_removes_resource_and_index() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("client-1", "domain-1", "hash-1"))
+            .await
+            .unwrap();
+        backend
+            .revoke_impl(&storage, "domain-1", "client-1", "operator-1")
+            .await
+            .unwrap();
+
+        backend
+            .purge_impl(&storage, "domain-1", "client-1")
+            .await
+            .unwrap();
+
+        let fetched = backend
+            .get_by_lookup_hash_impl(&storage, "domain-1", "hash-1")
+            .await
+            .unwrap();
+        assert!(fetched.is_none());
+
+        let by_client_id = backend
+            .get_by_client_id_impl(&storage, "domain-1", "client-1")
+            .await
+            .unwrap();
+        assert!(by_client_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_purge_missing_record_is_noop() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        // No prior create(): purging a record that never existed must not error.
+        backend
+            .purge_impl(&storage, "domain-1", "nonexistent")
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/api-types/src/v4.rs
+++ b/crates/api-types/src/v4.rs
@@ -12,10 +12,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # V4 API types
+pub mod api_key;
 pub mod auth;
 pub mod mapping;
 pub mod token_restriction;
 pub mod user;
 
+#[cfg(feature = "conv")]
+mod api_key_conv;
 #[cfg(feature = "conv")]
 mod token_restriction_conv;

--- a/crates/api-types/src/v4/api_key.rs
+++ b/crates/api-types/src/v4/api_key.rs
@@ -1,0 +1,267 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key (SCIM ingress machine identity) API types (ADR 0021).
+
+use chrono::{DateTime, Utc};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize, Serializer};
+#[cfg(feature = "validate")]
+use validator::Validate;
+
+/// A domain-owned machine identity credential used for stateless SCIM
+/// ingress authentication. Never carries `secret_hash`/`lookup_hash` -- those
+/// are internal to the authentication hot path and are not part of the admin
+/// surface (ADR 0021 §2.B).
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ApiKey {
+    /// CIDR allowlist restricting the source IP of the request. `None` means
+    /// no restriction applies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_ips: Option<Vec<String>>,
+
+    /// Public UUID used for management API references.
+    pub client_id: String,
+
+    /// UTC timestamp the key was created.
+    pub created_at: DateTime<Utc>,
+
+    /// Free-form administrative description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Domain owning this machine identity.
+    pub domain_id: String,
+
+    /// Whether the key currently authenticates.
+    pub enabled: bool,
+
+    /// Mandatory TTL.
+    pub expires_at: DateTime<Utc>,
+
+    /// UTC timestamp of the last successful authentication. Updated
+    /// asynchronously and may lag actual usage (ADR 0021 §6.F).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_used_at: Option<DateTime<Utc>>,
+
+    /// The Unified Mapping Engine (ADR 0020) `provider_id` this key
+    /// authenticates against.
+    pub provider_id: String,
+
+    /// UTC timestamp the key was revoked, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<DateTime<Utc>>,
+
+    /// User ID of the operator who revoked the key, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked_by: Option<String>,
+}
+
+/// API Key creation request payload.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ApiKeyCreate {
+    /// CIDR allowlist restricting the source IP of the request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_ips: Option<Vec<String>>,
+
+    /// Free-form administrative description.
+    #[cfg_attr(feature = "validate", validate(length(max = 512)))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Domain owning this machine identity.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub domain_id: String,
+
+    /// Mandatory TTL.
+    pub expires_at: DateTime<Utc>,
+
+    /// The Unified Mapping Engine (ADR 0020) `provider_id` this key
+    /// authenticates against.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 256)))]
+    pub provider_id: String,
+}
+
+/// API Key creation request wrapper.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ApiKeyCreateRequest {
+    /// API Key creation payload.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub api_key: ApiKeyCreate,
+}
+
+/// API Key creation response. `token` is the full opaque bearer value and is
+/// returned exactly once -- it is never retrievable again after this
+/// response (ADR 0021 §2.C).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ApiKeyCreateResponse {
+    /// The created API Key's metadata.
+    pub api_key: ApiKey,
+
+    /// The full `kscim_...` bearer token. Shown once; store it now.
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
+    #[serde(serialize_with = "serialize_secret_string")]
+    pub token: SecretString,
+}
+
+fn serialize_secret_string<S>(secret: &SecretString, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(secret.expose_secret())
+}
+
+/// API Key update request payload (`PUT /v4/api-keys/{client_id}`).
+///
+/// `allowed_ips` and `description` use nested `Option`s: the field being
+/// absent from the JSON body means "leave unchanged", while an explicit
+/// `null` clears it.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ApiKeyUpdate {
+    /// Absent = unchanged. `null` = clear. Present = set.
+    #[serde(default)]
+    pub allowed_ips: Option<Option<Vec<String>>>,
+
+    /// Absent = unchanged. `null` = clear. Present = set.
+    #[serde(default)]
+    pub description: Option<Option<String>>,
+
+    /// Absent = unchanged.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+/// API Key update request wrapper.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ApiKeyUpdateRequest {
+    /// API Key update payload.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub api_key: ApiKeyUpdate,
+}
+
+/// API Key response wrapper (show, update, revoke).
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ApiKeyResponse {
+    /// API Key object.
+    pub api_key: ApiKey,
+}
+
+/// API Key list response.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ApiKeyList {
+    /// Collection of API Keys.
+    pub api_keys: Vec<ApiKey>,
+}
+
+/// API Key list query parameters.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ApiKeyListParameters {
+    /// Domain to list keys for.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub domain_id: String,
+
+    /// Restrict to enabled/disabled keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    /// Restrict to keys bound to this `provider_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+}
+
+/// Dry-run auditing request (`POST /v4/api-keys/simulate-access`). Shifted
+/// to the body to prevent `client_id` leakage in proxy access logs (ADR 0021
+/// §5.E).
+///
+/// ADR 0021 specifies the payload as `{"client_id": "<uuid>"}` only.
+/// `domain_id` is added here because this implementation's storage partitions
+/// `ApiClientResource` by domain (ADR 0021 §2.A), so a lookup by `client_id`
+/// alone is not possible without it -- the same constraint applies to
+/// show/update/revoke, which take `domain_id` as a query parameter.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ApiKeySimulateAccessRequest {
+    /// Public UUID of the key to simulate.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub client_id: String,
+
+    /// Domain the key belongs to.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub domain_id: String,
+}
+
+/// The scope an API Key would be granted, were it to authenticate right now.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SimulatedScope {
+    /// Domain-level scope.
+    Domain {
+        /// Domain ID the key would be scoped to.
+        domain_id: String,
+    },
+    /// Project-level scope.
+    Project {
+        /// Project domain ID.
+        project_domain_id: String,
+        /// Project ID the key would be scoped to.
+        project_id: String,
+    },
+}
+
+/// Dry-run auditing response: the API Key's fully resolved authorization
+/// topology, as it would be hydrated by a real SCIM ingress request right
+/// now, without presenting the bearer token or performing cryptographic
+/// verification (ADR 0021 §5.E).
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ApiKeySimulateAccessResponse {
+    /// Public UUID of the simulated key.
+    pub client_id: String,
+
+    /// Domain owning the key.
+    pub domain_id: String,
+
+    /// Whether the key would successfully authenticate.
+    pub matched: bool,
+
+    /// The `provider_id` the key is bound to.
+    pub provider_id: String,
+
+    /// Explains why `matched` is `false`. Absent when `matched` is `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+
+    /// Effective role names, deduplicated and sorted. Empty when `matched`
+    /// is `false`.
+    pub roles: Vec<String>,
+
+    /// The scope the key would be granted. Absent when `matched` is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<SimulatedScope>,
+}

--- a/crates/api-types/src/v4/api_key_conv.rs
+++ b/crates/api-types/src/v4/api_key_conv.rs
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key (SCIM ingress) type conversions (ADR 0021).
+//!
+//! `ApiClientResourceCreate` is deliberately not built here: `client_id`,
+//! `lookup_hash`, and `secret_hash` are derived from freshly generated token
+//! entropy on the authentication-adjacent hot path (`crates/core/src/api_key`),
+//! not from the wire request, so that assembly stays in the HTTP handler
+//! rather than a pure structural conversion.
+
+use chrono::DateTime;
+
+use openstack_keystone_core_types::api_key as core;
+
+use crate::v4::api_key as api;
+
+impl From<core::ApiClientResource> for api::ApiKey {
+    fn from(value: core::ApiClientResource) -> Self {
+        Self {
+            allowed_ips: value.allowed_ips,
+            client_id: value.client_id,
+            created_at: DateTime::from_timestamp(value.created_at, 0).unwrap_or_default(),
+            description: value.description,
+            domain_id: value.domain_id,
+            enabled: value.enabled,
+            expires_at: DateTime::from_timestamp(value.expires_at, 0).unwrap_or_default(),
+            last_used_at: value
+                .last_used_at
+                .and_then(|ts| DateTime::from_timestamp(ts, 0)),
+            provider_id: value.provider_id,
+            revoked_at: value
+                .revoked_at
+                .and_then(|ts| DateTime::from_timestamp(ts, 0)),
+            revoked_by: value.revoked_by,
+        }
+    }
+}
+
+impl From<api::ApiKeyUpdate> for core::ApiClientResourceUpdate {
+    fn from(value: api::ApiKeyUpdate) -> Self {
+        Self {
+            allowed_ips: value.allowed_ips,
+            description: value.description,
+            enabled: value.enabled,
+        }
+    }
+}
+
+impl From<api::ApiKeyListParameters> for core::ApiClientResourceListParameters {
+    fn from(value: api::ApiKeyListParameters) -> Self {
+        Self {
+            domain_id: value.domain_id,
+            provider_id: value.provider_id,
+            enabled: value.enabled,
+        }
+    }
+}

--- a/crates/core/src/api_key/backend.rs
+++ b/crates/core/src/api_key/backend.rs
@@ -98,4 +98,21 @@ pub trait ApiKeyBackend: Send + Sync {
         lookup_hash: &'a str,
         secret_hash: String,
     ) -> Result<(), ApiKeyProviderError>;
+
+    /// Cross-domain listing of every `ApiClientResource`, for the janitor
+    /// sweep (ADR 0021 §6.F). Not part of the public admin API -- the
+    /// domain-scoped `list` above serves `GET /v4/api-keys`.
+    async fn list_all(
+        &self,
+        state: &ServiceState,
+    ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError>;
+
+    /// Hard-delete a tombstoned record (ADR 0021 §6.F physical
+    /// reclamation). A no-op if the record is already gone.
+    async fn purge<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+    ) -> Result<(), ApiKeyProviderError>;
 }

--- a/crates/core/src/api_key/janitor.rs
+++ b/crates/core/src/api_key/janitor.rs
@@ -1,0 +1,415 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key (SCIM ingress) janitor: proactive inactivity disablement and
+//! tombstone purge (ADR 0021 §6.F).
+//!
+//! Mirrors the leader-gated background sweep pattern already used by the
+//! storage crate's emergency-rotation confirmation-timeout sweeper
+//! (`crates/storage/src/app.rs`): [`spawn`] runs on every cluster node on a
+//! fixed interval, but [`run_once`]'s work only actually executes when that
+//! node is the current Raft leader (`current_leader() ==
+//! Some(node_id())`), so exactly one disablement/purge -- and one audit
+//! record -- is produced per key per threshold crossing.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use openstack_keystone_audit::{AuditDispatcher, CadfEventPayload, Initiator, Observer, Target};
+use openstack_keystone_core_types::api_key::{ApiClientResource, ApiClientResourceUpdate};
+
+use crate::api_key::ApiKeyProviderError;
+use crate::keystone::ServiceState;
+
+/// Interval between sweep passes. Thresholds are day-granularity, so this is
+/// deliberately coarse -- it only needs to run often enough to keep
+/// wall-clock drift against those thresholds small.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// Outcome of a single sweep pass.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct JanitorReport {
+    /// Keys disabled for inactivity this pass.
+    pub disabled: usize,
+    /// Tombstoned keys physically purged this pass.
+    pub purged: usize,
+    /// Keys whose disablement/purge attempt failed this pass (e.g. a Raft
+    /// CAS conflict with a concurrent admin update). Failures are isolated
+    /// per key -- one failing key does not prevent the rest of the sweep
+    /// from running -- and are retried on the next pass.
+    pub errors: usize,
+}
+
+/// Run a single janitor sweep pass over every domain's API Keys. Idempotent
+/// and safe to call repeatedly: a key already disabled, or already purged,
+/// is simply not matched again on the next pass.
+///
+/// Only [`ApiKeyApi::list_all`] failing aborts the whole pass (there is
+/// nothing to sweep without it); a failure disabling or purging one key is
+/// logged and counted in [`JanitorReport::errors`], and the pass continues
+/// with the remaining keys.
+pub async fn run_once(state: &ServiceState) -> Result<JanitorReport, ApiKeyProviderError> {
+    let cfg = state.config_manager.config.read().await.api_key.clone();
+    let now = Utc::now().timestamp();
+    let inactive_threshold_secs =
+        i64::from(cfg.janitor_inactive_days + cfg.janitor_grace_days) * 86_400;
+    let tombstone_retention_secs = i64::from(cfg.janitor_tombstone_retention_days) * 86_400;
+
+    let mut report = JanitorReport::default();
+    let all = state
+        .provider
+        .get_api_key_provider()
+        .list_all(state)
+        .await?;
+
+    for key in all {
+        if key.enabled {
+            let last_activity = key.last_used_at.unwrap_or(key.created_at);
+            if now - last_activity > inactive_threshold_secs {
+                match disable_for_inactivity(state, &key).await {
+                    Ok(()) => report.disabled += 1,
+                    Err(e) => {
+                        warn!(
+                            client_id = %key.client_id,
+                            domain_id = %key.domain_id,
+                            error = %e,
+                            "api_key janitor: failed to disable inactive key, continuing sweep"
+                        );
+                        report.errors += 1;
+                    }
+                }
+            }
+        } else if let Some(revoked_at) = key.revoked_at
+            && now - revoked_at > tombstone_retention_secs
+        {
+            match state
+                .provider
+                .get_api_key_provider()
+                .purge(state, &key.domain_id, &key.client_id)
+                .await
+            {
+                Ok(()) => report.purged += 1,
+                Err(e) => {
+                    warn!(
+                        client_id = %key.client_id,
+                        domain_id = %key.domain_id,
+                        error = %e,
+                        "api_key janitor: failed to purge tombstoned key, continuing sweep"
+                    );
+                    report.errors += 1;
+                }
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+async fn disable_for_inactivity(
+    state: &ServiceState,
+    key: &ApiClientResource,
+) -> Result<(), ApiKeyProviderError> {
+    // ADR 0021 §6.F: emit the maintenance audit event (and push an
+    // administrative alert) before executing the disablement.
+    //
+    // NOTE: the ADR also calls for "an administrative alert payload to the
+    // system notification bus" -- this codebase has no pub/sub or webhook
+    // dispatch infrastructure yet. The structured `warn!` below is the
+    // closest existing mechanism; wiring a real notification channel is
+    // tracked as follow-up work, not invented here.
+    emit_maintenance_event(&state.audit_dispatcher, "disable_inactive", &key.client_id);
+    warn!(
+        client_id = %key.client_id,
+        domain_id = %key.domain_id,
+        provider_id = %key.provider_id,
+        "api_key janitor: disabling inactive API key"
+    );
+
+    state
+        .provider
+        .get_api_key_provider()
+        .update(
+            state,
+            &key.domain_id,
+            &key.client_id,
+            ApiClientResourceUpdate {
+                enabled: Some(false),
+                allowed_ips: None,
+                description: None,
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+/// Emit a `maintenance` CADF event for a janitor-driven lifecycle action.
+/// Best-effort, mirroring the perimeter authentication event's dispatch
+/// discipline: this is background housekeeping, not a user-facing request,
+/// so there is no real correlation ID to thread through.
+fn emit_maintenance_event(dispatcher: &Arc<AuditDispatcher>, action: &str, client_id: &str) {
+    let node_id = dispatcher.node_id().to_string();
+    let event_id = format!("{node_id}:{}", Uuid::new_v4());
+    let correlation_id = format!("janitor:{}", Uuid::new_v4());
+    let initiator = Initiator::new("api_key_janitor".to_string(), None, None, None);
+    let payload = CadfEventPayload::new(
+        event_id,
+        "1.0".to_string(),
+        "default".to_string(),
+        correlation_id,
+        Utc::now().to_rfc3339(),
+        action.to_string(),
+        "success".to_string(),
+        None,
+        initiator,
+        Target {
+            id: client_id.to_string(),
+            type_uri: "data/security/keystone/api_key".to_string(),
+        },
+        Observer {
+            node_id: node_id.clone(),
+            id: format!("service/security/keystone/{node_id}"),
+        },
+    );
+    let event = payload.sign(dispatcher);
+    dispatcher.dispatch(event);
+}
+
+/// Spawn the leader-gated background sweep loop. Intended to be called once
+/// at server startup with the long-lived `ServiceState`.
+pub fn spawn(state: ServiceState) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SWEEP_INTERVAL);
+        loop {
+            interval.tick().await;
+
+            let Some(storage) = state.storage.as_deref() else {
+                continue;
+            };
+            if storage.current_leader().await != Some(storage.node_id().await) {
+                continue;
+            }
+
+            match run_once(&state).await {
+                Ok(report) if report.disabled > 0 || report.purged > 0 || report.errors > 0 => {
+                    info!(
+                        disabled = report.disabled,
+                        purged = report.purged,
+                        errors = report.errors,
+                        "api_key janitor: sweep complete"
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => warn!(error = %e, "api_key janitor: list_all failed, sweep aborted"),
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::mocks::MockApiKeyProvider;
+    use crate::provider::Provider;
+    use crate::tests::get_mocked_state;
+
+    fn key(
+        client_id: &str,
+        enabled: bool,
+        last_used_at: Option<i64>,
+        created_at: i64,
+        revoked_at: Option<i64>,
+    ) -> ApiClientResource {
+        ApiClientResource {
+            domain_id: "domain_id".into(),
+            provider_id: "provider-1".into(),
+            client_id: client_id.into(),
+            lookup_hash: format!("hash-{client_id}"),
+            secret_hash: "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into(),
+            allowed_ips: None,
+            description: None,
+            enabled,
+            created_at,
+            expires_at: Utc::now().timestamp() + 999_999,
+            last_used_at,
+            revoked_at,
+            revoked_by: revoked_at.map(|_| "operator-1".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_once_disables_inactive_key() {
+        let now = Utc::now().timestamp();
+        // 90 + 7 day default threshold comfortably exceeded.
+        let stale_last_used = now - (120 * 86_400);
+        let stale_key = key(
+            "client-1",
+            true,
+            Some(stale_last_used),
+            stale_last_used,
+            None,
+        );
+
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list_all()
+            .returning(move |_| Ok(vec![stale_key.clone()]));
+        mock.expect_update()
+            .withf(|_, domain_id, client_id, data| {
+                domain_id == "domain_id" && client_id == "client-1" && data.enabled == Some(false)
+            })
+            .returning(|_, _, _, _| Ok(key("client-1", false, None, 0, None)));
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_api_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.disabled, 1);
+        assert_eq!(report.purged, 0);
+    }
+
+    #[tokio::test]
+    async fn test_run_once_isolates_per_key_failure() {
+        // Two stale keys; the first's disablement fails (e.g. a Raft CAS
+        // conflict with a concurrent admin update). The sweep must still
+        // process the second key in the same pass rather than aborting.
+        let now = Utc::now().timestamp();
+        let stale_last_used = now - (120 * 86_400);
+        let failing_key = key(
+            "client-fails",
+            true,
+            Some(stale_last_used),
+            stale_last_used,
+            None,
+        );
+        let ok_key = key(
+            "client-ok",
+            true,
+            Some(stale_last_used),
+            stale_last_used,
+            None,
+        );
+
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list_all()
+            .returning(move |_| Ok(vec![failing_key.clone(), ok_key.clone()]));
+        mock.expect_update()
+            .withf(|_, _, client_id, _| client_id == "client-fails")
+            .returning(|_, _, _, _| Err(ApiKeyProviderError::Conflict("cas conflict".into())));
+        mock.expect_update()
+            .withf(|_, _, client_id, _| client_id == "client-ok")
+            .returning(|_, _, _, _| Ok(key("client-ok", false, None, 0, None)));
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_api_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.disabled, 1, "the second key must still be disabled");
+        assert_eq!(report.errors, 1, "the first key's failure must be counted");
+        assert_eq!(report.purged, 0);
+    }
+
+    #[tokio::test]
+    async fn test_run_once_leaves_recently_active_key_alone() {
+        let now = Utc::now().timestamp();
+        let recent = key("client-1", true, Some(now - 3_600), now - 3_600, None);
+
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list_all()
+            .returning(move |_| Ok(vec![recent.clone()]));
+        // No `expect_update`/`expect_purge`: calling either would panic the mock.
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_api_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.disabled, 0);
+        assert_eq!(report.purged, 0);
+    }
+
+    #[tokio::test]
+    async fn test_run_once_purges_old_tombstone() {
+        let now = Utc::now().timestamp();
+        // 365 day default retention comfortably exceeded.
+        let old_revoke = now - (400 * 86_400);
+        let tombstoned = key(
+            "client-1",
+            false,
+            None,
+            now - 500 * 86_400,
+            Some(old_revoke),
+        );
+
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list_all()
+            .returning(move |_| Ok(vec![tombstoned.clone()]));
+        mock.expect_purge()
+            .withf(|_, domain_id, client_id| domain_id == "domain_id" && client_id == "client-1")
+            .returning(|_, _, _| Ok(()));
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_api_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.disabled, 0);
+        assert_eq!(report.purged, 1);
+    }
+
+    #[tokio::test]
+    async fn test_run_once_leaves_recent_tombstone_alone() {
+        let now = Utc::now().timestamp();
+        let recent_revoke = now - 3_600;
+        let tombstoned = key(
+            "client-1",
+            false,
+            None,
+            now - 500 * 86_400,
+            Some(recent_revoke),
+        );
+
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list_all()
+            .returning(move |_| Ok(vec![tombstoned.clone()]));
+        // No `expect_purge`: calling it would panic the mock.
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_api_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.disabled, 0);
+        assert_eq!(report.purged, 0);
+    }
+
+    #[tokio::test]
+    async fn test_run_once_is_idempotent_over_two_passes() {
+        // A key already disabled (not enabled) and without a revoked_at
+        // tombstone (janitor-disabled, not admin-revoked) must never be
+        // touched by either branch.
+        let now = Utc::now().timestamp();
+        let disabled_not_revoked = key("client-1", false, None, now - 500 * 86_400, None);
+
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list_all()
+            .returning(move |_| Ok(vec![disabled_not_revoked.clone()]));
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_api_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.disabled, 0);
+        assert_eq!(report.purged, 0);
+    }
+}

--- a/crates/core/src/api_key/provider_api.rs
+++ b/crates/core/src/api_key/provider_api.rs
@@ -162,4 +162,21 @@ pub trait ApiKeyApi: Send + Sync {
         lookup_hash: &'a str,
         secret_hash: String,
     ) -> Result<(), ApiKeyProviderError>;
+
+    /// Cross-domain listing of every `ApiClientResource`, for the janitor
+    /// sweep (ADR 0021 §6.F). Not part of the public admin API -- the
+    /// domain-scoped `list` above serves `GET /v4/api-keys`.
+    async fn list_all(
+        &self,
+        state: &ServiceState,
+    ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError>;
+
+    /// Hard-delete a tombstoned record (ADR 0021 §6.F physical
+    /// reclamation). A no-op if the record is already gone.
+    async fn purge<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+    ) -> Result<(), ApiKeyProviderError>;
 }

--- a/crates/core/src/api_key/service.rs
+++ b/crates/core/src/api_key/service.rs
@@ -98,6 +98,24 @@ impl ApiKeyApi for ApiKeyService {
         client_id: &'a str,
         data: ApiClientResourceUpdate,
     ) -> Result<ApiClientResource, ApiKeyProviderError> {
+        // ADR 0021 §5.C: revocation is the emergency-response path and MUST
+        // NOT be reversible through the ordinary update surface. Enforced
+        // here (not just at the HTTP layer) so it holds for every caller,
+        // including direct provider use. Only checked when the caller is
+        // actually trying to re-enable, so the common update (allowed_ips /
+        // description, or disabling) doesn't pay for an extra read.
+        if data.enabled == Some(true) {
+            let current = self
+                .backend_driver
+                .get_by_client_id(state, domain_id, client_id)
+                .await?
+                .ok_or_else(|| ApiKeyProviderError::NotFound(client_id.to_string()))?;
+            if current.revoked_at.is_some() {
+                return Err(ApiKeyProviderError::Conflict(
+                    "cannot re-enable a revoked API key".to_string(),
+                ));
+            }
+        }
         self.backend_driver
             .update(state, domain_id, client_id, data)
             .await
@@ -137,5 +155,136 @@ impl ApiKeyApi for ApiKeyService {
         self.backend_driver
             .update_secret_hash(state, domain_id, lookup_hash, secret_hash)
             .await
+    }
+
+    async fn list_all(
+        &self,
+        state: &ServiceState,
+    ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError> {
+        self.backend_driver.list_all(state).await
+    }
+
+    async fn purge<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        client_id: &'a str,
+    ) -> Result<(), ApiKeyProviderError> {
+        self.backend_driver.purge(state, domain_id, client_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api_key::backend::MockApiKeyBackend;
+    use crate::tests::get_mocked_state;
+
+    fn sample_resource(revoked_at: Option<i64>) -> ApiClientResource {
+        ApiClientResource {
+            domain_id: "domain_id".into(),
+            provider_id: "provider-1".into(),
+            client_id: "client-1".into(),
+            lookup_hash: "hash-1".into(),
+            secret_hash: "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into(),
+            allowed_ips: None,
+            description: None,
+            enabled: revoked_at.is_none(),
+            created_at: 0,
+            expires_at: i64::MAX / 2,
+            last_used_at: None,
+            revoked_at,
+            revoked_by: revoked_at.map(|_| "operator-1".to_string()),
+        }
+    }
+
+    fn enable_patch() -> ApiClientResourceUpdate {
+        ApiClientResourceUpdate {
+            allowed_ips: None,
+            description: None,
+            enabled: Some(true),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_reactivating_revoked_key() {
+        let mut mock = MockApiKeyBackend::new();
+        mock.expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource(Some(1_000)))));
+        // `expect_update` deliberately not configured: mockall panics if it's
+        // called, proving the guard short-circuits before reaching the backend.
+        let service = ApiKeyService {
+            backend_driver: Arc::new(mock),
+        };
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .update(&state, "domain_id", "client-1", enable_patch())
+            .await;
+
+        assert!(matches!(result, Err(ApiKeyProviderError::Conflict(_))));
+    }
+
+    #[tokio::test]
+    async fn test_update_allows_reactivating_non_revoked_key() {
+        let mut mock = MockApiKeyBackend::new();
+        mock.expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource(None))));
+        mock.expect_update()
+            .returning(|_, _, _, _| Ok(sample_resource(None)));
+        let service = ApiKeyService {
+            backend_driver: Arc::new(mock),
+        };
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .update(&state, "domain_id", "client-1", enable_patch())
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_update_skips_guard_when_not_reactivating() {
+        let mut mock = MockApiKeyBackend::new();
+        // `expect_get_by_client_id` deliberately not configured: the guard
+        // must not fire (and must not read) when `enabled` isn't `Some(true)`.
+        mock.expect_update()
+            .returning(|_, _, _, _| Ok(sample_resource(None)));
+        let service = ApiKeyService {
+            backend_driver: Arc::new(mock),
+        };
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .update(
+                &state,
+                "domain_id",
+                "client-1",
+                ApiClientResourceUpdate {
+                    allowed_ips: Some(Some(vec!["10.0.0.0/8".to_string()])),
+                    description: None,
+                    enabled: None,
+                },
+            )
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_update_reactivate_missing_key_is_not_found() {
+        let mut mock = MockApiKeyBackend::new();
+        mock.expect_get_by_client_id().returning(|_, _, _| Ok(None));
+        let service = ApiKeyService {
+            backend_driver: Arc::new(mock),
+        };
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .update(&state, "domain_id", "nonexistent", enable_patch())
+            .await;
+
+        assert!(matches!(result, Err(ApiKeyProviderError::NotFound(_))));
     }
 }

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -95,6 +95,18 @@ mod api_key {
                 lookup_hash: &'a str,
                 secret_hash: String,
             ) -> Result<(), ApiKeyProviderError>;
+
+            async fn list_all(
+                &self,
+                state: &ServiceState,
+            ) -> Result<Vec<ApiClientResource>, ApiKeyProviderError>;
+
+            async fn purge<'a>(
+                &self,
+                state: &ServiceState,
+                domain_id: &'a str,
+                client_id: &'a str,
+            ) -> Result<(), ApiKeyProviderError>;
         }
     }
 }

--- a/crates/keystone/src/api/v4/api_key/create.rs
+++ b/crates/keystone/src/api/v4/api_key/create.rs
@@ -1,0 +1,248 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key: create.
+
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use secrecy::ExposeSecret;
+use validator::Validate;
+
+use openstack_keystone_api_types::v4::api_key::{
+    ApiKey, ApiKeyCreateRequest, ApiKeyCreateResponse,
+};
+use openstack_keystone_core_types::api_key::ApiClientResourceCreate;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::api_key::{crypto, token};
+use crate::keystone::ServiceState;
+
+/// Create a new API Key.
+#[utoipa::path(
+    post,
+    path = "/",
+    operation_id = "/api_key:create",
+    request_body = ApiKeyCreateRequest,
+    responses(
+        (status = CREATED, description = "API Key object, including the one-time bearer token", body = ApiKeyCreateResponse),
+    ),
+    security(("x-auth" = [])),
+    tag="api_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::api_key::create",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn create(
+    Auth(user_auth): Auth,
+    State(state): State<ServiceState>,
+    Json(req): Json<ApiKeyCreateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/api_key/create",
+            &user_auth,
+            serde_json::json!({"api_key": req.api_key}),
+            None,
+        )
+        .await?;
+
+    let cfg = state.config_manager.config.read().await.api_key.clone();
+    let generated = token::generate();
+    let secret_hash = crypto::hash_secret(generated.entropy.expose_secret(), &cfg).await?;
+
+    let data = ApiClientResourceCreate {
+        domain_id: req.api_key.domain_id,
+        provider_id: req.api_key.provider_id,
+        client_id: uuid::Uuid::new_v4().simple().to_string(),
+        lookup_hash: generated.lookup_hash,
+        secret_hash,
+        allowed_ips: req.api_key.allowed_ips,
+        description: req.api_key.description,
+        expires_at: req.api_key.expires_at.timestamp(),
+    };
+
+    let res = state
+        .provider
+        .get_api_key_provider()
+        .create(&state, data)
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ApiKeyCreateResponse {
+            api_key: ApiKey::from(res),
+            token: generated.token,
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use chrono::{TimeZone, Utc};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::api_key::{ApiKeyCreate, ApiKeyCreateRequest};
+    use openstack_keystone_core_types::api_key as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api_key::MockApiKeyProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource_core() -> provider_types::ApiClientResource {
+        provider_types::ApiClientResource {
+            domain_id: "domain_id".into(),
+            provider_id: "provider-1".into(),
+            client_id: "client-1".into(),
+            lookup_hash: "lookup-hash".into(),
+            secret_hash: "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into(),
+            allowed_ips: None,
+            description: Some("test key".into()),
+            enabled: true,
+            created_at: 1_000,
+            expires_at: 2_000,
+            last_used_at: None,
+            revoked_at: None,
+            revoked_by: None,
+        }
+    }
+
+    fn sample_request() -> ApiKeyCreateRequest {
+        ApiKeyCreateRequest {
+            api_key: ApiKeyCreate {
+                domain_id: "domain_id".into(),
+                provider_id: "provider-1".into(),
+                allowed_ips: None,
+                description: Some("test key".into()),
+                expires_at: Utc.timestamp_opt(2_000, 0).unwrap(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_create()
+            .returning(|_, _| Ok(sample_resource_core()));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res["api_key"]["client_id"], "client-1");
+        // The one-time bearer token must be present in the create response.
+        assert!(res["token"].as_str().unwrap().starts_with("kscim_"));
+    }
+
+    #[tokio::test]
+    async fn test_create_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_api_key(MockApiKeyProvider::default()),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_create_unauthorized() {
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_api_key(MockApiKeyProvider::default()),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/api_key/list.rs
+++ b/crates/keystone/src/api/v4/api_key/list.rs
@@ -1,0 +1,207 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key: list.
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use openstack_keystone_api_types::v4::api_key::{ApiKey, ApiKeyList, ApiKeyListParameters};
+use openstack_keystone_core_types::api_key::ApiClientResourceListParameters;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+
+/// List API Keys.
+///
+/// `domain_id` is a mandatory filter (ADR 0021 §5.B): unlike mapping
+/// rulesets, API Keys are always domain-owned, so there is no "global" or
+/// "all visible domains" listing mode.
+#[utoipa::path(
+    get,
+    path = "/",
+    operation_id = "/api_key:list",
+    params(ApiKeyListParameters),
+    responses(
+        (status = OK, description = "List of API Keys", body = ApiKeyList),
+    ),
+    security(("x-auth" = [])),
+    tag="api_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::api_key::list",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn list(
+    Auth(user_auth): Auth,
+    Query(query): Query<ApiKeyListParameters>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/api_key/list",
+            &user_auth,
+            serde_json::json!({"api_key": query}),
+            None,
+        )
+        .await?;
+
+    let params: ApiClientResourceListParameters = query.into();
+
+    let keys: Vec<ApiKey> = state
+        .provider
+        .get_api_key_provider()
+        .list(&state, &params)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+
+    Ok((StatusCode::OK, Json(ApiKeyList { api_keys: keys })).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::api_key::ApiKeyList;
+    use openstack_keystone_core_types::api_key as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api_key::MockApiKeyProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource_core() -> provider_types::ApiClientResource {
+        provider_types::ApiClientResource {
+            domain_id: "domain_id".into(),
+            provider_id: "provider-1".into(),
+            client_id: "client-1".into(),
+            lookup_hash: "lookup-hash".into(),
+            secret_hash: "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into(),
+            allowed_ips: None,
+            description: None,
+            enabled: true,
+            created_at: 1_000,
+            expires_at: 2_000,
+            last_used_at: None,
+            revoked_at: None,
+            revoked_by: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list()
+            .returning(|_, _| Ok(vec![sample_resource_core()]));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?domain_id=domain_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeyList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.api_keys.len(), 1);
+        assert_eq!(res.api_keys[0].client_id, "client-1");
+    }
+
+    #[tokio::test]
+    async fn test_list_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_api_key(MockApiKeyProvider::default()),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?domain_id=domain_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized() {
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_api_key(MockApiKeyProvider::default()),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?domain_id=domain_id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/api_key/mod.rs
+++ b/crates/keystone/src/api/v4/api_key/mod.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key (SCIM ingress machine identity) admin API (ADR 0021 §5).
+//!
+//! OPA input structure for all api_key operations:
+//! ```text
+//! {
+//!   "credentials": { ... },
+//!   "target": { "api_key": <object-or-null> },
+//!   "existing": { "api_key": <object-or-null> }
+//! }
+//! ```
+//!
+//! | Operation       | `input.target.api_key`  | `input.existing.api_key` |
+//! |------------------|--------------------------|---------------------------|
+//! | Create           | ApiKeyCreate payload     | null                      |
+//! | List             | ApiKeyListParameters     | null                      |
+//! | Show             | null                     | current key               |
+//! | Update           | ApiKeyUpdate patch       | current key               |
+//! | Revoke           | null                     | current key               |
+//! | SimulateAccess   | null                     | current key               |
+
+use utoipa::OpenApi;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+mod create;
+mod list;
+mod revoke;
+mod show;
+mod simulate_access;
+mod update;
+
+use crate::keystone::ServiceState;
+
+/// OpenApi specification for the API Key (SCIM ingress) admin API.
+#[derive(OpenApi)]
+#[openapi(
+    tags(
+        (name="api_key", description=r#"API Key (SCIM ingress) admin API (ADR 0021).
+
+Stateless, domain-owned machine-identity credentials for M2M SCIM provisioning
+ingress. Management of these credentials requires the `manager` role
+(DomainManager) scoped to the key's own domain, or `admin` (SystemAdmin).
+        "#),
+    )
+)]
+pub struct ApiDoc;
+
+pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new()
+        .routes(routes!(list::list, create::create))
+        .routes(routes!(simulate_access::simulate_access))
+        .routes(routes!(show::show, update::update))
+        .routes(routes!(revoke::revoke))
+}

--- a/crates/keystone/src/api/v4/api_key/revoke.rs
+++ b/crates/keystone/src/api/v4/api_key/revoke.rs
@@ -1,0 +1,284 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key: revoke (emergency revocation path, ADR 0021 §5.C).
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::Deserialize;
+
+use openstack_keystone_api_types::v4::api_key::{ApiKey, ApiKeyResponse};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::audit::{CorrelationId, build_initiator_from_vsc, emit_api_key_control_event};
+use crate::keystone::ServiceState;
+
+/// Query parameters for `POST /v4/api-keys/{client_id}/revoke`.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub(super) struct RevokeParams {
+    /// Domain the key belongs to.
+    domain_id: String,
+}
+
+/// Revoke an API Key: disables it and stamps the tombstone. Does not hard
+/// delete the record (ADR 0021 §5.C) -- physical reclamation is the
+/// janitor's job (§6.F).
+#[utoipa::path(
+    post,
+    path = "/{client_id}/revoke",
+    operation_id = "/api_key:revoke",
+    params(
+        ("client_id" = String, Path, description = "API Key client_id"),
+        RevokeParams,
+    ),
+    responses(
+        (status = OK, description = "Revoked API Key object", body = ApiKeyResponse),
+    ),
+    security(("x-auth" = [])),
+    tag="api_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::api_key::revoke",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn revoke(
+    CorrelationId(cid): CorrelationId,
+    Auth(user_auth): Auth,
+    Path(client_id): Path<String>,
+    Query(params): Query<RevokeParams>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_api_key_provider()
+        .get_by_client_id(&state, &params.domain_id, &client_id)
+        .await?
+        .ok_or_else(|| KeystoneApiError::NotFound {
+            resource: "api_key".into(),
+            identifier: client_id.clone(),
+        })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/api_key/revoke",
+            &user_auth,
+            serde_json::json!({"api_key": null}),
+            Some(serde_json::json!({"api_key": ApiKey::from(current)})),
+        )
+        .await?;
+
+    let revoked_by = user_auth.inner().principal().get_user_id();
+    let res = state
+        .provider
+        .get_api_key_provider()
+        .revoke(&state, &params.domain_id, &client_id, &revoked_by)
+        .await?;
+
+    emit_api_key_control_event(
+        &state.audit_dispatcher,
+        &cid,
+        "revoke",
+        build_initiator_from_vsc(&user_auth),
+        &client_id,
+        "success",
+        None,
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(ApiKeyResponse {
+            api_key: ApiKey::from(res),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::api_key::ApiKeyResponse;
+    use openstack_keystone_core_types::api_key as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api_key::MockApiKeyProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource_core() -> provider_types::ApiClientResource {
+        provider_types::ApiClientResource {
+            domain_id: "domain_id".into(),
+            provider_id: "provider-1".into(),
+            client_id: "client-1".into(),
+            lookup_hash: "lookup-hash".into(),
+            secret_hash: "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into(),
+            allowed_ips: None,
+            description: None,
+            enabled: true,
+            created_at: 1_000,
+            expires_at: 2_000,
+            last_used_at: None,
+            revoked_at: None,
+            revoked_by: None,
+        }
+    }
+
+    fn sample_revoked_core() -> provider_types::ApiClientResource {
+        let mut res = sample_resource_core();
+        res.enabled = false;
+        res.revoked_at = Some(1_500);
+        res.revoked_by = Some("uid".into());
+        res
+    }
+
+    #[tokio::test]
+    async fn test_revoke() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        mock.expect_revoke()
+            .returning(|_, _, _, _| Ok(sample_revoked_core()));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/client-1/revoke?domain_id=domain_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeyResponse = serde_json::from_slice(&body).unwrap();
+        assert!(!res.api_key.enabled);
+        assert!(res.api_key.revoked_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_revoke_not_found() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id().returning(|_, _, _| Ok(None));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/missing/revoke?domain_id=domain_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_revoke_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/client-1/revoke?domain_id=domain_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_revoke_unauthorized() {
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_api_key(MockApiKeyProvider::default()),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/client-1/revoke?domain_id=domain_id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/api_key/show.rs
+++ b/crates/keystone/src/api/v4/api_key/show.rs
@@ -1,0 +1,252 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key: show.
+//!
+//! Not specified by ADR 0021 §5.B (which only lists create/list/update), but
+//! added for consistency with every other v4 resource and because
+//! update/revoke/simulate-access all resolve a key by `client_id` anyway.
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::Deserialize;
+
+use openstack_keystone_api_types::v4::api_key::{ApiKey, ApiKeyResponse};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+
+/// Query parameters for `GET /v4/api-keys/{client_id}`.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub(super) struct ShowParams {
+    /// Domain the key belongs to.
+    domain_id: String,
+}
+
+/// Show an API Key by `client_id`.
+#[utoipa::path(
+    get,
+    path = "/{client_id}",
+    operation_id = "/api_key:show",
+    params(
+        ("client_id" = String, Path, description = "API Key client_id"),
+        ShowParams,
+    ),
+    responses(
+        (status = OK, description = "API Key object", body = ApiKeyResponse),
+    ),
+    security(("x-auth" = [])),
+    tag="api_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::api_key::show",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn show(
+    Auth(user_auth): Auth,
+    Path(client_id): Path<String>,
+    Query(params): Query<ShowParams>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_api_key_provider()
+        .get_by_client_id(&state, &params.domain_id, &client_id)
+        .await?
+        .ok_or_else(|| KeystoneApiError::NotFound {
+            resource: "api_key".into(),
+            identifier: client_id.clone(),
+        })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/api_key/show",
+            &user_auth,
+            serde_json::json!({"api_key": null}),
+            Some(serde_json::json!({"api_key": ApiKey::from(current.clone())})),
+        )
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(ApiKeyResponse {
+            api_key: ApiKey::from(current),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::api_key::ApiKeyResponse;
+    use openstack_keystone_core_types::api_key as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api_key::MockApiKeyProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource_core() -> provider_types::ApiClientResource {
+        provider_types::ApiClientResource {
+            domain_id: "domain_id".into(),
+            provider_id: "provider-1".into(),
+            client_id: "client-1".into(),
+            lookup_hash: "lookup-hash".into(),
+            secret_hash: "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into(),
+            allowed_ips: None,
+            description: None,
+            enabled: true,
+            created_at: 1_000,
+            expires_at: 2_000,
+            last_used_at: None,
+            revoked_at: None,
+            revoked_by: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_show() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/client-1?domain_id=domain_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeyResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.api_key.client_id, "client-1");
+    }
+
+    #[tokio::test]
+    async fn test_show_not_found() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id().returning(|_, _, _| Ok(None));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/missing?domain_id=domain_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_show_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/client-1?domain_id=domain_id")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_show_unauthorized() {
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_api_key(MockApiKeyProvider::default()),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/client-1?domain_id=domain_id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/api_key/simulate_access.rs
+++ b/crates/keystone/src/api/v4/api_key/simulate_access.rs
@@ -1,0 +1,476 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key: dry-run auditing endpoint (ADR 0021 §5.E).
+//!
+//! Deliberately does not call `MappingApi::authenticate_by_mapping`: that
+//! path may provision a real user row for `IdentityMode::Local` rules, which
+//! would be a side effect a *dry-run* endpoint must not have. Instead this
+//! re-derives the same claims `hydrate_ephemeral_context`
+//! (`crates/core/src/api/api_key_auth.rs`) would build, evaluates the
+//! ruleset, and reads the matched `Authorization`'s roles directly -- no
+//! token, no crypto verification, no provisioning.
+
+use std::collections::HashMap;
+
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use validator::Validate;
+
+use openstack_keystone_api_types::v4::api_key::{
+    ApiKey, ApiKeySimulateAccessRequest, ApiKeySimulateAccessResponse, SimulatedScope,
+};
+use openstack_keystone_core::auth::{ExecutionContext, ValidatedSecurityContext};
+use openstack_keystone_core::mapping::engine;
+use openstack_keystone_core_types::api_key::ApiClientResource;
+use openstack_keystone_core_types::mapping::authorization::Authorization;
+use openstack_keystone_core_types::mapping::resolution::IdentitySource;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+
+/// Perform a mock authentication pass for an API Key, returning its fully
+/// resolved authorization topology without presenting a bearer token.
+#[utoipa::path(
+    post,
+    path = "/simulate-access",
+    operation_id = "/api_key:simulate_access",
+    request_body = ApiKeySimulateAccessRequest,
+    responses(
+        (status = OK, description = "Simulated authorization topology", body = ApiKeySimulateAccessResponse),
+    ),
+    security(("x-auth" = [])),
+    tag="api_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::api_key::simulate_access",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn simulate_access(
+    Auth(user_auth): Auth,
+    State(state): State<ServiceState>,
+    Json(req): Json<ApiKeySimulateAccessRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    let current = state
+        .provider
+        .get_api_key_provider()
+        .get_by_client_id(&state, &req.domain_id, &req.client_id)
+        .await?
+        .ok_or_else(|| KeystoneApiError::NotFound {
+            resource: "api_key".into(),
+            identifier: req.client_id.clone(),
+        })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/api_key/simulate_access",
+            &user_auth,
+            serde_json::json!({"api_key": null}),
+            Some(serde_json::json!({"api_key": ApiKey::from(current.clone())})),
+        )
+        .await?;
+
+    let response = simulate(&state, &user_auth, &current).await?;
+
+    Ok((StatusCode::OK, Json(response)).into_response())
+}
+
+/// `base` carries the always-present identifying fields; each early return
+/// fills in `reason` and leaves `matched: false`.
+async fn simulate(
+    state: &ServiceState,
+    user_auth: &ValidatedSecurityContext,
+    resource: &ApiClientResource,
+) -> Result<ApiKeySimulateAccessResponse, KeystoneApiError> {
+    let base = ApiKeySimulateAccessResponse {
+        client_id: resource.client_id.clone(),
+        domain_id: resource.domain_id.clone(),
+        provider_id: resource.provider_id.clone(),
+        matched: false,
+        scope: None,
+        roles: Vec::new(),
+        reason: None,
+    };
+    let not_matched = |reason: &str| ApiKeySimulateAccessResponse {
+        reason: Some(reason.to_string()),
+        ..base.clone()
+    };
+
+    if !resource.enabled {
+        return Ok(not_matched("API key is disabled"));
+    }
+    if chrono::Utc::now().timestamp() >= resource.expires_at {
+        return Ok(not_matched("API key has expired"));
+    }
+
+    let source = IdentitySource::ApiClient {
+        provider_id: resource.provider_id.clone(),
+    };
+    let exec = ExecutionContext::from_auth(state, user_auth);
+    let ruleset = state
+        .provider
+        .get_mapping_provider()
+        .get_ruleset_by_source(&exec, &resource.domain_id, &source)
+        .await?;
+
+    let Some(ruleset) = ruleset else {
+        return Ok(not_matched("no mapping ruleset bound to provider_id"));
+    };
+    if !ruleset.enabled {
+        return Ok(not_matched("mapping ruleset is disabled"));
+    }
+
+    let mut claims: HashMap<String, Vec<String>> = HashMap::new();
+    claims.insert(
+        "api_client.client_id".to_string(),
+        vec![resource.client_id.clone()],
+    );
+    claims.insert(
+        "api_client.provider_id".to_string(),
+        vec![resource.provider_id.clone()],
+    );
+
+    let match_result =
+        engine::evaluate_ruleset(&ruleset, &claims, ruleset.domain_id.as_deref(), None)
+            .map_err(KeystoneApiError::from)?;
+
+    let Some(mr) = match_result else {
+        return Ok(not_matched("no mapping rule matched"));
+    };
+    if mr.authorizations.is_empty() {
+        return Ok(not_matched("mapping resolved zero authorizations"));
+    }
+    if mr.authorizations.len() > 1 {
+        return Ok(not_matched(
+            "mapping resolved multiple authorizations (ambiguous scope)",
+        ));
+    }
+
+    let (scope, roles) = match &mr.authorizations[0] {
+        Authorization::Domain { domain_id, roles } => (
+            SimulatedScope::Domain {
+                domain_id: domain_id.clone(),
+            },
+            roles,
+        ),
+        Authorization::Project {
+            project_id,
+            project_domain_id,
+            roles,
+        } => (
+            SimulatedScope::Project {
+                project_id: project_id.clone(),
+                project_domain_id: project_domain_id.clone(),
+            },
+            roles,
+        ),
+        Authorization::System { .. } => {
+            return Ok(not_matched(
+                "mapping resolved to system scope, which is forbidden for API keys",
+            ));
+        }
+    };
+
+    let mut role_names: Vec<String> = roles
+        .iter()
+        .map(|r| r.name.clone().unwrap_or_else(|| r.id.clone()))
+        .collect();
+    role_names.sort();
+    role_names.dedup();
+
+    Ok(ApiKeySimulateAccessResponse {
+        matched: true,
+        scope: Some(scope),
+        roles: role_names,
+        ..base
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::api_key::{
+        ApiKeySimulateAccessRequest, ApiKeySimulateAccessResponse,
+    };
+    use openstack_keystone_core_types::api_key as provider_types;
+    use openstack_keystone_core_types::mapping as mapping_types;
+    use openstack_keystone_core_types::role::RoleRef;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api_key::MockApiKeyProvider;
+    use crate::mapping::MockMappingProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource_core() -> provider_types::ApiClientResource {
+        provider_types::ApiClientResource {
+            domain_id: "domain_id".into(),
+            provider_id: "provider-1".into(),
+            client_id: "client-1".into(),
+            lookup_hash: "lookup-hash".into(),
+            secret_hash: "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into(),
+            allowed_ips: None,
+            description: None,
+            enabled: true,
+            created_at: 1_000,
+            expires_at: chrono::Utc::now().timestamp() + 3_600,
+            last_used_at: None,
+            revoked_at: None,
+            revoked_by: None,
+        }
+    }
+
+    fn sample_ruleset_matching() -> mapping_types::MappingRuleSet {
+        mapping_types::MappingRuleSet {
+            mapping_id: "test-ruleset".into(),
+            domain_id: Some("domain_id".into()),
+            source: mapping_types::IdentitySource::ApiClient {
+                provider_id: "provider-1".into(),
+            },
+            domain_resolution_mode: mapping_types::DomainResolutionMode::Fixed,
+            enabled: true,
+            rules: vec![mapping_types::MappingRule {
+                name: "rule-1".into(),
+                description: None,
+                r#match: mapping_types::MatchCriteria::AllOf(vec![]),
+                identity: mapping_types::IdentityBinding {
+                    identity_mode: None,
+                    user_name: "${claims.api_client.client_id}".into(),
+                    user_id: None,
+                    user_domain_id: None,
+                    is_system: false,
+                },
+                authorizations: vec![mapping_types::Authorization::Project {
+                    project_id: "project-1".into(),
+                    project_domain_id: "domain_id".into(),
+                    roles: vec![RoleRef {
+                        id: "role-1".into(),
+                        name: Some("member".into()),
+                        domain_id: None,
+                    }],
+                }],
+                groups: vec![],
+            }],
+            ruleset_version: 1,
+        }
+    }
+
+    fn sample_request() -> ApiKeySimulateAccessRequest {
+        ApiKeySimulateAccessRequest {
+            client_id: "client-1".into(),
+            domain_id: "domain_id".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_simulate_access_matched() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut api_key_mock = MockApiKeyProvider::default();
+        api_key_mock
+            .expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        provider = provider.mock_api_key(api_key_mock);
+        let mut mapping_mock = MockMappingProvider::default();
+        mapping_mock
+            .expect_get_ruleset_by_source()
+            .returning(|_, _, _| Ok(Some(sample_ruleset_matching())));
+        provider = provider.mock_mapping(mapping_mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/simulate-access")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeySimulateAccessResponse = serde_json::from_slice(&body).unwrap();
+        assert!(res.matched);
+        assert_eq!(res.roles, vec!["member".to_string()]);
+        assert!(res.reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_simulate_access_disabled_key_not_matched() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut api_key_mock = MockApiKeyProvider::default();
+        api_key_mock.expect_get_by_client_id().returning(|_, _, _| {
+            let mut res = sample_resource_core();
+            res.enabled = false;
+            Ok(Some(res))
+        });
+        provider = provider.mock_api_key(api_key_mock);
+        provider = provider.mock_mapping(MockMappingProvider::default());
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/simulate-access")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeySimulateAccessResponse = serde_json::from_slice(&body).unwrap();
+        assert!(!res.matched);
+        assert_eq!(res.reason.as_deref(), Some("API key is disabled"));
+    }
+
+    #[tokio::test]
+    async fn test_simulate_access_not_found() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut api_key_mock = MockApiKeyProvider::default();
+        api_key_mock
+            .expect_get_by_client_id()
+            .returning(|_, _, _| Ok(None));
+        provider = provider.mock_api_key(api_key_mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/simulate-access")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_simulate_access_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut api_key_mock = MockApiKeyProvider::default();
+        api_key_mock
+            .expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        provider = provider.mock_api_key(api_key_mock);
+
+        let state = get_mocked_state(provider, false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/simulate-access")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_simulate_access_unauthorized() {
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_api_key(MockApiKeyProvider::default()),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/simulate-access")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/api_key/update.rs
+++ b/crates/keystone/src/api/v4/api_key/update.rs
@@ -1,0 +1,292 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! API Key: update.
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::Deserialize;
+use validator::Validate;
+
+use openstack_keystone_api_types::v4::api_key::{ApiKey, ApiKeyResponse, ApiKeyUpdateRequest};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+
+/// Query parameters for `PUT /v4/api-keys/{client_id}`.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub(super) struct UpdateParams {
+    /// Domain the key belongs to.
+    domain_id: String,
+}
+
+/// Update an API Key's configuration.
+#[utoipa::path(
+    put,
+    path = "/{client_id}",
+    operation_id = "/api_key:update",
+    params(
+        ("client_id" = String, Path, description = "API Key client_id"),
+        UpdateParams,
+    ),
+    request_body = ApiKeyUpdateRequest,
+    responses(
+        (status = OK, description = "API Key object", body = ApiKeyResponse),
+    ),
+    security(("x-auth" = [])),
+    tag="api_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::api_key::update",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path(client_id): Path<String>,
+    Query(params): Query<UpdateParams>,
+    State(state): State<ServiceState>,
+    Json(req): Json<ApiKeyUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    let current = state
+        .provider
+        .get_api_key_provider()
+        .get_by_client_id(&state, &params.domain_id, &client_id)
+        .await?
+        .ok_or_else(|| KeystoneApiError::NotFound {
+            resource: "api_key".into(),
+            identifier: client_id.clone(),
+        })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/api_key/update",
+            &user_auth,
+            serde_json::json!({"api_key": req.api_key}),
+            Some(serde_json::json!({"api_key": ApiKey::from(current)})),
+        )
+        .await?;
+
+    let res = state
+        .provider
+        .get_api_key_provider()
+        .update(&state, &params.domain_id, &client_id, req.api_key.into())
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(ApiKeyResponse {
+            api_key: ApiKey::from(res),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::api_key::{
+        ApiKeyResponse, ApiKeyUpdate, ApiKeyUpdateRequest,
+    };
+    use openstack_keystone_core_types::api_key as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api_key::MockApiKeyProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource_core() -> provider_types::ApiClientResource {
+        provider_types::ApiClientResource {
+            domain_id: "domain_id".into(),
+            provider_id: "provider-1".into(),
+            client_id: "client-1".into(),
+            lookup_hash: "lookup-hash".into(),
+            secret_hash: "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into(),
+            allowed_ips: None,
+            description: None,
+            enabled: true,
+            created_at: 1_000,
+            expires_at: 2_000,
+            last_used_at: None,
+            revoked_at: None,
+            revoked_by: None,
+        }
+    }
+
+    fn sample_update() -> ApiKeyUpdateRequest {
+        ApiKeyUpdateRequest {
+            api_key: ApiKeyUpdate {
+                enabled: Some(false),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        mock.expect_update().returning(|_, _, _, _| {
+            let mut res = sample_resource_core();
+            res.enabled = false;
+            Ok(res)
+        });
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_update();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/client-1?domain_id=domain_id")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeyResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.api_key.client_id, "client-1");
+        assert!(!res.api_key.enabled);
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id().returning(|_, _, _| Ok(None));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_update();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/missing?domain_id=domain_id")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_update();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/client-1?domain_id=domain_id")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_api_key(MockApiKeyProvider::default()),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_update();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/client-1?domain_id=domain_id")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/mod.rs
+++ b/crates/keystone/src/api/v4/mod.rs
@@ -28,6 +28,7 @@ use crate::federation::api as federation;
 use crate::k8s_auth::api as k8s_auth;
 use crate::keystone::ServiceState;
 
+pub mod api_key;
 pub mod auth;
 pub mod group;
 pub mod mapping;
@@ -42,6 +43,7 @@ use crate::api::types::*;
 #[derive(OpenApi)]
 #[openapi(
     nest(
+      (path = "api-keys", api = api_key::ApiDoc),
       (path = "federation", api = federation::ApiDoc),
       (path = "k8s_auth", api = k8s_auth::ApiDoc),
       (path = "mappings", api = mapping::ApiDoc),
@@ -53,6 +55,7 @@ pub struct ApiDoc;
 
 pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new()
+        .nest("/api-keys", api_key::openapi_router())
         .nest("/auth", auth::openapi_router())
         .nest("/groups", group::openapi_router())
         .nest("/mappings", mapping::openapi_router())

--- a/crates/keystone/src/api_key.rs
+++ b/crates/keystone/src/api_key.rs
@@ -11,18 +11,6 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # API Key (SCIM ingress) machine identity management (ADR 0021)
+//! # API Key (SCIM ingress) provider re-export.
 
-pub mod backend;
-pub mod crypto;
-pub mod error;
-pub mod janitor;
-mod provider_api;
-pub mod service;
-pub mod token;
-
-#[cfg(any(test, feature = "mock"))]
-pub use crate::mocks::MockApiKeyProvider;
-pub use error::ApiKeyProviderError;
-pub use provider_api::ApiKeyApi;
-pub use service::ApiKeyService;
+pub use openstack_keystone_core::api_key::*;

--- a/crates/keystone/src/audit.rs
+++ b/crates/keystone/src/audit.rs
@@ -199,6 +199,46 @@ pub fn emit_perimeter_authenticate_event(
     dispatcher.dispatch(event);
 }
 
+/// Emit a `control` CADF event for an API Key lifecycle action performed by
+/// an administrator (revoke: ADR 0021 §5.C; janitor disablement/purge: §6.F
+/// use `action` `"maintenance"` instead via the same helper).
+///
+/// Unlike [`emit_perimeter_authenticate_event`], this is for low-volume
+/// administrative actions, not the high-volume authentication hot path.
+pub fn emit_api_key_control_event(
+    dispatcher: &Arc<AuditDispatcher>,
+    correlation_id: &str,
+    action: &str,
+    initiator: Initiator,
+    client_id: &str,
+    outcome: &str,
+    outcome_reason: Option<String>,
+) {
+    let node_id = dispatcher.node_id().to_string();
+    let event_id = format!("{}:{}", node_id, Uuid::new_v4());
+    let payload = CadfEventPayload::new(
+        event_id,
+        "1.0".to_string(),
+        "default".to_string(),
+        correlation_id.to_string(),
+        chrono::Utc::now().to_rfc3339(),
+        action.to_string(),
+        outcome.to_string(),
+        outcome_reason,
+        initiator,
+        Target {
+            id: client_id.to_string(),
+            type_uri: "data/security/keystone/api_key".to_string(),
+        },
+        Observer {
+            node_id: node_id.clone(),
+            id: format!("service/security/keystone/{node_id}"),
+        },
+    );
+    let event = payload.sign(dispatcher);
+    dispatcher.dispatch(event);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -80,6 +80,7 @@ use openstack_keystone::webauthn;
 use openstack_keystone::{api, common};
 use openstack_keystone_audit::spool::{replay_spool, run_spool_writer, spool_path};
 use openstack_keystone_audit::{AuditDispatcher, HmacKeyStore, derive_audit_hmac_key};
+use openstack_keystone_core::api_key::janitor as api_key_janitor;
 use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::cadf_hook::CadfAuditHook;
 use openstack_keystone_core::db::sync_schema;
@@ -395,6 +396,11 @@ async fn main() -> Result<(), Report> {
     );
 
     spawn(cleanup(cloned_token, shared_state.clone()));
+
+    // API Key (SCIM ingress) janitor: proactive inactivity disablement and
+    // tombstone purge (ADR 0021 §6.F). Runs on every node; gated to actually
+    // do work only on the current Raft leader.
+    api_key_janitor::spawn(shared_state.clone());
 
     // Reset the dummy-password-hash cache whenever the configuration is
     // hot-reloaded. The cache is keyed by (algorithm, rounds); if the operator

--- a/crates/keystone/src/lib.rs
+++ b/crates/keystone/src/lib.rs
@@ -73,6 +73,7 @@
 //! Rust service as the complement.
 
 pub mod api;
+pub mod api_key;
 pub mod application_credential;
 pub mod assignment;
 pub mod audit;

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -132,17 +132,17 @@ async fn check_node_id_uniqueness(
 /// Returns:
 /// - `Ok(true)` if at least one configured peer was reached and its live
 ///   membership confirms no conflict.
-/// - `Ok(false)` if no configured peer could be reached at all —
-///   verification is inconclusive. The caller should log a prominent
-///   warning but proceed rather than refuse to start: treating "no peer
-///   reachable" as fail-closed would make it impossible to recover from a
-///   full-cluster outage where every node restarts simultaneously with no
-///   live peer to ask (the ADR's literal fail-closed wording does not
-///   distinguish that case from an active network partition, so this is a
-///   deliberate, documented deviation in favor of cluster recoverability).
-/// - `Err` if a reachable peer's live membership shows an actual
-///   `(node_id, rpc_addr)` conflict — a real, actionable signal, so this
-///   remains fail-closed.
+/// - `Ok(false)` if no configured peer could be reached at all — verification
+///   is inconclusive. The caller should log a prominent warning but proceed
+///   rather than refuse to start: treating "no peer reachable" as fail-closed
+///   would make it impossible to recover from a full-cluster outage where every
+///   node restarts simultaneously with no live peer to ask (the ADR's literal
+///   fail-closed wording does not distinguish that case from an active network
+///   partition, so this is a deliberate, documented deviation in favor of
+///   cluster recoverability).
+/// - `Err` if a reachable peer's live membership shows an actual `(node_id,
+///   rpc_addr)` conflict — a real, actionable signal, so this remains
+///   fail-closed.
 async fn verify_node_id_uniqueness_live(
     tls_client: &RaftTlsClient,
     node_id: u64,

--- a/doc/src/adr/0021-api-key-scim.md
+++ b/doc/src/adr/0021-api-key-scim.md
@@ -235,6 +235,19 @@ mappings must be formally ratified in an upcoming revision to **ADR 0002
 (OpenStack Policy Engine Integration)** to ensure central governance of the RBAC
 hierarchy.
 
+**Implementation status:** The five policies above are implemented under
+`policy/identity/api_key/` (`create.rego`, `list.rego`, `update.rego`,
+`revoke.rego`, `simulate_access.rego`; a sixth, `show.rego`, gates a
+`GET /v4/api-keys/{client_id}` endpoint not explicitly enumerated by this
+section but added for consistency with every other v4 resource), each
+requiring the pre-existing `manager` role scoped to the key's own domain
+(this codebase's realization of `DomainManager`, used identically by
+`identity.user.*` and `identity.mapping.ruleset.*`), or `admin`/`is_admin`
+(`SystemAdmin`). Unlike `identity.user.list`, there is no `reader` carve-out
+on `identity:api_key:list` — all actions sit at the same privilege bar. This
+does not by itself constitute the formal ADR 0002 ratification called for
+above (see §8).
+
 ### B. CRUD Endpoints
 
 - **`POST /v4/api-keys`**: Generates a new key.
@@ -244,11 +257,16 @@ hierarchy.
 ### C. Revocation & Incident Response
 
 - **`POST /v4/api-keys/{client_id}/revoke`**: **Emergency Revocation Path.**
-  Sets `enabled: false`, stamps `revoked_at` and `revoked_by`, and emits a
-  `control` CADF event. **It does not perform a hard delete.** This preserves
-  the cryptographic footprint (`lookup_hash`) and metadata for incident response
-  audits. Physical storage reclamation is deferred to the janitor after the
-  organization's audit retention period.
+  Sets `enabled: false`, stamps `revoked_at` and `revoked_by`, and emits a CADF
+  event (`action: revoke`). **It does not perform a hard delete.** This
+  preserves the cryptographic footprint (`lookup_hash`) and metadata for
+  incident response audits. Physical storage reclamation is deferred to the
+  janitor after the organization's audit retention period.
+- **Revocation is irreversible via `PUT`.** `ApiKeyApi::update` MUST reject
+  (`409 Conflict`) any patch that sets `enabled: true` on a key whose
+  `revoked_at` is set. Without this, an emergency revocation could be undone
+  by an ordinary configuration update, defeating its purpose as an
+  incident-response control (see Invariant 9, §7).
 
 ### D. Zero-Downtime Key Rotation (N:1 Provider Mapping)
 
@@ -332,13 +350,18 @@ traffic migrates seamlessly, and Key A is subsequently revoked.
   acceptable async write staleness of 24 hours. The janitor operates with a
   7-day grace period beyond the 90-day threshold, mathematically absorbing this
   write-failure window. Before executing a disablement, the janitor emits a
-  `maintenance` CADF audit event and pushes an administrative alert payload to
-  the system notification bus.
+  CADF event (`action: disable_inactive`) and pushes an administrative alert
+  payload to the system notification bus.
 
 2. **Physical Reclamation:** To prevent unbounded keyspace bloat, the janitor
    executes a secondary garbage-collection phase. Any `ApiClientResource`
    containing a `revoked_at` timestamp older than 365 days is permanently purged
    from FjallDB.
+
+3. **Per-key fault isolation:** a single key failing its disablement or purge
+   (e.g. a storage CAS conflict with a concurrent admin update) MUST NOT
+   prevent the rest of the sweep pass from running. Failures are counted and
+   logged, and retried on the next pass.
 
 ---
 
@@ -384,3 +407,69 @@ a security defect.
    stored PHC string MUST be validated against configured minimums before
    accepting a verification as sufficient. Parameters below the floor trigger a
    lazy re-hash regardless of verification outcome.
+
+9. **Revocation is irreversible via the update surface.** `ApiKeyApi::update`
+   MUST reject with a conflict error any patch that would set `enabled: true`
+   on an `ApiClientResource` whose `revoked_at` is `Some`. A revoked key MUST
+   NOT become authenticatable again through `PUT /v4/api-keys/{client_id}`;
+   the only way back into service is administratively creating a new key
+   (§5.D covers zero-downtime rotation for exactly this case).
+
+---
+
+## 8. Implementation Status
+
+- **Done:**
+  - The SCIM ingress authentication pipeline (§3), including all security
+    invariants (§7).
+  - The write-time `is_system` prohibition (§6.C).
+  - The storage layer and internal `ApiKeyApi`/`ApiKeyBackend` traits (§2,
+    §5.D) with a Raft-backed implementation, including the janitor's
+    cross-domain `list_all` and hard-delete `purge` operations (§6.F).
+  - Rate limiting (§6.A).
+  - The OPA policies for §5.A (`policy/identity/api_key/`), plus a `show`
+    policy for the `GET /v4/api-keys/{client_id}` endpoint this section does
+    not explicitly enumerate.
+  - The `/v4/api-keys*` HTTP admin surface (§5.B): create, list, show,
+    update. `update` rejects (`409 Conflict`) re-enabling a revoked key
+    (Invariant 9, §5.C), enforced in `ApiKeyService::update`
+    (`crates/core/src/api_key/service.rs`) so it holds for every caller, not
+    just the HTTP layer.
+  - The revoke endpoint (§5.C), including a CADF audit event
+    (`action: revoke`).
+  - The dry-run `simulate-access` endpoint (§5.E). Deviates from the literal
+    request shape in one way: the payload also carries `domain_id` alongside
+    `client_id`, because this implementation's storage partitions
+    `ApiClientResource` by domain (§2.A), making a `client_id`-only lookup
+    impossible without it. The same constraint applies to show/update/revoke,
+    which take `domain_id` as a query parameter rather than encoding it in
+    the (flat, ADR-specified) URL path. It also does not call
+    `MappingApi::authenticate_by_mapping` -- that path may provision a real
+    user row for `IdentityMode::Local` rules, an unacceptable side effect for
+    a dry-run endpoint -- and instead evaluates the ruleset and reads the
+    matched `Authorization`'s roles directly.
+  - The janitor (§6.F): an in-process, leader-gated `tokio::time::interval`
+    sweep (mirroring the storage crate's existing emergency-rotation
+    confirmation-timeout sweeper in `crates/storage/src/app.rs`) that
+    disables keys inactive beyond `janitor_inactive_days` +
+    `janitor_grace_days`, purges tombstones older than
+    `janitor_tombstone_retention_days`, and emits a CADF event
+    (`action: disable_inactive`) per disablement. Per-key failures are
+    isolated (§6.F.3): one key's disablement/purge error is logged and
+    counted in `JanitorReport::errors`, not propagated, so it cannot stall
+    the rest of the pass.
+
+    Action strings are intentionally more specific than this ADR's earlier
+    `control`/`maintenance` category wording (`revoke`/`disable_inactive`
+    rather than a repeated generic label) -- more useful for audit
+    filtering; the wording above has been reconciled to match the code
+    rather than the other way around.
+- **Known gap:** the ADR's "pushes an administrative alert payload to the
+  system notification bus" (§6.F) is not implemented -- no pub/sub or webhook
+  dispatch infrastructure exists in this codebase yet. The janitor emits a
+  structured `warn!` log and its CADF event (`action: disable_inactive`) as
+  the closest existing substitutes; a real notification channel is unbuilt
+  follow-up work, not something to improvise here.
+- **Not yet done:** the `DomainManager` role's formal ratification in ADR
+  0002. In the interim, the OPA policies enforce the equivalent scoped
+  privilege using this codebase's existing `manager` role (§5.A).

--- a/policy/identity/api_key/common.rego
+++ b/policy/identity/api_key/common.rego
@@ -1,0 +1,29 @@
+# METADATA
+# description: Shared predicates for API Key (SCIM ingress) policies (ADR 0021)
+package identity.api_key
+
+import data.identity
+
+# Resolve domain_id from target or existing depending on operation.
+# Create/List: domain_id is in input.target.api_key.
+# Update/Revoke/SimulateAccess: domain_id is in input.existing.api_key.
+# Unlike mapping rulesets, an API Key's domain_id is always mandatory (ADR
+# 0021 §2: "Domain-Owned Machine Identities") -- there is no global/orphaned
+# case to account for.
+key_domain_id := input.target.api_key.domain_id if {
+	input.target.api_key.domain_id
+}
+
+key_domain_id := input.existing.api_key.domain_id if {
+	input.existing.api_key.domain_id
+}
+
+own_key if {
+	key_domain_id != null
+	key_domain_id == input.credentials.domain_id
+}
+
+foreign_key if {
+	key_domain_id != null
+	key_domain_id != input.credentials.domain_id
+}

--- a/policy/identity/api_key/create.rego
+++ b/policy/identity/api_key/create.rego
@@ -1,0 +1,50 @@
+# METADATA
+# description: Policy for creating API Keys (SCIM ingress machine identities, ADR 0021)
+package identity.api_key.create
+
+import data.identity.api_key as api_key_common
+
+# Create ApiClientResource (ApiClientResourceCreate).
+#
+# input.target.api_key fields:
+#   domain_id:    string            Domain owning the machine identity.
+#   provider_id:  string            ADR 0020 mapping provider_id the key authenticates against.
+#   allowed_ips:  array (optional)  CIDR allowlist restricting the source IP.
+#   description:  string (optional)
+#   expires_at:   number            Mandatory TTL, UTC epoch seconds.
+#
+# input.existing is null.
+#
+# Rules (ADR 0021 §5.A): API key management requires the `manager` role
+# (DomainManager) scoped to the key's own domain, or `admin` (SystemAdmin).
+# There is no reader/list-only carve-out and no unscoped-`admin`-implies-any-domain
+# ("DomainAdmin") shortcut -- cross-domain creation always requires `admin`.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	api_key_common.own_key
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	api_key_common.foreign_key
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "creating an API key for another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	api_key_common.own_key
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "creating an API key requires `manager` role."
+}

--- a/policy/identity/api_key/create_test.rego
+++ b/policy/identity/api_key/create_test.rego
@@ -1,0 +1,16 @@
+package test_api_key_create
+
+import data.identity.api_key.create
+
+test_allowed if {
+	create.allow with input as {"credentials": {"roles": ["admin"]}}
+	create.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	create.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"api_key": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not create.allow with input as {"credentials": {"roles": []}}
+	not create.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"api_key": {"domain_id": "foo1"}}}
+	not create.allow with input as {"credentials": {"roles": ["manager"]}, "target": {"api_key": {"domain_id": "foo"}}}
+	not create.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "target": {"api_key": {"domain_id": "foo"}}}
+}

--- a/policy/identity/api_key/list.rego
+++ b/policy/identity/api_key/list.rego
@@ -1,0 +1,47 @@
+# METADATA
+# description: Policy for listing API Keys (SCIM ingress machine identities, ADR 0021)
+package identity.api_key.list
+
+import data.identity.api_key as api_key_common
+
+# List ApiClientResources (ApiClientResourceListParameters).
+#
+# input.target.api_key fields:
+#   domain_id:    string            Domain to list keys for (mandatory filter).
+#   provider_id:  string (optional) Restrict to keys bound to this provider_id.
+#   enabled:      bool (optional)   Restrict to enabled/disabled keys.
+#
+# input.existing is null.
+#
+# Rules (ADR 0021 §5.A): unlike `identity.user.list`, there is no `reader`
+# carve-out -- listing API keys exposes metadata about machine-identity
+# credentials and requires the same `manager`/`admin` bar as create/update/revoke.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	api_key_common.own_key
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	api_key_common.foreign_key
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "listing API keys for another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	api_key_common.own_key
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "listing API keys requires `manager` role."
+}

--- a/policy/identity/api_key/list_test.rego
+++ b/policy/identity/api_key/list_test.rego
@@ -1,0 +1,19 @@
+package test_api_key_list
+
+import data.identity.api_key.list
+
+test_allowed if {
+	list.allow with input as {"credentials": {"roles": ["admin"]}}
+	list.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	list.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"api_key": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not list.allow with input as {"credentials": {"roles": []}}
+	not list.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"api_key": {"domain_id": "foo1"}}}
+	not list.allow with input as {"credentials": {"roles": ["manager"]}, "target": {"api_key": {"domain_id": "foo"}}}
+
+	# Unlike identity.user.list, `reader` is never sufficient here.
+	not list.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "target": {"api_key": {"domain_id": "foo"}}}
+	not list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
+}

--- a/policy/identity/api_key/revoke.rego
+++ b/policy/identity/api_key/revoke.rego
@@ -1,0 +1,43 @@
+# METADATA
+# description: Policy for the API Key emergency revocation path (ADR 0021 §5.C)
+package identity.api_key.revoke
+
+import data.identity.api_key as api_key_common
+
+# Revoke ApiClientResource (POST /v4/api-keys/{client_id}/revoke).
+#
+# input.target is null.
+# input.existing.api_key is the stored ApiClientResource to be revoked.
+#
+# Revocation is the incident-response path (disable + tombstone, no hard
+# delete) and holds to the same bar as create/update: `manager` scoped to
+# the key's own domain, or `admin`.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	api_key_common.own_key
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	api_key_common.foreign_key
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "revoking an API key in another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	api_key_common.own_key
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "revoking an API key requires `manager` role."
+}

--- a/policy/identity/api_key/revoke_test.rego
+++ b/policy/identity/api_key/revoke_test.rego
@@ -1,0 +1,16 @@
+package test_api_key_revoke
+
+import data.identity.api_key.revoke
+
+test_allowed if {
+	revoke.allow with input as {"credentials": {"roles": ["admin"]}}
+	revoke.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	revoke.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not revoke.allow with input as {"credentials": {"roles": []}}
+	not revoke.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo1"}}}
+	not revoke.allow with input as {"credentials": {"roles": ["manager"]}, "existing": {"api_key": {"domain_id": "foo"}}}
+	not revoke.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo"}}}
+}

--- a/policy/identity/api_key/show.rego
+++ b/policy/identity/api_key/show.rego
@@ -1,0 +1,43 @@
+# METADATA
+# description: Policy for viewing a single API Key's metadata (ADR 0021)
+package identity.api_key.show
+
+import data.identity.api_key as api_key_common
+
+# Show a single ApiClientResource (GET /v4/api-keys/{client_id}).
+#
+# input.target is null.
+# input.existing.api_key is the stored ApiClientResource.
+#
+# Not explicitly enumerated in ADR 0021 §5.A, but held to the same bar as
+# `identity.api_key.list` for consistency: no `reader` carve-out, since the
+# response describes a machine-identity credential's configuration.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	api_key_common.own_key
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	api_key_common.foreign_key
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "showing an API key in another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	api_key_common.own_key
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "showing an API key requires `manager` role."
+}

--- a/policy/identity/api_key/show_test.rego
+++ b/policy/identity/api_key/show_test.rego
@@ -1,0 +1,16 @@
+package test_api_key_show
+
+import data.identity.api_key.show
+
+test_allowed if {
+	show.allow with input as {"credentials": {"roles": ["admin"]}}
+	show.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	show.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not show.allow with input as {"credentials": {"roles": []}}
+	not show.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo1"}}}
+	not show.allow with input as {"credentials": {"roles": ["manager"]}, "existing": {"api_key": {"domain_id": "foo"}}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo"}}}
+}

--- a/policy/identity/api_key/simulate_access.rego
+++ b/policy/identity/api_key/simulate_access.rego
@@ -1,0 +1,45 @@
+# METADATA
+# description: Policy for the API Key dry-run auditing endpoint (ADR 0021 §5.E)
+package identity.api_key.simulate_access
+
+import data.identity.api_key as api_key_common
+
+# Simulate access for an ApiClientResource (POST /v4/api-keys/simulate-access).
+#
+# input.target is null.
+# input.existing.api_key is the stored ApiClientResource resolved server-side
+# from the `client_id` given in the request body (kept out of the URL/query
+# string to avoid leaking it into proxy access logs, per ADR 0021 §5.E).
+#
+# This performs a mock authentication pass and returns the key's fully
+# resolved authorization topology, so it holds to the same bar as the other
+# admin actions: `manager` scoped to the key's own domain, or `admin`.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	api_key_common.own_key
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	api_key_common.foreign_key
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "simulating access for an API key in another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	api_key_common.own_key
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "simulating access for an API key requires `manager` role."
+}

--- a/policy/identity/api_key/simulate_access_test.rego
+++ b/policy/identity/api_key/simulate_access_test.rego
@@ -1,0 +1,16 @@
+package test_api_key_simulate_access
+
+import data.identity.api_key.simulate_access
+
+test_allowed if {
+	simulate_access.allow with input as {"credentials": {"roles": ["admin"]}}
+	simulate_access.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	simulate_access.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not simulate_access.allow with input as {"credentials": {"roles": []}}
+	not simulate_access.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo1"}}}
+	not simulate_access.allow with input as {"credentials": {"roles": ["manager"]}, "existing": {"api_key": {"domain_id": "foo"}}}
+	not simulate_access.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo"}}}
+}

--- a/policy/identity/api_key/update.rego
+++ b/policy/identity/api_key/update.rego
@@ -1,0 +1,44 @@
+# METADATA
+# description: Policy for updating API Keys (SCIM ingress machine identities, ADR 0021)
+package identity.api_key.update
+
+import data.identity.api_key as api_key_common
+
+# Update ApiClientResource (PUT /v4/api-keys/{client_id}, ApiClientResourceUpdate).
+#
+# input.target.api_key is the update patch:
+#   allowed_ips:  array or null (optional)  New CIDR allowlist, or null to clear.
+#   description:  string or null (optional) New description, or null to clear.
+#   enabled:      bool (optional)           New enabled state.
+#
+# input.existing.api_key is the stored ApiClientResource, which carries
+# domain_id -- the patch itself does not.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	api_key_common.own_key
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	api_key_common.foreign_key
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "updating an API key in another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	api_key_common.own_key
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "updating an API key requires `manager` role."
+}

--- a/policy/identity/api_key/update_test.rego
+++ b/policy/identity/api_key/update_test.rego
@@ -1,0 +1,16 @@
+package test_api_key_update
+
+import data.identity.api_key.update
+
+test_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}}
+	update.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo1"}}}
+	not update.allow with input as {"credentials": {"roles": ["manager"]}, "existing": {"api_key": {"domain_id": "foo"}}}
+	not update.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "existing": {"api_key": {"domain_id": "foo"}}}
+}

--- a/tests/integration/src/api_key/mapping_system_scope.rs
+++ b/tests/integration/src/api_key/mapping_system_scope.rs
@@ -21,7 +21,6 @@ use eyre::Result;
 use tracing_test::traced_test;
 
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core::mapping::MappingApi;
 use openstack_keystone_core_types::mapping::authorization::Authorization;
 use openstack_keystone_core_types::mapping::error::MappingProviderError;
 use openstack_keystone_core_types::mapping::resolution::IdentitySource;

--- a/tests/integration/src/api_key/update.rs
+++ b/tests/integration/src/api_key/update.rs
@@ -140,6 +140,91 @@ async fn test_update_disable_key() -> Result<()> {
 
 #[traced_test]
 #[tokio::test]
+async fn test_update_cannot_reactivate_revoked_key() -> Result<()> {
+    // ADR 0021 §5.C / Invariant 9: revocation is the emergency-response path
+    // and must not be reversible through the ordinary update surface.
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    state
+        .provider
+        .get_api_key_provider()
+        .revoke(&state, &domain.id, &created.client_id, "operator-1")
+        .await?;
+
+    let result = state
+        .provider
+        .get_api_key_provider()
+        .update(
+            &state,
+            &domain.id,
+            &created.client_id,
+            ApiClientResourceUpdate {
+                allowed_ips: None,
+                description: None,
+                enabled: Some(true),
+            },
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    // The key must still be disabled: the rejected update must not have
+    // been applied.
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_client_id(&state, &domain.id, &created.client_id)
+        .await?
+        .expect("key still exists");
+    assert!(!fetched.enabled);
+    assert!(fetched.revoked_at.is_some());
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_can_still_disable_a_revoked_key() -> Result<()> {
+    // The reactivation guard is narrowly scoped to `enabled: true`; other
+    // fields (and re-disabling, a no-op) on a revoked key remain updatable.
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+
+    state
+        .provider
+        .get_api_key_provider()
+        .revoke(&state, &domain.id, &created.client_id, "operator-1")
+        .await?;
+
+    let updated = state
+        .provider
+        .get_api_key_provider()
+        .update(
+            &state,
+            &domain.id,
+            &created.client_id,
+            ApiClientResourceUpdate {
+                allowed_ips: None,
+                description: Some(Some("post-revocation note".to_string())),
+                enabled: None,
+            },
+        )
+        .await?;
+
+    assert_eq!(
+        updated.description,
+        Some("post-revocation note".to_string())
+    );
+    assert!(!updated.enabled);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
 async fn test_update_missing_key_fails() -> Result<()> {
     let (state, _) = get_state().await?;
     let domain = create_domain!(state)?;


### PR DESCRIPTION
- /v4/api-keys HTTP admin handlers (create, list, show, update, revoke),
  gated by the OPA policies added earlier, plus an ADR-unspecified GET
/v4/api-keys/{client_id} for consistency with other v4 resources.
- POST /v4/api-keys/simulate-access dry-run endpoint: evaluates the
  bound mapping ruleset and reads the matched Authorization's roles
directly, deliberately not calling authenticate_by_mapping to avoid the
real auth path's user-provisioning side effects.
- control CADF audit event on revoke.
- In-process janitor (ApiKeyApi::list_all/purge + RaftBackend support):
  a leader-gated tokio::time::interval sweep, mirroring the storage
crate's existing emergency-rotation-timeout sweeper, that disables
inactive keys and purges tombstones past retention, emitting a
maintenance CADF event per disablement.
- ADR 0021 updated with a corrected, consolidated Implementation Status
  section covering what's done and the one known gap (no
notification-bus infrastructure exists yet for the janitor's
administrative alert).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
