### PR TITLE
feat: Prepare PKCS#11/TPM KEK support in storage

### DIFF
--- a/crates/config/src/common.rs
+++ b/crates/config/src/common.rs
@@ -123,14 +123,18 @@ impl<'de> serde::de::Visitor<'de> for U32StrOrIntVisitor {
     type Value = u32;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a u32 as string or integer")
+        formatter.write_str("a u32 as string or integer, optionally 0x-prefixed hex")
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        v.parse().map_err(E::custom)
+        if let Some(hex) = v.strip_prefix("0x").or_else(|| v.strip_prefix("0X")) {
+            u32::from_str_radix(hex, 16).map_err(E::custom)
+        } else {
+            v.parse().map_err(E::custom)
+        }
     }
 
     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>

--- a/crates/config/src/distributed_storage.rs
+++ b/crates/config/src/distributed_storage.rs
@@ -14,32 +14,18 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
+use eyre::{Context, Report};
 use http::Uri;
+use secrecy::SecretSlice;
 use serde::Deserialize;
+use validator::Validate;
 
-use crate::common::{TlsConfiguration, csv};
+use crate::common::{TlsConfiguration, csv, option_u32_from_str_or_int};
 
 /// Raft cluster configuration.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Validate)]
+#[validate(schema(function = "validate_kek_selection"))]
 pub struct DistributedStorageConfiguration {
-    /// The address of the node in the cluster.
-    #[serde(with = "http_serde::uri")]
-    pub node_cluster_addr: Uri,
-
-    /// Address on which current node listens for peer connections.
-    #[serde(default = "default_tcp_address")]
-    pub node_listener_addr: SocketAddr,
-
-    /// Node id.
-    pub node_id: u64,
-
-    /// Path to the storage.
-    pub path: PathBuf,
-
-    /// TLS configuration for the Raft cluster communication.
-    #[serde(flatten)]
-    pub tls_configuration: RaftTlsConfiguration,
-
     /// Enable development mode.
     ///
     /// When `true` the node relaxes production-only enforcement:
@@ -54,6 +40,35 @@ pub struct DistributedStorageConfiguration {
     /// CI/CD deployment validation check (ADR 0016-v2 §10 invariant 11).
     #[serde(default)]
     pub dev_mode: bool,
+
+    /// Key Encryption Key (KEK) provider used to wrap/unwrap the storage
+    /// Data Encryption Key (ADR 0016-v2 §2.1 / §2.5).
+    ///
+    /// Defaults to `env`, which is only a valid choice when `dev_mode =
+    /// true` (ADR 0016-v2 invariant 6). Production deployments MUST set
+    /// this explicitly to `pkcs11` or `tpm`.
+    #[serde(default)]
+    pub kek_provider: KekProvider,
+
+    /// The address of the node in the cluster.
+    #[serde(with = "http_serde::uri")]
+    pub node_cluster_addr: Uri,
+
+    /// Node id.
+    pub node_id: u64,
+
+    /// Address on which current node listens for peer connections.
+    #[serde(default = "default_tcp_address")]
+    pub node_listener_addr: SocketAddr,
+
+    /// Path to the storage.
+    pub path: PathBuf,
+
+    /// PKCS#11 KEK configuration (ADR 0016-v2 §2.5.1). Required when
+    /// `kek_provider = "pkcs11"`.
+    #[serde(default)]
+    #[validate(nested)]
+    pub pkcs11: Option<Pkcs11KekConfiguration>,
 
     /// Nodes to attempt Raft cluster join against on startup (ADR 0016-v2
     /// §4.3).
@@ -76,6 +91,186 @@ pub struct DistributedStorageConfiguration {
     /// ```
     #[serde(default, deserialize_with = "deserialize_retry_join_nodes")]
     pub retry_join_nodes: Vec<(u64, String)>,
+
+    /// TLS configuration for the Raft cluster communication.
+    #[serde(flatten)]
+    pub tls_configuration: RaftTlsConfiguration,
+
+    /// TPM 2.0 KEK configuration (ADR 0016-v2 §2.5.2). Required when
+    /// `kek_provider = "tpm"`.
+    #[serde(default)]
+    #[validate(nested)]
+    pub tpm: Option<TpmKekConfiguration>,
+}
+
+/// Cross-field validation for the `kek_provider` selection (ADR 0016-v2
+/// §2.5): the selected provider's configuration section must be present,
+/// and `env` is only reachable in `dev_mode` (enforced again at startup —
+/// this is a config-time fail-fast, not the sole enforcement point).
+fn validate_kek_selection(
+    cfg: &DistributedStorageConfiguration,
+) -> Result<(), validator::ValidationError> {
+    match cfg.kek_provider {
+        KekProvider::Env => {
+            if !cfg.dev_mode {
+                return Err(validator::ValidationError::new("kek_provider_env_requires_dev_mode")
+                    .with_message(std::borrow::Cow::Borrowed(
+                        "kek_provider = \"env\" is only valid when dev_mode = true (ADR 0016-v2 invariant 6)",
+                    )));
+            }
+        }
+        KekProvider::Pkcs11 => {
+            if cfg.pkcs11.is_none() {
+                return Err(
+                    validator::ValidationError::new("kek_provider_pkcs11_missing_section")
+                        .with_message(std::borrow::Cow::Borrowed(
+                        "kek_provider = \"pkcs11\" requires a [distributed_storage.pkcs11] section",
+                    )),
+                );
+            }
+        }
+        KekProvider::Tpm => match &cfg.tpm {
+            None => {
+                return Err(
+                    validator::ValidationError::new("kek_provider_tpm_missing_section")
+                        .with_message(std::borrow::Cow::Borrowed(
+                            "kek_provider = \"tpm\" requires a [distributed_storage.tpm] section",
+                        )),
+                );
+            }
+            Some(tpm) => {
+                if tpm.tpm_key_handle.is_none() && tpm.tpm_key_context_file.is_none() {
+                    return Err(validator::ValidationError::new(
+                        "kek_provider_tpm_missing_key_reference",
+                    )
+                    .with_message(std::borrow::Cow::Borrowed(
+                        "[distributed_storage.tpm] requires either tpm_key_handle or tpm_key_context_file",
+                    )));
+                }
+                if tpm.tpm_key_handle.is_some() && tpm.tpm_key_context_file.is_some() {
+                    return Err(validator::ValidationError::new(
+                        "kek_provider_tpm_ambiguous_key_reference",
+                    )
+                    .with_message(std::borrow::Cow::Borrowed(
+                        "[distributed_storage.tpm] accepts either tpm_key_handle or tpm_key_context_file, not both",
+                    )));
+                }
+            }
+        },
+    }
+    Ok(())
+}
+
+/// Selects which Key Encryption Key provider backs DEK wrap/unwrap (ADR
+/// 0016-v2 §2.1 / §2.5).
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum KekProvider {
+    /// Development-mode KEK sourced from `KEYSTONE_DEV_KEK`. Only valid
+    /// when `dev_mode = true` (ADR 0016-v2 invariant 6).
+    #[default]
+    Env,
+    /// PKCS#11 HSM/token-backed KEK (ADR 0016-v2 §2.5.1).
+    Pkcs11,
+    /// TPM 2.0 resident-key-backed KEK (ADR 0016-v2 §2.5.2).
+    Tpm,
+}
+
+/// PKCS#11 KEK provider configuration (ADR 0016-v2 §2.5.1).
+#[derive(Debug, Deserialize, Clone, Validate)]
+pub struct Pkcs11KekConfiguration {
+    /// Path to the PKCS#11 module implementing the Cryptoki API, e.g.
+    /// `/usr/lib/softhsm/libsofthsm2.so` for SoftHSM2 or the vendor HSM's
+    /// PKCS#11 shared library in production.
+    /// `CKA_LABEL` of the AES-256 key object used as the KEK. The key MUST
+    /// be created with `CKA_EXTRACTABLE = false` (ADR 0016-v2 §10
+    /// invariant 13).
+    #[validate(length(min = 1))]
+    pub pkcs11_key_label: String,
+
+    pub pkcs11_module_path: PathBuf,
+
+    /// The PIN content, populated by [`Self::load_secrets`]. Never
+    /// serialised and never logged.
+    #[serde(skip)]
+    pub pkcs11_pin_content: Option<SecretSlice<u8>>,
+
+    /// Path to a file containing the token PIN. Read once at startup into
+    /// locked memory and never accepted via environment variable or inline
+    /// config value (ADR 0016-v2 §10 invariant 14).
+    pub pkcs11_pin_file: PathBuf,
+
+    /// Numeric slot id to open. Either this or `pkcs11_slot_label` must be
+    /// given; the label is preferred where supported since slot ids can
+    /// shift across token re-initialisation.
+    #[serde(default)]
+    pub pkcs11_slot_id: Option<u64>,
+
+    /// Token label used to resolve the slot when `pkcs11_slot_id` is not
+    /// given.
+    #[serde(default)]
+    pub pkcs11_slot_label: Option<String>,
+}
+
+impl Pkcs11KekConfiguration {
+    /// Read `pkcs11_pin_file` into [`Self::pkcs11_pin_content`].
+    pub fn load_secrets(&mut self) -> Result<(), Report> {
+        self.pkcs11_pin_content = Some(
+            std::fs::read(&self.pkcs11_pin_file)
+                .wrap_err_with(|| format!("reading PKCS#11 PIN file {:?}", self.pkcs11_pin_file))?
+                .into(),
+        );
+        Ok(())
+    }
+}
+
+/// TPM 2.0 KEK provider configuration (ADR 0016-v2 §2.5.2).
+#[derive(Debug, Deserialize, Clone, Validate)]
+pub struct TpmKekConfiguration {
+    /// Path to a file containing the key's auth value, if the key was
+    /// provisioned with `userWithAuth` authorisation. Optional because a
+    /// TPM key may instead rely on a PCR/policy session. Never accepted via
+    /// environment variable or inline config value (ADR 0016-v2 §10
+    /// invariant 14).
+    /// The auth value content, populated by [`Self::load_secrets`]. Never
+    /// serialised and never logged.
+    #[serde(skip)]
+    pub tpm_auth_content: Option<SecretSlice<u8>>,
+
+    #[serde(default)]
+    pub tpm_auth_file: Option<PathBuf>,
+
+    /// Path to a saved TPM2 key context blob, used instead of a persistent
+    /// handle. Mutually exclusive with `tpm_key_handle`.
+    #[serde(default)]
+    pub tpm_key_context_file: Option<PathBuf>,
+
+    /// Persistent handle (decimal or `0x`-prefixed hex, e.g. `0x81000001`)
+    /// of the pre-provisioned, non-duplicable AES-256 symmetric-cipher key
+    /// used as the KEK. Mutually exclusive with `tpm_key_context_file`.
+    #[serde(default, deserialize_with = "option_u32_from_str_or_int")]
+    pub tpm_key_handle: Option<u32>,
+
+    /// TCTI connection string for the TPM 2.0 stack, e.g.
+    /// `device:/dev/tpmrm0` for a hardware TPM or
+    /// `swtpm:host=127.0.0.1,port=2321` for the software TPM used in the
+    /// documented sample.
+    #[validate(length(min = 1))]
+    pub tpm_tcti: String,
+}
+
+impl TpmKekConfiguration {
+    /// Read `tpm_auth_file` (if configured) into [`Self::tpm_auth_content`].
+    pub fn load_secrets(&mut self) -> Result<(), Report> {
+        if let Some(path) = &self.tpm_auth_file {
+            self.tpm_auth_content = Some(
+                std::fs::read(path)
+                    .wrap_err_with(|| format!("reading TPM auth file {:?}", path))?
+                    .into(),
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Deserialize ``id=address`` pairs from a CSV string.
@@ -130,22 +325,6 @@ pub enum RaftTlsConfiguration {
 /// Spiffe backed mTLS for the Raft.
 #[derive(Debug, Deserialize, Clone)]
 pub struct SpiffeTls {
-    /// Trusted domains for SPIFFE verification.
-    #[serde(deserialize_with = "csv")]
-    pub trust_domains: Vec<String>,
-
-    /// SPIFFE path prefix required on all storage SVIDs (e.g.
-    /// `/keystone/storage/`). The role segment follows this prefix:
-    /// `spiffe://<td><spiffe_path_prefix><role>`.
-    #[serde(default = "default_spiffe_path_prefix")]
-    pub spiffe_path_prefix: String,
-
-    /// SPIFFE role that authorises sensitive management operations (backup,
-    /// restore, rotate DEK, clear quarantine, etc.).  Defaults to
-    /// `"storage-operator"`.
-    #[serde(default = "default_operator_role")]
-    pub operator_role: String,
-
     /// Allow-list of SPIFFE SVIDs that may participate in peer-to-peer Raft
     /// operations (`metrics`, `init`, `add_learner`, `change_membership`).
     /// When empty the check falls back to trust-domain-only validation.
@@ -158,6 +337,22 @@ pub struct SpiffeTls {
     /// ```
     #[serde(default)]
     pub allowed_peer_svids: Vec<String>,
+
+    /// SPIFFE role that authorises sensitive management operations (backup,
+    /// restore, rotate DEK, clear quarantine, etc.).  Defaults to
+    /// `"storage-operator"`.
+    #[serde(default = "default_operator_role")]
+    pub operator_role: String,
+
+    /// SPIFFE path prefix required on all storage SVIDs (e.g.
+    /// `/keystone/storage/`). The role segment follows this prefix:
+    /// `spiffe://<td><spiffe_path_prefix><role>`.
+    #[serde(default = "default_spiffe_path_prefix")]
+    pub spiffe_path_prefix: String,
+
+    /// Trusted domains for SPIFFE verification.
+    #[serde(deserialize_with = "csv")]
+    pub trust_domains: Vec<String>,
 }
 
 fn default_spiffe_path_prefix() -> String {
@@ -279,6 +474,199 @@ path = /foo
                         .to_string()
                 );
             },
+        );
+    }
+
+    #[test]
+    fn test_kek_provider_defaults_to_env() {
+        let cfg: DistributedStorageConfiguration = serde_json::from_value(json!({
+            "node_cluster_addr": "http://1.2.3.4:5678",
+            "node_id": 1,
+            "path": "/tmp",
+            "tls_cert_file": "/tmp/tls.cert",
+            "tls_key_file": "/tmp/tls.key"
+        }))
+        .unwrap();
+        assert_eq!(cfg.kek_provider, KekProvider::Env);
+        assert!(cfg.pkcs11.is_none());
+        assert!(cfg.tpm.is_none());
+    }
+
+    #[test]
+    fn test_kek_provider_env_requires_dev_mode() {
+        let cfg: DistributedStorageConfiguration = serde_json::from_value(json!({
+            "node_cluster_addr": "http://1.2.3.4:5678",
+            "node_id": 1,
+            "path": "/tmp",
+            "tls_cert_file": "/tmp/tls.cert",
+            "tls_key_file": "/tmp/tls.key",
+            "dev_mode": false
+        }))
+        .unwrap();
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("kek_provider = \"env\" is only valid when dev_mode"),
+            "unexpected error: {err}"
+        );
+
+        let cfg_dev: DistributedStorageConfiguration = serde_json::from_value(json!({
+            "node_cluster_addr": "http://1.2.3.4:5678",
+            "node_id": 1,
+            "path": "/tmp",
+            "tls_cert_file": "/tmp/tls.cert",
+            "tls_key_file": "/tmp/tls.key",
+            "dev_mode": true
+        }))
+        .unwrap();
+        cfg_dev
+            .validate()
+            .expect("dev_mode=true with env kek must validate");
+    }
+
+    #[test]
+    fn test_kek_provider_pkcs11_requires_section() {
+        let cfg: DistributedStorageConfiguration = serde_json::from_value(json!({
+            "node_cluster_addr": "http://1.2.3.4:5678",
+            "node_id": 1,
+            "path": "/tmp",
+            "tls_cert_file": "/tmp/tls.cert",
+            "tls_key_file": "/tmp/tls.key",
+            "kek_provider": "pkcs11"
+        }))
+        .unwrap();
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("requires a [distributed_storage.pkcs11] section"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_kek_provider_pkcs11_valid_section() {
+        let cfg: DistributedStorageConfiguration = serde_json::from_value(json!({
+            "node_cluster_addr": "http://1.2.3.4:5678",
+            "node_id": 1,
+            "path": "/tmp",
+            "tls_cert_file": "/tmp/tls.cert",
+            "tls_key_file": "/tmp/tls.key",
+            "kek_provider": "pkcs11",
+            "pkcs11": {
+                "pkcs11_module_path": "/usr/lib/softhsm/libsofthsm2.so",
+                "pkcs11_slot_label": "keystone",
+                "pkcs11_key_label": "keystone-kek",
+                "pkcs11_pin_file": "/etc/keystone/pkcs11-pin"
+            }
+        }))
+        .unwrap();
+        cfg.validate().expect("valid pkcs11 section must validate");
+    }
+
+    #[test]
+    fn test_kek_provider_tpm_requires_key_reference() {
+        let cfg: DistributedStorageConfiguration = serde_json::from_value(json!({
+            "node_cluster_addr": "http://1.2.3.4:5678",
+            "node_id": 1,
+            "path": "/tmp",
+            "tls_cert_file": "/tmp/tls.cert",
+            "tls_key_file": "/tmp/tls.key",
+            "kek_provider": "tpm",
+            "tpm": {
+                "tpm_tcti": "device:/dev/tpmrm0"
+            }
+        }))
+        .unwrap();
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("requires either tpm_key_handle or tpm_key_context_file"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_kek_provider_tpm_ambiguous_key_reference() {
+        let cfg: DistributedStorageConfiguration = serde_json::from_value(json!({
+            "node_cluster_addr": "http://1.2.3.4:5678",
+            "node_id": 1,
+            "path": "/tmp",
+            "tls_cert_file": "/tmp/tls.cert",
+            "tls_key_file": "/tmp/tls.key",
+            "kek_provider": "tpm",
+            "tpm": {
+                "tpm_tcti": "device:/dev/tpmrm0",
+                "tpm_key_handle": "0x81000001",
+                "tpm_key_context_file": "/var/lib/keystone/tpm-key.ctx"
+            }
+        }))
+        .unwrap();
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("accepts either tpm_key_handle or tpm_key_context_file, not both"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_kek_provider_tpm_valid_with_hex_handle() {
+        let cfg: DistributedStorageConfiguration = serde_json::from_value(json!({
+            "node_cluster_addr": "http://1.2.3.4:5678",
+            "node_id": 1,
+            "path": "/tmp",
+            "tls_cert_file": "/tmp/tls.cert",
+            "tls_key_file": "/tmp/tls.key",
+            "kek_provider": "tpm",
+            "tpm": {
+                "tpm_tcti": "swtpm:host=127.0.0.1,port=2321",
+                "tpm_key_handle": "0x81000001"
+            }
+        }))
+        .unwrap();
+        cfg.validate().expect("valid tpm section must validate");
+        assert_eq!(
+            cfg.tpm.as_ref().and_then(|t| t.tpm_key_handle),
+            Some(0x8100_0001)
+        );
+    }
+
+    #[test]
+    fn test_pkcs11_load_secrets() {
+        let mut pin_file = NamedTempFile::new().unwrap();
+        write!(pin_file, "1234").unwrap();
+        let mut cfg = Pkcs11KekConfiguration {
+            pkcs11_module_path: "/usr/lib/softhsm/libsofthsm2.so".into(),
+            pkcs11_slot_id: None,
+            pkcs11_slot_label: Some("keystone".to_string()),
+            pkcs11_key_label: "keystone-kek".to_string(),
+            pkcs11_pin_file: pin_file.path().to_path_buf(),
+            pkcs11_pin_content: None,
+        };
+        cfg.load_secrets().expect("load_secrets");
+        use secrecy::ExposeSecret;
+        assert_eq!(
+            cfg.pkcs11_pin_content.unwrap().expose_secret(),
+            b"1234".as_slice()
+        );
+    }
+
+    #[test]
+    fn test_tpm_load_secrets_optional_auth_file() {
+        let mut cfg = TpmKekConfiguration {
+            tpm_tcti: "device:/dev/tpmrm0".to_string(),
+            tpm_key_handle: Some(0x8100_0001),
+            tpm_key_context_file: None,
+            tpm_auth_file: None,
+            tpm_auth_content: None,
+        };
+        cfg.load_secrets().expect("load_secrets with no auth file");
+        assert!(cfg.tpm_auth_content.is_none());
+
+        let mut auth_file = NamedTempFile::new().unwrap();
+        write!(auth_file, "secret-auth").unwrap();
+        cfg.tpm_auth_file = Some(auth_file.path().to_path_buf());
+        cfg.load_secrets().expect("load_secrets with auth file");
+        use secrecy::ExposeSecret;
+        assert_eq!(
+            cfg.tpm_auth_content.unwrap().expose_secret(),
+            b"secret-auth".as_slice()
         );
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -159,6 +159,7 @@ pub struct Config {
 
     /// Distributed storage configuration.
     #[serde(default)]
+    #[validate(nested)]
     pub distributed_storage: Option<DistributedStorageConfiguration>,
 
     /// Federation provider configuration.
@@ -268,11 +269,20 @@ impl Config {
     /// - `Ok(Self)` if the config was parsed successfully
     pub fn load_all(path: PathBuf) -> Result<Self, Report> {
         let mut cfg = Self::new(path)?;
-        if let Some(ref mut ds) = cfg.distributed_storage
-            && let RaftTlsConfiguration::Tls(ref mut tls) = ds.tls_configuration
-        {
-            tls.read_certs()
-                .wrap_err("reading distributed storage TLS configuration")?;
+        if let Some(ref mut ds) = cfg.distributed_storage {
+            if let RaftTlsConfiguration::Tls(ref mut tls) = ds.tls_configuration {
+                tls.read_certs()
+                    .wrap_err("reading distributed storage TLS configuration")?;
+            }
+            if let Some(ref mut pkcs11) = ds.pkcs11 {
+                pkcs11
+                    .load_secrets()
+                    .wrap_err("reading distributed storage PKCS#11 configuration")?;
+            }
+            if let Some(ref mut tpm) = ds.tpm {
+                tpm.load_secrets()
+                    .wrap_err("reading distributed storage TPM configuration")?;
+            }
         }
         // Compile password regex at load time.
         cfg.security_compliance
@@ -628,6 +638,7 @@ mod tests {
     node_cluster_addr = https://localhost:8310
     node_id = 1
     path = /keystone/storage
+    dev_mode = true
     tls_key_file = {:?}
     tls_cert_file = {:?}
     tls_client_ca_file = {:?}
@@ -777,6 +788,7 @@ mod tests {
     node_cluster_addr = "https://localhost:8310"
     node_id = 1
     path = "/keystone/storage"
+    dev_mode = true
 
     [api_key]
     trusted_proxies = 10.0.0.0/8,192.168.1.0/24

--- a/crates/storage/benches/write.rs
+++ b/crates/storage/benches/write.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
 use openstack_keystone_config::{
-    Config, ConfigManager, DistributedStorageConfiguration, TlsConfiguration,
+    Config, ConfigManager, DistributedStorageConfiguration, KekProvider, TlsConfiguration,
     TlsConfigurationBuilder,
 };
 use openstack_keystone_distributed_storage::{
@@ -58,6 +58,9 @@ impl InstanceHolder {
             ),
             dev_mode: true,
             retry_join_nodes: vec![],
+            kek_provider: KekProvider::Env,
+            pkcs11: None,
+            tpm: None,
         }
     }
 

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -35,7 +35,7 @@ use tempfile::TempDir;
 use tonic::transport::{Channel, ClientTlsConfig, Uri};
 
 use openstack_keystone_config::{
-    Config, ConfigManager, DistributedStorageConfiguration, TlsConfiguration,
+    Config, ConfigManager, DistributedStorageConfiguration, KekProvider, TlsConfiguration,
     TlsConfigurationBuilder,
 };
 use openstack_keystone_distributed_storage::app::{Storage, get_app_server, init_storage};
@@ -555,6 +555,9 @@ async fn test_node_restart_inner() -> Result<()> {
         ),
         dev_mode: true,
         retry_join_nodes: vec![],
+        kek_provider: KekProvider::Env,
+        pkcs11: None,
+        tpm: None,
     };
     let config = Config {
         distributed_storage: Some(ds_config),
@@ -645,6 +648,9 @@ async fn test_node_restart_inner() -> Result<()> {
         ),
         dev_mode: true,
         retry_join_nodes: vec![],
+        kek_provider: KekProvider::Env,
+        pkcs11: None,
+        tpm: None,
     };
     let config_restart = Config {
         distributed_storage: Some(ds_config_restart),
@@ -1662,5 +1668,8 @@ fn get_ds_config_with_port(
         tls_configuration: openstack_keystone_config::RaftTlsConfiguration::Tls(tls_config.clone()),
         dev_mode: true,
         retry_join_nodes: vec![],
+        kek_provider: KekProvider::Env,
+        pkcs11: None,
+        tpm: None,
     }
 }

--- a/crates/webauthn/tests/common/mod.rs
+++ b/crates/webauthn/tests/common/mod.rs
@@ -33,8 +33,8 @@ use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
 
 use openstack_keystone_audit::AuditDispatcher;
 use openstack_keystone_config::{
-    Config, ConfigManager, DistributedStorageConfiguration, RaftTlsConfiguration, RelyingParty,
-    TlsConfiguration, TlsConfigurationBuilder,
+    Config, ConfigManager, DistributedStorageConfiguration, KekProvider, RaftTlsConfiguration,
+    RelyingParty, TlsConfiguration, TlsConfigurationBuilder,
 };
 use openstack_keystone_core::SqlDriverRegistration;
 use openstack_keystone_core::keystone::Service;
@@ -153,6 +153,9 @@ pub async fn get_state(
             tls_configuration: RaftTlsConfiguration::Tls(tls_configuration),
             dev_mode: true,
             retry_join_nodes: vec![],
+            kek_provider: KekProvider::Env,
+            pkcs11: None,
+            tpm: None,
         });
     }
     let mut policy_enforcer_mock = MockPolicy::default();

--- a/doc/plans/0016-v2-pkcs11-tpm-kek.md
+++ b/doc/plans/0016-v2-pkcs11-tpm-kek.md
@@ -1,0 +1,110 @@
+# Implementation plan: PKCS#11 and TPM KEK providers (ADR 0016-v2 §2.5)
+
+Status: **steps 1-2 complete**, steps 3-10 not started.
+
+This is a working implementation plan, not user-facing documentation — it is
+intentionally not linked from `doc/src/SUMMARY.md`. The durable design record
+is [ADR 0016-v2 §2.5](../src/adr/0016-v2-raft-storage.md); this file tracks
+how that design gets built.
+
+## Context
+
+ADR 0016-v2 §2.1 named "HSM / PKCS#11 / Cloud KMS" as the production KEK
+source but never specified a mechanism. `crates/storage-crypto/src/kek.rs`
+already reserves the abstraction boundary: the `KekProvider` trait, a working
+`EnvKek` (dev-mode only), and a `Pkcs11KekStub` that always returns
+`CryptoError::Pkcs11NotImplemented`. No TPM path exists at all. This plan
+replaces the stub with real PKCS#11 and TPM 2.0 providers.
+
+## Decisions taken
+
+These were confirmed with the requester before design work started:
+
+1. **Crate layout:** separate, feature-gated crates (`storage-crypto-pkcs11`,
+   `storage-crypto-tpm`), not new modules inside `storage-crypto`. Keeps the
+   FFI-heavy C-library bindings out of the crate that owns the workspace's
+   `unsafe_code = "deny"` core primitives, and matches ADR §1's cargo-vet
+   scoping for anything in the AES-HKDF-KMS call path.
+2. **TPM trust model:** a TPM-resident, non-duplicable AES key performs the
+   wrap/unwrap itself (`TPM2_EncryptDecrypt2`) — the KEK never enters process
+   RAM, matching invariant 2 exactly, the same guarantee the PKCS#11 path
+   gives. (Not the alternative: sealing a software-generated KEK to the TPM,
+   which would transiently expose it in RAM on every unseal.)
+3. **Test/sample scope:** SoftHSM gets a full CI-gated integration test
+   (installed via `apt-get`, same pattern as the existing SPIRE install step —
+   this repo does not use testcontainers anywhere). TPM gets a runnable
+   example/doc sample only, not wired into the required CI gate — real/virtual
+   TPM availability in CI runners isn't reliable enough to gate merges on.
+4. **Credential input:** PKCS#11 PIN and TPM auth value are supplied via a
+   file path in config (`pkcs11_pin_file`, `tpm_auth_file`), analogous to the
+   existing `tls_key_file` convention — never via environment variable (that
+   channel stays reserved for the dev-mode `KEYSTONE_DEV_KEK` path only).
+
+## Architecture summary
+
+- **PKCS#11:** a non-extractable (`CKA_EXTRACTABLE=false`, `CKA_SENSITIVE=true`)
+  AES-256 key object on the token. `wrap_dek`/`unwrap_dek` use `CKM_AES_GCM`
+  directly against that key object, producing the same
+  `[12-byte nonce][ciphertext][16-byte tag]` wire format `EnvKek` already
+  uses — nothing downstream of `KekProvider` needs to change.
+- **TPM 2.0:** a `fixedTPM | fixedParent`, non-duplicable symmetric-cipher
+  key. TPM 2.0 has **no native AES-GCM command** (`TPM2_EncryptDecrypt2` only
+  supports CFB/CBC/CTR/OFB/ECB), so the provider uses Encrypt-then-MAC:
+  AES-256-CFB via the TPM-resident key for confidentiality, HMAC-SHA256 (also
+  TPM-resident, `TPM2_HMAC`) for integrity, with the MAC checked before any
+  decryption is attempted. Wire format: `[16b iv][32b ciphertext][32b hmac
+  tag]` — different from the GCM format, but still opaque `Vec<u8>` behind the
+  `KekProvider` trait.
+
+Full mechanism detail, wire formats, and new invariants (13-15) are in
+[ADR 0016-v2 §2.5](../src/adr/0016-v2-raft-storage.md#25-pkcs11-and-tpm-kek-provisioning).
+
+## Sequencing
+
+1. **ADR addendum** (§2.5: mechanism + invariants 13-15). ✅ done
+   (`doc/src/adr/0016-v2-raft-storage.md`).
+2. **Config schema**: `kek_provider` selector (`env`/`pkcs11`/`tpm`) +
+   `Pkcs11KekConfiguration` / `TpmKekConfiguration` + cross-field validation
+   (env requires `dev_mode`; pkcs11/tpm require their section; TPM key
+   reference is exactly one of handle/context-file) + file-based secret
+   loading wired into `Config::load_all`. ✅ done
+   (`crates/config/src/distributed_storage.rs`, `crates/config/src/lib.rs`).
+3. **`storage-crypto-pkcs11` crate**: `cryptoki` dependency, `Pkcs11Kek`
+   implementing `KekProvider`, optional auto-generate-key-if-missing on first
+   startup, unit tests against SoftHSM2 (token init, wrap/unwrap round-trip,
+   tamper/tag-corruption rejection, wrong-PIN failure). ⬜ not started
+4. **`storage-crypto-tpm` crate**: `tss-esapi` dependency, `TpmKek`
+   implementing `KekProvider` (Encrypt-then-MAC per §2.5.2), example under
+   `examples/tpm_kek_demo.rs` targeting `swtpm`. ⬜ not started
+5. **Wire into `crates/storage/src/app.rs`**: replace the hardcoded
+   `dev_mode ? EnvKek : Pkcs11KekStub` selection with one driven by
+   `ds_config.kek_provider`; remove the implicit stub fallback so production
+   requires an explicit, valid provider selection (already enforced at
+   config-validation time by step 2, but must also be enforced at runtime
+   construction). Feature flags `pkcs11` / `tpm` on the `storage` crate pull
+   in the new provider crates. ⬜ not started
+6. **SoftHSM-backed integration test**: new file in `crates/storage/tests/`
+   (feature-gated `pkcs11`) that boots a single-node cluster with a
+   SoftHSM-backed KEK and does an end-to-end write/read, beyond the
+   unit-level wrap/unwrap coverage in step 3. ⬜ not started
+7. **CI**: add a "Install SoftHSM2 + init test token" step to
+   `.github/workflows/ci.yml` (apt-get, same pattern as the SPIRE binary
+   install) ahead of running the `pkcs11`-featured tests. Compile (but do not
+   run) the TPM example in CI to catch rot, without adding `swtpm` as a hard
+   CI dependency. ⬜ not started
+8. **Docs**: update `doc/src/raft_storage.md`'s crate-layout tree and key
+   hierarchy section, and `CONTRIBUTING.md`'s crate-purpose table, with the
+   two new crates. Add the TPM sample walkthrough. ⬜ not started
+9. **Supply chain**: add `cryptoki` and `tss-esapi` (pinned versions) to the
+   extended cargo-vet coverage list in ADR §1, and check `deny.toml` for any
+   new transitive-dependency rules needed. ⬜ not started
+
+## Open questions for step 3 onward
+
+- Exact `cryptoki` and `tss-esapi` version pins, and whether either requires
+  system packages beyond what CI/dev containers currently install
+  (`libp11-kit`, `tpm2-tss` headers, etc.) — needs a spike before locking
+  `Cargo.toml` entries.
+- Whether the PKCS#11 auto-generate-key-on-first-use convenience (step 3)
+  should be gated behind its own config flag, given it changes the operator
+  key-ceremony story for regulated deployments.

--- a/doc/src/adr/0016-v2-raft-storage.md
+++ b/doc/src/adr/0016-v2-raft-storage.md
@@ -1,7 +1,7 @@
 # ADR 0016-v2: Distributed Encrypted Storage via Raft and Fjall
 
 Date: 2026-06-13
-Last-revised: 2026-06-24 (security review)
+Last-revised: 2026-07-02 (PKCS#11/TPM KEK provisioning addendum)
 
 ## Status
 
@@ -18,6 +18,11 @@ Proposed
 - F6 LOW: Emergency rotation confirmation timeout now has an explicit abort + audit path (§6.2)
 - F7 LOW: NodeId uniqueness check specified as fail-closed when leader is unreachable (§4.3)
 - F8 LOW: Sub-key derivation notation changed from `HKDF-SHA256` to `HKDF-Expand` (§2.1)
+
+**Addendum applied (2026-07-02):** §2.5 added, specifying the concrete PKCS#11
+and TPM 2.0 KEK provider mechanisms that §2.1 previously deferred ("HSM /
+PKCS#11 / Cloud KMS"), the `kek_provider` configuration schema, and new
+invariants 13–15 (§10).
 
 ## Context
 
@@ -219,6 +224,99 @@ capabilities:
   has reviewed this limitation against applicable regulations (GDPR
   pseudonymisation obligations) and confirmed it meets the organization's
   privacy requirements.
+
+### 2.5 PKCS#11 and TPM KEK Provisioning
+
+§2.1 named "HSM / PKCS#11 / Cloud KMS" as the production KEK source but did
+not specify a mechanism. This section specifies the PKCS#11 and TPM 2.0
+`KekProvider` implementations. Both satisfy invariant 2 (§10): the KEK itself
+never enters process memory in plaintext, only wrapped DEK bytes cross the
+provider boundary.
+
+**Provider selection:** `[distributed_storage] kek_provider` selects between
+`env` (dev-mode only, §2.1), `pkcs11`, and `tpm`. Exactly one provider is
+active per node. Production deployments (`dev_mode = false`) MUST set this to
+`pkcs11` or `tpm`; `kek_provider = "env"` outside `dev_mode` is rejected at
+config-validation time, before any KEK material is touched (invariant 6).
+
+#### 2.5.1 PKCS#11
+
+The KEK is an AES-256 key object resident on a PKCS#11 token (a hardware HSM
+or, for development/CI, SoftHSM2), created with `CKA_EXTRACTABLE = false` and
+`CKA_SENSITIVE = true`. `wrap_dek`/`unwrap_dek` invoke `CKM_AES_GCM` directly
+against that key object (`C_EncryptInit`/`C_Encrypt` and
+`C_DecryptInit`/`C_Decrypt` with a `CK_GCM_PARAMS` structure carrying a
+freshly generated 12-byte nonce, `DEK_WRAP_AD` as additional authenticated
+data, and a 128-bit tag). The resulting wire format is byte-identical to
+`EnvKek`'s: `[12-byte nonce][ciphertext][16-byte tag]` — no downstream code
+(DEK bootstrap, Fjall metadata storage) needs to distinguish which
+`KekProvider` produced a wrapped blob.
+
+- **Key provisioning:** creating the AES-256 key object on the token is an
+  out-of-band operator step (e.g. `pkcs11-tool --keygen` or
+  `softhsm2-util --init-token` for development), documented in the operator
+  guide. The provider MAY auto-generate the key via `CKM_AES_KEY_GEN` on
+  first startup if `pkcs11_key_label` is not found on the configured slot —
+  this is an ergonomic convenience for fresh clusters, not a substitute for
+  operator-controlled key ceremony in regulated deployments.
+- **PIN handling:** the token PIN is read once at startup from
+  `pkcs11_pin_file` into a `Zeroizing` buffer, used for `C_Login`, and
+  zeroed immediately after. The PIN is never accepted via environment
+  variable or inline config value — only a file path, consistent with the
+  existing `tls_key_file`/`tls_cert_file` convention (§4.2).
+- **Failure handling:** a login failure, missing key object, or GCM tag
+  mismatch on unwrap is fatal to node startup (or, post-startup, treated the
+  same as any other GCM tag failure under invariant 5's quarantine logic).
+
+#### 2.5.2 TPM 2.0
+
+The KEK is a non-duplicable, TPM-resident symmetric-cipher key
+(`fixedTPM | fixedParent | sensitiveDataOrigin`, no duplication attribute).
+As with PKCS#11, the raw key material never leaves the TPM and never enters
+process memory — only the wrapped DEK crosses the boundary.
+
+**TPM 2.0 has no native AES-GCM command.** `TPM2_EncryptDecrypt2` supports
+only CFB/CBC/CTR/OFB/ECB symmetric modes; there is no AEAD primitive. The TPM
+provider therefore uses Encrypt-then-MAC instead of AES-GCM:
+
+```text
+wrap_dek(dek):
+  iv          = random 16 bytes
+  ciphertext  = TPM2_EncryptDecrypt2(key = tpm_kek, mode = AES-256-CFB, iv, data = dek)
+  tag         = TPM2_HMAC(key = tpm_hmac, data = iv ++ ciphertext ++ DEK_WRAP_AD)
+  wrapped     = iv ++ ciphertext ++ tag        // [16b][32b][32b] = 80 bytes
+
+unwrap_dek(wrapped):
+  split wrapped into iv, ciphertext, tag
+  expected_tag = TPM2_HMAC(key = tpm_hmac, data = iv ++ ciphertext ++ DEK_WRAP_AD)
+  reject unless expected_tag == tag (constant-time compare) — never attempt
+  TPM2_EncryptDecrypt2 on an unauthenticated ciphertext
+  dek = TPM2_EncryptDecrypt2(key = tpm_kek, mode = AES-256-CFB, iv, data = ciphertext, decrypt = true)
+```
+
+This is a deliberate deviation from "AES-256-GCM for all payloads" (§2.2)
+scoped strictly to the TPM KEK-wrap boundary: it does not touch the Log DEK,
+State DEK, or Backup DEK, which remain AES-256-GCM as specified elsewhere in
+this ADR. `tpm_kek` and `tpm_hmac` MAY be the same TPM key object used in two
+different USAGE modes if the provisioning tooling supports it, or two
+separate persistent handles; either is acceptable provided both satisfy the
+non-duplicable, non-extractable attributes above.
+
+- **Key provisioning:** a persistent handle (`tpm_key_handle`) or a saved key
+  context (`tpm_key_context_file`) identifying the pre-provisioned TPM key(s).
+  Provisioning itself (via `tpm2_create`/`tpm2_evictcontrol` or equivalent) is
+  an out-of-band operator step, documented alongside the PKCS#11 key ceremony.
+- **Auth handling:** if the key was provisioned with `userWithAuth`, the auth
+  value is read once from `tpm_auth_file` into a `Zeroizing` buffer and used
+  to authorize the TPM session; zeroed immediately after. As with PKCS#11,
+  only a file path is accepted, never an environment variable or inline
+  value. A key relying purely on PCR/policy session authorization may omit
+  `tpm_auth_file`.
+- **Sample scope:** the TPM provider ships with a runnable example targeting
+  a software TPM (`swtpm`) for local exploration, and is not part of the
+  required CI gate — real and virtual TPM availability in CI runners is not
+  reliable enough to gate merges on. The PKCS#11 path (§2.5.1), backed by
+  SoftHSM2, is the CI-gated path (§1).
 
 ---
 
@@ -782,3 +880,20 @@ Any code change violating the following is rejected at review:
 12. **Startup pre-flight:** At process startup (before KEK/DEK are loaded), the
     node must verify `RLIMIT_CORE == 0` and `PR_SET_DUMPABLE == 0`. If either
     check fails, the node must refuse to start in production mode.
+13. **Non-extractable KEK key material (§2.5):** PKCS#11 KEK key objects MUST
+    be created with `CKA_EXTRACTABLE = false` / `CKA_SENSITIVE = true`; TPM
+    KEK key objects MUST be created with `fixedTPM | fixedParent` and no
+    duplication attribute. A `KekProvider` implementation that can export raw
+    key bytes from the token/TPM is non-compliant regardless of how it is
+    otherwise used.
+14. **No PKCS#11/TPM credential via environment variable:** The PKCS#11 PIN
+    and TPM auth value are supplied only via `pkcs11_pin_file` /
+    `tpm_auth_file` (a file path in config). Neither may be supplied via an
+    environment variable or inline config value — that channel is reserved
+    exclusively for the dev-mode `KEYSTONE_DEV_KEK` path (invariant 6).
+15. **Authenticate-before-decrypt for Encrypt-then-MAC contexts:** Any
+    `KekProvider` that does not use an AEAD primitive natively (the TPM
+    provider, §2.5.2) MUST verify the MAC over the full ciphertext before
+    performing any decryption operation, and MUST use a constant-time
+    comparison. Decrypting unauthenticated ciphertext, even transiently, is
+    prohibited.

--- a/tests/integration/src/common.rs
+++ b/tests/integration/src/common.rs
@@ -37,7 +37,7 @@ use uuid::Uuid;
 use openstack_keystone::plugin_manager::PluginManager;
 use openstack_keystone_audit::AuditDispatcher;
 use openstack_keystone_config::{
-    Config, ConfigManager, DistributedStorageConfiguration, TlsConfiguration,
+    Config, ConfigManager, DistributedStorageConfiguration, KekProvider, TlsConfiguration,
     TlsConfigurationBuilder,
 };
 use openstack_keystone_core::policy::MockPolicy;
@@ -166,6 +166,9 @@ pub async fn get_state() -> Result<(Arc<Service>, TempDir)> {
             tls_configuration,
             dev_mode: true,
             retry_join_nodes: vec![],
+            kek_provider: KekProvider::Env,
+            pkcs11: None,
+            tpm: None,
         });
         cfg.k8s_auth.driver = "raft".to_string();
     }


### PR DESCRIPTION
ADR 0016-v2 §2.1 named "HSM / PKCS#11 / Cloud KMS" as the production KEK
source but never specified a mechanism, leaving the Pkcs11KekStub as a
reserved-but-unimplemented interface boundary. Adds §2.5, specifying the
PKCS#11 (CKM_AES_GCM against a non-extractable token key, same wire
format as EnvKek) and TPM 2.0 (TPM-resident non-duplicable key,
Encrypt-then-MAC since TPM2 has no native AES-GCM command) KEK
mechanisms, plus invariants 13-15 covering non-extractable key material,
file-only credential input, and authenticate-before-decrypt for non-AEAD
providers.

Adds the corresponding kek_provider configuration schema
(crates/config/src/distributed_storage.rs): an env/pkcs11/tpm selector
with per-provider sections, cross-field validation (env requires
dev_mode, pkcs11/tpm require their config section, TPM key reference is
exactly one of handle or context file), and file-based secret loading
for the PKCS#11 PIN and TPM auth value, wired into Config::load_all
alongside the existing TLS cert loading.

This lands the ADR and config groundwork only; the storage-crypto-pkcs11
and storage-crypto-tpm provider crates, SoftHSM-backed integration test,
and TPM sample are follow-up work.

Tracks the sequencing for ADR 0016-v2 §2.5 (added in the previous
commit): crate layout, TPM trust model, and test/credential-input
decisions taken with the requester, plus the step-by-step plan from ADR
addendum + config schema (done) through provider crates, wiring, SoftHSM
CI test, docs, and supply-chain updates (not started). Kept out of
doc/src/SUMMARY.md since it's a working tracking doc, not user-facing
documentation.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
