### PR TITLE
fix: Finalize ADR 0021 work

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -101,4 +101,3 @@ setup = "start-api"
 path = "junit.xml"
 store-success-output = false
 store-failure-output = true
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,4 @@ repos:
     rev: v8.27.2
     hooks:
       - id: gitleaks
+        args: ["--config=gitleaks.toml"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7362,8 +7362,10 @@ name = "test_integration"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "axum",
  "chrono",
  "eyre",
+ "http-body-util",
  "inventory",
  "itertools 0.15.0",
  "openstack-keystone",
@@ -7389,6 +7391,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "tower",
  "tracing",
  "tracing-test",
  "uuid",

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -33,4 +33,3 @@ validator = { workspace = true, features = ["derive"], optional = true }
 webauthn-rs-proto.workspace = true
 url = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4"], optional = true }
-

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -283,6 +283,9 @@ impl From<MappingProviderError> for KeystoneApiError {
             MappingProviderError::ApiClientSystemScopeForbidden(x) => Self::BadRequest(format!(
                 "rule '{x}' grants system scope, which is forbidden for API Key (ApiClient) mapping rulesets"
             )),
+            MappingProviderError::ApiClientNonDomainScopeForbidden(x) => Self::BadRequest(format!(
+                "rule '{x}' grants a non-domain scope, which is forbidden for API Key (ApiClient) mapping rulesets (only domain scope is accepted)"
+            )),
             MappingProviderError::RaftNotAvailable => Self::InternalError(
                 "raft storage is not available in the mapping provider".to_string(),
             ),

--- a/crates/core-types/src/auth.rs
+++ b/crates/core-types/src/auth.rs
@@ -159,6 +159,14 @@ pub enum AuthenticationError {
     #[error("system scope is forbidden for API-Key ingress")]
     SystemScopeForbiddenForApiKey,
 
+    /// An API Key's mapping resolved to an authorization other than
+    /// `Authorization::Domain`. API Keys are domain-owned machine identities
+    /// (ADR 0021 §2), so only a domain-scoped authorization is accepted at
+    /// ingress; the write-time prohibition (ADR 0021 §6.C) is
+    /// defense-in-depth, not a substitute for this runtime check.
+    #[error("only domain scope is accepted for API-Key ingress")]
+    NonDomainScopeForbiddenForApiKey,
+
     /// A role assignment failed to convert to a valid RoleRef.
     #[error("role assignment cannot be converted to a role reference")]
     RoleConversionFailed,

--- a/crates/core-types/src/mapping/error.rs
+++ b/crates/core-types/src/mapping/error.rs
@@ -149,6 +149,16 @@ pub enum MappingProviderError {
         "rule '{0}' grants system scope, which is forbidden for API Key (ApiClient) mapping rulesets"
     )]
     ApiClientSystemScopeForbidden(String),
+
+    /// A ruleset sourced from an API Key (SCIM ingress) provider granted an
+    /// authorization other than `Authorization::Domain`. Per ADR 0021, API
+    /// Keys are domain-owned machine identities, so only a domain-scoped
+    /// authorization is accepted; this is an allowlist enforced at
+    /// write-time as defense-in-depth for the runtime ingress guard.
+    #[error(
+        "rule '{0}' grants a non-domain scope, which is forbidden for API Key (ApiClient) mapping rulesets (only domain scope is accepted)"
+    )]
+    ApiClientNonDomainScopeForbidden(String),
 }
 
 impl MappingProviderError {

--- a/crates/core/src/api/api_key_auth.rs
+++ b/crates/core/src/api/api_key_auth.rs
@@ -345,43 +345,24 @@ async fn hydrate_ephemeral_context(
         return Err(AuthenticationError::SystemScopeForbiddenForApiKey.into());
     }
 
-    let scope = match authorization {
-        Authorization::Project {
-            project_id,
-            project_domain_id,
-            ..
-        } => openstack_keystone_core_types::auth::ScopeInfo::Project {
-            project: openstack_keystone_core_types::resource::Project {
-                id: project_id.clone(),
-                domain_id: project_domain_id.clone(),
-                name: String::new(),
-                description: None,
-                enabled: true,
-                is_domain: false,
-                parent_id: None,
-                extra: Default::default(),
-            },
-            project_domain: openstack_keystone_core_types::resource::Domain {
-                id: project_domain_id.clone(),
-                name: String::new(),
-                description: None,
-                enabled: true,
-                extra: Default::default(),
-            },
-        },
-        Authorization::Domain { domain_id, .. } => {
-            openstack_keystone_core_types::auth::ScopeInfo::Domain(
-                openstack_keystone_core_types::resource::Domain {
-                    id: domain_id.clone(),
-                    name: String::new(),
-                    description: None,
-                    enabled: true,
-                    extra: Default::default(),
-                },
-            )
-        }
-        Authorization::System { .. } => unreachable!("rejected above"),
+    // Invariant: API Keys are domain-owned machine identities (ADR 0021 §2);
+    // only a domain-scoped authorization is accepted at ingress. This is an
+    // allowlist, not a per-type denylist, so any non-domain authorization
+    // (including `Authorization::Project`) is rejected here. The write-time
+    // prohibition (ADR 0021 §6.C) is defense-in-depth, not a substitute for
+    // this runtime check.
+    let Authorization::Domain { domain_id, .. } = authorization else {
+        return Err(AuthenticationError::NonDomainScopeForbiddenForApiKey.into());
     };
+    let scope = openstack_keystone_core_types::auth::ScopeInfo::Domain(
+        openstack_keystone_core_types::resource::Domain {
+            id: domain_id.clone(),
+            name: String::new(),
+            description: None,
+            enabled: true,
+            extra: Default::default(),
+        },
+    );
     scope.validate()?;
 
     // Invariant 6: user_id derived exclusively from client_id, never from

--- a/crates/core/src/mapping/validation.rs
+++ b/crates/core/src/mapping/validation.rs
@@ -220,13 +220,18 @@ fn validate_rules(rules: &[MappingRule]) -> Result<(), MappingProviderError> {
     Ok(())
 }
 
-/// Reject `is_system` or `Authorization::System` grants in any rule of a
-/// ruleset sourced from an API Key (`IdentitySource::ApiClient`) provider.
+/// Reject `is_system`/`Authorization::System` grants, and enforce a
+/// domain-scope-only allowlist for every other authorization, in any rule of
+/// a ruleset sourced from an API Key (`IdentitySource::ApiClient`) provider.
 ///
 /// Per ADR 0021 §6.C, allowing an API Key to hold system scope is dangerous
 /// enough that the prohibition is enforced at both write-time (here) and at
 /// authentication time (`hydrate_ephemeral_context`); this check is
-/// defense-in-depth, not a substitute for the runtime guard.
+/// defense-in-depth, not a substitute for the runtime guard. By design, API
+/// Keys are domain-owned machine identities (§2), so once system scope is
+/// excluded, every remaining authorization MUST be `Authorization::Domain`
+/// -- this is an allowlist, not a denylist naming each forbidden variant, so
+/// it also covers any authorization type added in the future.
 fn validate_api_client_no_system_scope(
     source: &IdentitySource,
     rules: &[MappingRule],
@@ -242,6 +247,15 @@ fn validate_api_client_no_system_scope(
                 .any(|auth| matches!(auth, Authorization::System { .. }))
         {
             return Err(MappingProviderError::ApiClientSystemScopeForbidden(
+                rule.name.clone(),
+            ));
+        }
+        if rule
+            .authorizations
+            .iter()
+            .any(|auth| !matches!(auth, Authorization::Domain { .. }))
+        {
+            return Err(MappingProviderError::ApiClientNonDomainScopeForbidden(
                 rule.name.clone(),
             ));
         }
@@ -1530,6 +1544,68 @@ mod tests {
         assert!(matches!(
             result,
             Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "new-system-rule"
+        ));
+    }
+
+    fn rule_with_project_authorization(name: &str) -> MappingRule {
+        let mut rule = simple_rule(name, "user-name");
+        rule.authorizations = vec![Authorization::Project {
+            project_id: "project-1".to_string(),
+            project_domain_id: "test-domain".to_string(),
+            roles: Vec::new(),
+        }];
+        rule
+    }
+
+    #[test]
+    fn api_client_ruleset_rejects_non_domain_scope() {
+        // API Keys are domain-owned machine identities (ADR 0021 §2); only a
+        // domain-scoped authorization is accepted (allowlist, not a denylist
+        // naming each forbidden variant). Exercised here with Project, but
+        // the guard applies to any non-Domain authorization.
+        let ruleset = MappingRuleSetCreate {
+            source: api_client_source(),
+            rules: vec![rule_with_project_authorization("project-auth-rule")],
+            ..sample_ruleset_create()
+        };
+        let result = validate_ruleset_create(&ruleset);
+        assert!(matches!(
+            result,
+            Err(MappingProviderError::ApiClientNonDomainScopeForbidden(ref name)) if name == "project-auth-rule"
+        ));
+    }
+
+    #[test]
+    fn non_api_client_ruleset_allows_project_scope() {
+        // Defense-in-depth is scoped to ApiClient sources only; other
+        // sources (e.g. Federation) are unaffected by this guard.
+        let ruleset = MappingRuleSetCreate {
+            rules: vec![rule_with_project_authorization("project-auth-rule")],
+            ..sample_ruleset_create()
+        };
+        assert!(validate_ruleset_create(&ruleset).is_ok());
+    }
+
+    #[test]
+    fn api_client_ruleset_update_rejects_non_domain_scope() {
+        let existing = MappingRuleSet {
+            mapping_id: "test-123".to_string(),
+            domain_id: Some("test-domain".to_string()),
+            source: api_client_source(),
+            domain_resolution_mode: DomainResolutionMode::Fixed,
+            enabled: true,
+            rules: vec![simple_rule("existing-rule", "user-exists")],
+            ruleset_version: 0,
+        };
+        let update = MappingRuleSetUpdate {
+            rules: Some(vec![rule_with_project_authorization("new-project-rule")]),
+            enabled: None,
+            allowed_domains: None,
+        };
+        let result = validate_ruleset_update(&existing, &update);
+        assert!(matches!(
+            result,
+            Err(MappingProviderError::ApiClientNonDomainScopeForbidden(ref name)) if name == "new-project-rule"
         ));
     }
 }

--- a/crates/core/src/role/types.rs
+++ b/crates/core/src/role/types.rs
@@ -15,5 +15,5 @@
 pub mod provider_api;
 //pub mod role;
 
-pub use provider_api::*;
 pub use openstack_keystone_core_types::role::*;
+pub use provider_api::*;

--- a/crates/keystone/src/api/v4/api_key/simulate_access.rs
+++ b/crates/keystone/src/api/v4/api_key/simulate_access.rs
@@ -161,6 +161,10 @@ async fn simulate(
         ));
     }
 
+    // API Keys are domain-owned machine identities (ADR 0021 §2): only a
+    // domain-scoped authorization is accepted. This is an allowlist, not a
+    // denylist naming each forbidden variant, so it also covers any
+    // authorization type added in the future.
     let (scope, roles) = match &mr.authorizations[0] {
         Authorization::Domain { domain_id, roles } => (
             SimulatedScope::Domain {
@@ -168,20 +172,14 @@ async fn simulate(
             },
             roles,
         ),
-        Authorization::Project {
-            project_id,
-            project_domain_id,
-            roles,
-        } => (
-            SimulatedScope::Project {
-                project_id: project_id.clone(),
-                project_domain_id: project_domain_id.clone(),
-            },
-            roles,
-        ),
         Authorization::System { .. } => {
             return Ok(not_matched(
                 "mapping resolved to system scope, which is forbidden for API keys",
+            ));
+        }
+        _ => {
+            return Ok(not_matched(
+                "mapping resolved to a non-domain scope, which is forbidden for API keys (only domain scope is accepted)",
             ));
         }
     };
@@ -262,9 +260,8 @@ mod tests {
                     user_domain_id: None,
                     is_system: false,
                 },
-                authorizations: vec![mapping_types::Authorization::Project {
-                    project_id: "project-1".into(),
-                    project_domain_id: "domain_id".into(),
+                authorizations: vec![mapping_types::Authorization::Domain {
+                    domain_id: "domain_id".into(),
                     roles: vec![RoleRef {
                         id: "role-1".into(),
                         name: Some("member".into()),
@@ -328,6 +325,74 @@ mod tests {
         assert!(res.matched);
         assert_eq!(res.roles, vec!["member".to_string()]);
         assert!(res.reason.is_none());
+    }
+
+    fn sample_ruleset_project_scoped() -> mapping_types::MappingRuleSet {
+        let mut ruleset = sample_ruleset_matching();
+        ruleset.rules[0].authorizations = vec![mapping_types::Authorization::Project {
+            project_id: "project-1".into(),
+            project_domain_id: "domain_id".into(),
+            roles: vec![RoleRef {
+                id: "role-1".into(),
+                name: Some("member".into()),
+                domain_id: None,
+            }],
+        }];
+        ruleset
+    }
+
+    #[tokio::test]
+    async fn test_simulate_access_project_scope_not_matched() {
+        // API Keys are domain-owned machine identities (ADR 0021 §2) and
+        // must resolve to a domain scope only; a project-scoped match must
+        // not be reported as `matched`.
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut api_key_mock = MockApiKeyProvider::default();
+        api_key_mock
+            .expect_get_by_client_id()
+            .returning(|_, _, _| Ok(Some(sample_resource_core())));
+        provider = provider.mock_api_key(api_key_mock);
+        let mut mapping_mock = MockMappingProvider::default();
+        mapping_mock
+            .expect_get_ruleset_by_source()
+            .returning(|_, _, _| Ok(Some(sample_ruleset_project_scoped())));
+        provider = provider.mock_mapping(mapping_mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_request();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/simulate-access")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeySimulateAccessResponse = serde_json::from_slice(&body).unwrap();
+        assert!(!res.matched);
+        assert!(res.scope.is_none());
+        assert_eq!(
+            res.reason.as_deref(),
+            Some(
+                "mapping resolved to a non-domain scope, which is forbidden for API keys (only domain scope is accepted)"
+            )
+        );
     }
 
     #[tokio::test]

--- a/crates/keystone/src/audit.rs
+++ b/crates/keystone/src/audit.rs
@@ -129,6 +129,7 @@ pub fn sanitize_authentication_error(e: &AuthenticationError) -> &'static str {
         AuthenticationError::NoAuthorizationsFound => "NoAuthorizationsFound",
         AuthenticationError::MultipleScopesForbidden => "MultipleScopesForbidden",
         AuthenticationError::SystemScopeForbiddenForApiKey => "SystemScopeForbiddenForApiKey",
+        AuthenticationError::NonDomainScopeForbiddenForApiKey => "NonDomainScopeForbiddenForApiKey",
     }
 }
 

--- a/crates/revoke-driver-sql/src/list.rs
+++ b/crates/revoke-driver-sql/src/list.rs
@@ -441,7 +441,7 @@ mod tests {
         .build(DatabaseBackend::Sqlite)
         .to_string();
         assert!(
-            query.contains("AND (\"revocation_event\".\"domain_id\" IS NULL OR \"revocation_event\".\"domain_id\" IN ('d1', 'd2'))"), 
+            query.contains("AND (\"revocation_event\".\"domain_id\" IS NULL OR \"revocation_event\".\"domain_id\" IN ('d1', 'd2'))"),
             "{}", query
         );
     }
@@ -459,7 +459,7 @@ mod tests {
         .to_string();
         assert!(
             query.contains("AND (\"revocation_event\".\"project_id\" IS NULL OR \"revocation_event\".\"project_id\" = 'pid')"),
-            "{}", 
+            "{}",
             query
         );
     }
@@ -494,8 +494,8 @@ mod tests {
         .build(DatabaseBackend::Sqlite)
         .to_string();
         assert!(
-            query.contains("AND (\"revocation_event\".\"role_id\" IS NULL OR \"revocation_event\".\"role_id\" IN ('d1', 'd2'))"), 
-            "{}", 
+            query.contains("AND (\"revocation_event\".\"role_id\" IS NULL OR \"revocation_event\".\"role_id\" IN ('d1', 'd2'))"),
+            "{}",
             query
         );
     }
@@ -530,8 +530,8 @@ mod tests {
         .build(DatabaseBackend::Sqlite)
         .to_string();
         assert!(
-            query.contains("AND (\"revocation_event\".\"user_id\" IS NULL OR \"revocation_event\".\"user_id\" IN ('d1', 'd2'))"), 
-            "{}", 
+            query.contains("AND (\"revocation_event\".\"user_id\" IS NULL OR \"revocation_event\".\"user_id\" IN ('d1', 'd2'))"),
+            "{}",
             query
         );
     }

--- a/crates/storage/proto/raft.proto
+++ b/crates/storage/proto/raft.proto
@@ -293,4 +293,3 @@ message BackupChunk {
 message RestoreChunk {
   bytes data = 1;
 }
-

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -52,6 +52,7 @@
   - [Okta](federation/okta.md)
   - [Dex](federation/dex.md)
 - [Passkeys](passkey.md)
+- [API-Key Authentication (SCIM)](api_key.md)
 - [Kubernetes TokenReview Auth](k8s_auth.md)
 - [Mapping Engine](mapping.md)
 

--- a/doc/src/adr/0002-open-policy-agent.md
+++ b/doc/src/adr/0002-open-policy-agent.md
@@ -145,4 +145,3 @@ cases.
   - Update tests:
     `"target": { "binding": { ... } }, "existing": { "binding": { ... } }`
   - Show/Delete tests: `"target": { "binding": { ... } }`
-

--- a/doc/src/adr/0021-api-key-scim.md
+++ b/doc/src/adr/0021-api-key-scim.md
@@ -2,11 +2,18 @@
 
 **Date:** 2026-06-12
 
-**Last-revised:** 2026-06-24 (security review)
+**Last-revised:** 2026-07-02 (implementation-status review)
 
 ## Status
 
-Proposed
+Accepted
+
+**Implementation-status review 2026-07-02:** implementation confirmed complete
+against every §7 Security Invariant and §5/§6 requirement (see §8). Status
+moved from Proposed to Accepted. §6.B's `subtle`-crate wording corrected to
+match what's actually implemented (Argon2's own constant-time comparison);
+this was a doc/code drift, not a security gap. Added janitor and full-pipeline
+integration test coverage (previously mock/unit-test only) per §8.
 
 **Security review 2026-06-24:**
 
@@ -148,7 +155,11 @@ The entropy is verified against the PHC-formatted `secret_hash` using
 ### Step 4: Ephemeral Context Hydration (Anti-Bleed Scoping)
 
 To prevent cross-domain privilege bleeding, an Ephemeral Security Context must
-operate under exactly _one_ scope.
+operate under exactly _one_ scope. API Keys are **domain-owned machine
+identities** (§2); by design only a domain-scoped authorization is accepted.
+This is an allowlist -- `Authorization::Domain` is the sole accepted variant
+-- rather than a denylist naming each forbidden authorization type, so it
+also covers any authorization type added in the future.
 
 ```rust
 pub async fn hydrate_ephemeral_context(...) -> Result<ValidatedSecurityContext, AuthenticationError> {
@@ -174,24 +185,23 @@ pub async fn hydrate_ephemeral_context(...) -> Result<ValidatedSecurityContext, 
 
     validate_target_entities_are_active(state, &match_result.authorizations)?;
 
-    let mut effective_roles = Vec::new();
-    if let Some(auth) = match_result.authorizations.first() {
-        match auth {
-            Authorization::Domain { domain_id, roles } => {
-                ctx.set_scope(ScopeInfo::Domain(domain_id.clone()));
-                effective_roles.extend(roles.clone());
-            },
-            Authorization::Project { project_id, roles } => {
-                ctx.set_scope(ScopeInfo::Project(project_id.clone()));
-                effective_roles.extend(roles.clone());
-            },
-            Authorization::System { .. } => {
-                // System scopes are strictly forbidden for API-Key ingress.
-                return Err(AuthenticationError::SystemScopeForbiddenForApiKey);
-            }
-        }
+    let authorization = &match_result.authorizations[0];
+
+    // System scopes are strictly forbidden for API-Key ingress.
+    if matches!(authorization, Authorization::System { .. }) {
+        return Err(AuthenticationError::SystemScopeForbiddenForApiKey);
     }
 
+    // Allowlist: only a domain-scoped authorization is accepted. API Keys
+    // are domain-owned machine identities (§2), so anything else --
+    // `Authorization::Project` included -- is rejected here rather than
+    // being enumerated as its own forbidden case.
+    let Authorization::Domain { domain_id, roles } = authorization else {
+        return Err(AuthenticationError::NonDomainScopeForbiddenForApiKey);
+    };
+    ctx.set_scope(ScopeInfo::Domain(domain_id.clone()));
+
+    let mut effective_roles = roles.clone();
     effective_roles.sort();
     effective_roles.dedup();
     Ok(ValidatedSecurityContext::finalize(ctx, effective_roles))
@@ -307,7 +317,10 @@ traffic migrates seamlessly, and Key A is subsequently revoked.
 - **Measures:** Argon2id parameters are globally defined in `keystone.conf` with
   OWASP-compliant strict minimums (e.g., $m=65536, t=3, p=4$). Dummy hashes for
   invalid tokens utilize these exact parameters. Comparisons against the PHC
-  strings use the `subtle` crate for constant-time equality checks.
+  strings are constant-time, performed internally by the `argon2` crate's
+  `verify_password` (not a separate manual `subtle::ConstantTimeEq` step --
+  `verify_password` already provides this property, so a second comparison
+  would be redundant).
 
 ### C. Write-Time `is_system` Prohibition
 
@@ -317,7 +330,12 @@ traffic migrates seamlessly, and Key A is subsequently revoked.
   mapping rule where the `provider_id` belongs to an
   `IdentitySource::ApiClient`, and any authorization grants `is_system: true` or
   `Authorization::System`, the Mapping Engine CRUD API rejects it immediately
-  with `422 Unprocessable Entity`.
+  with `422 Unprocessable Entity`. The same write-time guard also enforces a
+  domain-scope-only allowlist for `IdentitySource::ApiClient` rulesets: once
+  `is_system`/`Authorization::System` is excluded, every remaining
+  authorization MUST be `Authorization::Domain` -- API Keys are domain-owned
+  machine identities (§2) -- so `Authorization::Project` (or any other
+  non-domain authorization) is rejected the same way.
 
 ### D. OPSEC Leakage & Log Injection
 
@@ -383,6 +401,17 @@ a security defect.
    companion write-time prohibition (§6.C) is defense-in-depth, not a substitute
    for this runtime check.
 
+3a. **Domain scope only, by allowlist.** API Keys are domain-owned machine
+   identities (§2). Once the Invariant 3 system-scope check passes,
+   `hydrate_ephemeral_context` MUST accept only `Authorization::Domain`; any
+   other authorization (`Authorization::Project` included) MUST return
+   `NonDomainScopeForbiddenForApiKey` rather than resolving a non-domain
+   `ScopeInfo`. This is an allowlist keyed on the accepted variant, not a
+   denylist enumerating each forbidden one, so it also covers any
+   authorization type added in the future. The companion write-time
+   prohibition (§6.C) is defense-in-depth, not a substitute for this runtime
+   check.
+
 4. **XFF rightmost-non-trusted algorithm.** Effective client IP MUST be the
    rightmost address in the XFF chain (with TCP peer appended) that is not in
    `trusted_proxies`. Implementations MUST NOT use XFF[0] (leftmost) as the
@@ -422,7 +451,15 @@ a security defect.
 - **Done:**
   - The SCIM ingress authentication pipeline (§3), including all security
     invariants (§7).
-  - The write-time `is_system` prohibition (§6.C).
+  - The write-time `is_system` prohibition (§6.C), plus the domain-scope-only
+    allowlist (Invariant 3a): both `hydrate_ephemeral_context`
+    (`crates/core/src/api/api_key_auth.rs`) and the write-time mapping
+    validation (`crates/core/src/mapping/validation.rs`) accept only
+    `Authorization::Domain` for `IdentitySource::ApiClient` rulesets, since
+    API Keys are domain-owned machine identities (§2). `Authorization::Project`
+    is rejected as a consequence of the allowlist, not as a named special
+    case. The `simulate-access` dry-run endpoint (§5.E) mirrors this and
+    reports `matched: false` for any non-domain match.
   - The storage layer and internal `ApiKeyApi`/`ApiKeyBackend` traits (§2,
     §5.D) with a Raft-backed implementation, including the janitor's
     cross-domain `list_all` and hard-delete `purge` operations (§6.F).
@@ -464,6 +501,15 @@ a security defect.
     rather than a repeated generic label) -- more useful for audit
     filtering; the wording above has been reconciled to match the code
     rather than the other way around.
+  - Integration test coverage exercising the real Raft-backed provider and a
+    live HTTP router, not just mocks: a janitor sweep suite
+    (`tests/integration/src/api_key/janitor.rs`) covering disablement,
+    tombstone purge, and cross-domain sweeping against the real storage/CAS
+    layer; and a full-pipeline suite
+    (`tests/integration/src/api_key/ingress.rs`) driving real requests
+    through `openstack_keystone::scim::router()` -- successful end-to-end
+    authentication, wrong-secret rejection, an XFF-spoof-through-a-trusted-
+    proxy regression case (Invariant 4), and rate-limit tripping (§6.A).
 - **Known gap:** the ADR's "pushes an administrative alert payload to the
   system notification bus" (§6.F) is not implemented -- no pub/sub or webhook
   dispatch infrastructure exists in this codebase yet. The janitor emits a

--- a/doc/src/api_key.md
+++ b/doc/src/api_key.md
@@ -1,0 +1,180 @@
+# API-Key Authentication (SCIM)
+
+API keys give Identity Providers (IdPs) doing SCIM provisioning a static,
+long-lived bearer credential that authenticates in a single request, without a
+prior `/v3/auth/tokens` exchange. See
+[ADR 0021](adr/0021-api-key-scim.md) for the full design and security
+rationale; this page covers day-to-day usage.
+
+API keys are **domain-owned machine identities**, not human user accounts.
+They are only accepted on the SCIM sub-router — core `/v3`/`/v4` endpoints
+reject them outright.
+
+## Token format
+
+A generated token looks like:
+
+```
+kscim_{43-char base62 entropy}_{crc32 checksum}
+```
+
+The token is shown to the administrator **once**, at creation time. Keystone
+never stores it in recoverable form — only a `lookup_hash` (fast SHA-256, used
+as the DB index) and a `secret_hash` (Argon2id, used for verification).
+
+## Managing keys
+
+All admin endpoints below require the `DomainManager` (or `SystemAdmin`) role
+and are authenticated with a normal Fernet token, not an API key.
+
+### Create a key
+
+```
+POST /v4/api-keys/
+```
+
+```json
+{
+  "api_key": {
+    "domain_id": "d1",
+    "provider_id": "entra-scim",
+    "expires_at": 1798761600,
+    "allowed_ips": ["198.51.100.0/24"],
+    "description": "Entra ID SCIM provisioning"
+  }
+}
+```
+
+Response (`201`) — this is the only time the raw token is returned:
+
+```json
+{
+  "api_key": { "client_id": "9f2c...", "domain_id": "d1", "provider_id": "entra-scim",
+               "enabled": true, "created_at": 1751500000, "expires_at": 1798761600,
+               "allowed_ips": ["198.51.100.0/24"], "description": "Entra ID SCIM provisioning" },
+  "token": "kscim_9pQ...xz_1a2b3c4d"
+}
+```
+
+### List / show
+
+```
+GET /v4/api-keys/?domain_id=d1[&enabled=true][&provider_id=entra-scim]
+GET /v4/api-keys/{client_id}?domain_id=d1
+```
+
+Neither ever returns `secret_hash` or `lookup_hash`.
+
+### Update
+
+```
+PUT /v4/api-keys/{client_id}?domain_id=d1
+```
+
+```json
+{ "api_key": { "description": "renamed", "allowed_ips": null } }
+```
+
+Fields use nested-Option semantics: an absent field leaves the value
+unchanged, `null` clears it. A revoked key cannot be re-enabled through this
+endpoint (`409 Conflict` on `enabled: true`) — see Revocation below.
+
+### Revoke
+
+```
+POST /v4/api-keys/{client_id}/revoke?domain_id=d1
+```
+
+Soft-revoke only: sets `enabled: false`, stamps `revoked_at`/`revoked_by`,
+emits a CADF `revoke` event. Nothing is hard-deleted (needed for incident
+audit trails). Revocation is permanent — the only way back into service is
+creating a new key. Physical purge of revoked records happens later via the
+janitor (see Configuration below).
+
+### Zero-downtime rotation
+
+Create a new key against the same `provider_id`, update the IdP with the new
+token, then revoke the old key once traffic has moved. Both keys resolve
+against the same mapping ruleset for `provider_id` in the interim.
+
+### Dry-run: simulate access
+
+```
+POST /v4/api-keys/simulate-access
+```
+
+```json
+{ "client_id": "9f2c...", "domain_id": "d1" }
+```
+
+`client_id` is passed in the body (not the URL) so it doesn't leak into proxy
+access logs. Response shows what the key would resolve to without performing
+real authentication:
+
+```json
+{
+  "client_id": "9f2c...", "domain_id": "d1", "provider_id": "entra-scim",
+  "matched": true,
+  "scope": { "type": "domain", "domain_id": "d1" },
+  "roles": ["member"],
+  "reason": null
+}
+```
+
+## Using a key
+
+Only the SCIM sub-router accepts API keys, via `Authorization: Bearer`:
+
+```
+GET /SCIM/v2/{domain_id}/whoami
+Authorization: Bearer kscim_9pQ...xz_1a2b3c4d
+```
+
+```json
+{ "user_id": "...", "scope": { "type": "domain", "domain_id": "d1" } }
+```
+
+By design, SCIM API keys are **domain-scoped only** — a key authenticates
+only if its mapping ruleset (ADR 0020) resolves to **exactly one**
+domain-scoped authorization for the key's own `domain_id`. This is an
+allowlist: only a domain scope is accepted, so zero matches, multiple
+matches, or a match resolving to any other scope (project, system, or
+otherwise) are all rejected.
+
+## IP allow-listing
+
+If `allowed_ips` is set, the request's effective client IP must fall inside
+one of the listed CIDR blocks. The effective IP is the rightmost address in
+`X-Forwarded-For` that isn't in the configured `trusted_proxies`, with the raw
+TCP peer appended to the right of that chain first — this defeats
+leftmost-entry XFF spoofing through an untrusted intermediate proxy. If
+`allowed_ips` is unset, no IP restriction applies.
+
+## Configuration (`[api_key]` in `keystone.conf`)
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `argon2_memory_kib` | 65536 | Argon2id memory cost |
+| `argon2_time_cost` | 3 | Argon2id iterations |
+| `argon2_parallelism` | 4 | Argon2id parallelism |
+| `trusted_proxies` | (empty) | CSV of CIDRs, e.g. `10.0.0.0/8,192.168.1.0/24` |
+| `rate_limit_burst_size` | 10 | Token-bucket burst, keyed on `lookup_hash` (or source IP for malformed tokens) |
+| `rate_limit_replenish_per_minute` | 60 | Token-bucket refill rate |
+| `janitor_inactive_days` | 90 | Auto-disable a key unused for this long |
+| `janitor_grace_days` | 7 | Extra grace period absorbing async `last_used_at` write drift |
+| `janitor_tombstone_retention_days` | 365 | Hard-purge revoked keys older than this |
+
+Exceeding the rate limit returns `429 Too Many Requests`.
+
+## Errors
+
+| Condition | Response |
+| --- | --- |
+| Malformed token / bad CRC32 | request dropped |
+| Unknown / disabled / expired key | `401` (dummy Argon2id hash computed regardless, to avoid timing-based lookup enumeration) |
+| IP outside `allowed_ips` | `401` |
+| Mapping resolves to zero authorizations | `401` |
+| Mapping resolves to more than one authorization | `401` |
+| Mapping resolves to any authorization other than a domain scope (project, system, ...) | `401` |
+| Rate limit exceeded | `429` |
+| Re-enabling a revoked key via `PUT` | `409` |

--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+description = "Ignore all files in the docs directory"
+paths = [
+    '''(^|/)doc/'''
+]

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -11,8 +11,10 @@ dist = false
 
 [dependencies]
 async-trait.workspace = true
+axum = { workspace = true, features = ["http1", "tokio"] }
 chrono.workspace = true
 eyre.workspace = true
+http-body-util.workspace = true
 inventory.workspace = true
 itertools.workspace = true
 openstack-keystone-audit = { workspace = true, features = ["testing"] }
@@ -36,6 +38,7 @@ serde_json.workspace = true
 serde_urlencoded.workspace = true
 time = { version = "0.3", default-features = true }
 tempfile.workspace = true
+tower.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/tests/integration/src/api_key.rs
+++ b/tests/integration/src/api_key.rs
@@ -29,6 +29,8 @@ use openstack_keystone_core_types::api_key::*;
 
 mod create;
 mod get;
+mod ingress;
+mod janitor;
 mod last_used;
 mod list;
 mod mapping_system_scope;

--- a/tests/integration/src/api_key/ingress.rs
+++ b/tests/integration/src/api_key/ingress.rs
@@ -1,0 +1,261 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! End-to-end SCIM ingress pipeline tests (ADR 0021 §3) driven over real
+//! HTTP through `openstack_keystone::scim::router()`, complementing the
+//! pure-function unit tests in `crates/core/src/api/api_key_auth.rs`
+//! (which cover `resolve_client_ip`/`ip_allowed` in isolation but never
+//! exercise the full extractor -- rate limiting, storage lookup, Argon2id
+//! verification and mapping-engine hydration -- together over a real
+//! request).
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode, header};
+use eyre::Result;
+use http_body_util::BodyExt;
+use secrecy::ExposeSecret;
+use tower::ServiceExt;
+use tracing_test::traced_test;
+
+use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::api_key::{crypto, token};
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::api_key::ApiClientResource;
+use openstack_keystone_core_types::mapping::authorization::Authorization;
+use openstack_keystone_core_types::mapping::resolution::IdentitySource;
+use openstack_keystone_core_types::mapping::*;
+use openstack_keystone_core_types::resource::Domain;
+use openstack_keystone_core_types::role::RoleRefBuilder;
+
+use super::{create_api_key, sample_api_key_create};
+
+use crate::common::{AsyncResourceGuard, get_state};
+use crate::create_domain;
+
+/// Generate a real `kscim_...` bearer token, persist its `ApiClientResource`
+/// (with a genuine Argon2id `secret_hash`, unlike `sample_api_key_create`'s
+/// placeholder), and wire a matching ADR 0020 mapping ruleset granting
+/// `Authorization::Domain` on the key's own domain. Returns the plaintext
+/// bearer token to present over HTTP, plus the resource guard -- which the
+/// caller MUST keep bound to a variable for the HTTP calls' duration: an
+/// unbound guard is dropped (and the key revoked by its cleanup `Drop` impl)
+/// at the end of the creating statement.
+async fn provision_working_api_key(
+    state: &ServiceState,
+    domain: &Domain,
+    provider_id: &str,
+    allowed_ips: Option<Vec<String>>,
+) -> Result<(String, AsyncResourceGuard<ApiClientResource, ServiceState>)> {
+    let generated = token::generate();
+    let entropy = generated.entropy.expose_secret().to_string();
+    let cfg = state.config_manager.config.read().await.api_key.clone();
+    let secret_hash = crypto::hash_secret(&entropy, &cfg).await?;
+
+    let mut create = sample_api_key_create(&domain.id, provider_id);
+    create.lookup_hash = generated.lookup_hash;
+    create.secret_hash = secret_hash;
+    create.allowed_ips = allowed_ips;
+    let guard = create_api_key(state, create).await?;
+
+    let ruleset = MappingRuleSetCreate {
+        mapping_id: Some(uuid::Uuid::new_v4().simple().to_string()),
+        domain_id: Some(domain.id.clone()),
+        source: IdentitySource::ApiClient {
+            provider_id: provider_id.to_string(),
+        },
+        domain_resolution_mode: DomainResolutionMode::Fixed,
+        enabled: true,
+        rules: vec![MappingRule {
+            name: "ingress-e2e-rule".into(),
+            description: None,
+            r#match: MatchCriteria::AllOf(vec![]),
+            identity: IdentityBinding {
+                identity_mode: None,
+                user_name: "${claims.api_client.client_id}".into(),
+                user_id: None,
+                user_domain_id: None,
+                is_system: false,
+            },
+            authorizations: vec![Authorization::Domain {
+                domain_id: domain.id.clone(),
+                roles: vec![
+                    RoleRefBuilder::default()
+                        .id("member")
+                        .name("member")
+                        .build()
+                        .unwrap(),
+                ],
+            }],
+            groups: Vec::new(),
+        }],
+    };
+    state
+        .provider
+        .get_mapping_provider()
+        .create_ruleset(&ExecutionContext::internal(state), ruleset)
+        .await?;
+
+    Ok((generated.token.expose_secret().to_string(), guard))
+}
+
+fn whoami_request(
+    domain_id: &str,
+    token: &str,
+    peer: SocketAddr,
+    xff: Option<&str>,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .uri(format!("/{domain_id}/whoami"))
+        .method("GET")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .extension(ConnectInfo(peer));
+    if let Some(xff) = xff {
+        builder = builder.header("x-forwarded-for", xff);
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_valid_key_authenticates_end_to_end() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let (token, _guard) = provision_working_api_key(&state, &domain, "provider-1", None).await?;
+
+    let router = openstack_keystone::scim::router().with_state(state.clone());
+    let peer: SocketAddr = "203.0.113.9:54321".parse()?;
+
+    let response = router
+        .oneshot(whoami_request(&domain.id, &token, peer, None))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await?.to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body)?;
+    assert!(json["scope"].as_str().unwrap().contains(&domain.id));
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_wrong_secret_is_rejected() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let (_token, _guard) = provision_working_api_key(&state, &domain, "provider-1", None).await?;
+
+    // Well-formed token, but never persisted -- lookup_hash won't match.
+    let forged = token::generate();
+    let forged_token = forged.token.expose_secret().to_string();
+
+    let router = openstack_keystone::scim::router().with_state(state.clone());
+    let peer: SocketAddr = "203.0.113.9:54321".parse()?;
+
+    let response = router
+        .oneshot(whoami_request(&domain.id, &forged_token, peer, None))
+        .await?;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_xff_spoof_through_trusted_proxy_is_rejected() -> Result<()> {
+    // ADR 0021 §3 Step 2 / §6.E / Invariant 4: the rightmost-non-trusted
+    // algorithm must resolve to the hop adjacent to the trusted proxy, not
+    // whatever an attacker prepends as the leftmost XFF entry. The key only
+    // allows 198.51.100.0/24; an attacker prepends that allowed range as the
+    // leftmost entry hoping it gets picked, while their real (disallowed)
+    // origin is the rightmost, proxy-adjacent hop.
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    {
+        let mut cfg = state.config_manager.config.write().await;
+        cfg.api_key.trusted_proxies = vec!["10.0.0.0/8".to_string()];
+    }
+    let (token, _guard) = provision_working_api_key(
+        &state,
+        &domain,
+        "provider-1",
+        Some(vec!["198.51.100.0/24".to_string()]),
+    )
+    .await?;
+
+    let router = openstack_keystone::scim::router().with_state(state.clone());
+    let trusted_peer: SocketAddr = "10.0.0.1:54321".parse()?;
+
+    // Legitimate path: rightmost-non-trusted hop is the allowed range.
+    let ok_response = router
+        .clone()
+        .oneshot(whoami_request(
+            &domain.id,
+            &token,
+            trusted_peer,
+            Some("198.51.100.9"),
+        ))
+        .await?;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+
+    // Spoof attempt: attacker prepends the allowed range as bait, but their
+    // real origin (rightmost, adjacent to the trusted proxy) is outside it.
+    let spoofed_response = router
+        .oneshot(whoami_request(
+            &domain.id,
+            &token,
+            trusted_peer,
+            Some("198.51.100.9, 9.9.9.9"),
+        ))
+        .await?;
+    assert_eq!(spoofed_response.status(), StatusCode::UNAUTHORIZED);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_rate_limit_trips_after_burst_from_same_peer() -> Result<()> {
+    // ADR 0021 §6.A: malformed tokens (no valid entropy) key the limiter on
+    // source IP so brute-force garbage traffic can't dodge rate limiting.
+    // Default quota is burst=10 / 60 per minute (crates/config/src/api_key.rs).
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let router = openstack_keystone::scim::router().with_state(state.clone());
+    let peer: SocketAddr = "203.0.113.77:54321".parse()?;
+
+    let mut saw_rate_limited = false;
+    for _ in 0..15 {
+        let response = router
+            .clone()
+            .oneshot(whoami_request(&domain.id, "not-a-real-token", peer, None))
+            .await?;
+        if response.status() == StatusCode::TOO_MANY_REQUESTS {
+            saw_rate_limited = true;
+            break;
+        }
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        // Keep well within the 60/minute replenish window.
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+
+    assert!(
+        saw_rate_limited,
+        "expected TOO_MANY_REQUESTS within the burst window"
+    );
+
+    Ok(())
+}

--- a/tests/integration/src/api_key/janitor.rs
+++ b/tests/integration/src/api_key/janitor.rs
@@ -1,0 +1,128 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Janitor sweep (ADR 0021 §6.F) exercised against the real Raft-backed
+//! provider, complementing `crates/core/src/api_key/janitor.rs`'s mocked
+//! unit tests: those cover the branching logic in isolation, this confirms
+//! `list_all`/`update`/`purge` actually round-trip through the real
+//! storage/CAS layer end to end.
+
+use std::time::Duration;
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::api_key::janitor;
+
+use super::{create_api_key, sample_api_key_create};
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_janitor_disables_inactive_key_via_real_backend() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    // Zero thresholds so a freshly created (never-used) key is immediately
+    // past the inactivity threshold, without waiting real days.
+    {
+        let mut cfg = state.config_manager.config.write().await;
+        cfg.api_key.janitor_inactive_days = 0;
+        cfg.api_key.janitor_grace_days = 0;
+    }
+
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+    // Guarantee `now - created_at > 0` (second-granularity timestamps).
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let report = janitor::run_once(&state).await?;
+    assert_eq!(report.disabled, 1);
+    assert_eq!(report.errors, 0);
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain.id, &created.lookup_hash)
+        .await?
+        .expect("disabled key must still be resolvable, not hard-deleted");
+    assert!(!fetched.enabled);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_janitor_purges_old_tombstone_via_real_backend() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    // Zero retention so a just-revoked key's tombstone is immediately
+    // eligible for physical purge.
+    {
+        let mut cfg = state.config_manager.config.write().await;
+        cfg.api_key.janitor_tombstone_retention_days = 0;
+    }
+
+    let created = create_api_key(&state, sample_api_key_create(&domain.id, "provider-1")).await?;
+    state
+        .provider
+        .get_api_key_provider()
+        .revoke(&state, &domain.id, &created.client_id, "operator-1")
+        .await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let report = janitor::run_once(&state).await?;
+    assert_eq!(report.purged, 1);
+    assert_eq!(report.errors, 0);
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain.id, &created.lookup_hash)
+        .await?;
+    assert!(
+        fetched.is_none(),
+        "purge must be a hard delete from the real backend"
+    );
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_janitor_leaves_active_key_across_domains_alone() -> Result<()> {
+    // list_all (§2, §6.F) must sweep across every domain's keyspace
+    // partition, but a recently-active key in any domain must survive.
+    let (state, _) = get_state().await?;
+    let domain_a = create_domain!(state)?;
+    let domain_b = create_domain!(state)?;
+
+    let key_a = create_api_key(&state, sample_api_key_create(&domain_a.id, "provider-1")).await?;
+    let _key_b = create_api_key(&state, sample_api_key_create(&domain_b.id, "provider-1")).await?;
+
+    let report = janitor::run_once(&state).await?;
+    assert_eq!(report.disabled, 0);
+    assert_eq!(report.purged, 0);
+
+    let fetched = state
+        .provider
+        .get_api_key_provider()
+        .get_by_lookup_hash(&state, &domain_a.id, &key_a.lookup_hash)
+        .await?
+        .expect("key must still exist");
+    assert!(fetched.enabled);
+
+    Ok(())
+}

--- a/tests/integration/src/api_key/mapping_system_scope.rs
+++ b/tests/integration/src/api_key/mapping_system_scope.rs
@@ -13,9 +13,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Cross-provider integration test: the mapping engine's write-time guard
 //! (ADR 0021 §6.C, Invariant 3 defense-in-depth) must reject any
-//! `IdentitySource::ApiClient` ruleset that grants system scope, exercised
-//! through the real (raft-backed) mapping provider rather than the
-//! `crates/core` unit tests.
+//! `IdentitySource::ApiClient` ruleset that grants system scope, and must
+//! accept only `Authorization::Domain` for every other authorization (API
+//! Keys are domain-owned machine identities, ADR 0021 §2), exercised through
+//! the real (raft-backed) mapping provider rather than the `crates/core`
+//! unit tests.
 
 use eyre::Result;
 use tracing_test::traced_test;
@@ -117,7 +119,7 @@ async fn test_api_client_ruleset_rejects_system_authorization() -> Result<()> {
 
 #[traced_test]
 #[tokio::test]
-async fn test_api_client_ruleset_allows_non_system_scope() -> Result<()> {
+async fn test_api_client_ruleset_rejects_non_domain_scope() -> Result<()> {
     let (state, _) = get_state().await?;
     let domain = create_domain!(state)?;
 
@@ -135,6 +137,44 @@ async fn test_api_client_ruleset_allows_non_system_scope() -> Result<()> {
             vec![Authorization::Project {
                 project_id: "project-1".into(),
                 project_domain_id: domain.id.clone(),
+                roles: Vec::new(),
+            }],
+        )],
+    };
+
+    let result = state
+        .provider
+        .get_mapping_provider()
+        .create_ruleset(&ExecutionContext::internal(&state), ruleset)
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(MappingProviderError::ApiClientNonDomainScopeForbidden(ref name)) if name == "project-rule"
+    ));
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_api_client_ruleset_allows_domain_scope() -> Result<()> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let ruleset = MappingRuleSetCreate {
+        mapping_id: Some(uuid::Uuid::new_v4().simple().to_string()),
+        domain_id: Some(domain.id.clone()),
+        source: IdentitySource::ApiClient {
+            provider_id: "provider-1".into(),
+        },
+        domain_resolution_mode: DomainResolutionMode::Fixed,
+        enabled: true,
+        rules: vec![api_client_rule(
+            "domain-rule",
+            false,
+            vec![Authorization::Domain {
+                domain_id: domain.id.clone(),
                 roles: Vec::new(),
             }],
         )],

--- a/tests/integration/src/mapping/k8s.rs
+++ b/tests/integration/src/mapping/k8s.rs
@@ -62,7 +62,7 @@ async fn test_k8s_happy_path() -> Result<()> {
             }),
         ]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-${claims.k8s.serviceaccount.name}".into(),
             user_id: None,
             user_domain_id: None,
@@ -148,7 +148,7 @@ async fn test_k8s_no_matching_rule() -> Result<()> {
             }),
         ]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-other".into(),
             user_id: None,
             user_domain_id: None,
@@ -219,7 +219,7 @@ async fn test_k8s_any_of_match() -> Result<()> {
             }),
         ]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-ci".into(),
             user_id: None,
             user_domain_id: None,
@@ -298,7 +298,7 @@ async fn test_k8s_matches_regex() -> Result<()> {
             }),
         ]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-${claims.k8s.serviceaccount.name}".into(),
             user_id: None,
             user_domain_id: None,
@@ -380,7 +380,7 @@ async fn test_k8s_all_of_strict() -> Result<()> {
             require_all_keys: true,
         },
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-strict".into(),
             user_id: None,
             user_domain_id: None,
@@ -474,7 +474,7 @@ async fn test_k8s_with_authorizations() -> Result<()> {
             value: serde_json::Value::String("admin-sa".into()),
         })]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-admin".into(),
             user_id: None,
             user_domain_id: None,
@@ -567,7 +567,7 @@ async fn test_k8s_template_interpolation() -> Result<()> {
             }),
         ]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-${claims.k8s.serviceaccount.name}".into(),
             user_id: None,
             user_domain_id: None,
@@ -641,7 +641,7 @@ async fn test_k8s_disabled_ruleset() -> Result<()> {
             value: serde_json::Value::String("any-sa".into()),
         })]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-disabled".into(),
             user_id: None,
             user_domain_id: None,
@@ -703,7 +703,7 @@ async fn test_k8s_unique_workload_id() -> Result<()> {
             value: serde_json::Value::String("unique-sa".into()),
         })]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-unique".into(),
             user_id: None,
             user_domain_id: None,
@@ -811,7 +811,7 @@ async fn test_k8s_aud_claim_passthrough() -> Result<()> {
             }),
         ]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-aud".into(),
             user_id: None,
             user_domain_id: None,
@@ -972,7 +972,7 @@ async fn test_k8s_project_authorization() -> Result<()> {
             value: serde_json::Value::String("pipeline-sa".into()),
         })]),
         identity: IdentityBinding {
-                identity_mode: None,
+            identity_mode: None,
             user_name: "svc-k8s-pipeline".into(),
             user_id: None,
             user_domain_id: None,

--- a/tools/k8s/tests/dex/deployment.yaml
+++ b/tools/k8s/tests/dex/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - mountPath: /etc/dex/config.docker.yaml
               name: dex
               subPath: config.yaml
-      volumes: 
+      volumes:
         - name: dex
           configMap:
             name: dex

--- a/tools/k8s/tests/dex/job.yaml
+++ b/tools/k8s/tests/dex/job.yaml
@@ -59,7 +59,7 @@ spec:
 #             - mountPath: /etc/dex/config.docker.yaml
 #               name: dex
 #               subPath: config.yaml
-#       volumes: 
+#       volumes:
 #         - name: dex
 #           configMap:
 #             name: dex

--- a/tools/setup-db.sh
+++ b/tools/setup-db.sh
@@ -38,14 +38,14 @@ else
       printf "."
       sleep 1
     done
-    
+
     echo -e "\nMySQL temporary server detected. Waiting for final restart..."
-    
+
     until $CMD logs "$TARGET" 2>&1 | grep -q "Shutting down mysqld"; do
         printf "s"
         sleep 1
     done
-    
+
     # 3. Now wait for the FINAL server to be ready.
     echo -e "\nInitialization finished. Waiting for final server..."
     until $CMD exec "$TARGET" mysql -u root -p'password' -e "SELECT 1" > /dev/null 2>&1; do

--- a/tools/start-spire.sh
+++ b/tools/start-spire.sh
@@ -51,7 +51,7 @@ agent {
     server_port = "13081"
     socket_path = "$AGENT_SOCKET"
     trust_domain = "$TRUST_DOMAIN"
-    insecure_bootstrap = true 
+    insecure_bootstrap = true
 }
 plugins {
     KeyManager "memory" {


### PR DESCRIPTION
Review of ADR 0021's implementation found it functionally complete, with
two gaps: §6.B claimed PHC comparisons use the `subtle` crate for
constant-time equality, but the code only relies on argon2's own
constant-time verify_password (doc corrected to match); and
janitor/ingress-pipeline coverage was mock/unit-test only, never
exercised against the real Raft-backed provider or a live HTTP router.

- tests/integration/src/api_key/janitor.rs: sweep disablement, tombstone
  purge, and cross-domain sweeping against the real storage/CAS layer.
- tests/integration/src/api_key/ingress.rs: full requests through
  openstack_keystone::scim::router() -- successful end-to-end auth,
  wrong- secret rejection, an XFF-spoof-through-a-trusted-proxy
  regression case (Invariant 4), and rate-limit tripping (§6.A).
- Status moved from Proposed to Accepted; §8 updated to list the new
  integration coverage.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
