### PR TITLE
fix: Prevent user enumeration via passkey authentication start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4429,6 +4429,7 @@ dependencies = [
  "rmp-serde",
  "sea-orm",
  "sea-orm-migration",
+ "secrecy",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/config/src/webauthn.rs
+++ b/crates/config/src/webauthn.rs
@@ -14,6 +14,7 @@
 //! # Keystone configuration
 //!
 //! Parsing of the Keystone configuration file implementation.
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -26,6 +27,17 @@ pub struct WebauthnSection {
     /// Enable WebauthN support.
     #[serde(default)]
     pub enabled: bool,
+    /// Secret HMAC key used to derive deterministic decoy credential IDs for
+    /// authentication start requests naming users that do not exist or have
+    /// no registered passkeys. This hides whether an account exists (user
+    /// enumeration prevention). Any sufficiently random string (16+
+    /// characters) is suitable. The key must stay stable across restarts and
+    /// be identical on all nodes of a deployment; otherwise decoy credential
+    /// IDs change between requests, which lets a caller distinguish decoys
+    /// from real credentials. When unset, a random per-process key is
+    /// generated at startup (adequate only for single-node deployments).
+    #[serde(default)]
+    pub fake_credential_hmac_key: Option<SecretString>,
     /// The relying party configuration for the WebauthN.
     #[serde(default, flatten)]
     pub relying_party: Option<RelyingParty>,
@@ -57,6 +69,7 @@ impl Default for WebauthnSection {
         Self {
             driver: default_raft(),
             enabled: false,
+            fake_credential_hmac_key: None,
             relying_party: None,
         }
     }

--- a/crates/webauthn/Cargo.toml
+++ b/crates/webauthn/Cargo.toml
@@ -22,6 +22,7 @@ openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage = { workspace = true, features = ["mock"] }
 rmp-serde.workspace = true
 sea-orm = { workspace = true, features = ["default"] }
+secrecy.workspace = true
 sea-orm-migration = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
@@ -34,6 +35,7 @@ utoipa-axum.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 validator.workspace = true
 webauthn-rs = { workspace = true, features = ["danger-allow-state-serialisation"] }
+webauthn-rs-proto.workspace = true
 
 [dev-dependencies]
 axum = { workspace = true, features = ["http2", "tokio"] }

--- a/crates/webauthn/src/api.rs
+++ b/crates/webauthn/src/api.rs
@@ -14,14 +14,16 @@
 //! # WebAuthN extension REST API
 
 use axum::Router;
+use secrecy::ExposeSecret;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{spawn, time};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, trace};
+use tracing::{error, info, trace, warn};
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 use webauthn_rs::WebauthnBuilder;
+use webauthn_rs::fake::{FakePasskeyDistribution, WebauthnFakeCredentialGenerator};
 
 use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::error::KeystoneError;
@@ -99,9 +101,25 @@ pub async fn init_extension_state(
         "raft" => Box::new(RaftDriver::default()),
         other => return Err(WebauthnError::UnsupportedDriver(other.to_string()))?,
     };
+    let fake_credential_hmac_key: Vec<u8> = match &config.fake_credential_hmac_key {
+        Some(key) => key.expose_secret().as_bytes().to_vec(),
+        None => {
+            warn!(
+                "`[webauthn]fake_credential_hmac_key` is not configured; using a random \
+                 per-process key for decoy credential IDs. Configure a stable key to keep user \
+                 enumeration prevention effective across restarts and in multi-node deployments."
+            );
+            WebauthnFakeCredentialGenerator::<FakePasskeyDistribution>::new_hmac_key()
+                .map_err(WebauthnError::from)?
+        }
+    };
+    let fake_credential_generator = WebauthnFakeCredentialGenerator::new(&fake_credential_hmac_key)
+        .map_err(WebauthnError::from)?;
+
     let extension_state = Arc::new(ExtensionState {
         provider: driver,
         webauthn,
+        fake_credential_generator,
     });
 
     let combined_state = CombinedExtensionState {

--- a/crates/webauthn/src/api/auth/start.rs
+++ b/crates/webauthn/src/api/auth/start.rs
@@ -19,6 +19,7 @@ use validator::Validate;
 use openstack_keystone_api_types::error::KeystoneApiError;
 use openstack_keystone_core::auth::ExecutionContext;
 
+use crate::WebauthnError;
 use crate::api::types::{CombinedExtensionState, auth::*};
 
 /// Start passkey authentication for the user.
@@ -47,8 +48,6 @@ pub async fn start(
     Json(req): Json<PasskeyAuthenticationStartRequest>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     req.validate()?;
-    // TODO: Check user existence and simulate the response when the user does not
-    // exist.
     let allow_credentials: Vec<webauthn_rs::prelude::Passkey> = state
         .extension
         .provider
@@ -65,7 +64,28 @@ pub async fn start(
         .webauthn
         .start_passkey_authentication(allow_credentials.as_ref())
     {
-        Ok((rcr, auth_state)) => {
+        Ok((mut rcr, auth_state)) => {
+            if allow_credentials.is_empty() {
+                // The user does not exist or has no registered passkeys. To
+                // prevent user enumeration respond with deterministic decoy
+                // credential IDs (stable per user_id) instead of an empty
+                // `allow_credentials` list. The ceremony state is stored as
+                // usual; completing it fails exactly like an attempt against
+                // a real user with a credential that is not in the allow
+                // list.
+                rcr.public_key.allow_credentials = state
+                    .extension
+                    .fake_credential_generator
+                    .generate(req.passkey.user_id.as_bytes())
+                    .map_err(WebauthnError::from)?
+                    .iter()
+                    .map(|id| webauthn_rs_proto::options::AllowCredentials {
+                        type_: "public-key".to_string(),
+                        id: id.as_ref().into(),
+                        transports: None,
+                    })
+                    .collect();
+            }
             state
                 .extension
                 .provider

--- a/crates/webauthn/src/api/types.rs
+++ b/crates/webauthn/src/api/types.rs
@@ -15,6 +15,7 @@
 use axum::{extract::FromRequestParts, http::request::Parts};
 use std::sync::Arc;
 use webauthn_rs::Webauthn;
+use webauthn_rs::fake::{FakePasskeyDistribution, WebauthnFakeCredentialGenerator};
 
 use openstack_keystone_core::api::KeystoneApiError;
 use openstack_keystone_core::api::auth::Auth;
@@ -32,6 +33,11 @@ pub struct ExtensionState {
     pub provider: Box<dyn WebauthnApi>,
     /// WebAuthN provider.
     pub webauthn: Webauthn,
+    /// Generator of deterministic decoy credential IDs, used to answer
+    /// authentication start requests for unknown users (or users without
+    /// passkeys) indistinguishably from real ones (user enumeration
+    /// prevention).
+    pub fake_credential_generator: WebauthnFakeCredentialGenerator<FakePasskeyDistribution>,
 }
 
 /// Combined state of core Keystone and WebAuthN extension.

--- a/crates/webauthn/tests/api.rs
+++ b/crates/webauthn/tests/api.rs
@@ -317,3 +317,74 @@ async fn test_webauthn_roundtrip() -> Result<()> {
         .to_string();
     Ok(())
 }
+
+/// Authentication start for a user without passkeys (e.g. a non-existing
+/// user) must be indistinguishable from a real one: a `200` response with
+/// decoy `allow_credentials` that are stable per user id, so the endpoint
+/// cannot be used for user enumeration.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_webauthn_auth_start_unknown_user_returns_decoys() -> Result<()> {
+    let (state, _dir) = get_state(None).await?;
+
+    let addr = ReservedSocketAddr::reserve_random_socket_addr()?.socket_addr();
+    let cancel_token = CancellationToken::new();
+    let listener = TcpListener::bind(&addr).await?;
+    let mut handles = tokio::task::JoinSet::new();
+    let app = init_extension(state.core.clone(), cancel_token).await?;
+    handles.spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    let client = Client::new();
+
+    let start = async |user_id: &str| -> Result<PasskeyAuthenticationStartResponse> {
+        let rsp = client
+            .post(format!("http://{}/auth/passkey/start", addr))
+            .json(&serde_json::to_value(&PasskeyAuthenticationStartRequest {
+                passkey: PasskeyUserAuthenticationRequest {
+                    user_id: user_id.into(),
+                },
+            })?)
+            .send()
+            .await?;
+        assert_eq!(rsp.status(), 200, "start must succeed for unknown users");
+        Ok(rsp.json::<PasskeyAuthenticationStartResponse>().await?)
+    };
+
+    let mut users_with_decoys = 0;
+    let mut all_decoy_ids: Vec<Vec<String>> = Vec::new();
+    for _ in 0..20 {
+        let user_id = Uuid::new_v4().to_string();
+        let first = start(&user_id).await?;
+        let second = start(&user_id).await?;
+
+        // Decoy credential IDs are deterministic per user id, while the
+        // challenge is freshly random - just like for real users.
+        let ids = |r: &PasskeyAuthenticationStartResponse| {
+            r.public_key
+                .allow_credentials
+                .iter()
+                .map(|c| c.id.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(ids(&first), ids(&second));
+        assert_ne!(first.public_key.challenge, second.public_key.challenge);
+
+        if !first.public_key.allow_credentials.is_empty() {
+            users_with_decoys += 1;
+            all_decoy_ids.push(ids(&first));
+        }
+    }
+    // The decoy distribution may legitimately produce zero credentials for
+    // some user ids, but over 20 users it is virtually impossible that all
+    // of them get an empty list.
+    assert!(users_with_decoys > 0, "expected decoy credentials");
+    // Different users must get different decoys.
+    let unique = all_decoy_ids
+        .iter()
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(unique.len(), all_decoy_ids.len());
+    Ok(())
+}

--- a/doc/src/passkey.md
+++ b/doc/src/passkey.md
@@ -27,6 +27,22 @@ sequenceDiagram
     Server->>Client: Token
 ```
 
+## User enumeration prevention
+
+The `/auth/passkey/start` endpoint must not reveal whether a user exists or
+has registered passkeys. When authentication is started for an unknown user
+(or a user without passkeys), Keystone responds with a regular challenge
+containing deterministic **decoy** credential IDs (stable per user id) instead
+of an error or an empty `allow_credentials` list. Completing such a ceremony
+fails with the same `401` as an attempt against a real user with a credential
+that is not in the allow list.
+
+The decoy credential IDs are derived with an HMAC key configured as
+`[webauthn]fake_credential_hmac_key`. The key must stay stable across restarts
+and be identical on all nodes of a deployment, otherwise decoys become
+distinguishable from real credentials. When unset, a random per-process key is
+generated at startup and a warning is logged.
+
 ## API changes
 
 Few dedicated API resources are added controlling the necessary aspects:


### PR DESCRIPTION
Starting a passkey authentication for a user that does not exist (or has
no registered passkeys) previously returned a challenge with an empty
allow_credentials list, while real users received a non-empty one. This
made /auth/passkey/start a user enumeration oracle.

Respond with deterministic decoy credential IDs generated by
webauthn-rs' HMAC-keyed WebauthnFakeCredentialGenerator, stable per user
id, so the response is indistinguishable from a real user's. The
ceremony state is stored as usual and completing it fails exactly like
an attempt against a real user with a credential outside the allow list.

The HMAC key is configurable via [webauthn]fake_credential_hmac_key so
it can be kept stable across restarts and nodes; when unset a random
per-process key is generated and a warning is logged.

Assisted-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
