### PR TITLE
feat(loadtest): Add intensive user/project list tests

### DIFF
--- a/tests/loadtest/Cargo.lock
+++ b/tests/loadtest/Cargo.lock
@@ -1342,6 +1342,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 name = "load_test"
 version = "0.0.0"
 dependencies = [
+ "fastrand",
  "goose",
  "openstack_sdk",
  "reqwest 0.12.28",

--- a/tests/loadtest/Cargo.toml
+++ b/tests/loadtest/Cargo.toml
@@ -13,6 +13,7 @@ openstack_sdk = { version = "^0.22", default-features = false, features = ["asyn
 reqwest = { version = "0.12", features = ["json"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+fastrand = "2"
 
 [[bin]]
 name="load_test"

--- a/tests/loadtest/src/main.rs
+++ b/tests/loadtest/src/main.rs
@@ -24,9 +24,11 @@ use crate::v3::auth::{token_lifecycle, validate as validate_token};
 use crate::v3::domain::list as domain_list;
 use crate::v3::project::{
     create as project_create, delete as project_delete, list as project_list, show as project_show,
+    show_random as project_show_random,
 };
 use crate::v3::user::{
     create as user_create, delete as user_delete, list as user_list, show as user_show,
+    show_random as user_show_random,
 };
 
 /// Per-GooseUser session state shared across transactions.
@@ -47,11 +49,16 @@ async fn main() -> Result<(), GooseError> {
     // Pre-populate the database so list endpoints operate on non-trivial data.
     let seed_state = seed::seed(&host, &admin_token).await;
 
-    // Default to 20 users so all weighted scenarios get at least 1 user
-    // (total weight = 13; 20 ensures proportional coverage).
+    // Share the seeded ID pools with the catalog-read scenarios so virtual users
+    // can pick random IDs without needing to issue their own list calls first.
+    v3::user::set_seeded_ids(seed_state.user_ids.clone());
+    v3::project::set_seeded_ids(seed_state.project_ids.clone());
+
+    // Default to 30 users so all weighted scenarios get at least 1 user
+    // (total weight = 20; 30 ensures proportional coverage).
     // Can be overridden by passing --users on the CLI.
     let attack = GooseAttack::initialize()?
-        .set_default(GooseDefault::Users, 20usize)?
+        .set_default(GooseDefault::Users, 30usize)?
         // Read-heavy workload: list endpoints hit the most common production path.
         .register_scenario(
             scenario!("ReadHeavy")
@@ -92,6 +99,26 @@ async fn main() -> Result<(), GooseError> {
                 .register_transaction(transaction!(project_create).set_on_start())
                 .register_transaction(transaction!(project_show))
                 .register_transaction(transaction!(project_delete).set_on_stop()),
+        )
+        // Catalog read: list all users then fetch a randomly chosen one from the
+        // pre-seeded pool.  Exercises the list + point-read path under realistic
+        // data volumes (100 seeded users).
+        .register_scenario(
+            scenario!("UserRead")
+                .set_weight(4)?
+                .register_transaction(transaction!(openstack_login).set_on_start())
+                .register_transaction(transaction!(user_list))
+                .register_transaction(transaction!(user_show_random)),
+        )
+        // Catalog read: list all projects then fetch a randomly chosen one from the
+        // pre-seeded pool.  Exercises the list + point-read path under realistic
+        // data volumes (100 seeded projects).
+        .register_scenario(
+            scenario!("ProjectRead")
+                .set_weight(3)?
+                .register_transaction(transaction!(openstack_login).set_on_start())
+                .register_transaction(transaction!(project_list))
+                .register_transaction(transaction!(project_show_random)),
         );
 
     attack.execute().await?;
@@ -105,10 +132,7 @@ async fn main() -> Result<(), GooseError> {
 pub async fn openstack_login(user: &mut GooseUser) -> TransactionResult {
     let cfg = ConfigFile::new().unwrap();
     let cloud_name = env::var("OS_CLOUD").unwrap_or("devstack".to_string());
-    let profile = cfg
-        .get_cloud_config(cloud_name)
-        .unwrap()
-        .unwrap();
+    let profile = cfg.get_cloud_config(cloud_name).unwrap().unwrap();
     let session = AsyncOpenStack::new(&profile)
         .await
         .expect("cannot connect to the cloud");

--- a/tests/loadtest/src/seed.rs
+++ b/tests/loadtest/src/seed.rs
@@ -21,8 +21,8 @@ use serde_json::json;
 use uuid::Uuid;
 
 const DEFAULT_DOMAIN_ID: &str = "default";
-const SEED_USERS: usize = 20;
-const SEED_PROJECTS: usize = 10;
+const SEED_USERS: usize = 100;
+const SEED_PROJECTS: usize = 100;
 
 pub struct SeedState {
     pub user_ids: Vec<String>,

--- a/tests/loadtest/src/v3/auth.rs
+++ b/tests/loadtest/src/v3/auth.rs
@@ -27,9 +27,7 @@ pub async fn validate(user: &mut GooseUser) -> TransactionResult {
         .header("x-auth-token", &token)
         .header("x-subject-token", &token);
 
-    let goose_request = GooseRequest::builder()
-        .set_request_builder(req)
-        .build();
+    let goose_request = GooseRequest::builder().set_request_builder(req).build();
 
     user.request(goose_request).await?;
     Ok(())

--- a/tests/loadtest/src/v3/domain.rs
+++ b/tests/loadtest/src/v3/domain.rs
@@ -25,9 +25,7 @@ pub async fn list(user: &mut GooseUser) -> TransactionResult {
         .get_request_builder(&GooseMethod::Get, "/v3/domains")?
         .header("x-auth-token", &token);
 
-    let goose_request = GooseRequest::builder()
-        .set_request_builder(req)
-        .build();
+    let goose_request = GooseRequest::builder().set_request_builder(req).build();
 
     user.request(goose_request).await?;
     Ok(())

--- a/tests/loadtest/src/v3/project.rs
+++ b/tests/loadtest/src/v3/project.rs
@@ -14,11 +14,20 @@
 
 use goose::prelude::*;
 use serde_json::json;
+use std::sync::OnceLock;
 use uuid::Uuid;
 
 use crate::Session;
 
 const DEFAULT_DOMAIN_ID: &str = "default";
+
+static SEEDED_PROJECT_IDS: OnceLock<Vec<String>> = OnceLock::new();
+
+/// Call once before `GooseAttack::execute()` to share the seeded project ID pool
+/// with all virtual users.
+pub fn set_seeded_ids(ids: Vec<String>) {
+    SEEDED_PROJECT_IDS.set(ids).ok();
+}
 
 /// List all projects (read-heavy scenario transaction).
 pub async fn list(user: &mut GooseUser) -> TransactionResult {
@@ -29,7 +38,32 @@ pub async fn list(user: &mut GooseUser) -> TransactionResult {
         .get_request_builder(&GooseMethod::Get, "/v3/projects")?
         .header("x-auth-token", &token);
 
+    let goose_request = GooseRequest::builder().set_request_builder(req).build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// Show a randomly chosen project from the pre-seeded pool.
+///
+/// Measures GET /v3/projects/:id latency against a realistic, pre-populated dataset.
+/// Returns Ok(()) silently if the pool is empty (seed failed entirely).
+pub async fn show_random(user: &mut GooseUser) -> TransactionResult {
+    let ids = match SEEDED_PROJECT_IDS.get() {
+        Some(v) if !v.is_empty() => v,
+        _ => return Ok(()),
+    };
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+    let id = &ids[fastrand::usize(..ids.len())];
+    let path = format!("/v3/projects/{id}");
+
+    let req = user
+        .get_request_builder(&GooseMethod::Get, &path)?
+        .header("x-auth-token", &token);
+
     let goose_request = GooseRequest::builder()
+        .name("GET /v3/projects/:id (catalog)")
         .set_request_builder(req)
         .build();
 

--- a/tests/loadtest/src/v3/user.rs
+++ b/tests/loadtest/src/v3/user.rs
@@ -14,11 +14,20 @@
 
 use goose::prelude::*;
 use serde_json::json;
+use std::sync::OnceLock;
 use uuid::Uuid;
 
 use crate::Session;
 
 const DEFAULT_DOMAIN_ID: &str = "default";
+
+static SEEDED_USER_IDS: OnceLock<Vec<String>> = OnceLock::new();
+
+/// Call once before `GooseAttack::execute()` to share the seeded user ID pool
+/// with all virtual users.
+pub fn set_seeded_ids(ids: Vec<String>) {
+    SEEDED_USER_IDS.set(ids).ok();
+}
 
 /// List all users (read-heavy scenario transaction).
 pub async fn list(user: &mut GooseUser) -> TransactionResult {
@@ -29,7 +38,32 @@ pub async fn list(user: &mut GooseUser) -> TransactionResult {
         .get_request_builder(&GooseMethod::Get, "/v3/users")?
         .header("x-auth-token", &token);
 
+    let goose_request = GooseRequest::builder().set_request_builder(req).build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// Show a randomly chosen user from the pre-seeded pool.
+///
+/// Measures GET /v3/users/:id latency against a realistic, pre-populated dataset.
+/// Returns Ok(()) silently if the pool is empty (seed failed entirely).
+pub async fn show_random(user: &mut GooseUser) -> TransactionResult {
+    let ids = match SEEDED_USER_IDS.get() {
+        Some(v) if !v.is_empty() => v,
+        _ => return Ok(()),
+    };
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+    let id = &ids[fastrand::usize(..ids.len())];
+    let path = format!("/v3/users/{id}");
+
+    let req = user
+        .get_request_builder(&GooseMethod::Get, &path)?
+        .header("x-auth-token", &token);
+
     let goose_request = GooseRequest::builder()
+        .name("GET /v3/users/:id (catalog)")
         .set_request_builder(req)
         .build();
 


### PR DESCRIPTION
Seed counts raised from 20 users/10 projects to 100/100 so list responses
reflect realistic catalogue sizes.  Default virtual-user count raised
from 20 to 30 to ensure all 7 scenarios (total weight 20) receive at
least one user.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
