### PR TITLE
Moves health and metrics endpoints to dedicated listener on separate port

### DIFF
--- a/crates/config/src/interface.rs
+++ b/crates/config/src/interface.rs
@@ -66,6 +66,26 @@ impl Default for PublicInterface {
     }
 }
 
+/// Keystone health/metrics API interface.
+#[derive(Debug, Deserialize, Clone)]
+pub struct MetricsInterface {
+    /// Default address for the health/metrics endpoint. Defaults to `0.0.0.0:8082`.
+    #[serde(default = "default_metrics_tcp_address")]
+    pub tcp_address: SocketAddr,
+}
+
+impl Default for MetricsInterface {
+    fn default() -> Self {
+        Self {
+            tcp_address: default_metrics_tcp_address(),
+        }
+    }
+}
+
+fn default_metrics_tcp_address() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8099)
+}
+
 fn default_public_tcp_address() -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8080)
 }

--- a/crates/config/src/interface.rs
+++ b/crates/config/src/interface.rs
@@ -69,7 +69,7 @@ impl Default for PublicInterface {
 /// Keystone health/metrics API interface.
 #[derive(Debug, Deserialize, Clone)]
 pub struct MetricsInterface {
-    /// Default address for the health/metrics endpoint. Defaults to `0.0.0.0:8082`.
+    /// Default address for the health/metrics endpoint. Defaults to `0.0.0.0:8099`.
     #[serde(default = "default_metrics_tcp_address")]
     pub tcp_address: SocketAddr,
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -257,7 +257,7 @@ pub struct Config {
     /// Reverse proxies trusted by the global per-IP rate limiter.
     #[serde(rename = "rate_limit_trusted_proxies", default)]
     pub rate_limit_trusted_proxies: RateLimitTrustedProxiesSection,
-    
+
     /// Server listener configuration for the health/metrics interface.
     #[serde(rename = "interface_metrics", default)]
     pub interface_metrics: MetricsInterface,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -237,7 +237,7 @@ pub struct Config {
     #[serde(rename = "interface_internal", default)]
     pub interface_internal: Option<InternalInterface>,
 
-    /// Server listener configuration for the internal interface.
+    /// Server listener configuration for the public interface.
     #[serde(rename = "interface_public", default)]
     pub interface_public: PublicInterface,
 
@@ -257,6 +257,10 @@ pub struct Config {
     /// Reverse proxies trusted by the global per-IP rate limiter.
     #[serde(rename = "rate_limit_trusted_proxies", default)]
     pub rate_limit_trusted_proxies: RateLimitTrustedProxiesSection,
+    
+    /// Server listener configuration for the health/metrics interface.
+    #[serde(rename = "interface_metrics", default)]
+    pub interface_metrics: MetricsInterface,
 
     /// Per-user authentication rate limiting (ADR-0022, §1).
     ///

--- a/crates/keystone/src/api/health.rs
+++ b/crates/keystone/src/api/health.rs
@@ -295,7 +295,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn health_returns_service_unavailable_for_disconnected_db() {
         let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
-        let (router, _api) = super::super::openapi_router().split_for_parts();
+        let (router, _api) = super::super::metrics_router().split_for_parts();
         let app = router.with_state(state);
 
         let response = app

--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -70,8 +70,12 @@ pub fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new()
         .nest("/v3", v3::openapi_router())
         .nest("/v4", v4::openapi_router())
-        .merge(health::openapi_router())
         .routes(routes!(version))
+}
+
+/// Dedicated health/metrics router for the internal health/metrics interface.
+pub fn metrics_router() -> OpenApiRouter<ServiceState> {
+    health::openapi_router()
 }
 
 /// Version discovery endpoint.

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -328,6 +328,7 @@ async fn main() -> Result<(), Report> {
     spawn_opa_subprocess(&cfg, &token, &mut handles).await?;
     spawn_public_listener(&cfg, app.clone(), &token, &mut handles).await?;
     spawn_internal_listener(&cfg, app.clone(), &token, &mut handles)?;
+    spawn_metrics_listener(&cfg, &shared_state, &token, &mut handles).await?;
     spawn_admin_listener(&cfg, app, &token, &mut handles);
 
     // Wait for both (or handle errors)
@@ -740,13 +741,7 @@ async fn build_router(
         .layer(PropagateRequestIdLayer::new(x_request_id));
     //.layer(middleware::from_fn(cert_extension_middleware));
 
-    let metrics_router = Router::new()
-        .route("/metrics", axum::routing::get(metrics_handler))
-        .with_state(shared_state.clone());
-
-    let mut app = Router::new()
-        .merge(main_router.with_state(shared_state.clone()))
-        .merge(metrics_router);
+    let mut app = Router::new().merge(main_router.with_state(shared_state.clone()));
 
     if shared_state
         .config_manager
@@ -1164,6 +1159,39 @@ fn spawn_internal_listener(
     Ok(())
 }
 
+/// Start the metrics and health interface listener on a dedicated port.
+async fn spawn_metrics_listener(
+    cfg: &Config,
+    shared_state: &ServiceState,
+    token: &CancellationToken,
+    handles: &mut tokio::task::JoinSet<()>,
+) -> Result<(), Report> {
+    info!(
+        "Starting metrics/health API at {}",
+        cfg.interface_metrics.tcp_address
+    );
+    let listener = TcpListener::bind(&cfg.interface_metrics.tcp_address).await?;
+    let cancel_token = token.clone();
+
+    let (metrics_router, _) = api::metrics_router().split_for_parts();
+    let metrics_app = Router::new()
+        .merge(metrics_router.with_state(shared_state.clone()))
+        .route("/metrics", axum::routing::get(metrics_handler))
+        .with_state(shared_state.clone());
+
+    handles.spawn(async move {
+        if let Err(e) = axum::serve(listener, metrics_app.into_make_service())
+            .with_graceful_shutdown(async move {
+                cancel_token.cancelled().await;
+            })
+            .await
+        {
+            error!("Metrics/health listener error: {:#}", e);
+        }
+    });
+    Ok(())
+}
+
 /// Start the SPIFFE mTLS listener on the admin Unix-domain-socket interface,
 /// when configured.
 fn spawn_admin_listener(
@@ -1460,7 +1488,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
-                    .uri("/metrics/")
+                    .uri("/v3/")
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )

--- a/tools/k8s/keystone/base/statefulset-rs.yaml
+++ b/tools/k8s/keystone/base/statefulset-rs.yaml
@@ -43,19 +43,22 @@ spec:
             - containerPort: 8300
               name: keystone-raft
               protocol: TCP
+            - containerPort: 8099
+              name: keystone-metrics
+              protocol: TCP
 
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /health
-              port: keystone-rs
+              port: keystone-metrics
               scheme: HTTP
             periodSeconds: 10
           readinessProbe:
             failureThreshold: 3
             httpGet:
               path: /ready
-              port: keystone-rs
+              port: keystone-metrics
               scheme: HTTP
             periodSeconds: 10
             successThreshold: 1
@@ -64,7 +67,7 @@ spec:
             failureThreshold: 600
             httpGet:
               path: /ready
-              port: keystone-rs
+              port: keystone-metrics
               scheme: HTTP
             periodSeconds: 1
             successThreshold: 1

--- a/tools/k8s/keystone/base/statefulset-rs.yaml
+++ b/tools/k8s/keystone/base/statefulset-rs.yaml
@@ -44,21 +44,21 @@ spec:
               name: keystone-raft
               protocol: TCP
             - containerPort: 8099
-              name: keystone-metrics
+              name: metrics
               protocol: TCP
 
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /health
-              port: keystone-metrics
+              port: metrics
               scheme: HTTP
             periodSeconds: 10
           readinessProbe:
             failureThreshold: 3
             httpGet:
               path: /ready
-              port: keystone-metrics
+              port: metrics
               scheme: HTTP
             periodSeconds: 10
             successThreshold: 1
@@ -67,7 +67,7 @@ spec:
             failureThreshold: 600
             httpGet:
               path: /ready
-              port: keystone-metrics
+              port: metrics
               scheme: HTTP
             periodSeconds: 1
             successThreshold: 1

--- a/tools/start-api.sh
+++ b/tools/start-api.sh
@@ -155,8 +155,9 @@ echo "$AXUM_PID" > "$STATE_DIR/keystone.pid"
 
 # 6. Wait for the local port to become active
 URL="http://127.0.0.1:8080"
+URL_METRICS="http://127.0.0.1:8099"
 for i in {1..30}; do
-    if curl -s "$URL/health" > /dev/null; then
+    if curl -s "$URL_METRICS/health" > /dev/null; then
         echo "✅ Keystone health url started responding!"
         # Wait for the admin socket to appear
         until [ -S "${STATE_DIR}/keystone.sock" ]; do


### PR DESCRIPTION
Health and metrics endpoints were previously attached to the public API router, allowing end users to access /health, /ready, and /metrics directly, which is a potential DDoS vector. This change moves them to a dedicated listener on port 8082, separate from the public API on port 8080. Also updates relevant tests to work with new structure/naming schema. Adds modular spawn_metrics_listener function to crates/keystone/src/bin/keystone.rs and API interface structure MetricsInterface in crates/config/src/interface.rs, as well as updating pathways in crates/config/src/lib.rs, crates/keystone/src/api/mod.rs, and crates/keystone/src/api/health.rs.

Closes #719.

This contribution was developed with the assistance of AI tools.