### PR TITLE
fix: Pass resolved token to OPA policy checks

### DIFF
--- a/crates/keystone/src/api/v3/auth/token/delete.rs
+++ b/crates/keystone/src/api/v3/auth/token/delete.rs
@@ -21,6 +21,7 @@ use axum::{
 use serde_json::{Value, json, to_value};
 use tracing::error;
 
+use openstack_keystone_api_types::v3::auth::token::TokenBuilder;
 use openstack_keystone_core::auth::ExecutionContext;
 
 use crate::api::{auth::Auth, error::KeystoneApiError};
@@ -76,13 +77,15 @@ pub(super) async fn delete(
             identifier: String::new(),
         })?;
 
+    let token = TokenBuilder::try_from(&vsc)?.build()?;
+
     state
         .policy_enforcer
         .enforce(
             "identity/auth/token/revoke",
             &user_auth,
             Value::Null,
-            Some(to_value(json!({"token": &vsc.token()?}))?),
+            Some(to_value(json!({"token": &token}))?),
         )
         .await?;
 

--- a/crates/keystone/src/api/v3/auth/token/show.rs
+++ b/crates/keystone/src/api/v3/auth/token/show.rs
@@ -93,19 +93,19 @@ pub(super) async fn show(
             identifier: String::new(),
         })?;
 
+    let token = TokenBuilder::try_from(&vsc)?.build()?;
+
     state
         .policy_enforcer
         .enforce(
             "identity/auth/token/show",
             &user_auth,
             Value::Null,
-            Some(to_value(json!({"token": &vsc.token()?}))?),
+            Some(to_value(json!({"token": &token}))?),
         )
         .await?;
 
-    let mut response_token = TokenResponse {
-        token: TokenBuilder::try_from(&vsc)?.build()?,
-    };
+    let mut response_token = TokenResponse { token };
 
     if !query.nocatalog.is_some_and(|x| x) {
         let catalog: Catalog = Catalog(


### PR DESCRIPTION
Closes #715

This updates token show and revoke policy checks to pass the resolved token response object to OPA instead of the raw FernetToken payload.

The subject token is already validated into a ValidatedSecurityContext. This change builds the resolved token object from that context and uses it as the policy target for:

- identity/auth/token/show
- identity/auth/token/revoke

The revoke backend still receives the raw token payload because it needs the internal token data for revocation.

Note: Used CodeX for assistance.