### PR TITLE
feat(credential): Implement ADR 0019 phases 1-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ dependencies = [
  "openstack-keystone-config",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
+ "openstack-keystone-credential-driver-sql",
  "openstack-keystone-distributed-storage",
  "openstack-keystone-federation-driver-sql",
  "openstack-keystone-identity-driver-sql",
@@ -4090,6 +4091,31 @@ dependencies = [
  "url",
  "uuid",
  "validator",
+]
+
+[[package]]
+name = "openstack-keystone-credential-driver-sql"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "fernet",
+ "inventory",
+ "nix 0.31.3",
+ "openstack-keystone-config",
+ "openstack-keystone-core",
+ "openstack-keystone-core-types",
+ "scopeguard",
+ "sea-orm",
+ "secrecy",
+ "serde_json",
+ "sha1",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -7345,6 +7371,7 @@ dependencies = [
  "openstack-keystone-config",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
+ "openstack-keystone-credential-driver-sql",
  "openstack-keystone-distributed-storage",
  "openstack-keystone-identity-driver-sql",
  "openstack-keystone-storage-api",
@@ -7356,6 +7383,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha2 0.11.0",
  "tempfile",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/config",
   "crates/core",
   "crates/core-types",
+  "crates/credential-driver-sql",
   "crates/federation-driver-sql",
   "crates/identity-driver-sql",
   "crates/idmapping-driver-sql",
@@ -103,6 +104,7 @@ openstack-keystone-catalog-driver-sql = { version = "0.1", path = "crates/catalo
 openstack-keystone-config = { version = "0.1.0", path = "crates/config"}
 openstack-keystone-core = { version = "0.1.0", path = "crates/core" }
 openstack-keystone-core-types = { version = "0.1.0", path = "crates/core-types" }
+openstack-keystone-credential-driver-sql = { version = "0.1", path = "crates/credential-driver-sql/" }
 openstack-keystone-distributed-storage = { version = "0.1.0", path = "crates/storage"}
 openstack-keystone-storage-api = { version = "0.1.0", path = "crates/storage-api" }
 openstack-keystone-storage-crypto = { version = "0.1.0", path = "crates/storage-crypto" }
@@ -135,6 +137,7 @@ serial_test = { version = "3.2" }
 sea-orm = { version = "1.1", default-features = false }
 sea-orm-migration = { version = "1.1", default-features = false }
 secrecy = { version = "0.10" }
+sha1 = { version = "0.10" }
 sha2 = "0.11"
 serde = { version = "1.0" }
 serde_bytes = { version = "0.11" }

--- a/crates/config/src/credential.rs
+++ b/crates/config/src/credential.rs
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Credential provider configuration (ADR 0019)
+use serde::Deserialize;
+use std::path::PathBuf;
+
+use crate::common::default_sql_driver;
+
+/// Credential provider.
+///
+/// The Fernet key repository used here is separate from `[fernet_tokens]`
+/// (ADR 0019 §4) and is hard-capped at 3 active keys (`MAX_ACTIVE_KEYS = 3`,
+/// matching the Python Keystone constant); unlike token Fernet keys this is
+/// intentionally not configurable.
+#[derive(Debug, Deserialize, Clone)]
+pub struct CredentialProvider {
+    /// Credential provider driver.
+    #[serde(default = "default_sql_driver")]
+    pub driver: String,
+
+    /// Path to the credential Fernet keys. Must be a directory distinct from
+    /// `[fernet_tokens] key_repository`.
+    #[serde(default = "default_credential_key_repository")]
+    pub key_repository: PathBuf,
+
+    /// Allow starting (and encrypting/decrypting with) the well-known Null
+    /// Key (`base64.urlsafe_b64encode(b'\x00' * 32)`). This exists solely as
+    /// a transient migration aid; it must be `false` in any real deployment.
+    /// Defaults to `false` (refuse to start if a key file decodes to the
+    /// Null Key).
+    #[serde(default)]
+    pub insecure_allow_null_key: bool,
+}
+
+fn default_credential_key_repository() -> PathBuf {
+    PathBuf::from("/etc/keystone/credential-keys/")
+}
+
+impl Default for CredentialProvider {
+    fn default() -> Self {
+        Self {
+            driver: default_sql_driver(),
+            key_repository: default_credential_key_repository(),
+            insecure_allow_null_key: false,
+        }
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -63,6 +63,7 @@ mod audit;
 mod auth;
 mod catalog;
 mod common;
+mod credential;
 mod database;
 mod default;
 mod distributed_storage;
@@ -91,6 +92,7 @@ pub use audit::*;
 pub use auth::*;
 pub use catalog::*;
 pub use common::*;
+pub use credential::*;
 pub use database::*;
 pub use default::*;
 pub use distributed_storage::*;
@@ -142,6 +144,10 @@ pub struct Config {
     /// Catalog provider configuration.
     #[serde(default)]
     pub catalog: CatalogProvider,
+
+    /// Credential provider configuration.
+    #[serde(default)]
+    pub credential: CredentialProvider,
 
     /// Database configuration.
     //#[serde(default)]

--- a/crates/core-types/src/credential.rs
+++ b/crates/core-types/src/credential.rs
@@ -1,7 +1,6 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -12,32 +11,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! # OpenStack Keystone core provider types
+//! # Credentials provider (ADR 0019)
+//!
+//! Blind storage for sensitive authentication secrets (EC2 access/secret
+//! keys, TOTP seeds, and arbitrary third-party blobs). The `credential` table
+//! is owned and schema-managed exclusively by the Python Keystone service via
+//! `alembic`; Keystone-NG treats it as read/write but never issues DDL
+//! against it.
 
-#![allow(clippy::module_inception)]
-#![deny(clippy::unwrap_used)]
+mod credential;
+mod error;
 
-pub mod api_key;
-pub mod application_credential;
-pub mod assignment;
-pub mod auth;
-pub mod catalog;
-pub mod credential;
-pub mod error;
-pub mod events;
-pub mod federation;
-pub mod identity;
-pub mod idmapping;
-pub mod k8s_auth;
-pub mod mapping;
-pub mod resource;
-pub mod revoke;
-pub mod role;
-pub mod scope;
-pub mod token;
-pub mod trust;
-
-/// Return `true` to be used as a positive default for the serde macros.
-pub fn default_true() -> bool {
-    true
-}
+pub use credential::*;
+pub use error::*;

--- a/crates/core-types/src/credential/credential.rs
+++ b/crates/core-types/src/credential/credential.rs
@@ -1,0 +1,138 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Credential types
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use serde::Serialize;
+use serde_json::Value;
+use validator::Validate;
+
+use crate::error::BuilderError;
+
+/// The credential object as returned to API clients.
+///
+/// `blob` is the *decrypted* secret, serialised the same way Python Keystone
+/// serialises it: as a JSON-encoded **string** (not a nested object) — see
+/// ADR 0019 §2 "Wire format of `blob`". `encrypted_blob` and `key_hash` are
+/// never exposed here.
+#[derive(Builder, Clone, Debug, PartialEq, Serialize, Validate)]
+#[builder(setter(strip_option, into))]
+#[builder(build_fn(error = "BuilderError"))]
+pub struct Credential {
+    /// Extensible JSON field, stored by Python as a JSON-encoded string in a
+    /// `Text` column (`JsonBlob`). Modelled as a parsed map here for API
+    /// serialisation.
+    #[builder(default)]
+    pub extra: Option<HashMap<String, Value>>,
+
+    /// The ID of the credential. For `ec2` this is `SHA-256(blob['access'])`
+    /// hex-encoded; otherwise a random UUID.
+    #[validate(length(min = 1, max = 64))]
+    pub id: String,
+
+    /// The decrypted secret blob, as a JSON-encoded string.
+    pub blob: String,
+
+    /// The ID of the project associated with the credential (mandatory for
+    /// `ec2`).
+    #[builder(default)]
+    #[validate(length(max = 64))]
+    pub project_id: Option<String>,
+
+    /// The credential type (`ec2`, `totp`, or an arbitrary custom string).
+    #[validate(length(min = 1, max = 255))]
+    pub r#type: String,
+
+    /// The ID of the user who owns the credential.
+    #[validate(length(min = 1, max = 64))]
+    pub user_id: String,
+}
+
+/// The credential object to be created.
+#[derive(Builder, Clone, Debug, Default, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct CredentialCreate {
+    /// Extensible JSON field.
+    #[builder(default)]
+    pub extra: Option<HashMap<String, Value>>,
+
+    /// The decrypted secret blob, as a JSON string. For `ec2` must contain an
+    /// `access` key.
+    pub blob: String,
+
+    /// The ID of the credential. Computed by the service layer before the
+    /// backend call so it is known up-front for audit events: `ec2` uses
+    /// `SHA-256(blob['access'])` hex-encoded; other types use a random UUID
+    /// (ADR 0019 §1, ID Generation). Not user-settable via the public API.
+    #[builder(default)]
+    #[validate(length(min = 1, max = 64))]
+    pub id: Option<String>,
+
+    /// The ID of the project associated with the credential. Required if
+    /// `r#type` is `ec2`.
+    #[builder(default)]
+    #[validate(length(max = 64))]
+    pub project_id: Option<String>,
+
+    /// The credential type.
+    #[validate(length(min = 1, max = 255))]
+    pub r#type: String,
+
+    /// The ID of the user who owns the credential. Defaults to the
+    /// authenticated user when the request is user-scoped; must be supplied
+    /// explicitly under system scope (ADR 0019 §2, Create).
+    #[builder(default)]
+    #[validate(length(max = 64))]
+    pub user_id: Option<String>,
+}
+
+/// The credential object to be updated. Only `Some` fields are applied;
+/// `user_id` is intentionally absent — it is immutable (CVE-2020-12691).
+#[derive(Builder, Clone, Debug, Default, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct CredentialUpdate {
+    /// New decrypted secret blob (triggers re-encryption with the current
+    /// Primary Key and updates `key_hash`).
+    #[builder(default)]
+    pub blob: Option<String>,
+
+    /// New project association.
+    #[builder(default)]
+    #[validate(length(max = 64))]
+    pub project_id: Option<String>,
+
+    /// New credential type.
+    #[builder(default)]
+    #[validate(length(min = 1, max = 255))]
+    pub r#type: Option<String>,
+}
+
+/// Parameters for listing credentials.
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct CredentialListParameters {
+    /// Filter by credential type.
+    #[builder(default)]
+    #[validate(length(max = 255))]
+    pub r#type: Option<String>,
+
+    /// Filter by owning user.
+    #[builder(default)]
+    #[validate(length(max = 64))]
+    pub user_id: Option<String>,
+}

--- a/crates/core-types/src/credential/error.rs
+++ b/crates/core-types/src/credential/error.rs
@@ -1,0 +1,84 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Credential provider error.
+use thiserror::Error;
+
+use crate::error::BuilderError;
+
+/// Credential provider error.
+#[derive(Error, Debug)]
+pub enum CredentialProviderError {
+    /// Credential with the given ID was not found.
+    #[error("credential with id: {0} not found")]
+    CredentialNotFound(String),
+
+    /// EC2 access key hash collision on create (id derived from
+    /// `SHA-256(blob['access'])` already exists), or another uniqueness
+    /// conflict reported by the backend.
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Driver error.
+    #[error("backend driver error: {0}")]
+    Driver(String),
+
+    /// Fernet encryption/decryption error (e.g. all active keys failed to
+    /// decrypt `encrypted_blob`, or the key repository is unavailable).
+    #[error("credential encryption error: {0}")]
+    Encryption(String),
+
+    /// The `blob` field is not valid JSON, or is missing a mandatory
+    /// per-type field (e.g. `access` for `ec2`).
+    #[error("invalid credential blob: {0}")]
+    InvalidBlob(String),
+
+    /// Attempt to change a field that is immutable on update (`user_id`,
+    /// `project_id`, or the delegation fields inside the EC2 blob).
+    #[error("field `{0}` is immutable and cannot be updated")]
+    ImmutableField(String),
+
+    /// `user_id` was not provided on create and could not be defaulted
+    /// (e.g. the caller holds a system-scoped token).
+    #[error("user_id is required")]
+    MissingUserId,
+
+    /// `project_id` is mandatory for `ec2` credentials.
+    #[error("project_id is required for ec2 credentials")]
+    MissingProjectId,
+
+    /// (de)serialization error.
+    #[error(transparent)]
+    Serde {
+        #[from]
+        source: serde_json::Error,
+    },
+
+    /// Structures builder error.
+    #[error(transparent)]
+    StructBuilder {
+        #[from]
+        source: BuilderError,
+    },
+
+    /// Unsupported driver.
+    #[error("unsupported driver `{0}` for the credential provider")]
+    UnsupportedDriver(String),
+
+    /// Request validation error.
+    #[error("request validation error: {}", source)]
+    Validation {
+        #[from]
+        source: validator::ValidationErrors,
+    },
+}

--- a/crates/core-types/src/error.rs
+++ b/crates/core-types/src/error.rs
@@ -21,6 +21,7 @@ use crate::application_credential::ApplicationCredentialProviderError;
 use crate::assignment::AssignmentProviderError;
 use crate::auth::AuthenticationError;
 use crate::catalog::CatalogProviderError;
+use crate::credential::CredentialProviderError;
 use crate::federation::FederationProviderError;
 use crate::identity::IdentityProviderError;
 use crate::idmapping::IdMappingProviderError;
@@ -100,6 +101,14 @@ pub enum KeystoneError {
         /// The source of the error.
         #[from]
         source: CatalogProviderError,
+    },
+
+    /// Credential provider.
+    #[error(transparent)]
+    CredentialProvider {
+        /// The source of the error.
+        #[from]
+        source: CredentialProviderError,
     },
 
     /// Federation provider.

--- a/crates/core-types/src/events.rs
+++ b/crates/core-types/src/events.rs
@@ -110,6 +110,12 @@ pub enum EventPayload {
         user_id: String,
     },
 
+    // Credentials provider (ADR 0019: EC2/TOTP/custom credential blobs)
+    Credential {
+        id: String,
+        user_id: String,
+    },
+
     // Catalog
     Endpoint {
         id: String,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -52,7 +52,7 @@ scrypt = "0.11"
 subtle = "2.6.1"
 
 [dev-dependencies]
-axum = { workspace = true, default-features = false, features = ["json"] }
+axum = { workspace = true, default-features = false, features = ["json", "tokio"] }
 config = { workspace = true }
 httpmock = { version = "0.8", features = ["http2"] }
 mockall.workspace = true

--- a/crates/core/src/cadf_hook.rs
+++ b/crates/core/src/cadf_hook.rs
@@ -84,6 +84,7 @@ fn build_target_from_event(event: &Event) -> Target {
             (id, "data/security/identity/application-credential")
         }
         EventPayload::AccessRule { id, .. } => (id, "data/security/identity/access-rule"),
+        EventPayload::Credential { id, .. } => (id, "data/security/identity/credential"),
         EventPayload::Endpoint { id } => (id, "data/compute/catalog/endpoint"),
         EventPayload::Region { id } => (id, "data/compute/catalog/region"),
         EventPayload::Service { id } => (id, "data/compute/catalog/service"),

--- a/crates/core/src/credential/backend.rs
+++ b/crates/core/src/credential/backend.rs
@@ -1,0 +1,114 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Credential provider backend
+
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::credential::*;
+
+use crate::credential::CredentialProviderError;
+use crate::keystone::ServiceState;
+
+/// Credential backend driver interface (ADR 0019).
+///
+/// The backend owns the Fernet encryption/decryption of `blob` and the
+/// `key_hash` bookkeeping; every method here deals in plaintext `blob`
+/// values only. The backing `credential` table is owned and schema-managed
+/// exclusively by the Python Keystone service via `alembic` — no
+/// implementation of this trait may issue DDL against it.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait CredentialBackend: Send + Sync {
+    /// Create a new credential.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `rec`: The credential creation request (`user_id` must already be
+    ///   resolved by the caller — see ADR 0019 §2 for the system-scope rule).
+    ///
+    /// # Returns
+    /// - `Result<Credential, CredentialProviderError>` - The created credential
+    ///   (decrypted `blob`) or an error.
+    async fn create_credential(
+        &self,
+        state: &ServiceState,
+        rec: CredentialCreate,
+    ) -> Result<Credential, CredentialProviderError>;
+
+    /// Get a single credential by ID.
+    async fn get_credential<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Credential>, CredentialProviderError>;
+
+    /// Look up a credential by the plaintext EC2 access key
+    /// (`id == SHA-256(access)`). Used by the OS-EC2 legacy endpoints and by
+    /// `/v3/ec2tokens` (ADR 0019 §3, §5).
+    async fn get_credential_by_ec2_access<'a>(
+        &self,
+        state: &ServiceState,
+        access: &'a str,
+    ) -> Result<Option<Credential>, CredentialProviderError>;
+
+    /// List credentials matching the given driver-level hints
+    /// (`user_id`/`type`). Callers are responsible for the second policy
+    /// enforcement pass described in ADR 0019 §2 (CVE-2019-19687).
+    async fn list_credentials(
+        &self,
+        state: &ServiceState,
+        params: &CredentialListParameters,
+    ) -> Result<Vec<Credential>, CredentialProviderError>;
+
+    /// List all credentials owned by a user, optionally filtered by type.
+    /// Used by the TOTP/MFA auth pipeline (`type = "totp"`) and by the
+    /// OS-EC2 listing endpoint (`type = "ec2"`).
+    async fn list_credentials_for_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+        r#type: Option<&'a str>,
+    ) -> Result<Vec<Credential>, CredentialProviderError>;
+
+    /// Update a credential. Updating `blob` triggers re-encryption with the
+    /// current Primary Key and updates `key_hash`.
+    async fn update_credential<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        rec: CredentialUpdate,
+    ) -> Result<Credential, CredentialProviderError>;
+
+    /// Delete a credential by ID.
+    async fn delete_credential<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CredentialProviderError>;
+
+    /// Delete all credentials owned by a user (identity lifecycle cascade).
+    async fn delete_credentials_for_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<(), CredentialProviderError>;
+
+    /// Delete all credentials bound to a project (identity lifecycle
+    /// cascade; primarily EC2 credentials).
+    async fn delete_credentials_for_project<'a>(
+        &self,
+        state: &ServiceState,
+        project_id: &'a str,
+    ) -> Result<(), CredentialProviderError>;
+}

--- a/crates/core/src/credential/error.rs
+++ b/crates/core/src/credential/error.rs
@@ -11,33 +11,15 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+//! # Credential provider error.
+pub use openstack_keystone_core_types::credential::CredentialProviderError;
 
-//! # OpenStack Keystone core provider types
-
-#![allow(clippy::module_inception)]
-#![deny(clippy::unwrap_used)]
-
-pub mod api_key;
-pub mod application_credential;
-pub mod assignment;
-pub mod auth;
-pub mod catalog;
-pub mod credential;
-pub mod error;
-pub mod events;
-pub mod federation;
-pub mod identity;
-pub mod idmapping;
-pub mod k8s_auth;
-pub mod mapping;
-pub mod resource;
-pub mod revoke;
-pub mod role;
-pub mod scope;
-pub mod token;
-pub mod trust;
-
-/// Return `true` to be used as a positive default for the serde macros.
-pub fn default_true() -> bool {
-    true
+impl From<crate::error::DatabaseError> for CredentialProviderError {
+    /// Convert a database error into a credential provider error.
+    fn from(source: crate::error::DatabaseError) -> Self {
+        match source {
+            cfl @ crate::error::DatabaseError::Conflict { .. } => Self::Conflict(cfl.to_string()),
+            other => Self::Driver(other.to_string()),
+        }
+    }
 }

--- a/crates/core/src/credential/hook.rs
+++ b/crates/core/src/credential/hook.rs
@@ -1,0 +1,44 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Credential provider hooks for inter-provider events.
+
+use crate::events::ProviderHooks;
+use crate::keystone::ServiceState;
+use async_trait::async_trait;
+use openstack_keystone_core_types::events::Event;
+
+/// Hook that subscribes the credential provider to inter-provider events.
+///
+/// Not yet wired to cascading user/project deletion (ADR 0019 §3, Identity
+/// Lifecycle Management) — that requires the identity/resource providers to
+/// call `delete_credentials_for_user`/`delete_credentials_for_project`
+/// directly or dispatch a deletion event for this hook to react to. This
+/// mirrors the same as-yet-unwired stub pattern used by every other provider
+/// hook in this crate.
+pub struct CredentialHook {
+    #[allow(unused)]
+    state: ServiceState,
+}
+
+impl CredentialHook {
+    /// Create a new hook bound to the given service state.
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ProviderHooks for CredentialHook {
+    async fn on_event(&self, _event: &Event) {}
+}

--- a/crates/core/src/credential/mod.rs
+++ b/crates/core/src/credential/mod.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Credentials provider (ADR 0019)
+//!
+//! Blind storage for sensitive authentication secrets (EC2 access/secret
+//! keys, TOTP seeds, and arbitrary third-party blobs), encrypted at rest
+//! with Fernet using a key repository separate from `[fernet_tokens]`. The
+//! `credential` table is owned and schema-managed exclusively by the Python
+//! Keystone service via `alembic`; Keystone-NG treats it as read/write but
+//! never issues DDL against it, and all encryption/hashing behaviour is
+//! byte-for-byte compatible with Python Keystone so blobs written by either
+//! service can be decrypted by the other.
+
+pub mod backend;
+pub mod error;
+pub mod hook;
+mod provider_api;
+pub mod service;
+
+pub use error::CredentialProviderError;
+pub use hook::CredentialHook;
+pub use provider_api::CredentialApi;
+pub use service::CredentialService;
+
+#[cfg(any(test, feature = "mock"))]
+pub use crate::mocks::MockCredentialProvider;

--- a/crates/core/src/credential/provider_api.rs
+++ b/crates/core/src/credential/provider_api.rs
@@ -1,0 +1,98 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::credential::*;
+
+use crate::auth::ExecutionContext;
+use crate::credential::error::CredentialProviderError;
+
+/// Credentials API (ADR 0019).
+#[async_trait]
+pub trait CredentialApi: Send + Sync {
+    /// Create a new credential.
+    ///
+    /// `rec.user_id` must already be resolved by the caller: defaulted to the
+    /// authenticated user under user scope, or rejected with
+    /// `CredentialProviderError::MissingUserId` if absent under system scope
+    /// (ADR 0019 §2).
+    async fn create_credential<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        rec: CredentialCreate,
+    ) -> Result<Credential, CredentialProviderError>;
+
+    /// Get a single credential by ID.
+    async fn get_credential<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        id: &'a str,
+    ) -> Result<Option<Credential>, CredentialProviderError>;
+
+    /// Look up a credential by the plaintext EC2 access key.
+    async fn get_credential_by_ec2_access<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        access: &'a str,
+    ) -> Result<Option<Credential>, CredentialProviderError>;
+
+    /// List credentials matching the given driver-level hints. Note: this
+    /// does not perform the second, per-item `identity:get_credential`
+    /// policy pass required by ADR 0019 §2 (CVE-2019-19687) — that is the
+    /// API layer's responsibility, since it is the layer with access to the
+    /// policy engine.
+    async fn list_credentials<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        params: &CredentialListParameters,
+    ) -> Result<Vec<Credential>, CredentialProviderError>;
+
+    /// List all credentials owned by a user, optionally filtered by type.
+    async fn list_credentials_for_user<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        user_id: &'a str,
+        r#type: Option<&'a str>,
+    ) -> Result<Vec<Credential>, CredentialProviderError>;
+
+    /// Update a credential.
+    async fn update_credential<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        id: &'a str,
+        rec: CredentialUpdate,
+    ) -> Result<Credential, CredentialProviderError>;
+
+    /// Delete a credential by ID.
+    async fn delete_credential<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        id: &'a str,
+    ) -> Result<(), CredentialProviderError>;
+
+    /// Delete all credentials owned by a user.
+    async fn delete_credentials_for_user<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        user_id: &'a str,
+    ) -> Result<(), CredentialProviderError>;
+
+    /// Delete all credentials bound to a project.
+    async fn delete_credentials_for_project<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        project_id: &'a str,
+    ) -> Result<(), CredentialProviderError>;
+}

--- a/crates/core/src/credential/service.rs
+++ b/crates/core/src/credential/service.rs
@@ -1,0 +1,487 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Credentials provider (ADR 0019)
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+use validator::Validate;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core_types::auth::ScopeInfo;
+use openstack_keystone_core_types::credential::*;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
+
+use crate::auth::ExecutionContext;
+use crate::credential::{CredentialApi, CredentialProviderError, backend::CredentialBackend};
+use crate::events::AuditDispatchError;
+use crate::plugin_manager::PluginManagerApi;
+
+/// Fields inside the EC2 `blob` that are immutable on update (ADR 0019 §2,
+/// Update; CVE-2020-12691 fix scope extended to the delegation fields).
+const IMMUTABLE_BLOB_FIELDS: &[&str] = &["access", "trust_id", "app_cred_id", "access_token_id"];
+
+/// Credential provider.
+pub struct CredentialService {
+    backend_driver: Arc<dyn CredentialBackend>,
+}
+
+impl CredentialService {
+    /// Create a new credential service.
+    pub fn new<P: PluginManagerApi>(
+        config: &Config,
+        plugin_manager: &P,
+    ) -> Result<Self, CredentialProviderError> {
+        let backend_driver = plugin_manager
+            .get_credential_backend(config.credential.driver.clone())?
+            .clone();
+        Ok(Self { backend_driver })
+    }
+}
+
+#[async_trait]
+impl CredentialApi for CredentialService {
+    async fn create_credential<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        rec: CredentialCreate,
+    ) -> Result<Credential, CredentialProviderError> {
+        rec.validate()?;
+        let mut rec = rec;
+
+        if rec.r#type == "ec2" && rec.project_id.is_none() {
+            return Err(CredentialProviderError::MissingProjectId);
+        }
+
+        if rec.user_id.is_none() {
+            match ctx.ctx() {
+                Some(vsc) => {
+                    // Under system scope there is no implicit "acting user"
+                    // to default to (ADR 0019 §2, Create).
+                    let is_system_scoped = matches!(
+                        vsc.authorization().map(|a| &a.scope),
+                        Some(ScopeInfo::System(_))
+                    );
+                    if is_system_scoped {
+                        return Err(CredentialProviderError::MissingUserId);
+                    }
+                    rec.user_id = Some(vsc.principal().get_user_id());
+                }
+                None => return Err(CredentialProviderError::MissingUserId),
+            }
+        }
+
+        if rec.id.is_none() {
+            rec.id = Some(if rec.r#type == "ec2" {
+                let blob_val: Value = serde_json::from_str(&rec.blob)
+                    .map_err(|e| CredentialProviderError::InvalidBlob(e.to_string()))?;
+                let access = blob_val
+                    .get("access")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        CredentialProviderError::InvalidBlob(
+                            "ec2 blob missing mandatory `access` field".into(),
+                        )
+                    })?;
+                let mut hasher = Sha256::new();
+                hasher.update(access.as_bytes());
+                hasher
+                    .finalize()
+                    .iter()
+                    .map(|b| format!("{b:02x}"))
+                    .collect::<String>()
+            } else {
+                Uuid::new_v4().simple().to_string()
+            });
+        }
+
+        let user_id = rec.user_id.clone().unwrap_or_default();
+        let cred_id = rec.id.clone().unwrap_or_default();
+        let credential = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let rec_clone = rec.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::Credential {
+                        id: cred_id.clone(),
+                        user_id: user_id.clone(),
+                    },
+                ),
+                operation: async {
+                    backend_driver.create_credential(ctx.state(), rec_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| CredentialProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let credential = self
+                .backend_driver
+                .create_credential(ctx.state(), rec)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::Credential {
+                        id: credential.id.clone(),
+                        user_id: user_id.clone(),
+                    },
+                ))
+                .await;
+
+            credential
+        };
+
+        Ok(credential)
+    }
+
+    async fn get_credential<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        id: &'a str,
+    ) -> Result<Option<Credential>, CredentialProviderError> {
+        self.backend_driver.get_credential(ctx.state(), id).await
+    }
+
+    async fn get_credential_by_ec2_access<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        access: &'a str,
+    ) -> Result<Option<Credential>, CredentialProviderError> {
+        self.backend_driver
+            .get_credential_by_ec2_access(ctx.state(), access)
+            .await
+    }
+
+    async fn list_credentials<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        params: &CredentialListParameters,
+    ) -> Result<Vec<Credential>, CredentialProviderError> {
+        self.backend_driver
+            .list_credentials(ctx.state(), params)
+            .await
+    }
+
+    async fn list_credentials_for_user<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        user_id: &'a str,
+        r#type: Option<&'a str>,
+    ) -> Result<Vec<Credential>, CredentialProviderError> {
+        self.backend_driver
+            .list_credentials_for_user(ctx.state(), user_id, r#type)
+            .await
+    }
+
+    async fn update_credential<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        id: &'a str,
+        rec: CredentialUpdate,
+    ) -> Result<Credential, CredentialProviderError> {
+        rec.validate()?;
+
+        if let Some(new_blob) = &rec.blob {
+            let existing = self
+                .backend_driver
+                .get_credential(ctx.state(), id)
+                .await?
+                .ok_or_else(|| CredentialProviderError::CredentialNotFound(id.to_string()))?;
+
+            let old_val: Value = serde_json::from_str(&existing.blob)?;
+            let new_val: Value = serde_json::from_str(new_blob)?;
+            for field in IMMUTABLE_BLOB_FIELDS {
+                if old_val.get(field) != new_val.get(field) {
+                    return Err(CredentialProviderError::ImmutableField(
+                        (*field).to_string(),
+                    ));
+                }
+            }
+        }
+
+        let user_id = self
+            .backend_driver
+            .get_credential(ctx.state(), id)
+            .await?
+            .map(|c| c.user_id)
+            .unwrap_or_default();
+
+        let credential = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let rec_clone = rec.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::Credential {
+                        id: id.to_string(),
+                        user_id: user_id.clone(),
+                    },
+                ),
+                operation: async {
+                    backend_driver.update_credential(ctx.state(), id, rec_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| CredentialProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            self.backend_driver
+                .update_credential(ctx.state(), id, rec)
+                .await?
+        };
+
+        Ok(credential)
+    }
+
+    async fn delete_credential<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        id: &'a str,
+    ) -> Result<(), CredentialProviderError> {
+        let user_id = self
+            .backend_driver
+            .get_credential(ctx.state(), id)
+            .await?
+            .map(|c| c.user_id)
+            .unwrap_or_default();
+
+        if let Some(vsc) = ctx.ctx() {
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::Credential {
+                        id: id.to_string(),
+                        user_id: user_id.clone(),
+                    },
+                ),
+                operation: async {
+                    self.backend_driver.delete_credential(ctx.state(), id).await?;
+                    Ok::<(), CredentialProviderError>(())
+                },
+                on_audit_error: |_: AuditDispatchError| CredentialProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver
+                .delete_credential(ctx.state(), id)
+                .await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::Credential {
+                        id: id.to_string(),
+                        user_id,
+                    },
+                ))
+                .await;
+        }
+
+        Ok(())
+    }
+
+    async fn delete_credentials_for_user<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        user_id: &'a str,
+    ) -> Result<(), CredentialProviderError> {
+        self.backend_driver
+            .delete_credentials_for_user(ctx.state(), user_id)
+            .await
+    }
+
+    async fn delete_credentials_for_project<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        project_id: &'a str,
+    ) -> Result<(), CredentialProviderError> {
+        self.backend_driver
+            .delete_credentials_for_project(ctx.state(), project_id)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credential::backend::MockCredentialBackend;
+    use crate::tests::get_mocked_state;
+
+    fn create_provider(backend: MockCredentialBackend) -> CredentialService {
+        CredentialService {
+            backend_driver: Arc::new(backend),
+        }
+    }
+
+    fn ec2_id(access: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(access.as_bytes());
+        hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_create_ec2_requires_project_id() {
+        let state = get_mocked_state(None, None).await;
+        let provider = create_provider(MockCredentialBackend::default());
+
+        let rec = CredentialCreate {
+            blob: r#"{"access":"AKIA123"}"#.into(),
+            r#type: "ec2".into(),
+            user_id: Some("user_id".into()),
+            project_id: None,
+            ..Default::default()
+        };
+
+        let err = provider
+            .create_credential(&ExecutionContext::internal(&state), rec)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CredentialProviderError::MissingProjectId));
+    }
+
+    #[tokio::test]
+    async fn test_create_requires_user_id_when_no_context() {
+        let state = get_mocked_state(None, None).await;
+        let provider = create_provider(MockCredentialBackend::default());
+
+        let rec = CredentialCreate {
+            blob: r#"{"seed":"JBSWY3DPEHPK3PXP"}"#.into(),
+            r#type: "totp".into(),
+            user_id: None,
+            ..Default::default()
+        };
+
+        let err = provider
+            .create_credential(&ExecutionContext::internal(&state), rec)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CredentialProviderError::MissingUserId));
+    }
+
+    #[tokio::test]
+    async fn test_create_ec2_computes_sha256_id() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockCredentialBackend::default();
+        let expected_id = ec2_id("AKIAIOSFODNN7EXAMPLE");
+        let expected_id_clone = expected_id.clone();
+        backend
+            .expect_create_credential()
+            .withf(move |_, rec: &CredentialCreate| {
+                rec.id.as_deref() == Some(expected_id_clone.as_str())
+            })
+            .returning(move |_, rec| {
+                Ok(Credential {
+                    id: rec.id.clone().unwrap_or_default(),
+                    user_id: rec.user_id.clone().unwrap_or_default(),
+                    project_id: rec.project_id.clone(),
+                    blob: rec.blob.clone(),
+                    r#type: rec.r#type.clone(),
+                    extra: rec.extra.clone(),
+                })
+            });
+        let provider = create_provider(backend);
+
+        let rec = CredentialCreate {
+            blob: r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"x"}"#.into(),
+            r#type: "ec2".into(),
+            user_id: Some("user_id".into()),
+            project_id: Some("project_id".into()),
+            ..Default::default()
+        };
+
+        let created = provider
+            .create_credential(&ExecutionContext::internal(&state), rec)
+            .await
+            .unwrap();
+        assert_eq!(created.id, expected_id);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_change_to_immutable_access_field() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockCredentialBackend::default();
+        backend.expect_get_credential().returning(|_, _| {
+            Ok(Some(Credential {
+                id: "cred_id".into(),
+                user_id: "user_id".into(),
+                project_id: Some("project_id".into()),
+                blob: r#"{"access":"AKIA_OLD","secret":"s"}"#.into(),
+                r#type: "ec2".into(),
+                extra: None,
+            }))
+        });
+        let provider = create_provider(backend);
+
+        let rec = CredentialUpdate {
+            blob: Some(r#"{"access":"AKIA_NEW","secret":"s"}"#.into()),
+            ..Default::default()
+        };
+
+        let err = provider
+            .update_credential(&ExecutionContext::internal(&state), "cred_id", rec)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CredentialProviderError::ImmutableField(f) if f == "access"));
+    }
+
+    #[tokio::test]
+    async fn test_update_allows_blob_change_when_immutable_fields_unchanged() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockCredentialBackend::default();
+        backend.expect_get_credential().returning(|_, _| {
+            Ok(Some(Credential {
+                id: "cred_id".into(),
+                user_id: "user_id".into(),
+                project_id: Some("project_id".into()),
+                blob: r#"{"access":"AKIA_OLD","secret":"old"}"#.into(),
+                r#type: "ec2".into(),
+                extra: None,
+            }))
+        });
+        backend.expect_update_credential().returning(|_, id, _| {
+            Ok(Credential {
+                id: id.to_string(),
+                user_id: "user_id".into(),
+                project_id: Some("project_id".into()),
+                blob: r#"{"access":"AKIA_OLD","secret":"new"}"#.into(),
+                r#type: "ec2".into(),
+                extra: None,
+            })
+        });
+        let provider = create_provider(backend);
+
+        let rec = CredentialUpdate {
+            blob: Some(r#"{"access":"AKIA_OLD","secret":"new"}"#.into()),
+            ..Default::default()
+        };
+
+        let updated = provider
+            .update_credential(&ExecutionContext::internal(&state), "cred_id", rec)
+            .await
+            .unwrap();
+        assert_eq!(updated.blob, r#"{"access":"AKIA_OLD","secret":"new"}"#);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -85,6 +85,7 @@ pub mod auth;
 pub mod cadf_hook;
 pub mod catalog;
 pub mod common;
+pub mod credential;
 pub mod db;
 pub mod error;
 pub mod events;

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -174,6 +174,78 @@ mod application_credential {
 }
 pub use application_credential::MockApplicationCredentialProvider;
 
+mod credential {
+    use super::*;
+
+    use openstack_keystone_core_types::credential::*;
+
+    use crate::credential::{CredentialApi, CredentialProviderError};
+
+    mock! {
+        pub CredentialProvider {}
+
+        #[async_trait]
+        impl CredentialApi for CredentialProvider {
+            async fn create_credential<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                rec: CredentialCreate,
+            ) -> Result<Credential, CredentialProviderError>;
+
+            async fn get_credential<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                id: &'a str,
+            ) -> Result<Option<Credential>, CredentialProviderError>;
+
+            async fn get_credential_by_ec2_access<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                access: &'a str,
+            ) -> Result<Option<Credential>, CredentialProviderError>;
+
+            async fn list_credentials<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                params: &CredentialListParameters,
+            ) -> Result<Vec<Credential>, CredentialProviderError>;
+
+            async fn list_credentials_for_user<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                user_id: &'a str,
+                r#type: Option<&'a str>,
+            ) -> Result<Vec<Credential>, CredentialProviderError>;
+
+            async fn update_credential<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                id: &'a str,
+                rec: CredentialUpdate,
+            ) -> Result<Credential, CredentialProviderError>;
+
+            async fn delete_credential<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                id: &'a str,
+            ) -> Result<(), CredentialProviderError>;
+
+            async fn delete_credentials_for_user<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                user_id: &'a str,
+            ) -> Result<(), CredentialProviderError>;
+
+            async fn delete_credentials_for_project<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                project_id: &'a str,
+            ) -> Result<(), CredentialProviderError>;
+        }
+    }
+}
+pub use credential::MockCredentialProvider;
+
 mod assignment {
     use super::*;
 

--- a/crates/core/src/plugin_manager.rs
+++ b/crates/core/src/plugin_manager.rs
@@ -31,6 +31,8 @@ use crate::assignment::backend::AssignmentBackend;
 use crate::assignment::error::AssignmentProviderError;
 use crate::catalog::backend::CatalogBackend;
 use crate::catalog::error::CatalogProviderError;
+use crate::credential::CredentialProviderError;
+use crate::credential::backend::CredentialBackend;
 use crate::federation::backend::FederationBackend;
 use crate::federation::error::FederationProviderError;
 use crate::identity::backend::IdentityBackend;
@@ -106,6 +108,19 @@ pub trait PluginManagerApi {
         &self,
         name: S,
     ) -> Result<&Arc<dyn CatalogBackend>, CatalogProviderError>;
+
+    /// Get registered credential backend.
+    ///
+    /// # Parameters
+    /// - `name`: The name of the backend to retrieve.
+    ///
+    /// # Returns
+    /// - `Ok(&Arc<dyn CredentialBackend>)` if found, otherwise
+    ///   `Err(CredentialProviderError)`.
+    fn get_credential_backend<S: AsRef<str>>(
+        &self,
+        name: S,
+    ) -> Result<&Arc<dyn CredentialBackend>, CredentialProviderError>;
 
     /// Get registered federation backend.
     ///
@@ -266,6 +281,17 @@ pub trait PluginManagerApi {
         &mut self,
         name: S,
         plugin: Arc<dyn ApplicationCredentialBackend>,
+    );
+
+    /// Register credential backend.
+    ///
+    /// # Parameters
+    /// - `name`: The name to register the backend under.
+    /// - `plugin`: The backend implementation.
+    fn register_credential_backend<S: AsRef<str>>(
+        &mut self,
+        name: S,
+        plugin: Arc<dyn CredentialBackend>,
     );
 
     /// Register assignment backend.

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -34,6 +34,9 @@ use crate::assignment::MockAssignmentProvider;
 use crate::catalog::CatalogApi;
 #[cfg(any(test, feature = "mock"))]
 use crate::catalog::MockCatalogProvider;
+use crate::credential::CredentialApi;
+#[cfg(any(test, feature = "mock"))]
+use crate::credential::MockCredentialProvider;
 use crate::error::KeystoneError;
 use crate::federation::FederationApi;
 #[cfg(any(test, feature = "mock"))]
@@ -80,6 +83,8 @@ pub struct Provider {
     assignment: Box<dyn AssignmentApi>,
     /// Catalog provider.
     catalog: Box<dyn CatalogApi>,
+    /// Credential provider.
+    credential: Box<dyn CredentialApi>,
     /// Federation provider.
     federation: Box<dyn FederationApi>,
     /// Identity provider.
@@ -128,6 +133,12 @@ impl ProviderBuilder {
     pub fn mock_catalog(self, value: impl CatalogApi + 'static) -> Self {
         let mut new = self;
         new.catalog = Some(Box::new(value));
+        new
+    }
+
+    pub fn mock_credential(self, value: impl CredentialApi + 'static) -> Self {
+        let mut new = self;
+        new.credential = Some(Box::new(value));
         new
     }
 
@@ -208,6 +219,10 @@ impl Provider {
             plugin_manager,
         )?);
         let catalog = Box::new(crate::catalog::CatalogService::new(cfg, plugin_manager)?);
+        let credential = Box::new(crate::credential::CredentialService::new(
+            cfg,
+            plugin_manager,
+        )?);
         let federation = Box::new(crate::federation::FederationService::new(
             cfg,
             plugin_manager,
@@ -233,6 +248,7 @@ impl Provider {
             application_credential,
             assignment,
             catalog,
+            credential,
             federation,
             identity,
             idmapping,
@@ -254,6 +270,7 @@ impl Provider {
             .mock_application_credential(MockApplicationCredentialProvider::default())
             .mock_assignment(MockAssignmentProvider::default())
             .mock_catalog(MockCatalogProvider::default())
+            .mock_credential(MockCredentialProvider::default())
             .mock_identity(MockIdentityProvider::default())
             .mock_idmapping(MockIdMappingProvider::default())
             .mock_mapping(MockMappingProvider::default())
@@ -284,6 +301,11 @@ impl Provider {
     /// Get the catalog provider.
     pub fn get_catalog_provider(&self) -> &dyn CatalogApi {
         &*self.catalog
+    }
+
+    /// Get the credential provider.
+    pub fn get_credential_provider(&self) -> &dyn CredentialApi {
+        &*self.credential
     }
 
     /// Get the federation provider.

--- a/crates/credential-driver-sql/Cargo.toml
+++ b/crates/credential-driver-sql/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "openstack-keystone-credential-driver-sql"
+description = "OpenStack Keystone credentials SQL driver (ADR 0019)"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+exclude.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+base64 = { workspace = true }
+fernet = { workspace = true, features = ["rustcrypto"] }
+inventory.workspace = true
+nix = { workspace = true, features = ["fs", "user"] }
+openstack-keystone-config.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
+scopeguard = { workspace = true }
+sea-orm = { workspace = true, features = ["default"] }
+secrecy = { workspace = true }
+serde_json.workspace = true
+sha1 = { workspace = true }
+sha2.workspace = true
+tempfile = { workspace = true }
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs", "macros"] }
+tracing.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+openstack-keystone-core = { workspace = true, features = ["mock"] }
+sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite"] }
+tempfile = { workspace = true }
+
+[features]
+test-support = []
+
+[lints]
+workspace = true

--- a/crates/credential-driver-sql/src/credential.rs
+++ b/crates/credential-driver-sql/src/credential.rs
@@ -1,0 +1,111 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Credentials SQL backend (ADR 0019)
+
+mod create;
+mod delete;
+pub(crate) mod get;
+mod list;
+mod update;
+
+use async_trait::async_trait;
+
+use openstack_keystone_core::credential::{CredentialProviderError, backend::CredentialBackend};
+use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core_types::credential::*;
+
+use crate::SqlBackend;
+
+#[async_trait]
+impl CredentialBackend for SqlBackend {
+    async fn create_credential(
+        &self,
+        state: &ServiceState,
+        rec: CredentialCreate,
+    ) -> Result<Credential, CredentialProviderError> {
+        let cfg = state.config_manager.config.read().await;
+        create::create(&cfg, &state.db, rec).await
+    }
+
+    async fn get_credential<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<Option<Credential>, CredentialProviderError> {
+        let cfg = state.config_manager.config.read().await;
+        get::get(&cfg, &state.db, id).await
+    }
+
+    async fn get_credential_by_ec2_access<'a>(
+        &self,
+        state: &ServiceState,
+        access: &'a str,
+    ) -> Result<Option<Credential>, CredentialProviderError> {
+        let cfg = state.config_manager.config.read().await;
+        get::get_by_ec2_access(&cfg, &state.db, access).await
+    }
+
+    async fn list_credentials(
+        &self,
+        state: &ServiceState,
+        params: &CredentialListParameters,
+    ) -> Result<Vec<Credential>, CredentialProviderError> {
+        let cfg = state.config_manager.config.read().await;
+        list::list(&cfg, &state.db, params).await
+    }
+
+    async fn list_credentials_for_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+        r#type: Option<&'a str>,
+    ) -> Result<Vec<Credential>, CredentialProviderError> {
+        let cfg = state.config_manager.config.read().await;
+        list::list_for_user(&cfg, &state.db, user_id, r#type).await
+    }
+
+    async fn update_credential<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+        rec: CredentialUpdate,
+    ) -> Result<Credential, CredentialProviderError> {
+        let cfg = state.config_manager.config.read().await;
+        update::update(&cfg, &state.db, id, rec).await
+    }
+
+    async fn delete_credential<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), CredentialProviderError> {
+        delete::delete(&state.db, id).await
+    }
+
+    async fn delete_credentials_for_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<(), CredentialProviderError> {
+        delete::delete_for_user(&state.db, user_id).await
+    }
+
+    async fn delete_credentials_for_project<'a>(
+        &self,
+        state: &ServiceState,
+        project_id: &'a str,
+    ) -> Result<(), CredentialProviderError> {
+        delete::delete_for_project(&state.db, project_id).await
+    }
+}

--- a/crates/credential-driver-sql/src/credential/create.rs
+++ b/crates/credential-driver-sql/src/credential/create.rs
@@ -1,0 +1,72 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::ActiveValue::Set;
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core::credential::CredentialProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::credential::*;
+
+use crate::entity::credential as db_credential;
+use crate::fernet::FernetKeyRepository;
+
+/// Create a new credential row, encrypting `rec.blob` with the current
+/// Primary Key.
+///
+/// `rec.id` and `rec.user_id` must already be resolved by the caller (the
+/// core `CredentialService` computes the EC2/UUID id and defaults
+/// `user_id` before calling the backend — ADR 0019 §1, §2).
+pub async fn create(
+    cfg: &Config,
+    db: &DatabaseConnection,
+    rec: CredentialCreate,
+) -> Result<Credential, CredentialProviderError> {
+    let id = rec
+        .id
+        .clone()
+        .ok_or_else(|| CredentialProviderError::Driver("credential id not set".into()))?;
+    let user_id = rec
+        .user_id
+        .clone()
+        .ok_or(CredentialProviderError::MissingUserId)?;
+
+    let repo = FernetKeyRepository::new(cfg.credential.key_repository.clone());
+    let keys = repo.load(cfg.credential.insecure_allow_null_key)?;
+    let encrypted_blob = keys.multi_fernet.encrypt(rec.blob.as_bytes());
+
+    let extra = rec.extra.as_ref().map(serde_json::to_string).transpose()?;
+
+    let model = db_credential::ActiveModel {
+        id: Set(id.clone()),
+        user_id: Set(user_id.clone()),
+        project_id: Set(rec.project_id.clone()),
+        encrypted_blob: Set(encrypted_blob),
+        r#type: Set(rec.r#type.clone()),
+        key_hash: Set(keys.primary_key_hash),
+        extra: Set(extra),
+    };
+    model.insert(db).await.context("creating credential")?;
+
+    Ok(Credential {
+        id,
+        user_id,
+        project_id: rec.project_id,
+        blob: rec.blob,
+        r#type: rec.r#type,
+        extra: rec.extra,
+    })
+}

--- a/crates/credential-driver-sql/src/credential/delete.rs
+++ b/crates/credential-driver-sql/src/credential/delete.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_core::credential::CredentialProviderError;
+use openstack_keystone_core::error::DbContextExt;
+
+use crate::entity::{credential as db_credential, prelude::Credential as DbCredential};
+
+/// Delete a credential by ID.
+pub async fn delete(db: &DatabaseConnection, id: &str) -> Result<(), CredentialProviderError> {
+    DbCredential::delete_many()
+        .filter(db_credential::Column::Id.eq(id))
+        .exec(db)
+        .await
+        .context("deleting credential")?;
+    Ok(())
+}
+
+/// Delete all credentials owned by a user (identity lifecycle cascade).
+pub async fn delete_for_user(
+    db: &DatabaseConnection,
+    user_id: &str,
+) -> Result<(), CredentialProviderError> {
+    DbCredential::delete_many()
+        .filter(db_credential::Column::UserId.eq(user_id))
+        .exec(db)
+        .await
+        .context("deleting credentials for user")?;
+    Ok(())
+}
+
+/// Delete all credentials bound to a project (identity lifecycle cascade;
+/// primarily EC2 credentials).
+pub async fn delete_for_project(
+    db: &DatabaseConnection,
+    project_id: &str,
+) -> Result<(), CredentialProviderError> {
+    DbCredential::delete_many()
+        .filter(db_credential::Column::ProjectId.eq(project_id))
+        .exec(db)
+        .await
+        .context("deleting credentials for project")?;
+    Ok(())
+}

--- a/crates/credential-driver-sql/src/credential/get.rs
+++ b/crates/credential-driver-sql/src/credential/get.rs
@@ -1,0 +1,143 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core::credential::CredentialProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::credential::*;
+
+use crate::entity::{credential as db_credential, prelude::Credential as DbCredential};
+use crate::fernet::FernetKeyRepository;
+
+/// Decrypt a stored credential row into the plaintext API representation.
+pub fn to_plaintext(
+    cfg: &Config,
+    model: db_credential::Model,
+) -> Result<Credential, CredentialProviderError> {
+    let repo = FernetKeyRepository::new(cfg.credential.key_repository.clone());
+    let keys = repo.load(cfg.credential.insecure_allow_null_key)?;
+    let plaintext = keys
+        .multi_fernet
+        .decrypt(&model.encrypted_blob)
+        .map_err(|_| CredentialProviderError::Encryption("failed to decrypt blob".into()))?;
+    let blob = String::from_utf8(plaintext)
+        .map_err(|e| CredentialProviderError::Encryption(e.to_string()))?;
+
+    let extra = model
+        .extra
+        .as_ref()
+        .filter(|e| e.as_str() != "{}")
+        .map(|e| serde_json::from_str(e))
+        .transpose()?;
+
+    Ok(Credential {
+        id: model.id,
+        user_id: model.user_id,
+        project_id: model.project_id,
+        blob,
+        r#type: model.r#type,
+        extra,
+    })
+}
+
+/// Get a credential by its ID.
+pub async fn get<I: AsRef<str>>(
+    cfg: &Config,
+    db: &DatabaseConnection,
+    id: I,
+) -> Result<Option<Credential>, CredentialProviderError> {
+    let select = DbCredential::find().filter(db_credential::Column::Id.eq(id.as_ref()));
+
+    if let Some(model) = select.one(db).await.context("fetching credential by id")? {
+        return Ok(Some(to_plaintext(cfg, model)?));
+    }
+    Ok(None)
+}
+
+/// Get a credential by the plaintext EC2 access key
+/// (`id == SHA-256(access)`).
+pub async fn get_by_ec2_access(
+    cfg: &Config,
+    db: &DatabaseConnection,
+    access: &str,
+) -> Result<Option<Credential>, CredentialProviderError> {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(access.as_bytes());
+    let id: String = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+
+    get(cfg, db, &id).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+
+    fn mock_model() -> db_credential::Model {
+        db_credential::Model {
+            id: "cred_id".into(),
+            user_id: "user_id".into(),
+            project_id: Some("project_id".into()),
+            encrypted_blob: String::new(),
+            r#type: "custom".into(),
+            key_hash: "deadbeef".into(),
+            extra: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_not_found() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<db_credential::Model, _, _>([vec![]])
+            .into_connection();
+        let cfg = Config::default();
+
+        assert_eq!(get(&cfg, &db, "missing").await.unwrap(), None);
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "credential"."id", "credential"."user_id", "credential"."project_id", "credential"."encrypted_blob", "credential"."type", "credential"."key_hash", "credential"."extra" FROM "credential" WHERE "credential"."id" = $1 LIMIT $2"#,
+                ["missing".into(), 1u64.into()]
+            )]
+        );
+    }
+
+    #[test]
+    fn test_to_plaintext_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = Config::default();
+        cfg.credential.key_repository = dir.path().to_path_buf();
+        let repo = FernetKeyRepository::new(cfg.credential.key_repository.clone());
+        repo.setup().unwrap();
+        let keys = repo.load(false).unwrap();
+
+        let mut model = mock_model();
+        model.encrypted_blob = keys.multi_fernet.encrypt(br#"{"access":"AKIA"}"#);
+
+        let cred = to_plaintext(&cfg, model).unwrap();
+        assert_eq!(cred.blob, r#"{"access":"AKIA"}"#);
+        assert_eq!(cred.id, "cred_id");
+    }
+}

--- a/crates/credential-driver-sql/src/credential/list.rs
+++ b/crates/credential-driver-sql/src/credential/list.rs
@@ -1,0 +1,67 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core::credential::CredentialProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::credential::*;
+
+use crate::credential::get::to_plaintext;
+use crate::entity::{credential as db_credential, prelude::Credential as DbCredential};
+
+/// List credentials matching the given driver-level hints
+/// (`user_id`/`type`).
+pub async fn list(
+    cfg: &Config,
+    db: &DatabaseConnection,
+    params: &CredentialListParameters,
+) -> Result<Vec<Credential>, CredentialProviderError> {
+    let mut select = DbCredential::find();
+    if let Some(user_id) = &params.user_id {
+        select = select.filter(db_credential::Column::UserId.eq(user_id.as_str()));
+    }
+    if let Some(r#type) = &params.r#type {
+        select = select.filter(db_credential::Column::Type.eq(r#type.as_str()));
+    }
+
+    let models = select.all(db).await.context("listing credentials")?;
+
+    let mut result = Vec::with_capacity(models.len());
+    for model in models {
+        result.push(to_plaintext(cfg, model)?);
+    }
+    Ok(result)
+}
+
+/// List all credentials owned by a user, optionally filtered by type.
+pub async fn list_for_user<'a>(
+    cfg: &Config,
+    db: &DatabaseConnection,
+    user_id: &'a str,
+    r#type: Option<&'a str>,
+) -> Result<Vec<Credential>, CredentialProviderError> {
+    list(
+        cfg,
+        db,
+        &CredentialListParameters {
+            user_id: Some(user_id.to_string()),
+            r#type: r#type.map(str::to_string),
+        },
+    )
+    .await
+}

--- a/crates/credential-driver-sql/src/credential/update.rs
+++ b/crates/credential-driver-sql/src/credential/update.rs
@@ -1,0 +1,62 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::ActiveValue::Set;
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core::credential::CredentialProviderError;
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::credential::*;
+
+use crate::credential::get::to_plaintext;
+use crate::entity::{credential as db_credential, prelude::Credential as DbCredential};
+use crate::fernet::FernetKeyRepository;
+
+/// Update a credential. Updating `blob` re-encrypts it with the current
+/// Primary Key and updates `key_hash` (ADR 0019 §2, Update).
+pub async fn update(
+    cfg: &Config,
+    db: &DatabaseConnection,
+    id: &str,
+    rec: CredentialUpdate,
+) -> Result<Credential, CredentialProviderError> {
+    let model = DbCredential::find()
+        .filter(db_credential::Column::Id.eq(id))
+        .one(db)
+        .await
+        .context("fetching credential for update")?
+        .ok_or_else(|| CredentialProviderError::CredentialNotFound(id.to_string()))?;
+
+    let mut active: db_credential::ActiveModel = model.into();
+
+    if let Some(new_type) = rec.r#type {
+        active.r#type = Set(new_type);
+    }
+    if let Some(new_project_id) = rec.project_id {
+        active.project_id = Set(Some(new_project_id));
+    }
+    if let Some(new_blob) = rec.blob {
+        let repo = FernetKeyRepository::new(cfg.credential.key_repository.clone());
+        let keys = repo.load(cfg.credential.insecure_allow_null_key)?;
+        active.encrypted_blob = Set(keys.multi_fernet.encrypt(new_blob.as_bytes()));
+        active.key_hash = Set(keys.primary_key_hash);
+    }
+
+    let updated = active.update(db).await.context("updating credential")?;
+
+    to_plaintext(cfg, updated)
+}

--- a/crates/credential-driver-sql/src/entity.rs
+++ b/crates/credential-driver-sql/src/entity.rs
@@ -11,33 +11,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::doc_paragraphs_missing_punctuation)]
+//! `SeaORM` entities for the (Python-owned) `credential` table.
 
-//! # OpenStack Keystone core provider types
+pub mod prelude;
 
-#![allow(clippy::module_inception)]
-#![deny(clippy::unwrap_used)]
-
-pub mod api_key;
-pub mod application_credential;
-pub mod assignment;
-pub mod auth;
-pub mod catalog;
 pub mod credential;
-pub mod error;
-pub mod events;
-pub mod federation;
-pub mod identity;
-pub mod idmapping;
-pub mod k8s_auth;
-pub mod mapping;
-pub mod resource;
-pub mod revoke;
-pub mod role;
-pub mod scope;
-pub mod token;
-pub mod trust;
-
-/// Return `true` to be used as a positive default for the serde macros.
-pub fn default_true() -> bool {
-    true
-}

--- a/crates/credential-driver-sql/src/entity/credential.rs
+++ b/crates/credential-driver-sql/src/entity/credential.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `SeaORM` entity mirroring the `credential` table owned by Python Keystone
+//! (ADR 0019 §1). This entity is used for reads/writes only — the table's
+//! schema is exclusively managed by Python's `alembic` migrations, and no
+//! `SqlDriver::setup()` in this crate issues DDL against it (see
+//! `crate::SqlBackend`).
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
+#[sea_orm(table_name = "credential")]
+pub struct Model {
+    /// Primary key. For `ec2`: `SHA-256(blob['access'])` hex-encoded.
+    /// Otherwise a random UUID.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+
+    /// The ID of the user who owns the credential.
+    pub user_id: String,
+
+    /// The ID of the project associated with the credential (mandatory for
+    /// `ec2`).
+    pub project_id: Option<String>,
+
+    /// The Fernet-encrypted secret blob.
+    #[sea_orm(column_type = "Text")]
+    pub encrypted_blob: String,
+
+    /// The credential type (`ec2`, `totp`, or a custom string).
+    pub r#type: String,
+
+    /// SHA-1 hex digest of the primary key used for encryption (ADR 0019
+    /// §4, `key_hash` Specification).
+    pub key_hash: String,
+
+    /// Extensible JSON field, stored by Python as a JSON-encoded string in a
+    /// `Text` column (`JsonBlob`). Modelled as `Option<String>`, matching
+    /// the convention already used by `identity-driver-sql`'s `user`/`group`
+    /// entities — never a native JSON/JSONB column.
+    #[sea_orm(column_type = "Text", nullable)]
+    pub extra: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/credential-driver-sql/src/entity/prelude.rs
+++ b/crates/credential-driver-sql/src/entity/prelude.rs
@@ -11,33 +11,6 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+#![allow(unused_imports)]
 
-//! # OpenStack Keystone core provider types
-
-#![allow(clippy::module_inception)]
-#![deny(clippy::unwrap_used)]
-
-pub mod api_key;
-pub mod application_credential;
-pub mod assignment;
-pub mod auth;
-pub mod catalog;
-pub mod credential;
-pub mod error;
-pub mod events;
-pub mod federation;
-pub mod identity;
-pub mod idmapping;
-pub mod k8s_auth;
-pub mod mapping;
-pub mod resource;
-pub mod revoke;
-pub mod role;
-pub mod scope;
-pub mod token;
-pub mod trust;
-
-/// Return `true` to be used as a positive default for the serde macros.
-pub fn default_true() -> bool {
-    true
-}
+pub use super::credential::Entity as Credential;

--- a/crates/credential-driver-sql/src/error.rs
+++ b/crates/credential-driver-sql/src/error.rs
@@ -1,0 +1,70 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Credential Fernet key repository error.
+use std::path::PathBuf;
+
+use openstack_keystone_core::credential::CredentialProviderError;
+use thiserror::Error;
+
+/// Errors from the Fernet key repository (ADR 0019 §4).
+#[derive(Error, Debug)]
+pub enum CredentialFernetError {
+    /// I/O error reading/writing a key file.
+    #[error("I/O error on key repository path {path:?}: {source}")]
+    Io {
+        #[source]
+        source: std::io::Error,
+        path: PathBuf,
+    },
+
+    /// A key file's contents could not be parsed as a Fernet key.
+    #[error("key file `{0}` is not a valid Fernet key")]
+    InvalidKey(i8),
+
+    /// No usable key files were found in the repository.
+    #[error("no Fernet keys found in the credential key repository")]
+    KeysMissing,
+
+    /// A key file decodes to the well-known Null Key and
+    /// `insecure_allow_null_key` is not set (ADR 0019 §4, Security).
+    #[error(
+        "credential key repository contains the well-known Null Key; refusing to start (set \
+         [credential] insecure_allow_null_key to override — production tolerance is zero)"
+    )]
+    NullKeyDetected,
+
+    /// Fernet index arithmetic would overflow the `i8` file-naming scheme.
+    #[error("key rotation index overflow")]
+    IndexOverflow,
+
+    /// Encryption/decryption failed (e.g. no active key could decrypt the
+    /// blob).
+    #[error("fernet decryption failed: all active keys were tried")]
+    DecryptionFailed,
+
+    /// Persisting a rotated/staged key file failed.
+    #[error("failed to persist key file: {0}")]
+    Persist(String),
+}
+
+impl From<CredentialFernetError> for CredentialProviderError {
+    fn from(source: CredentialFernetError) -> Self {
+        match source {
+            CredentialFernetError::NullKeyDetected => {
+                CredentialProviderError::Encryption(source.to_string())
+            }
+            other => CredentialProviderError::Encryption(other.to_string()),
+        }
+    }
+}

--- a/crates/credential-driver-sql/src/fernet.rs
+++ b/crates/credential-driver-sql/src/fernet.rs
@@ -1,0 +1,405 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Credential Fernet key repository (ADR 0019 §4)
+//!
+//! Separate from `[fernet_tokens] key_repository`. Hard-capped at
+//! [`MAX_ACTIVE_KEYS`] active keys, matching the Python Keystone constant —
+//! unlike token Fernet keys this is intentionally not configurable.
+//!
+//! Rotation is staged-key promotion, not primary renumbering: the staged key
+//! `0` is renamed to `old_primary + 1` (becoming the new primary), the old
+//! primary is left in place for decryption, a fresh key is staged as the new
+//! `0`, and files beyond [`MAX_ACTIVE_KEYS`] are pruned.
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE;
+use fernet::{Fernet, MultiFernet};
+use nix::sys::stat::{Mode, umask};
+use sha1::{Digest, Sha1};
+use tempfile::NamedTempFile;
+use tracing::{info, warn};
+
+use crate::error::CredentialFernetError;
+
+/// The credential Fernet key repository is hard-capped at this many active
+/// keys (ADR 0019 §4). Intentionally not configurable.
+pub const MAX_ACTIVE_KEYS: usize = 3;
+
+/// A loaded, ready-to-use view of the key repository.
+pub struct LoadedKeys {
+    /// All active keys, primary first, wrapped for
+    /// decrypt-any/encrypt-with-primary use.
+    pub multi_fernet: MultiFernet,
+
+    /// SHA-1 hex digest of the *raw base64url bytes* of the primary key
+    /// file (ADR 0019 §4, `key_hash` Specification) — not the decoded
+    /// 32-byte AES key.
+    pub primary_key_hash: String,
+
+    /// Number of active key files loaded.
+    pub key_count: usize,
+}
+
+/// The Fernet key repository on the local filesystem.
+///
+/// Per ADR 0019 §4, this directory must resolve to the identical file set on
+/// every Python and Rust node — that synchronization is an operational
+/// deployment requirement, not something this type enforces.
+#[derive(Clone, Debug)]
+pub struct FernetKeyRepository {
+    pub key_repository: PathBuf,
+}
+
+impl FernetKeyRepository {
+    /// Create a new repository handle for the given directory.
+    pub fn new(key_repository: PathBuf) -> Self {
+        Self { key_repository }
+    }
+
+    /// Compute `key_hash` per the ADR 0019 §4 specification: SHA-1 hex
+    /// digest over the raw base64url-encoded key-file bytes, as read from
+    /// disk (i.e. *before* base64url-decoding).
+    #[must_use]
+    pub fn key_hash(raw_key_file_bytes: &[u8]) -> String {
+        let mut hasher = Sha1::new();
+        hasher.update(raw_key_file_bytes);
+        hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect()
+    }
+
+    /// Whether the given raw (base64url-encoded) key-file bytes decode to
+    /// the well-known Null Key (32 zero bytes).
+    #[must_use]
+    pub fn is_null_key(raw_key_file_bytes: &[u8]) -> bool {
+        match URL_SAFE.decode(raw_key_file_bytes) {
+            Ok(decoded) => decoded.len() == 32 && decoded.iter().all(|b| *b == 0),
+            Err(_) => false,
+        }
+    }
+
+    /// Read all integer-named key files, keyed by their file-name index.
+    /// The raw bytes are exactly as read from disk with a single trailing
+    /// newline stripped (matching Python's `hashlib.sha1(keys[0]).hexdigest()`
+    /// over the file's content stripped of its trailing newline).
+    fn read_key_files(&self) -> Result<BTreeMap<i8, Vec<u8>>, CredentialFernetError> {
+        let mut keys = BTreeMap::new();
+        if !self.key_repository.exists() {
+            return Ok(keys);
+        }
+        for entry in fs::read_dir(&self.key_repository).map_err(|e| CredentialFernetError::Io {
+            source: e,
+            path: self.key_repository.clone(),
+        })? {
+            let entry = entry.map_err(|e| CredentialFernetError::Io {
+                source: e,
+                path: self.key_repository.clone(),
+            })?;
+            let Ok(fname) = entry.file_name().into_string() else {
+                continue;
+            };
+            let Ok(idx) = fname.parse::<i8>() else {
+                continue;
+            };
+            let mut raw = fs::read(entry.path()).map_err(|e| CredentialFernetError::Io {
+                source: e,
+                path: entry.path(),
+            })?;
+            if raw.last() == Some(&b'\n') {
+                raw.pop();
+            }
+            keys.insert(idx, raw);
+        }
+        Ok(keys)
+    }
+
+    /// Atomically write `contents` to `key_repository/<name>` using a
+    /// temp-file-then-rename strategy with `umask 0o177` (ADR 0019 §4,
+    /// Security).
+    fn write_key_file(&self, name: &str, contents: &[u8]) -> Result<(), CredentialFernetError> {
+        fs::create_dir_all(&self.key_repository).map_err(|e| CredentialFernetError::Io {
+            source: e,
+            path: self.key_repository.clone(),
+        })?;
+        let old_umask = umask(Mode::from_bits_truncate(0o177));
+        let _umask_guard = scopeguard::guard(old_umask, |old| {
+            umask(old);
+        });
+
+        let mut tmp_file =
+            NamedTempFile::new_in(&self.key_repository).map_err(|e| CredentialFernetError::Io {
+                source: e,
+                path: self.key_repository.clone(),
+            })?;
+        tmp_file
+            .write_all(contents)
+            .map_err(|e| CredentialFernetError::Io {
+                source: e,
+                path: self.key_repository.clone(),
+            })?;
+        tmp_file.flush().map_err(|e| CredentialFernetError::Io {
+            source: e,
+            path: self.key_repository.clone(),
+        })?;
+        tmp_file
+            .persist(self.key_repository.join(name))
+            .map_err(|e| CredentialFernetError::Persist(e.to_string()))?;
+        Ok(())
+    }
+
+    /// `credential_setup`: create the initial staged key (`0.tmp` -> `0`).
+    /// Idempotent-ish: overwrites `0` if it already exists, matching the
+    /// underlying atomic-rename semantics.
+    pub fn setup(&self) -> Result<(), CredentialFernetError> {
+        let key = Fernet::generate_key();
+        self.write_key_file("0", key.as_bytes())?;
+        info!("Created new credential Fernet staged key at index 0");
+        Ok(())
+    }
+
+    /// Load all active keys, primary first (highest index).
+    ///
+    /// # Errors
+    /// - [`CredentialFernetError::KeysMissing`] if the repository is empty.
+    /// - [`CredentialFernetError::NullKeyDetected`] if any key file decodes to
+    ///   the Null Key and `insecure_allow_null_key` is `false`.
+    pub fn load(&self, insecure_allow_null_key: bool) -> Result<LoadedKeys, CredentialFernetError> {
+        let key_files = self.read_key_files()?;
+        if key_files.is_empty() {
+            return Err(CredentialFernetError::KeysMissing);
+        }
+
+        for (idx, raw) in &key_files {
+            if Self::is_null_key(raw) {
+                if insecure_allow_null_key {
+                    warn!(
+                        key_index = idx,
+                        "credential key repository contains the well-known Null Key \
+                         (insecure_allow_null_key=true — any credential encrypted with it \
+                         is effectively stored in plaintext)"
+                    );
+                } else {
+                    return Err(CredentialFernetError::NullKeyDetected);
+                }
+            }
+        }
+
+        let mut fernets = Vec::with_capacity(key_files.len());
+        let mut primary_key_hash = None;
+        // Highest index first == primary first.
+        for (_idx, raw) in key_files.iter().rev() {
+            let key_str = String::from_utf8_lossy(raw);
+            let fernet =
+                Fernet::new(key_str.trim()).ok_or(CredentialFernetError::InvalidKey(*_idx))?;
+            if primary_key_hash.is_none() {
+                primary_key_hash = Some(Self::key_hash(raw));
+            }
+            fernets.push(fernet);
+        }
+
+        Ok(LoadedKeys {
+            multi_fernet: MultiFernet::new(fernets),
+            primary_key_hash: primary_key_hash.ok_or(CredentialFernetError::KeysMissing)?,
+            key_count: key_files.len(),
+        })
+    }
+
+    /// `credential_rotate`: promote the staged key `0` to primary, stage a
+    /// fresh key `0`, and prune beyond [`MAX_ACTIVE_KEYS`].
+    ///
+    /// Callers are responsible for the safety check described in ADR 0019
+    /// §4 (all credentials must already be encrypted with the current
+    /// primary key before calling this).
+    pub fn rotate(&self) -> Result<(), CredentialFernetError> {
+        let key_files = self.read_key_files()?;
+        if !key_files.contains_key(&0) {
+            return Err(CredentialFernetError::KeysMissing);
+        }
+
+        let old_primary_idx = key_files
+            .keys()
+            .copied()
+            .filter(|i| *i != 0)
+            .max()
+            .unwrap_or(0);
+        let new_primary_idx = old_primary_idx
+            .checked_add(1)
+            .ok_or(CredentialFernetError::IndexOverflow)?;
+
+        // 1. Promote: rename staged `0` -> new_primary_idx. This is a rename of the
+        //    *staged* file, not the outgoing primary — the outgoing primary keeps its
+        //    own file name and stays active for decryption.
+        fs::rename(
+            self.key_repository.join("0"),
+            self.key_repository.join(new_primary_idx.to_string()),
+        )
+        .map_err(|e| CredentialFernetError::Io {
+            source: e,
+            path: self.key_repository.clone(),
+        })?;
+
+        // 2. Stage a fresh key `0` for the next rotation cycle.
+        self.setup()?;
+
+        // 3. Prune beyond MAX_ACTIVE_KEYS, oldest (smallest positive index) first. `0`
+        //    (staged) is never pruned.
+        let mut remaining = self.read_key_files()?;
+        remaining.remove(&0);
+        while remaining.len() + 1 > MAX_ACTIVE_KEYS {
+            if let Some((&oldest, _)) = remaining.iter().min_by_key(|(idx, _)| **idx) {
+                fs::remove_file(self.key_repository.join(oldest.to_string())).map_err(|e| {
+                    CredentialFernetError::Io {
+                        source: e,
+                        path: self.key_repository.clone(),
+                    }
+                })?;
+                remaining.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+
+        info!(
+            new_primary = new_primary_idx,
+            "Rotated credential Fernet key repository"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_hash_matches_python_semantics() {
+        // key_hash = SHA-1(raw base64url bytes of the key file), lowercase
+        // hex — NOT over the decoded 32-byte key.
+        let raw = Fernet::generate_key().into_bytes();
+        let hash = FernetKeyRepository::key_hash(&raw);
+        assert_eq!(hash.len(), 40);
+        assert!(
+            hash.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+
+        // Sanity: hashing the decoded key bytes must NOT produce the same
+        // digest — this guards against silently hashing the wrong input.
+        let decoded = URL_SAFE.decode(&raw).unwrap();
+        assert_ne!(hash, FernetKeyRepository::key_hash(&decoded));
+    }
+
+    #[test]
+    fn test_is_null_key_detection() {
+        let null_key_raw = URL_SAFE.encode([0u8; 32]);
+        assert!(FernetKeyRepository::is_null_key(null_key_raw.as_bytes()));
+
+        let real_key_raw = Fernet::generate_key();
+        assert!(!FernetKeyRepository::is_null_key(real_key_raw.as_bytes()));
+    }
+
+    #[test]
+    fn test_setup_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = FernetKeyRepository::new(dir.path().to_path_buf());
+        repo.setup().unwrap();
+
+        let loaded = repo.load(false).unwrap();
+        assert_eq!(loaded.key_count, 1);
+
+        let plaintext = b"super secret ec2 key";
+        let token = loaded.multi_fernet.encrypt(plaintext);
+        let decrypted = loaded.multi_fernet.decrypt(&token).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_load_refuses_null_key_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = FernetKeyRepository::new(dir.path().to_path_buf());
+        let null_key = URL_SAFE.encode([0u8; 32]);
+        std::fs::write(dir.path().join("0"), null_key).unwrap();
+
+        assert!(matches!(
+            repo.load(false),
+            Err(CredentialFernetError::NullKeyDetected)
+        ));
+        // Explicit opt-in still loads it.
+        assert!(repo.load(true).is_ok());
+    }
+
+    #[test]
+    fn test_rotate_promotes_staged_key_and_keeps_old_primary_decryptable() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = FernetKeyRepository::new(dir.path().to_path_buf());
+        repo.setup().unwrap();
+        // First rotation: 0 -> 1, new 0 staged.
+        repo.rotate().unwrap();
+        assert!(dir.path().join("1").exists());
+        assert!(dir.path().join("0").exists());
+
+        let after_first_rotation = repo.load(false).unwrap();
+        let token_v1 = after_first_rotation.multi_fernet.encrypt(b"payload-v1");
+        // key_hash after first rotation must reflect key `1` as primary.
+        let key1_raw = std::fs::read(dir.path().join("1")).unwrap();
+        assert_eq!(
+            after_first_rotation.primary_key_hash,
+            FernetKeyRepository::key_hash(&key1_raw)
+        );
+
+        // Second rotation: staged 0 -> 2 (not overwriting 1). Old primary
+        // (1) must remain in place and still decryptable.
+        repo.rotate().unwrap();
+        assert!(dir.path().join("2").exists());
+        assert!(
+            dir.path().join("1").exists(),
+            "old primary must be retained for decryption"
+        );
+        assert!(dir.path().join("0").exists(), "a fresh key must be staged");
+
+        let after_second_rotation = repo.load(false).unwrap();
+        assert_eq!(after_second_rotation.key_count, 3);
+        // A blob encrypted with the now-superseded key `1` must still
+        // decrypt via MultiFernet.
+        let decrypted = after_second_rotation
+            .multi_fernet
+            .decrypt(&token_v1)
+            .unwrap();
+        assert_eq!(decrypted, b"payload-v1");
+    }
+
+    #[test]
+    fn test_rotate_prunes_beyond_max_active_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = FernetKeyRepository::new(dir.path().to_path_buf());
+        repo.setup().unwrap();
+        // Rotate MAX_ACTIVE_KEYS + 2 times; repository must never exceed
+        // MAX_ACTIVE_KEYS files, and the oldest primaries get pruned first.
+        for _ in 0..(MAX_ACTIVE_KEYS + 2) {
+            repo.rotate().unwrap();
+        }
+        let remaining = repo.read_key_files().unwrap();
+        assert_eq!(remaining.len(), MAX_ACTIVE_KEYS);
+        assert!(
+            remaining.contains_key(&0),
+            "staged key must always survive pruning"
+        );
+    }
+}

--- a/crates/credential-driver-sql/src/lib.rs
+++ b/crates/credential-driver-sql/src/lib.rs
@@ -1,0 +1,73 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OpenStack Keystone Credentials SQL driver (ADR 0019)
+//!
+//! Persists to the `credential` table, which is owned and schema-managed
+//! **exclusively** by the Python Keystone service via `alembic`. Unlike
+//! every other SQL driver in this workspace, [`SqlBackend::setup`] is a
+//! deliberate no-op: it must never issue DDL against this table, including
+//! when `sync_schema()` iterates the [`SqlDriverRegistration`] inventory for
+//! test/dev bootstrapping. Tests that need the table to exist create it via
+//! [`test_support::create_credential_table`] instead, kept separate from the
+//! production setup path.
+
+use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, Schema};
+
+use openstack_keystone_core::{SqlDriver, SqlDriverRegistration, error::DatabaseError};
+
+mod credential;
+pub mod entity;
+pub mod error;
+pub mod fernet;
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
+
+/// SQL backend provider implementing the `CredentialBackend` interface.
+///
+/// Deliberately zero-sized: all per-call configuration (key repository
+/// path, Null Key policy) is read fresh from `state.config_manager` on each
+/// call, matching the pattern used by other config-dependent backends in
+/// this workspace (e.g. the Fernet token driver).
+#[derive(Default)]
+pub struct SqlBackend {}
+
+/// Linkage anchor — see ADR-0018. Referenced by the `keystone` crate's
+/// `build.rs`-generated `_ANCHORS` static so the linker extracts `.rlib`
+/// members, keeping `inventory::submit!` sections visible at runtime.
+#[allow(dead_code)]
+pub fn anchor() {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    /// Deliberate no-op (ADR 0019: "Keystone-NG never runs DDL against
+    /// tables owned by the Python Keystone service"). The `credential`
+    /// table's schema is exclusively managed by Python's `alembic`
+    /// migrations, in every environment including tests that share this
+    /// setup path with other, Rust-owned drivers.
+    async fn setup(
+        &self,
+        _connection: &DatabaseConnection,
+        _schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+}

--- a/crates/credential-driver-sql/src/test_support.rs
+++ b/crates/credential-driver-sql/src/test_support.rs
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Test-only table creation
+//!
+//! `SqlBackend::setup()` is a deliberate no-op in production (ADR 0019: the
+//! `credential` table's schema is exclusively owned by Python Keystone's
+//! `alembic` migrations). Integration tests that exercise this crate
+//! against a real (throwaway, in-memory) database need the table to exist,
+//! so this helper creates it directly — entirely separate from the
+//! production `SqlDriver::setup()` path, and never wired into
+//! `sync_schema()`.
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, Schema};
+
+use openstack_keystone_core::db::create_table;
+use openstack_keystone_core::error::DatabaseError;
+
+/// Create the `credential` table in a test database.
+///
+/// # Errors
+/// Returns a [`DatabaseError`] if the table creation fails.
+pub async fn create_credential_table(db: &DatabaseConnection) -> Result<(), DatabaseError> {
+    let schema = Schema::new(db.get_database_backend());
+    create_table(db, &schema, crate::entity::prelude::Credential).await
+}

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -39,6 +39,7 @@ openstack-keystone-appcred-driver-sql.workspace = true
 openstack-keystone-assignment-driver-sql.workspace = true
 openstack-keystone-catalog-driver-sql.workspace = true
 openstack-keystone-config.workspace = true
+openstack-keystone-credential-driver-sql.workspace = true
 openstack-keystone-core = { workspace = true, features = ["api"] }
 openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage.workspace = true

--- a/crates/keystone/src/plugin_manager.rs
+++ b/crates/keystone/src/plugin_manager.rs
@@ -33,6 +33,8 @@ use openstack_keystone_core::assignment::backend::AssignmentBackend;
 use openstack_keystone_core::assignment::error::AssignmentProviderError;
 use openstack_keystone_core::catalog::backend::CatalogBackend;
 use openstack_keystone_core::catalog::error::CatalogProviderError;
+use openstack_keystone_core::credential::CredentialProviderError;
+use openstack_keystone_core::credential::backend::CredentialBackend;
 use openstack_keystone_core::federation::backend::FederationBackend;
 use openstack_keystone_core::federation::error::FederationProviderError;
 use openstack_keystone_core::identity::backend::IdentityBackend;
@@ -68,6 +70,8 @@ pub struct PluginManager {
     assignment_backends: HashMap<String, Arc<dyn AssignmentBackend>>,
     /// Catalog backend plugins.
     catalog_backends: HashMap<String, Arc<dyn CatalogBackend>>,
+    /// Credential backend plugins.
+    credential_backends: HashMap<String, Arc<dyn CredentialBackend>>,
     /// Federation backend plugins.
     federation_backends: HashMap<String, Arc<dyn FederationBackend>>,
     /// Identity backend plugins.
@@ -169,6 +173,24 @@ impl PluginManagerApi for PluginManager {
             .ok_or(CatalogProviderError::UnsupportedDriver(
                 name.as_ref().to_string(),
             ))
+    }
+
+    /// Get registered credential backend.
+    ///
+    /// # Parameters
+    /// * `name` - The name of the backend to retrieve.
+    ///
+    /// # Returns
+    /// A `Result` containing a reference to the `CredentialBackend` if found,
+    /// or a `CredentialProviderError`.
+    #[allow(clippy::borrowed_box)]
+    fn get_credential_backend<S: AsRef<str>>(
+        &self,
+        name: S,
+    ) -> Result<&Arc<dyn CredentialBackend>, CredentialProviderError> {
+        self.credential_backends.get(name.as_ref()).ok_or(
+            CredentialProviderError::UnsupportedDriver(name.as_ref().to_string()),
+        )
     }
 
     /// Get registered federation backend.
@@ -439,6 +461,20 @@ impl PluginManagerApi for PluginManager {
             .insert(name.as_ref().to_string(), plugin);
     }
 
+    /// Register credential backend.
+    ///
+    /// # Parameters
+    /// * `name` - The name of the backend to register.
+    /// * `plugin` - The backend implementation.
+    fn register_credential_backend<S: AsRef<str>>(
+        &mut self,
+        name: S,
+        plugin: Arc<dyn CredentialBackend>,
+    ) {
+        self.credential_backends
+            .insert(name.as_ref().to_string(), plugin);
+    }
+
     /// Register federation backend.
     ///
     /// # Parameters
@@ -592,6 +628,10 @@ impl PluginManager {
             "sql",
             Arc::new(openstack_keystone_catalog_driver_sql::SqlBackend::default()),
         );
+        self.register_credential_backend(
+            "sql",
+            Arc::new(openstack_keystone_credential_driver_sql::SqlBackend::default()),
+        );
         self.register_federation_backend(
             "sql",
             Arc::new(openstack_keystone_federation_driver_sql::SqlBackend::default()),
@@ -643,6 +683,7 @@ impl PluginManager {
             application_credential_backends: HashMap::new(),
             assignment_backends: HashMap::new(),
             catalog_backends: HashMap::new(),
+            credential_backends: HashMap::new(),
             federation_backends: HashMap::new(),
             identity_backends: HashMap::new(),
             idmapping_backends: HashMap::new(),

--- a/doc/src/adr/0019-credentials.md
+++ b/doc/src/adr/0019-credentials.md
@@ -58,9 +58,21 @@ expected structure:
 ```json
 {
   "access": "AKIAIOSFODNN7EXAMPLE",
-  "secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  "secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  "trust_id": "optional, present if created via a trust-scoped token",
+  "app_cred_id": "optional, present if created via an application credential",
+  "access_token_id": "optional, present if created via an OAuth1 access token"
 }
 ```
+
+`trust_id`, `app_cred_id`, and `access_token_id` are mutually exclusive,
+optional delegation-context fields. They are populated from the scope of the
+token used to create the credential and must be passed through to the token
+provider on `POST /v3/ec2tokens` (see §3, "Credential metadata in the token").
+They are part of the same encrypted JSON blob as `access`/`secret` — the field
+names above (not `access_id`) are the cross-service contract; a Rust and a
+Python node must serialize identical keys or the two services will silently fail
+to exchange delegation metadata.
 
 **TOTP Blob:**
 
@@ -94,15 +106,15 @@ Keystone-NG treats this table as read/write but never issues DDL against it.
 
 **Schema Definition:**
 
-| Column           | Type                | Nullable | Description                                                                                                                                                                                         |
-| :--------------- | :------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | `String(64)`        | No       | Primary Key. (For EC2: SHA-256 hex of the `access_id`).                                                                                                                                             |
-| `user_id`        | `String(64)`        | No       | Foreign key to the user who owns the credential.                                                                                                                                                    |
-| `project_id`     | `String(64)`        | Yes      | Project association (Mandatory for EC2 credentials).                                                                                                                                                |
-| `encrypted_blob` | `Text`              | No       | The Fernet-encrypted secret string.                                                                                                                                                                 |
-| `type`           | `String(255)`       | No       | Credential type (e.g., `'ec2'`, `'totp'`).                                                                                                                                                          |
-| `key_hash`       | `String(64)`        | No       | SHA-1 hex digest of the primary key used for encryption (see §4).                                                                                                                                   |
-| `extra`          | `Text` / `JsonBlob` | Yes      | Extensible JSON field. The Python backend stores this as a JSON-encoded string in a `Text` column; the Rust implementation must handle both native JSON columns and stringified JSON transparently. |
+| Column           | Type          | Nullable | Description                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| :--------------- | :------------ | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`             | `String(64)`  | No       | Primary Key. (For EC2: SHA-256 hex of the `access` key, per §1 ID Generation).                                                                                                                                                                                                                                                                                                                                                                    |
+| `user_id`        | `String(64)`  | No       | Foreign key to the user who owns the credential.                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `project_id`     | `String(64)`  | Yes      | Project association (Mandatory for EC2 credentials).                                                                                                                                                                                                                                                                                                                                                                                              |
+| `encrypted_blob` | `Text`        | No       | The Fernet-encrypted secret string.                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `type`           | `String(255)` | No       | Credential type (e.g., `'ec2'`, `'totp'`).                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `key_hash`       | `String(64)`  | No       | SHA-1 hex digest of the primary key used for encryption (see §4).                                                                                                                                                                                                                                                                                                                                                                                 |
+| `extra`          | `Text`        | Yes      | Extensible JSON field. Python stores this via its `JsonBlob` `TypeDecorator`, which is backed by a plain `Text` column on every DB dialect Keystone supports — there is no native-JSON variant to detect. The Rust entity must model `extra` as `Option<String>` containing JSON text, parsed with `serde_json` (matching the existing `extra` handling in `identity-driver-sql`'s `user`/`group` entities), not a native JSON/JSONB column type. |
 
 ---
 
@@ -118,7 +130,12 @@ Keystone-NG treats this table as read/write but never issues DDL against it.
   - `project_id`: Required if `type` is `'ec2'`.
   - `user_id`: Defaults to the authenticated user. This default applies only
     when the request is user-scoped; it must not be applied when the caller
-    holds a system-scoped token (to match Python Keystone behaviour).
+    holds a system-scoped token (to match Python Keystone behaviour). Under
+    system scope there is no implicit "acting user" to fall back to, so if
+    `user_id` is also omitted from the request body the server must reject the
+    request with `400 Bad Request` rather than defaulting it to anything (e.g.
+    the system-scoped caller's own user, which would silently create a
+    credential owned by an operator account).
 - **ID Generation**:
   - **EC2**: `SHA-256(blob['access'])` hex-encoded.
   - **Others**: Random UUID.
@@ -128,6 +145,13 @@ Keystone-NG treats this table as read/write but never issues DDL against it.
 - Returns the credential reference.
 - **Security**: The `encrypted_blob` and `key_hash` are stripped from the
   response; the `blob` is decrypted to plaintext before serialisation.
+- **Wire format of `blob`**: Python Keystone returns `blob` as a JSON-encoded
+  **string** (the same string form that was originally submitted on create), not
+  as a nested JSON object — clients are expected to `json.loads()` it
+  themselves. Keystone-NG must serialise the `blob` field in its API response
+  the same way (a string value), not as a parsed/nested object, or existing SDKs
+  and clients that call `json.loads(cred["blob"])` will break against
+  Keystone-NG.
 - **List filtering — two-phase policy check** (required to address
   CVE-2019-19687): The `GET /v3/credentials` endpoint first enforces the
   `identity:list_credentials` policy and applies driver-level hints (e.g.
@@ -137,14 +161,21 @@ Keystone-NG treats this table as read/write but never issues DDL against it.
   project role cannot view credentials belonging to other users when
   `enforce_scope` is false. The performance implication is accepted and matches
   Python Keystone behaviour.
+  - **Policy target correctness**: The per-item re-enforcement must build its
+    policy target from _that record's own_ `user_id`/`project_id`, not from the
+    requester's identity or scope. Evaluating `identity:get_credential` against
+    the wrong target (e.g. the caller's own attributes, or a cached target from
+    the first item) would make the re-check a no-op and reintroduce a variant of
+    CVE-2019-19687 rather than closing it.
 
 #### Update (`PATCH /v3/credentials/{id}`)
 
 - **Updatable**: `type`, `blob`, `project_id`.
 - **Immutable**: `user_id` and `project_id` may not be changed to point at a
   user or project the acting user has no access to (CVE-2020-12691). Within the
-  `blob`, the following fields are additionally immutable: `access_id`,
-  `trust_id`, `app_cred_id`, and `access_token_id`.
+  `blob`, the following fields are additionally immutable: `access` (the EC2
+  access key — changing it would desynchronize the record from its
+  SHA-256-derived `id`), `trust_id`, `app_cred_id`, and `access_token_id`.
 - **Process**: Updating the `blob` triggers automatic re-encryption with the
   current Primary Key and updates `key_hash`.
 
@@ -234,16 +265,42 @@ The provider uses **Fernet (symmetric encryption)**, which is built upon:
 - **Storage**: Keys are stored as individual files in a filesystem directory.
 - **Naming**: Files use integer names. The highest number is the **Primary
   Key**.
+- **Cross-node synchronization (required precondition)**: Because the key
+  repository is a local filesystem directory, not a table in the shared
+  database, the whole byte-compatibility story in this section only holds if
+  every Python node and every Rust node reads the _same_ set of key files (e.g.
+  a shared network filesystem, or a config-management job that distributes the
+  directory to all nodes). `credential_setup` and `credential_rotate` are
+  cluster-wide operations: a run is not complete until the resulting key files
+  have been propagated to every node of both services. Keystone-NG must document
+  this as a deployment requirement, not assume it happens implicitly from
+  "sharing the same database".
 - **Maximum active keys**: The credential key repository is **hard-capped at 3
   active keys** (`MAX_ACTIVE_KEYS = 3`). This matches the Python Keystone
   constant and is intentionally not configurable. Unlike Fernet token key
   rotation, credential key rotation is driven by `key_hash` tracking, not by a
   configurable window. The Rust implementation must enforce this same limit when
   loading the key repository.
-- **Rotation Logic**:
-  - New keys are created as `0.tmp` $\rightarrow$ `0` (staged).
-  - On rotation, the primary is incremented (e.g., `1` $\rightarrow$ `2`) and
-    the staged key `0` becomes the new primary.
+- **Rotation Logic** (staged-key promotion, not primary renumbering):
+  1. Setup (`credential_setup`) creates the first key as `0.tmp` $\rightarrow$
+     `0` (staged; not yet used for encryption).
+  2. On rotation (`credential_rotate`), the **staged key `0` is renamed** to
+     `(current_primary_index + 1)` — e.g. if `1` is the current primary, `0` is
+     renamed to `2`. This renamed file is the new Primary. The old primary (`1`)
+     is left in place, unchanged, and is still used for decryption.
+  3. A fresh key is generated and written as the new staged `0.tmp`
+     $\rightarrow$ `0`, ready for the next rotation cycle.
+  4. If the number of key files now exceeds `MAX_ACTIVE_KEYS` (3), the oldest
+     non-staged key file(s) are deleted to bring the count back down to 3.
+
+  Note the staged key is never renumbered "in place" to become primary while
+  simultaneously incrementing some other file — those are the same rename
+  operation applied to the _staged_ file, not the outgoing primary. An
+  implementation that instead renames the outgoing primary upward while
+  separately trying to promote `0` (as an earlier ambiguous phrasing of this
+  section could be read) produces two files claiming to be primary and must be
+  avoided.
+
 - **Security**:
   - Directory must not be world-readable.
   - Files are created with `umask 0o177` and a temporary-file-then-rename
@@ -255,9 +312,13 @@ The provider uses **Fernet (symmetric encryption)**, which is built upon:
     transient migration aid and carries zero production tolerance.
   - **Startup enforcement**: Keystone-NG must check the key repository on
     startup. If any key file decodes to 32 null bytes (the Null Key), it must
-    emit a hard warning log. In production mode, it should refuse to start. The
-    Python service emits a warning on every encryption operation that uses the
-    Null Key; Keystone-NG matches this behaviour and adds the startup gate.
+    emit a hard warning log. Whether this is a hard-refuse-to-start condition
+    must be controlled by an explicit, named configuration value (e.g.
+    `[credential] insecure_allow_null_key`, defaulting to `false`) rather than
+    an undefined "production mode" — refuse to start unless the operator has
+    explicitly opted in. The Python service emits a warning on every encryption
+    operation that uses the Null Key; Keystone-NG matches this behaviour and
+    adds the startup gate.
 
 #### `key_hash` Specification
 
@@ -547,13 +608,11 @@ port-stripping retry. The Python HMAC object is stateful (accumulated via
 
 The server must check both locations and reject any request where the timestamp
 is outside the configured TTL window. The TTL is read from `[ec2] auth_ttl` in
-the shared `keystone.conf` (default: **300 seconds / 5 minutes**).
-
-> **Note on the ADR's stated default of 4 hours**: The Python Keystone default
-> is **300 seconds** (5 minutes), not 4 hours. The 4-hour figure was the AWS
-> SigV2 recommendation. The Keystone implementation uses a tighter window.
-> Keystone-NG must read the `[ec2] auth_ttl` config value from `keystone.conf`
-> and apply it identically.
+the shared `keystone.conf`, **defaulting to 300 seconds (5 minutes)** — this is
+the Python Keystone default and must not be confused with the 4-hour window that
+is only an AWS SigV2 recommendation, not what Keystone implements. Keystone-NG
+must read the `[ec2] auth_ttl` config value from `keystone.conf` and apply it
+identically.
 
 Prior to the CVE-2020-12692 fix, SigV4 requests had no timestamp check because
 the timestamp appears in the `Authorization` header rather than a query

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -20,6 +20,7 @@ openstack-keystone-config.workspace = true
 openstack-keystone-api-types = { workspace = true, features = ["builder", "conv"] }
 openstack-keystone-core = { workspace = true, features = ["mock"] }
 openstack-keystone-core-types = { workspace = true, features = ["mock"] }
+openstack-keystone-credential-driver-sql = { version = "0.1", path = "../../crates/credential-driver-sql/", features = ["test-support"] }
 openstack-keystone-identity-driver-sql = { version = "0.1", path = "../../crates/identity-driver-sql/" }
 openstack-keystone-token-driver-fernet.workspace = true
 openstack-keystone-trust-driver-sql = { version = "0.1", path = "../../crates/trust-driver-sql/" }
@@ -30,6 +31,7 @@ rcgen.workspace = true
 sea-orm = { workspace = true, features = ["sqlx-mysql", "sqlx-postgres", "sqlx-sqlite", "runtime-tokio", "runtime-tokio-native-tls"] }
 secrecy = { workspace = true, features = ["serde"] }
 serde.workspace = true
+sha2.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
 time = { version = "0.3", default-features = true }

--- a/tests/integration/src/credential.rs
+++ b/tests/integration/src/credential.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Integration tests for the credentials provider (ADR 0019).
+//!
+//! Unlike every other entity exercised in this test suite, the `credential`
+//! table is owned exclusively by Python Keystone's `alembic` migrations
+//! (ADR 0019 §1): `SqlDriver::setup()` for the credential backend is a
+//! deliberate no-op, so it is never created by
+//! `common::setup_schema()`/`common::get_state()`. [`get_state`] below
+//! layers on top of `common::get_state()` to create the table via the
+//! crate's `test_support` helper (test-only, never used in production) and
+//! to initialize a throwaway Fernet key repository, so the two extra setup
+//! steps are contained to credential tests only.
+
+use std::fs::create_dir;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use eyre::Result;
+use tempfile::TempDir;
+
+use openstack_keystone::keystone::Service;
+use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::credential::*;
+use openstack_keystone_credential_driver_sql::fernet::FernetKeyRepository;
+
+use crate::common::*;
+use crate::impl_deleter;
+
+mod create;
+mod delete;
+mod get;
+mod list;
+mod update;
+
+impl_deleter!(
+    Service,
+    Credential,
+    get_credential_provider,
+    delete_credential
+);
+
+/// Build a [`ServiceState`] with the `credential` table present and a
+/// working Fernet key repository — the two preconditions this provider
+/// needs that `common::get_state()` does not set up generically (see
+/// module docs).
+pub async fn get_state() -> Result<(ServiceState, TempDir)> {
+    let (state, tmp_dir) = crate::common::get_state().await?;
+
+    openstack_keystone_credential_driver_sql::test_support::create_credential_table(&state.db)
+        .await?;
+
+    let key_repository = tmp_dir.path().join("credential-keys");
+    create_dir(&key_repository)?;
+    FernetKeyRepository::new(key_repository.clone()).setup()?;
+
+    {
+        let mut cfg = state.config_manager.config.write().await;
+        cfg.credential.key_repository = key_repository;
+    }
+
+    Ok((state, tmp_dir))
+}
+
+pub async fn create_credential(
+    state: &ServiceState,
+    data: CredentialCreate,
+) -> Result<AsyncResourceGuard<Credential, ServiceState>> {
+    let res = state
+        .provider
+        .get_credential_provider()
+        .create_credential(&ExecutionContext::internal(state), data)
+        .await?;
+    Ok(AsyncResourceGuard::new(res, state.clone()))
+}

--- a/tests/integration/src/credential/create.rs
+++ b/tests/integration/src/credential/create.rs
@@ -1,0 +1,206 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test credential creation (ADR 0019 §1, §2).
+
+use eyre::Result;
+use sha2::{Digest, Sha256};
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::credential::*;
+
+use crate::credential::get_state;
+use crate::{create_domain, create_project, create_user};
+
+fn ec2_id(access: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(access.as_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_ec2_computes_sha256_id() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let cred = state
+        .provider
+        .get_credential_provider()
+        .create_credential(
+            &ExecutionContext::internal(&state),
+            CredentialCreate {
+                blob: r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"wJalrXUtnFEMI"}"#.into(),
+                r#type: "ec2".into(),
+                project_id: Some(project.id.clone()),
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(
+        cred.id,
+        ec2_id("AKIAIOSFODNN7EXAMPLE"),
+        "id is SHA-256(access)"
+    );
+    assert_eq!(cred.user_id, user.id);
+    assert_eq!(cred.project_id, Some(project.id.clone()));
+    assert_eq!(cred.r#type, "ec2");
+    assert_eq!(
+        cred.blob, r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"wJalrXUtnFEMI"}"#,
+        "blob round-trips as plaintext JSON string"
+    );
+
+    // Cleanup (create_credential returns a plain Credential, not a guard).
+    state
+        .provider
+        .get_credential_provider()
+        .delete_credential(&ExecutionContext::internal(&state), &cred.id)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_ec2_requires_project_id() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let err = state
+        .provider
+        .get_credential_provider()
+        .create_credential(
+            &ExecutionContext::internal(&state),
+            CredentialCreate {
+                blob: r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"s"}"#.into(),
+                r#type: "ec2".into(),
+                project_id: None,
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("ec2 credential without project_id must be rejected");
+
+    assert!(matches!(err, CredentialProviderError::MissingProjectId));
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_totp_generates_uuid_id() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let cred = state
+        .provider
+        .get_credential_provider()
+        .create_credential(
+            &ExecutionContext::internal(&state),
+            CredentialCreate {
+                blob: r#"{"seed":"JBSWY3DPEHPK3PXP","digits":6,"period":30}"#.into(),
+                r#type: "totp".into(),
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert!(
+        Uuid::parse_str(&cred.id).is_ok(),
+        "non-ec2 credential id is a random UUID, got {}",
+        cred.id
+    );
+    assert_eq!(cred.project_id, None);
+
+    state
+        .provider
+        .get_credential_provider()
+        .delete_credential(&ExecutionContext::internal(&state), &cred.id)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_custom_type_with_extra() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let mut extra = std::collections::HashMap::new();
+    extra.insert(
+        "note".to_string(),
+        serde_json::json!("third-party integration"),
+    );
+
+    let cred = state
+        .provider
+        .get_credential_provider()
+        .create_credential(
+            &ExecutionContext::internal(&state),
+            CredentialCreate {
+                blob: r#"{"anything":"goes"}"#.into(),
+                r#type: "my-custom-type".into(),
+                user_id: Some(user.id.clone()),
+                extra: Some(extra.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(cred.r#type, "my-custom-type");
+    assert_eq!(cred.extra, Some(extra), "extra JSON round-trips");
+
+    state
+        .provider
+        .get_credential_provider()
+        .delete_credential(&ExecutionContext::internal(&state), &cred.id)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_requires_user_id_without_security_context() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let err = state
+        .provider
+        .get_credential_provider()
+        .create_credential(
+            &ExecutionContext::internal(&state),
+            CredentialCreate {
+                blob: r#"{"seed":"JBSWY3DPEHPK3PXP"}"#.into(),
+                r#type: "totp".into(),
+                user_id: None,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("internal calls have no security context to default user_id from");
+
+    assert!(matches!(err, CredentialProviderError::MissingUserId));
+    Ok(())
+}

--- a/tests/integration/src/credential/delete.rs
+++ b/tests/integration/src/credential/delete.rs
@@ -1,0 +1,202 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test credential deletion, including the identity-lifecycle cascade
+//! helpers (ADR 0019 §3): `delete_credentials_for_user` and
+//! `delete_credentials_for_project`.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::credential::*;
+
+use crate::credential::{create_credential, get_state};
+use crate::{create_domain, create_project, create_user};
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_by_id() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let created = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"seed":"AAAA"}"#.into(),
+            r#type: "totp".into(),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let id = created.id.clone();
+    // Detach the auto-cleanup guard since we're explicitly testing deletion.
+    std::mem::forget(created);
+
+    state
+        .provider
+        .get_credential_provider()
+        .delete_credential(&ExecutionContext::internal(&state), &id)
+        .await?;
+
+    let fetched = state
+        .provider
+        .get_credential_provider()
+        .get_credential(&ExecutionContext::internal(&state), &id)
+        .await?;
+    assert!(fetched.is_none(), "credential is gone after delete");
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_credentials_for_user() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let user_a = create_user!(state, domain.id.clone())?;
+    let user_b = create_user!(state, domain.id.clone())?;
+
+    let a1 = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"seed":"AAAA"}"#.into(),
+            r#type: "totp".into(),
+            user_id: Some(user_a.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let a2 = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"x":"y"}"#.into(),
+            r#type: "custom".into(),
+            user_id: Some(user_a.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let b1 = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"seed":"BBBB"}"#.into(),
+            r#type: "totp".into(),
+            user_id: Some(user_b.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let (a1_id, a2_id, b1_id) = (a1.id.clone(), a2.id.clone(), b1.id.clone());
+    std::mem::forget(a1);
+    std::mem::forget(a2);
+
+    state
+        .provider
+        .get_credential_provider()
+        .delete_credentials_for_user(&ExecutionContext::internal(&state), &user_a.id)
+        .await?;
+
+    let provider = state.provider.get_credential_provider();
+    assert!(
+        provider
+            .get_credential(&ExecutionContext::internal(&state), &a1_id)
+            .await?
+            .is_none(),
+        "user_a's totp credential was cascade-deleted"
+    );
+    assert!(
+        provider
+            .get_credential(&ExecutionContext::internal(&state), &a2_id)
+            .await?
+            .is_none(),
+        "user_a's custom credential was cascade-deleted"
+    );
+    assert!(
+        provider
+            .get_credential(&ExecutionContext::internal(&state), &b1_id)
+            .await?
+            .is_some(),
+        "user_b's credential is untouched"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_credentials_for_project() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project_a = create_project!(state, domain.id.clone())?;
+    let project_b = create_project!(state, domain.id.clone())?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let ec2_a = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"access":"AKIAPROJECTA00000000","secret":"s"}"#.into(),
+            r#type: "ec2".into(),
+            project_id: Some(project_a.id.clone()),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let ec2_b = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"access":"AKIAPROJECTB00000000","secret":"s"}"#.into(),
+            r#type: "ec2".into(),
+            project_id: Some(project_b.id.clone()),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let (a_id, b_id) = (ec2_a.id.clone(), ec2_b.id.clone());
+    std::mem::forget(ec2_a);
+
+    state
+        .provider
+        .get_credential_provider()
+        .delete_credentials_for_project(&ExecutionContext::internal(&state), &project_a.id)
+        .await?;
+
+    let provider = state.provider.get_credential_provider();
+    assert!(
+        provider
+            .get_credential(&ExecutionContext::internal(&state), &a_id)
+            .await?
+            .is_none(),
+        "project_a's ec2 credential was cascade-deleted"
+    );
+    assert!(
+        provider
+            .get_credential(&ExecutionContext::internal(&state), &b_id)
+            .await?
+            .is_some(),
+        "project_b's ec2 credential is untouched"
+    );
+
+    // Cleanup remaining fixture.
+    state
+        .provider
+        .get_credential_provider()
+        .delete_credential(&ExecutionContext::internal(&state), &b_id)
+        .await?;
+
+    Ok(())
+}

--- a/tests/integration/src/credential/get.rs
+++ b/tests/integration/src/credential/get.rs
@@ -1,0 +1,108 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test credential retrieval, including the EC2 plaintext-access-key lookup
+//! used by the OS-EC2 legacy endpoints and `/v3/ec2tokens` (ADR 0019 §3, §5).
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::credential::*;
+
+use crate::credential::{create_credential, get_state};
+use crate::{create_domain, create_project, create_user};
+
+#[tokio::test]
+#[traced_test]
+async fn test_get_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let created = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"seed":"JBSWY3DPEHPK3PXP"}"#.into(),
+            r#type: "totp".into(),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let fetched = state
+        .provider
+        .get_credential_provider()
+        .get_credential(&ExecutionContext::internal(&state), &created.id)
+        .await?
+        .expect("credential is found");
+
+    assert_eq!(fetched.id, created.id);
+    assert_eq!(fetched.blob, created.blob);
+    assert_eq!(fetched.user_id, created.user_id);
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_get_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let fetched = state
+        .provider
+        .get_credential_provider()
+        .get_credential(&ExecutionContext::internal(&state), "does-not-exist")
+        .await?;
+
+    assert!(fetched.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_get_by_ec2_access() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let created = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"wJalrXUtnFEMI"}"#.into(),
+            r#type: "ec2".into(),
+            project_id: Some(project.id.clone()),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let fetched = state
+        .provider
+        .get_credential_provider()
+        .get_credential_by_ec2_access(&ExecutionContext::internal(&state), "AKIAIOSFODNN7EXAMPLE")
+        .await?
+        .expect("credential is found by plaintext access key");
+
+    assert_eq!(fetched.id, created.id);
+
+    let missing = state
+        .provider
+        .get_credential_provider()
+        .get_credential_by_ec2_access(&ExecutionContext::internal(&state), "NOT-A-REAL-KEY")
+        .await?;
+    assert!(missing.is_none());
+    Ok(())
+}

--- a/tests/integration/src/credential/list.rs
+++ b/tests/integration/src/credential/list.rs
@@ -1,0 +1,148 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test credential listing and the driver-level `user_id`/`type` filters
+//! (ADR 0019 §2, §3 — `list_credentials_for_user` backs both the TOTP auth
+//! pipeline and the OS-EC2 listing endpoint).
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::credential::*;
+
+use crate::credential::{create_credential, get_state};
+use crate::{create_domain, create_user};
+
+#[tokio::test]
+#[traced_test]
+async fn test_list_filters_by_user_and_type() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let user_a = create_user!(state, domain.id.clone())?;
+    let user_b = create_user!(state, domain.id.clone())?;
+
+    let a_totp = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"seed":"AAAA"}"#.into(),
+            r#type: "totp".into(),
+            user_id: Some(user_a.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let a_custom = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"x":"y"}"#.into(),
+            r#type: "custom".into(),
+            user_id: Some(user_a.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let _b_totp = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"seed":"BBBB"}"#.into(),
+            r#type: "totp".into(),
+            user_id: Some(user_b.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    // All of user_a's credentials.
+    let user_a_creds = state
+        .provider
+        .get_credential_provider()
+        .list_credentials(
+            &ExecutionContext::internal(&state),
+            &CredentialListParameters {
+                user_id: Some(user_a.id.clone()),
+                r#type: None,
+            },
+        )
+        .await?;
+    let user_a_ids: Vec<&str> = user_a_creds.iter().map(|c| c.id.as_str()).collect();
+    assert!(user_a_ids.contains(&a_totp.id.as_str()));
+    assert!(user_a_ids.contains(&a_custom.id.as_str()));
+    assert_eq!(user_a_creds.len(), 2);
+
+    // user_a's totp credentials only.
+    let user_a_totp = state
+        .provider
+        .get_credential_provider()
+        .list_credentials(
+            &ExecutionContext::internal(&state),
+            &CredentialListParameters {
+                user_id: Some(user_a.id.clone()),
+                r#type: Some("totp".into()),
+            },
+        )
+        .await?;
+    assert_eq!(user_a_totp.len(), 1);
+    assert_eq!(user_a_totp[0].id, a_totp.id);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_list_credentials_for_user() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let totp = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"seed":"AAAA"}"#.into(),
+            r#type: "totp".into(),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let _custom = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"x":"y"}"#.into(),
+            r#type: "custom".into(),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    // Used by the TOTP auth plugin: list_credentials_for_user(user_id,
+    // type='totp').
+    let totp_creds = state
+        .provider
+        .get_credential_provider()
+        .list_credentials_for_user(&ExecutionContext::internal(&state), &user.id, Some("totp"))
+        .await?;
+    assert_eq!(totp_creds.len(), 1);
+    assert_eq!(totp_creds[0].id, totp.id);
+
+    // No type filter: all of the user's credentials.
+    let all_creds = state
+        .provider
+        .get_credential_provider()
+        .list_credentials_for_user(&ExecutionContext::internal(&state), &user.id, None)
+        .await?;
+    assert_eq!(all_creds.len(), 2);
+
+    Ok(())
+}

--- a/tests/integration/src/credential/update.rs
+++ b/tests/integration/src/credential/update.rs
@@ -1,0 +1,164 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test credential update: blob re-encryption and the immutable-field
+//! guardrails from ADR 0019 §2 (CVE-2020-12691).
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::credential::*;
+
+use crate::credential::{create_credential, get_state};
+use crate::{create_domain, create_project, create_user};
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_blob_re_encrypts_and_persists() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let created = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"old-secret"}"#.into(),
+            r#type: "ec2".into(),
+            project_id: Some(project.id.clone()),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let updated = state
+        .provider
+        .get_credential_provider()
+        .update_credential(
+            &ExecutionContext::internal(&state),
+            &created.id,
+            CredentialUpdate {
+                blob: Some(r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"new-secret"}"#.into()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(
+        updated.blob,
+        r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"new-secret"}"#
+    );
+
+    // Re-fetch to confirm the new blob was actually persisted (re-encrypted
+    // and decrypted back), not just returned from the update call.
+    let fetched = state
+        .provider
+        .get_credential_provider()
+        .get_credential(&ExecutionContext::internal(&state), &created.id)
+        .await?
+        .expect("credential still exists");
+    assert_eq!(fetched.blob, updated.blob);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_rejects_change_to_ec2_access() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let created = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"s"}"#.into(),
+            r#type: "ec2".into(),
+            project_id: Some(project.id.clone()),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let err = state
+        .provider
+        .get_credential_provider()
+        .update_credential(
+            &ExecutionContext::internal(&state),
+            &created.id,
+            CredentialUpdate {
+                // Changing `access` would desynchronize the record from its
+                // SHA-256-derived id — must be rejected.
+                blob: Some(r#"{"access":"AKIADIFFERENTKEY0000","secret":"s"}"#.into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("changing the EC2 access key via update must be rejected");
+
+    assert!(matches!(err, CredentialProviderError::ImmutableField(f) if f == "access"));
+
+    // Original blob must be untouched.
+    let fetched = state
+        .provider
+        .get_credential_provider()
+        .get_credential(&ExecutionContext::internal(&state), &created.id)
+        .await?
+        .expect("credential still exists");
+    assert_eq!(fetched.blob, created.blob);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_project_id() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project_a = create_project!(state, domain.id.clone())?;
+    let project_b = create_project!(state, domain.id.clone())?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    let created = create_credential(
+        &state,
+        CredentialCreate {
+            blob: r#"{"access":"AKIAIOSFODNN7EXAMPLE","secret":"s"}"#.into(),
+            r#type: "ec2".into(),
+            project_id: Some(project_a.id.clone()),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let updated = state
+        .provider
+        .get_credential_provider()
+        .update_credential(
+            &ExecutionContext::internal(&state),
+            &created.id,
+            CredentialUpdate {
+                project_id: Some(project_b.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(updated.project_id, Some(project_b.id.clone()));
+
+    Ok(())
+}

--- a/tests/integration/src/integration.rs
+++ b/tests/integration/src/integration.rs
@@ -21,6 +21,7 @@ mod assignment;
 mod audit;
 mod catalog;
 mod common;
+mod credential;
 mod identity;
 mod k8s_auth;
 mod mapping;


### PR DESCRIPTION
Foundational credentials provider (EC2/TOTP/custom blob storage):
core traits plus SQL/Fernet backend. Phases 3-9 (HTTP API routes,
OS-EC2 legacy endpoints, /v3/ec2tokens signing, TOTP auth-pipeline
integration, cascading-delete wiring, keystone-manage CLI, OPA
policies) not included.

core-types/core:
- New `credential` module: Credential/CredentialCreate/
  CredentialUpdate/CredentialListParameters DTOs,
  CredentialProviderError.
- CredentialBackend/CredentialApi traits + CredentialService: EC2 id
  = SHA-256(blob.access) computed pre-backend-call for audit events,
  UUID id otherwise, 400 on missing user_id under system scope,
  access/trust_id/app_cred_id/access_token_id in blob immutable on
  update (CVE-2020-12691).
- Wired into ServiceState/PluginManager; new
  EventPayload::Credential variant for audit dispatch.

credential-driver-sql (new crate):
- SeaORM entity for `credential` table. Per ADR 0019 the table is
  owned exclusively by Python Keystone's alembic migrations, so
  SqlDriver::setup() is a deliberate no-op unlike every other SQL
  driver here. test_support creates the table for this crate's tests
  only.
- fernet.rs: setup/load/rotate per corrected ADR 0019 rotation —
  staged key `0` promoted by rename to `old_primary + 1`, outgoing
  primary kept for decryption, fresh key staged, files beyond
  MAX_ACTIVE_KEYS (3, hardcoded) pruned oldest-first. key_hash =
  SHA-1 over raw base64url key-file bytes (not decoded key), matching
  keystone/credential/providers/fernet/core.py. Null Key detection
  refuses to load unless insecure_allow_null_key set.
- CRUD backend (create/get/list/update/delete, delete-for-user/
  -project, EC2 access-key lookup via SHA-256 hash); reads
  `[credential]` config fresh per call via
  ServiceState.config_manager, matching identity-driver-sql.

Config: new `[credential]` section (driver, key_repository default
/etc/keystone/credential-keys/, insecure_allow_null_key).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
