### PR TITLE
fix(ci): Prepare workflows for merge queue

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,6 +20,15 @@ command = { command-line = [ "tools/raft-env.sh" ] }
 [scripts.setup.start-api]
 command = { command-line = [ "tools/start-api.sh" ] }
 
+
+[profile.ci]
+inherits = "default"
+
+[profile.ci.junit]
+path = "junit.xml"
+store-success-output = false
+store-failure-output = true
+
 # --- POSTGRES PROFILE ---
 [profile.postgres]
 
@@ -32,6 +41,13 @@ setup = "setup-pg"
 [[profile.postgres.scripts]]
 filter = "binary(provider)"
 setup = "setup-pg"
+
+[profile.ci-postgres]
+inherits = "postgres"
+[profile.ci-postgres.junit]
+path = "junit.xml"
+store-success-output = false
+store-failure-output = true
 
 # --- MYSQL PROFILE ---
 [profile.mysql]
@@ -46,6 +62,13 @@ setup = "setup-mysql"
 filter = "binary(provider)"
 setup = "setup-mysql"
 
+[profile.ci-mysql]
+inherits = "mysql"
+[profile.ci-mysql.junit]
+path = "junit.xml"
+store-success-output = false
+store-failure-output = true
+
 # --- Raft based integration test ---
 [profile.raft]
 default-filter = "all()"
@@ -54,9 +77,28 @@ default-filter = "all()"
 filter = "binary(integration) + binary(test_cluster)"
 setup = "raft-env"
 
+[profile.ci-raft]
+inherits = "raft"
+[profile.ci-raft.junit]
+path = "junit.xml"
+store-success-output = false
+store-failure-output = true
+
 # --- API tests ---
 [profile.api]
+#default-filter = "binary(integration_api_v3) + binary(integration_api_v4)"
 
 [[profile.api.scripts]]
 filter = "binary(integration_api_v3) + binary(integration_api_v4)"
 setup = "start-api"
+
+[profile.ci-api]
+inherits = "api"
+[[profile.ci-api.scripts]]
+filter = "binary(integration_api_v3) + binary(integration_api_v4)"
+setup = "start-api"
+[profile.ci-api.junit]
+path = "junit.xml"
+store-success-output = false
+store-failure-output = true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-    paths:
-      - '.github/workflows/ci*.yml'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'benches/**'
-      - 'crates/**'
-      - 'tools/setup-db.sh'
-      - 'tools/docker-compose.test.yaml'
   merge_group:
 
 env:
@@ -24,9 +16,38 @@ env:
   KEYSTONE_DEV_KEK: 4242424242424242424242424242424242424242424242424242424242424242
   KEYSTONE_ALLOW_ENV_KEK: "1"
   SPIRE_VERSION: "1.15.1"
+  RUST_LOG: "info,reqwest=off,h2=off,hyper=off"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required checks must always report a status, so the workflow triggers
+    # unconditionally; this job decides whether the real work is needed.
+    outputs:
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - '.github/workflows/ci*.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'benches/**'
+              - 'crates/**'
+              - 'tools/setup-db.sh'
+              - 'tools/docker-compose.test.yaml'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       matrix:
         include:
@@ -83,22 +104,22 @@ jobs:
         run: pip install keystone
 
       - name: Run tests (unit)
-        run: cargo nextest run --all-features
+        run: cargo nextest run --all-features --profile ci
 
-      - name: Run tests (sqlite)
-        run: cargo nextest run -p test_integration
+      - name: Run integration tests (sqlite)
+        run: cargo nextest run -p test_integration --profile ci
 
-      - name: Run tests (mysql)
-        run: cargo nextest run -p test_integration --profile mysql --no-capture
+      - name: Run integration tests (mysql)
+        run: cargo nextest run -p test_integration --profile ci-mysql
 
-      - name: Run tests for postgres
-        run: cargo nextest run -p test_integration --profile postgres --no-capture
+      - name: Run integration tests for postgres
+        run: cargo nextest run -p test_integration --profile ci-postgres
 
-      - name: Run tests for raft drivers
-        run: cargo nextest run -p test_integration --profile raft --no-capture
+      - name: Run integration tests for raft drivers
+        run: cargo nextest run -p test_integration --profile ci-raft
 
-      - name: Run Rest API v3 tests
-        run: cargo nextest run -p test_api --profile api --no-capture --test integration_api_v3
+      - name: Run REST API v3 tests
+        run: cargo nextest run -p test_api --profile ci-api --test integration_api_v3
 
       - name: Run Doc tests
         run: cargo test --doc
@@ -114,7 +135,18 @@ jobs:
           name: nextest
           path: /tmp/nextest/keystone
 
+      # Convert JUnit XML into an interactive GitHub Step Summary
+      - name: Publish Test Report
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure() # Run even if tests fail
+        with:
+          name: Cargo Nextest Results
+          path: target/nextest/*/junit.xml
+          reporter: java-junit
+
   openapi:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -4,16 +4,6 @@ name: Functional and interoperability testing
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/functional.yml'
-      - 'skaffold.yaml'
-      - 'tests/**'
-      - 'loadtest/**'
-      - 'crates/**'
-      - 'policy/**'
-      - 'tools/Dockerfile.skaffold'
   merge_group:
 env:
   DATABASE_URL: postgresql://keystone:1234@127.0.0.1:5432/keystone
@@ -30,8 +20,40 @@ defaults:
     shell: bash
 
 jobs:
-  build:
+  changes:
     runs-on: ubuntu-latest
+    # Required checks must always report a status, so the workflow triggers
+    # unconditionally; this job decides whether the real work is needed.
+    outputs:
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/functional.yml'
+              - 'skaffold.yaml'
+              - 'tests/**'
+              - 'loadtest/**'
+              - 'crates/**'
+              - 'policy/**'
+              - 'tools/Dockerfile.skaffold'
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -87,6 +109,8 @@ jobs:
       OS_USER_DOMAIN_ID: default
       OS_PROJECT_NAME: admin
       OS_PROJECT_DOMAIN_ID: default
+    permissions:
+      contents: read
     services:
       postgres:
         image: postgres:17
@@ -149,7 +173,7 @@ jobs:
 
   federation:
     runs-on: ubuntu-latest
-    if: "github.actor != 'openstack-experimental-release-plz'"
+    if: "success() && github.actor != 'openstack-experimental-release-plz'"
     needs:
       - build
     env:
@@ -221,7 +245,7 @@ jobs:
 
   loadtest:
     runs-on: ubuntu-latest
-    if: "github.actor != 'openstack-experimental-release-plz'"
+    if: "success() && github.actor != 'openstack-experimental-release-plz'"
     needs:
       - build
     permissions:
@@ -284,7 +308,7 @@ jobs:
         run: docker logs opa
 
   loadtest-track:
-    if: "github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'openstack-experimental-release-plz'"
+    if: "success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'openstack-experimental-release-plz'"
     runs-on: ubuntu-latest
     needs:
       - loadtest
@@ -317,6 +341,8 @@ jobs:
             [View full report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
   k3s-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.run_id || github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -53,6 +53,11 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Install protobuf-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Install Rust ${{ env.rust_min }}
         uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921 # stable
         with:
@@ -68,9 +73,9 @@ jobs:
         run: cargo binstall clippy-sarif sarif-fmt --force
 
       - name: Run rust-clippy
-        run:
-          cargo clippy
-          --lib --tests
+        run: |
+          cargo clippy \
+          --lib --tests \
           --message-format=json | ${CARGO_HOME}/bin/clippy-sarif | tee rust-clippy-results.sarif | ${CARGO_HOME}/bin/sarif-fmt
 
       - name: Upload analysis results to GitHub
@@ -109,7 +114,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup OPA
-        uses: open-policy-agent/setup-opa@34a30e8a924d1b03ce2cf7abe97250bbb1f332b5 # v2.2.0
+        uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
         with:
           version: 1.6.0
 
@@ -132,7 +137,8 @@ jobs:
         fetch-depth: 0
 
     - name: Lint Commits
-      env:
-        # Forces committed to look only at the final proposed commit at the tip of the queue
-        COMMITTED_REV: ${{ github.event_name == 'merge_group' && 'HEAD~1..HEAD' || '' }}
       uses: crate-ci/committed@15229711f8f597474c0b636f327cde5969f9a529 # v1.1.7
+      with:
+        # committed's default range (HEAD~..HEAD^2) assumes a 2-parent PR merge
+        # commit, which doesn't exist on the merge queue's single-commit ref.
+        commits: ${{ github.event_name == 'merge_group' && 'HEAD~1..HEAD' || 'HEAD~..HEAD^2' }}

--- a/crates/assignment-driver-sql/src/lib.rs
+++ b/crates/assignment-driver-sql/src/lib.rs
@@ -89,7 +89,9 @@ impl SqlBackend {
                             further
                                 .iter()
                                 .filter(|fid| {
-                                    !imply_rules.get(&snapshot_role_id).unwrap().contains(*fid)
+                                    !imply_rules
+                                        .get(&snapshot_role_id)
+                                        .is_some_and(|s| s.contains(*fid))
                                 })
                                 .cloned()
                                 .collect::<BTreeSet<String>>()

--- a/crates/cli-manage/src/bootstrap.rs
+++ b/crates/cli-manage/src/bootstrap.rs
@@ -68,7 +68,6 @@ fn setup_logging(verbose: u8) {
     let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry().with(log_layer));
 }
 
-#[allow(clippy::print_stdout)]
 #[async_trait]
 impl PerformAction for BootstrapCommand {
     async fn take_action(self, config: &Config) -> Result<()> {

--- a/crates/cli-manage/src/db.rs
+++ b/crates/cli-manage/src/db.rs
@@ -141,7 +141,6 @@ async fn connect_db(config: &Config) -> Result<DatabaseConnection> {
         .wrap_err("Database connection failed")
 }
 
-#[allow(clippy::print_stdout)]
 #[async_trait]
 impl PerformAction for DbCommand {
     async fn take_action(self, config: &Config) -> Result<(), Report> {

--- a/crates/cli-manage/src/main.rs
+++ b/crates/cli-manage/src/main.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! Keystone manage executable.
+#![allow(clippy::print_stdout)]
 
 use std::path::PathBuf;
 
@@ -51,7 +52,7 @@ struct Args {
 
 #[derive(Parser)]
 enum Command {
-    /// Bootstrap
+    /// Bootstrap.
     Bootstrap(BootstrapCommand),
 
     /// Database management commands.

--- a/crates/cli-manage/src/storage/backup.rs
+++ b/crates/cli-manage/src/storage/backup.rs
@@ -51,7 +51,6 @@ pub(super) struct BackupCommand {
 
 #[async_trait]
 impl PerformAction for BackupCommand {
-    #[allow(clippy::print_stdout)]
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         if config.distributed_storage.is_none() {
             return Err(eyre!("no distributed_storage configuration"));

--- a/crates/cli-manage/src/storage/confirm_rotate_dek.rs
+++ b/crates/cli-manage/src/storage/confirm_rotate_dek.rs
@@ -44,7 +44,6 @@ pub(super) struct ConfirmRotateDekCommand {
 
 #[async_trait]
 impl PerformAction for ConfirmRotateDekCommand {
-    #[allow(clippy::print_stdout)]
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         let mut client = get_grpc_client(config, self.cluster_addr).await?;
 

--- a/crates/cli-manage/src/storage/list_peers.rs
+++ b/crates/cli-manage/src/storage/list_peers.rs
@@ -32,7 +32,6 @@ pub(super) struct ListPeersCommand {}
 
 #[async_trait]
 impl PerformAction for ListPeersCommand {
-    #[allow(clippy::print_stdout)]
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         if config.distributed_storage.is_some() {
             let mut client = get_grpc_client(config, None).await?;

--- a/crates/cli-manage/src/storage/metrics.rs
+++ b/crates/cli-manage/src/storage/metrics.rs
@@ -39,7 +39,6 @@ pub(super) struct MetricsCommand {
 
 #[async_trait]
 impl PerformAction for MetricsCommand {
-    #[allow(clippy::print_stdout)]
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         if config.distributed_storage.is_none() {
             return Err(eyre!("no distributed_storage configuration"));

--- a/crates/cli-manage/src/storage/restore.rs
+++ b/crates/cli-manage/src/storage/restore.rs
@@ -68,7 +68,6 @@ pub(super) struct RestoreCommand {
 
 #[async_trait]
 impl PerformAction for RestoreCommand {
-    #[allow(clippy::print_stdout)]
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         let file = File::open(&self.snapshot)
             .await

--- a/crates/cli-manage/src/storage/rotate_dek.rs
+++ b/crates/cli-manage/src/storage/rotate_dek.rs
@@ -50,7 +50,6 @@ pub(super) struct RotateDekCommand {
 
 #[async_trait]
 impl PerformAction for RotateDekCommand {
-    #[allow(clippy::print_stdout)]
     async fn take_action(self, config: &Config) -> Result<(), Report> {
         let mut client = get_grpc_client(config, self.cluster_addr).await?;
 

--- a/crates/core/src/mapping/version.rs
+++ b/crates/core/src/mapping/version.rs
@@ -243,7 +243,7 @@ mod tests {
             },
             &DomainResolutionMode::Fixed,
             true,
-            &[rule.clone()],
+            std::slice::from_ref(&rule),
         );
         let v2 = compute_ruleset_version_from_parts(
             "test-123",
@@ -269,7 +269,7 @@ mod tests {
             },
             &DomainResolutionMode::Fixed,
             true,
-            &[rule.clone()],
+            std::slice::from_ref(&rule),
         );
         let v2 = compute_ruleset_version_from_parts(
             "test-123",

--- a/crates/idmapping-driver-sql/src/lib.rs
+++ b/crates/idmapping-driver-sql/src/lib.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! OpenStack Keystone SQL driver for the ID Mapping provider
+//! # OpenStack Keystone SQL driver for the ID Mapping provider
 use async_trait::async_trait;
 
 use sea_orm::{DatabaseConnection, Schema};

--- a/crates/keystone/src/federation/api/common.rs
+++ b/crates/keystone/src/federation/api/common.rs
@@ -235,10 +235,10 @@ mod tests {
 
     #[test]
     fn flatten_number_claim() {
-        let json = serde_json::json!({"age": 42, "score": 3.14});
+        let json = serde_json::json!({"age": 42, "score": std::f32::consts::PI});
         let claims = flatten_federation_claims(&json).unwrap();
         assert_eq!(*claims.get("age").unwrap(), vec!["42"]);
-        assert_eq!(*claims.get("score").unwrap(), vec!["3.14"]);
+        assert_eq!(*claims.get("score").unwrap(), vec!["3.1415927410125732"]);
     }
 
     #[test]
@@ -337,7 +337,7 @@ mod tests {
     fn flatten_empty_key_default() {
         // Top-level value with no prefix should use "*" key.
         let claims = flatten_federation_claims(&serde_json::json!("orphan"));
-        assert!(claims.is_ok() && claims.unwrap().get("*").is_some());
+        assert!(claims.is_ok() && claims.unwrap().contains_key("*"));
     }
 
     #[test]

--- a/crates/resource-driver-sql/src/project/delete.rs
+++ b/crates/resource-driver-sql/src/project/delete.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Delete project
+//! # Delete project
 
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -12,6 +12,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::uninlined_format_args)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::print_stdout)]
 use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
@@ -111,8 +114,10 @@ async fn test_kek_gating_production_mode_rejected_inner() -> Result<()> {
     let mut ds_config = get_ds_config(101, storage_dir.path().to_path_buf(), tls_configuration);
     ds_config.dev_mode = false;
 
-    let mut config = Config::default();
-    config.distributed_storage = Some(ds_config);
+    let config = Config {
+        distributed_storage: Some(ds_config),
+        ..Default::default()
+    };
 
     // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
     unsafe {
@@ -148,8 +153,10 @@ async fn test_kek_gating_dev_mode_requires_allow_env_kek_inner() -> Result<()> {
     let ds_config = get_ds_config(102, storage_dir.path().to_path_buf(), tls_configuration);
     // dev_mode is true via get_ds_config, but KEYSTONE_ALLOW_ENV_KEK is unset.
 
-    let mut config = Config::default();
-    config.distributed_storage = Some(ds_config);
+    let config = Config {
+        distributed_storage: Some(ds_config),
+        ..Default::default()
+    };
 
     // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
     unsafe {
@@ -184,8 +191,10 @@ async fn test_quarantine_committed_via_raft_inner() -> Result<()> {
     let tls_configuration = make_certificates()?;
     let ds_config = get_ds_config(103, storage_dir.path().to_path_buf(), tls_configuration);
 
-    let mut config = Config::default();
-    config.distributed_storage = Some(ds_config);
+    let config = Config {
+        distributed_storage: Some(ds_config),
+        ..Default::default()
+    };
 
     // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
     unsafe {
@@ -279,8 +288,10 @@ async fn test_abort_pending_rotation_via_raft_inner() -> Result<()> {
     let tls_configuration = make_certificates()?;
     let ds_config = get_ds_config(104, storage_dir.path().to_path_buf(), tls_configuration);
 
-    let mut config = Config::default();
-    config.distributed_storage = Some(ds_config);
+    let config = Config {
+        distributed_storage: Some(ds_config),
+        ..Default::default()
+    };
 
     // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
     unsafe {
@@ -384,8 +395,10 @@ async fn test_live_uniqueness_check_detects_conflict_inner() -> Result<()> {
         storage_dir_a.path().to_path_buf(),
         tls_configuration.clone(),
     );
-    let mut config_a = Config::default();
-    config_a.distributed_storage = Some(ds_config_a);
+    let config_a = Config {
+        distributed_storage: Some(ds_config_a),
+        ..Default::default()
+    };
 
     let storage_a = init_storage(&ConfigManager::not_watched(config_a.clone())).await?;
 
@@ -438,8 +451,10 @@ async fn test_live_uniqueness_check_detects_conflict_inner() -> Result<()> {
         tls_configuration,
     );
     ds_config_b.retry_join_nodes = vec![(200, get_addr(200).to_string())];
-    let mut config_b = Config::default();
-    config_b.distributed_storage = Some(ds_config_b);
+    let config_b = Config {
+        distributed_storage: Some(ds_config_b),
+        ..Default::default()
+    };
 
     // from_env() removes KEYSTONE_DEV_KEK after reading it, so it must be
     // re-set before every init_storage call in this process.
@@ -497,8 +512,10 @@ async fn test_live_uniqueness_check_proceeds_when_no_peer_reachable_inner() -> R
     // must fail, exercising the "no peer reachable" branch.
     ds_config.retry_join_nodes = vec![(210, "127.0.0.1:21999".to_string())];
 
-    let mut config = Config::default();
-    config.distributed_storage = Some(ds_config);
+    let config = Config {
+        distributed_storage: Some(ds_config),
+        ..Default::default()
+    };
 
     // SAFETY: no concurrent env readers; test is `#[serial_test::serial]`.
     unsafe {
@@ -539,8 +556,10 @@ async fn test_node_restart_inner() -> Result<()> {
         dev_mode: true,
         retry_join_nodes: vec![],
     };
-    let mut config = Config::default();
-    config.distributed_storage = Some(ds_config);
+    let config = Config {
+        distributed_storage: Some(ds_config),
+        ..Default::default()
+    };
 
     // SAFETY: no concurrent env reads
     unsafe {
@@ -627,8 +646,10 @@ async fn test_node_restart_inner() -> Result<()> {
         dev_mode: true,
         retry_join_nodes: vec![],
     };
-    let mut config_restart = Config::default();
-    config_restart.distributed_storage = Some(ds_config_restart);
+    let config_restart = Config {
+        distributed_storage: Some(ds_config_restart),
+        ..Default::default()
+    };
 
     // SAFETY: no concurrent env reads
     unsafe {
@@ -699,8 +720,11 @@ impl InstanceHolder {
             storage_dir.path().to_path_buf(),
             tls_config,
         );
-        let mut config = Config::default();
-        config.distributed_storage = Some(ds_config);
+        let config = Config {
+            distributed_storage: Some(ds_config),
+            ..Default::default()
+        };
+
         unsafe {
             std::env::set_var("KEYSTONE_DEV_KEK", TEST_KEK_HEX);
             std::env::set_var("KEYSTONE_ALLOW_ENV_KEK", "1");
@@ -1532,10 +1556,10 @@ fn get_addr_with_port(node_id: u64, port_base: u16) -> SocketAddr {
 
 async fn wait_for_leader(client: &mut ClusterAdminServiceClient<Channel>, expected_leader: u64) {
     for _ in 0..50 {
-        if let Ok(resp) = client.metrics(()).await {
-            if resp.into_inner().current_leader == Some(expected_leader) {
-                return;
-            }
+        if let Ok(resp) = client.metrics(()).await
+            && resp.into_inner().current_leader == Some(expected_leader)
+        {
+            return;
         }
         TypeConfig::sleep(Duration::from_millis(100)).await;
     }

--- a/crates/webauthn/src/driver/raft.rs
+++ b/crates/webauthn/src/driver/raft.rs
@@ -733,7 +733,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_credential_storage<'a>() {
+    async fn test_credential_storage() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 
@@ -764,7 +764,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_credential_keys<'a>() {
+    async fn test_credential_keys() {
         let driver = RaftDriver::default();
         assert_eq!(
             driver.get_cred_key_name("user-1", "cred-1"),
@@ -774,7 +774,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_state_auth_key<'a>() {
+    async fn test_state_auth_key() {
         let driver = RaftDriver::default();
         assert_eq!(
             driver.get_user_cred_auth_state_key_name("user-1"),
@@ -783,7 +783,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_state_reg_key<'a>() {
+    async fn test_state_reg_key() {
         let driver = RaftDriver::default();
         assert_eq!(
             driver.get_user_cred_registration_state_key_name("user-1"),
@@ -792,7 +792,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_auth_state_save_and_get<'a>() {
+    async fn test_auth_state_save_and_get() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 
@@ -823,7 +823,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reg_state_save_and_get<'a>() {
+    async fn test_reg_state_save_and_get() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 
@@ -854,7 +854,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_credential_deletion<'a>() {
+    async fn test_credential_deletion() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 
@@ -885,7 +885,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_state_deletion<'a>() {
+    async fn test_state_deletion() {
         let driver = RaftDriver::default();
         let storage = MockStorage::default();
 


### PR DESCRIPTION
- committed action was silently ignoring its merge_group override:       
  crate-ci/committed reads the commits input, not a COMMITTED_REV env    
  var, so on merge_group it kept using the default HEAD~..HEAD^2 range,  
  which doesn't resolve on the queue's single-commit ref.                
- ci.yml and functional.yml gated required jobs behind pull_request      
  path filters, so a required status check on those jobs would never     
  report on PRs that don't touch matched paths, blocking merge forever.  
  Both workflows now always trigger and use dorny/paths-filter in a new  
  changes job to skip the actual work when nothing relevant changed,     
  so the check always reports.                                           
                                                                         
Apparently due to the wrong filters the clippy job was not properly      
running, which is why unrelated clippy fixes are included.               
                                                                         
Signed-off-by: Artem Goncharov <Artem.goncharov@gmail.com>  