### PR TITLE
feat(scim): ADR 0024 - Phase 4 (protocol surface completion)

### DIFF
--- a/crates/core-types/src/scim/error.rs
+++ b/crates/core-types/src/scim/error.rs
@@ -97,6 +97,13 @@ pub enum ScimResourceProviderError {
     #[error("conflict: {0}")]
     Conflict(String),
 
+    /// `If-Match` precondition failed — the caller's expected `version`
+    /// doesn't match the resource's current one, either because it was
+    /// already stale when read, or because a concurrent write won the race
+    /// between this write's read and its compare-and-swap (ADR 0024 §5.E).
+    #[error("ETag precondition failed: {0}")]
+    VersionMismatch(String),
+
     /// Driver error.
     #[error("backend driver error: {source}")]
     Driver {

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -1242,6 +1242,7 @@ mod scim_resource {
                 resource_type: ScimResourceType,
                 keystone_id: &'a str,
                 data: ScimResourceIndexUpdate,
+                expected_version: Option<u64>,
             ) -> Result<ScimResourceIndex, ScimResourceProviderError>;
         }
     }

--- a/crates/core/src/scim_resource/backend.rs
+++ b/crates/core/src/scim_resource/backend.rs
@@ -65,6 +65,13 @@ pub trait ScimResourceBackend: Send + Sync {
     ) -> Result<Vec<ScimResourceIndex>, ScimResourceProviderError>;
 
     /// Apply a partial update (e.g. soft-disable, `externalId` change).
+    ///
+    /// `expected_version`, when `Some`, is the SCIM `If-Match` ETag version
+    /// the caller last observed; the update is rejected with
+    /// [`ScimResourceProviderError::VersionMismatch`] if the resource's
+    /// current `version` has moved on, closing the lost-update race ADR 0024
+    /// §5.E describes.
+    #[allow(clippy::too_many_arguments)]
     async fn update<'a>(
         &self,
         state: &ServiceState,
@@ -73,5 +80,6 @@ pub trait ScimResourceBackend: Send + Sync {
         resource_type: ScimResourceType,
         keystone_id: &'a str,
         data: ScimResourceIndexUpdate,
+        expected_version: Option<u64>,
     ) -> Result<ScimResourceIndex, ScimResourceProviderError>;
 }

--- a/crates/core/src/scim_resource/provider_api.rs
+++ b/crates/core/src/scim_resource/provider_api.rs
@@ -66,6 +66,12 @@ pub trait ScimResourceApi: Send + Sync {
     ) -> Result<Vec<ScimResourceIndex>, ScimResourceProviderError>;
 
     /// Apply a partial update (e.g. soft-disable, `externalId` change).
+    ///
+    /// `expected_version`, when `Some`, is the SCIM `If-Match` ETag version
+    /// the caller last observed; the update is rejected with
+    /// [`ScimResourceProviderError::VersionMismatch`] if the resource's
+    /// current `version` has moved on (ADR 0024 §5.E).
+    #[allow(clippy::too_many_arguments)]
     async fn update_index<'a>(
         &self,
         ctx: &ExecutionContext<'a>,
@@ -74,5 +80,6 @@ pub trait ScimResourceApi: Send + Sync {
         resource_type: ScimResourceType,
         keystone_id: &'a str,
         data: ScimResourceIndexUpdate,
+        expected_version: Option<u64>,
     ) -> Result<ScimResourceIndex, ScimResourceProviderError>;
 }

--- a/crates/core/src/scim_resource/service.rs
+++ b/crates/core/src/scim_resource/service.rs
@@ -121,6 +121,7 @@ impl ScimResourceApi for ScimResourceService {
         resource_type: ScimResourceType,
         keystone_id: &'a str,
         data: ScimResourceIndexUpdate,
+        expected_version: Option<u64>,
     ) -> Result<ScimResourceIndex, ScimResourceProviderError> {
         self.backend_driver
             .update(
@@ -130,6 +131,7 @@ impl ScimResourceApi for ScimResourceService {
                 resource_type,
                 keystone_id,
                 data,
+                expected_version,
             )
             .await
     }

--- a/crates/keystone/src/scim.rs
+++ b/crates/keystone/src/scim.rs
@@ -29,8 +29,12 @@ use serde::Serialize;
 use openstack_keystone_core::api::api_key_auth::ApiKeyAuth;
 use openstack_keystone_core::keystone::ServiceState;
 
+mod discovery;
 pub mod error;
+pub mod etag;
+pub mod filter;
 mod group;
+pub mod patch;
 pub mod types;
 mod user;
 
@@ -58,4 +62,5 @@ pub fn router() -> Router<ServiceState> {
         .route("/{domain_id}/whoami", get(whoami))
         .nest("/{domain_id}/Users", user::router())
         .nest("/{domain_id}/Groups", group::router())
+        .nest("/{domain_id}", discovery::router())
 }

--- a/crates/keystone/src/scim/discovery.rs
+++ b/crates/keystone/src/scim/discovery.rs
@@ -1,0 +1,123 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `GET /SCIM/v2/{domain_id}/{ServiceProviderConfig,Schemas,ResourceTypes}`
+//! (ADR 0024 §5.A tail) — static discovery documents. Unauthenticated within
+//! the SCIM sub-router: these describe the protocol surface only, carry no
+//! tenant data, and RFC 7644 clients probe them before presenting
+//! credentials, so gating them behind `ScimRealmAuth` would break discovery
+//! for exactly the clients that need it. Honestly advertises
+//! `bulk.supported: false`, `sort.supported: false`, and the restricted
+//! filter grammar (§5.B) rather than claiming full RFC 7644 compliance.
+
+use axum::{Json, Router, routing::get};
+use serde_json::{Value, json};
+
+use openstack_keystone_core::keystone::ServiceState;
+
+async fn service_provider_config() -> Json<Value> {
+    Json(json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+        "patch": { "supported": true },
+        "bulk": { "supported": false, "maxOperations": 0, "maxPayloadSize": 0 },
+        "filter": { "supported": true, "maxResults": 200 },
+        "changePassword": { "supported": false },
+        "sort": { "supported": false },
+        "etag": { "supported": true },
+        "authenticationSchemes": [{
+            "type": "oauthbearertoken",
+            "name": "API Key",
+            "description": "Realm-scoped API key bearer token (ADR 0021)",
+            "primary": true
+        }]
+    }))
+}
+
+async fn schemas() -> Json<Value> {
+    Json(json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+        "totalResults": 2,
+        "Resources": [
+            {
+                "id": "urn:ietf:params:scim:schemas:core:2.0:User",
+                "name": "User",
+                "description": "ADR 0024 pragmatic subset of the RFC 7644 User resource",
+            },
+            {
+                "id": "urn:ietf:params:scim:schemas:core:2.0:Group",
+                "name": "Group",
+                "description": "ADR 0024 pragmatic subset of the RFC 7644 Group resource",
+            },
+        ]
+    }))
+}
+
+async fn resource_types() -> Json<Value> {
+    Json(json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+        "totalResults": 2,
+        "Resources": [
+            {
+                "id": "User",
+                "name": "User",
+                "endpoint": "/Users",
+                "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
+            },
+            {
+                "id": "Group",
+                "name": "Group",
+                "endpoint": "/Groups",
+                "schema": "urn:ietf:params:scim:schemas:core:2.0:Group",
+            },
+        ]
+    }))
+}
+
+/// SCIM discovery sub-router, nested at `/SCIM/v2/{domain_id}`.
+pub fn router() -> Router<ServiceState> {
+    Router::new()
+        .route("/ServiceProviderConfig", get(service_provider_config))
+        .route("/Schemas", get(schemas))
+        .route("/ResourceTypes", get(resource_types))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_service_provider_config_advertises_no_bulk_or_sort() {
+        let Json(body) = service_provider_config().await;
+        assert_eq!(body["bulk"]["supported"], false);
+        assert_eq!(body["sort"]["supported"], false);
+        assert_eq!(body["patch"]["supported"], true);
+    }
+
+    #[tokio::test]
+    async fn test_schemas_lists_user_and_group() {
+        let Json(body) = schemas().await;
+        assert_eq!(body["totalResults"], 2);
+    }
+
+    #[tokio::test]
+    async fn test_resource_types_lists_user_and_group_endpoints() {
+        let Json(body) = resource_types().await;
+        let endpoints: Vec<&str> = body["Resources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r["endpoint"].as_str().unwrap())
+            .collect();
+        assert_eq!(endpoints, vec!["/Users", "/Groups"]);
+    }
+}

--- a/crates/keystone/src/scim/error.rs
+++ b/crates/keystone/src/scim/error.rs
@@ -55,6 +55,16 @@ pub enum ScimApiError {
     /// exceeding the §11 cap (400, `scimType: "invalidValue"`, ADR 0024 §7,
     /// §11).
     InvalidValue(String),
+    /// A `filter` query parameter outside the ADR 0024 §5.B grammar (400,
+    /// `scimType: "invalidFilter"`).
+    InvalidFilter(String),
+    /// A `PATCH` `Operations[].path` outside the ADR 0024 §5.C allowlist
+    /// (400, `scimType: "invalidPath"`).
+    InvalidPath(String),
+    /// `If-Match` precondition failed against the resource's current ETag
+    /// version (412, ADR 0024 §5.E). RFC 7644 §3.12 doesn't define a
+    /// `scimType` for this status, so the body carries none.
+    PreconditionFailed(String),
     /// Everything else — reuses the generic Keystone error envelope.
     Api(KeystoneApiError),
 }
@@ -78,6 +88,36 @@ impl IntoResponse for ScimApiError {
                     schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
                     status: StatusCode::BAD_REQUEST.as_str().to_string(),
                     scim_type: Some("invalidValue".to_string()),
+                    detail,
+                }),
+            )
+                .into_response(),
+            Self::InvalidFilter(detail) => (
+                StatusCode::BAD_REQUEST,
+                Json(ScimErrorBody {
+                    schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
+                    status: StatusCode::BAD_REQUEST.as_str().to_string(),
+                    scim_type: Some("invalidFilter".to_string()),
+                    detail,
+                }),
+            )
+                .into_response(),
+            Self::InvalidPath(detail) => (
+                StatusCode::BAD_REQUEST,
+                Json(ScimErrorBody {
+                    schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
+                    status: StatusCode::BAD_REQUEST.as_str().to_string(),
+                    scim_type: Some("invalidPath".to_string()),
+                    detail,
+                }),
+            )
+                .into_response(),
+            Self::PreconditionFailed(detail) => (
+                StatusCode::PRECONDITION_FAILED,
+                Json(ScimErrorBody {
+                    schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
+                    status: StatusCode::PRECONDITION_FAILED.as_str().to_string(),
+                    scim_type: None,
                     detail,
                 }),
             )

--- a/crates/keystone/src/scim/etag.rs
+++ b/crates/keystone/src/scim/etag.rs
@@ -1,0 +1,98 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # SCIM ETag helpers (ADR 0024 §5.E)
+//!
+//! `ScimResourceIndex.version` is the sole source of the SCIM weak ETag.
+//! Handlers use [`etag_header`] to render it on responses and
+//! [`parse_if_match`] to read a request's `If-Match` precondition before
+//! passing it through as `expected_version` on the `update_index` call,
+//! which performs the actual compare-and-swap.
+
+use axum::http::HeaderMap;
+
+use openstack_keystone_core::api::KeystoneApiError;
+
+use crate::scim::error::ScimApiError;
+
+/// Render a `ScimResourceIndex.version` as a weak ETag: `W/"<version>"`.
+pub fn etag_header(version: u64) -> String {
+    format!(r#"W/"{version}""#)
+}
+
+/// Parse an `If-Match` header value into the version it names.
+///
+/// Accepts `W/"<n>"`, `"<n>"`, or a bare `<n>`. Absent header returns
+/// `Ok(None)` (no precondition to enforce); a present-but-unparsable value
+/// is a client error, not a precondition mismatch.
+pub fn parse_if_match(headers: &HeaderMap) -> Result<Option<u64>, ScimApiError> {
+    let Some(value) = headers.get("if-match") else {
+        return Ok(None);
+    };
+    let value = value.to_str().map_err(|_| {
+        KeystoneApiError::BadRequest("If-Match header is not valid UTF-8".to_string())
+    })?;
+    let trimmed = value.strip_prefix("W/").unwrap_or(value).trim();
+    let trimmed = trimmed
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(trimmed);
+    trimmed.parse::<u64>().map(Some).map_err(|_| {
+        KeystoneApiError::BadRequest(format!("malformed If-Match header: `{value}`")).into()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("if-match", value.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn test_etag_header_format() {
+        assert_eq!(etag_header(3), r#"W/"3""#);
+    }
+
+    #[test]
+    fn test_parse_if_match_weak_form() {
+        assert_eq!(parse_if_match(&headers_with(r#"W/"3""#)).unwrap(), Some(3));
+    }
+
+    #[test]
+    fn test_parse_if_match_bare_quoted() {
+        assert_eq!(parse_if_match(&headers_with(r#""5""#)).unwrap(), Some(5));
+    }
+
+    #[test]
+    fn test_parse_if_match_bare_number() {
+        assert_eq!(parse_if_match(&headers_with("7")).unwrap(), Some(7));
+    }
+
+    #[test]
+    fn test_parse_if_match_absent() {
+        assert_eq!(parse_if_match(&HeaderMap::new()).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_if_match_malformed() {
+        let result = parse_if_match(&headers_with("not-a-number"));
+        assert!(matches!(
+            result,
+            Err(ScimApiError::Api(KeystoneApiError::BadRequest(_)))
+        ));
+    }
+}

--- a/crates/keystone/src/scim/filter.rs
+++ b/crates/keystone/src/scim/filter.rs
@@ -1,0 +1,417 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # SCIM `filter` query grammar (ADR 0024 §5.B)
+//!
+//! A deliberately narrow subset of RFC 7644 filtering: a homogeneous
+//! `and`/`or` chain of `ATTR OP [value]` terms, five operators, and a
+//! per-resource attribute allowlist. Anything else -- mixed logical
+//! operators, nested/parenthesized expressions, an attribute or operator
+//! outside the table, or a filter exceeding the size/term caps -- is
+//! rejected with `400 invalidFilter` before it ever reaches a handler's
+//! resource lookup.
+
+use crate::scim::error::ScimApiError;
+
+/// Hard caps from ADR 0024 §5.B, matching the DoS-hardening posture used
+/// elsewhere in the codebase (regex/claim size bounds, rate limiting).
+const MAX_FILTER_BYTES: usize = 512;
+const MAX_FILTER_TERMS: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilterOp {
+    Eq,
+    Ne,
+    Co,
+    Sw,
+    Pr,
+}
+
+impl FilterOp {
+    fn parse(token: &str) -> Option<Self> {
+        match token.to_ascii_lowercase().as_str() {
+            "eq" => Some(Self::Eq),
+            "ne" => Some(Self::Ne),
+            "co" => Some(Self::Co),
+            "sw" => Some(Self::Sw),
+            "pr" => Some(Self::Pr),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogicalOp {
+    And,
+    Or,
+}
+
+/// One allowlisted attribute and the operators §5.B permits against it.
+pub struct FilterAttr {
+    pub name: &'static str,
+    pub ops: &'static [FilterOp],
+}
+
+/// ADR 0024 §5.B User attribute table.
+pub const USER_FILTER_ATTRS: &[FilterAttr] = &[
+    FilterAttr {
+        name: "username",
+        ops: &[
+            FilterOp::Eq,
+            FilterOp::Ne,
+            FilterOp::Co,
+            FilterOp::Sw,
+            FilterOp::Pr,
+        ],
+    },
+    FilterAttr {
+        name: "externalid",
+        ops: &[FilterOp::Eq, FilterOp::Ne, FilterOp::Pr],
+    },
+    FilterAttr {
+        name: "id",
+        ops: &[FilterOp::Eq, FilterOp::Pr],
+    },
+    FilterAttr {
+        name: "active",
+        ops: &[FilterOp::Eq, FilterOp::Pr],
+    },
+];
+
+/// ADR 0024 §5.B Group attribute table.
+pub const GROUP_FILTER_ATTRS: &[FilterAttr] = &[
+    FilterAttr {
+        name: "displayname",
+        ops: &[
+            FilterOp::Eq,
+            FilterOp::Ne,
+            FilterOp::Co,
+            FilterOp::Sw,
+            FilterOp::Pr,
+        ],
+    },
+    FilterAttr {
+        name: "externalid",
+        ops: &[FilterOp::Eq, FilterOp::Ne, FilterOp::Pr],
+    },
+    FilterAttr {
+        name: "id",
+        ops: &[FilterOp::Eq, FilterOp::Pr],
+    },
+];
+
+#[derive(Debug, Clone)]
+pub struct FilterTerm {
+    /// Lowercased attribute name, already validated against the table.
+    pub attr: String,
+    pub op: FilterOp,
+    pub value: Option<String>,
+}
+
+impl FilterTerm {
+    fn matches(&self, actual: Option<&str>) -> bool {
+        match self.op {
+            FilterOp::Pr => actual.is_some_and(|v| !v.is_empty()),
+            FilterOp::Eq => match (actual, &self.value) {
+                (Some(a), Some(v)) => {
+                    if self.attr == "id" {
+                        a == v
+                    } else {
+                        a.eq_ignore_ascii_case(v)
+                    }
+                }
+                _ => false,
+            },
+            FilterOp::Ne => match (actual, &self.value) {
+                (Some(a), Some(v)) => {
+                    if self.attr == "id" {
+                        a != v
+                    } else {
+                        !a.eq_ignore_ascii_case(v)
+                    }
+                }
+                _ => true,
+            },
+            FilterOp::Co => match (actual, &self.value) {
+                (Some(a), Some(v)) => a.to_lowercase().contains(&v.to_lowercase()),
+                _ => false,
+            },
+            FilterOp::Sw => match (actual, &self.value) {
+                (Some(a), Some(v)) => a.to_lowercase().starts_with(&v.to_lowercase()),
+                _ => false,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedFilter {
+    pub terms: Vec<FilterTerm>,
+    pub logical_op: Option<LogicalOp>,
+}
+
+impl ParsedFilter {
+    /// Evaluate against a resource, resolving each term's attribute value
+    /// via `resolve` (a per-resource closure over its hydrated fields).
+    pub fn matches(&self, resolve: impl Fn(&str) -> Option<String>) -> bool {
+        let mut results = self
+            .terms
+            .iter()
+            .map(|t| t.matches(resolve(&t.attr).as_deref()));
+        match self.logical_op {
+            Some(LogicalOp::Or) => results.any(|b| b),
+            _ => results.all(|b| b),
+        }
+    }
+}
+
+/// Tokenize respecting double-quoted string values, so a quoted value can
+/// itself contain whitespace (e.g. `displayName eq "Site Admins"`).
+fn tokenize(input: &str) -> Result<Vec<String>, ScimApiError> {
+    let mut tokens = Vec::new();
+    let mut chars = input.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+            continue;
+        }
+        if c == '"' {
+            chars.next();
+            let mut value = String::new();
+            let mut closed = false;
+            for c in chars.by_ref() {
+                if c == '"' {
+                    closed = true;
+                    break;
+                }
+                value.push(c);
+            }
+            if !closed {
+                return Err(ScimApiError::InvalidFilter(
+                    "unterminated quoted value".to_string(),
+                ));
+            }
+            tokens.push(value);
+        } else {
+            let mut value = String::new();
+            while let Some(&c) = chars.peek() {
+                if c.is_whitespace() {
+                    break;
+                }
+                value.push(c);
+                chars.next();
+            }
+            tokens.push(value);
+        }
+    }
+    Ok(tokens)
+}
+
+/// Parse and validate a `filter` query parameter against `table`. Rejects
+/// anything outside the ADR 0024 §5.B grammar with `ScimApiError::
+/// InvalidFilter` (400, `scimType: "invalidFilter"`).
+pub fn parse_filter(raw: &str, table: &[FilterAttr]) -> Result<ParsedFilter, ScimApiError> {
+    if raw.len() > MAX_FILTER_BYTES {
+        return Err(ScimApiError::InvalidFilter(format!(
+            "filter exceeds the {MAX_FILTER_BYTES}-byte limit"
+        )));
+    }
+
+    let tokens = tokenize(raw)?;
+    if tokens.is_empty() {
+        return Err(ScimApiError::InvalidFilter("empty filter".to_string()));
+    }
+
+    let mut terms = Vec::new();
+    let mut logical_op: Option<LogicalOp> = None;
+    let mut i = 0;
+    loop {
+        if terms.len() >= MAX_FILTER_TERMS {
+            return Err(ScimApiError::InvalidFilter(format!(
+                "filter exceeds the {MAX_FILTER_TERMS}-term limit"
+            )));
+        }
+        let Some(attr_token) = tokens.get(i) else {
+            return Err(ScimApiError::InvalidFilter(
+                "expected an attribute name".to_string(),
+            ));
+        };
+        let attr_lower = attr_token.to_ascii_lowercase();
+        let Some(entry) = table.iter().find(|a| a.name == attr_lower) else {
+            return Err(ScimApiError::InvalidFilter(format!(
+                "attribute `{attr_token}` is not filterable"
+            )));
+        };
+        let Some(op_token) = tokens.get(i + 1) else {
+            return Err(ScimApiError::InvalidFilter(
+                "expected a filter operator".to_string(),
+            ));
+        };
+        let Some(op) = FilterOp::parse(op_token) else {
+            return Err(ScimApiError::InvalidFilter(format!(
+                "unsupported operator `{op_token}`"
+            )));
+        };
+        if !entry.ops.contains(&op) {
+            return Err(ScimApiError::InvalidFilter(format!(
+                "operator `{op_token}` is not allowed on `{attr_token}`"
+            )));
+        }
+
+        let (value, consumed) = if op == FilterOp::Pr {
+            (None, 2)
+        } else {
+            let Some(value_token) = tokens.get(i + 2) else {
+                return Err(ScimApiError::InvalidFilter(format!(
+                    "expected a value for `{attr_token} {op_token}`"
+                )));
+            };
+            (Some(value_token.clone()), 3)
+        };
+
+        terms.push(FilterTerm {
+            attr: attr_lower,
+            op,
+            value,
+        });
+        i += consumed;
+
+        match tokens.get(i) {
+            None => break,
+            Some(sep) => {
+                let sep_op = match sep.to_ascii_lowercase().as_str() {
+                    "and" => LogicalOp::And,
+                    "or" => LogicalOp::Or,
+                    other => {
+                        return Err(ScimApiError::InvalidFilter(format!(
+                            "expected `and`/`or`, found `{other}`"
+                        )));
+                    }
+                };
+                match logical_op {
+                    None => logical_op = Some(sep_op),
+                    Some(existing) if existing == sep_op => {}
+                    Some(_) => {
+                        return Err(ScimApiError::InvalidFilter(
+                            "`and` and `or` must not be mixed in one filter".to_string(),
+                        ));
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+
+    Ok(ParsedFilter { terms, logical_op })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_single_eq_term() {
+        let parsed = parse_filter(r#"userName eq "alice""#, USER_FILTER_ATTRS).unwrap();
+        assert_eq!(parsed.terms.len(), 1);
+        assert!(parsed.matches(|attr| (attr == "username").then(|| "alice".to_string())));
+        assert!(!parsed.matches(|attr| (attr == "username").then(|| "bob".to_string())));
+    }
+
+    #[test]
+    fn test_parse_pr_term_no_value() {
+        let parsed = parse_filter("externalId pr", USER_FILTER_ATTRS).unwrap();
+        assert!(parsed.matches(|_| Some("anything".to_string())));
+        assert!(!parsed.matches(|_| None));
+    }
+
+    #[test]
+    fn test_parse_and_chain() {
+        let parsed = parse_filter(
+            r#"userName sw "al" and active eq "true""#,
+            USER_FILTER_ATTRS,
+        )
+        .unwrap();
+        assert!(parsed.matches(|attr| match attr {
+            "username" => Some("alice".to_string()),
+            "active" => Some("true".to_string()),
+            _ => None,
+        }));
+        assert!(!parsed.matches(|attr| match attr {
+            "username" => Some("bob".to_string()),
+            "active" => Some("true".to_string()),
+            _ => None,
+        }));
+    }
+
+    #[test]
+    fn test_parse_or_chain() {
+        let parsed = parse_filter(
+            r#"userName eq "alice" or userName eq "bob""#,
+            USER_FILTER_ATTRS,
+        )
+        .unwrap();
+        assert!(parsed.matches(|_| Some("bob".to_string())));
+        assert!(!parsed.matches(|_| Some("carol".to_string())));
+    }
+
+    #[test]
+    fn test_reject_mixed_and_or() {
+        let result = parse_filter(
+            r#"userName eq "a" and active pr or externalId pr"#,
+            USER_FILTER_ATTRS,
+        );
+        assert!(matches!(result, Err(ScimApiError::InvalidFilter(_))));
+    }
+
+    #[test]
+    fn test_reject_disallowed_attribute() {
+        let result = parse_filter(r#"password eq "x""#, USER_FILTER_ATTRS);
+        assert!(matches!(result, Err(ScimApiError::InvalidFilter(_))));
+    }
+
+    #[test]
+    fn test_reject_disallowed_operator_for_attribute() {
+        // `co` is not permitted on `id` per the §5.B table.
+        let result = parse_filter(r#"id co "abc""#, USER_FILTER_ATTRS);
+        assert!(matches!(result, Err(ScimApiError::InvalidFilter(_))));
+    }
+
+    #[test]
+    fn test_reject_oversized_filter() {
+        let huge = format!(r#"userName eq "{}""#, "a".repeat(600));
+        let result = parse_filter(&huge, USER_FILTER_ATTRS);
+        assert!(matches!(result, Err(ScimApiError::InvalidFilter(_))));
+    }
+
+    #[test]
+    fn test_reject_too_many_terms() {
+        let filter = (0..9)
+            .map(|_| r#"externalId pr"#)
+            .collect::<Vec<_>>()
+            .join(" and ");
+        let result = parse_filter(&filter, USER_FILTER_ATTRS);
+        assert!(matches!(result, Err(ScimApiError::InvalidFilter(_))));
+    }
+
+    #[test]
+    fn test_group_attrs_reject_username() {
+        let result = parse_filter(r#"userName eq "x""#, GROUP_FILTER_ATTRS);
+        assert!(matches!(result, Err(ScimApiError::InvalidFilter(_))));
+    }
+
+    #[test]
+    fn test_group_displayname_filter() {
+        let parsed = parse_filter(r#"displayName eq "Engineers""#, GROUP_FILTER_ATTRS).unwrap();
+        assert!(parsed.matches(|attr| (attr == "displayname").then(|| "engineers".to_string())));
+    }
+}

--- a/crates/keystone/src/scim/group.rs
+++ b/crates/keystone/src/scim/group.rs
@@ -21,6 +21,7 @@ mod create;
 mod delete;
 mod list;
 mod membership;
+mod patch;
 mod show;
 mod update;
 
@@ -30,6 +31,9 @@ pub fn router() -> Router<ServiceState> {
         .route("/", get(list::list).post(create::create))
         .route(
             "/{id}",
-            get(show::show).put(update::update).delete(delete::delete),
+            get(show::show)
+                .put(update::update)
+                .patch(patch::patch)
+                .delete(delete::delete),
         )
 }

--- a/crates/keystone/src/scim/group/create.rs
+++ b/crates/keystone/src/scim/group/create.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! `POST /SCIM/v2/{domain_id}/Groups` (ADR 0024 §3.C, §3.D, §4, §7, §11).
 
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{Json, extract::State, http::HeaderMap, http::StatusCode};
 use serde_json::json;
 
 use openstack_keystone_core::api::KeystoneApiError;
@@ -25,6 +25,7 @@ use openstack_keystone_core_types::scim::{
 
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
+use crate::scim::etag::etag_header;
 use crate::scim::group::membership::validate_members_owned_by_realm;
 use crate::scim::types::{MAX_GROUP_MEMBERS, ScimGroup, ScimGroupWrite};
 
@@ -32,7 +33,7 @@ pub(super) async fn create(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     State(state): State<ServiceState>,
     Json(req): Json<ScimGroupWrite>,
-) -> Result<(StatusCode, Json<ScimGroup>), ScimApiError> {
+) -> Result<(StatusCode, HeaderMap, Json<ScimGroup>), ScimApiError> {
     if req.display_name.trim().is_empty() {
         return Err(KeystoneApiError::BadRequest("displayName is required".to_string()).into());
     }
@@ -137,8 +138,16 @@ pub(super) async fn create(
             .await?;
     }
 
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "etag",
+        etag_header(index.version)
+            .parse()
+            .expect("weak etag is valid header value"),
+    );
     Ok((
         StatusCode::CREATED,
+        headers,
         Json(ScimGroup::from_domain(&group, &index, &member_ids)),
     ))
 }
@@ -249,7 +258,7 @@ mod tests {
         )
         .await;
 
-        let (status, Json(body)) = create(
+        let (status, headers, Json(body)) = create(
             domain_scoped_auth("domain-1"),
             State(state),
             Json(req("engineers", vec![])),
@@ -259,6 +268,7 @@ mod tests {
         assert_eq!(status, StatusCode::CREATED);
         assert_eq!(body.display_name, "engineers");
         assert_eq!(body.id, "group-1");
+        assert_eq!(headers.get("etag").unwrap(), r#"W/"0""#);
     }
 
     #[tokio::test]
@@ -321,7 +331,7 @@ mod tests {
         )
         .await;
 
-        let (status, Json(body)) = create(
+        let (status, _headers, Json(body)) = create(
             domain_scoped_auth("domain-1"),
             State(state),
             Json(req("engineers", vec!["user-1"])),

--- a/crates/keystone/src/scim/group/delete.rs
+++ b/crates/keystone/src/scim/group/delete.rs
@@ -88,6 +88,7 @@ pub(super) async fn delete(
                 external_id: None,
                 deprovisioned_at: Some(Some(now)),
             },
+            None,
         )
         .await?;
 
@@ -179,8 +180,8 @@ mod tests {
             .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
         resource_mock
             .expect_update_index()
-            .withf(|_, _, _, _, _, update| matches!(update.deprovisioned_at, Some(Some(_))))
-            .returning(|_, _, _, _, id, _| Ok(make_index(id)));
+            .withf(|_, _, _, _, _, update, _| matches!(update.deprovisioned_at, Some(Some(_))))
+            .returning(|_, _, _, _, id, _, _| Ok(make_index(id)));
 
         let mut identity_mock = MockIdentityProvider::default();
         identity_mock.expect_get_group().returning(|_, id| {

--- a/crates/keystone/src/scim/group/list.rs
+++ b/crates/keystone/src/scim/group/list.rs
@@ -11,7 +11,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! `GET /SCIM/v2/{domain_id}/Groups` (ADR 0024 §3, §5.D bare pagination).
+//! `GET /SCIM/v2/{domain_id}/Groups` (ADR 0024 §3, §5.B filter, §5.D
+//! pagination).
 
 use axum::{Json, extract::Query, extract::State};
 use serde::Deserialize;
@@ -23,6 +24,7 @@ use openstack_keystone_core_types::scim::ScimResourceType;
 
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
+use crate::scim::filter::{GROUP_FILTER_ATTRS, parse_filter};
 use crate::scim::types::{LIST_RESPONSE_SCHEMA, ScimGroup, ScimGroupListResponse};
 
 #[derive(Debug, Deserialize, Default)]
@@ -31,6 +33,8 @@ pub(super) struct ListParams {
     start_index: Option<usize>,
     #[serde(default)]
     count: Option<usize>,
+    #[serde(default)]
+    filter: Option<String>,
 }
 
 pub(super) async fn list(
@@ -48,6 +52,12 @@ pub(super) async fn list(
         )
         .await?;
 
+    let parsed_filter = params
+        .filter
+        .as_deref()
+        .map(|f| parse_filter(f, GROUP_FILTER_ATTRS))
+        .transpose()?;
+
     let exec = ExecutionContext::from_auth(&state, &ctx);
 
     let indexes = state
@@ -64,31 +74,45 @@ pub(super) async fn list(
     let start_index = params.start_index.unwrap_or(1).max(1);
     let count = params.count.unwrap_or(200).min(200);
 
-    let active_indexes: Vec<_> = indexes
-        .into_iter()
-        .filter(|i| i.deprovisioned_at.is_none())
-        .collect();
-    let total_results = active_indexes.len();
-
-    let mut resources = Vec::new();
-    for index in active_indexes
-        .into_iter()
-        .skip(start_index.saturating_sub(1))
-        .take(count)
-    {
-        if let Some(group) = state
+    // As with Users (§5.D), a `filter` requires hydrating every active
+    // group up front to evaluate `displayName` -- still bounded to this
+    // realm's own resource count.
+    let mut matched = Vec::new();
+    for index in indexes.into_iter().filter(|i| i.deprovisioned_at.is_none()) {
+        let Some(group) = state
             .provider
             .get_identity_provider()
             .get_group(&exec, &index.keystone_id)
             .await?
-        {
-            let member_ids = state
-                .provider
-                .get_identity_provider()
-                .list_users_of_group(&exec, &group.id)
-                .await?;
-            resources.push(ScimGroup::from_domain(&group, &index, &member_ids));
+        else {
+            continue;
+        };
+        let matches = parsed_filter.as_ref().is_none_or(|f| {
+            f.matches(|attr| match attr {
+                "displayname" => Some(group.name.clone()),
+                "externalid" => index.external_id.clone(),
+                "id" => Some(group.id.clone()),
+                _ => None,
+            })
+        });
+        if matches {
+            matched.push((group, index));
         }
+    }
+
+    let total_results = matched.len();
+    let mut resources = Vec::new();
+    for (group, index) in matched
+        .into_iter()
+        .skip(start_index.saturating_sub(1))
+        .take(count)
+    {
+        let member_ids = state
+            .provider
+            .get_identity_provider()
+            .list_users_of_group(&exec, &group.id)
+            .await?;
+        resources.push(ScimGroup::from_domain(&group, &index, &member_ids));
     }
 
     Ok(Json(ScimGroupListResponse {

--- a/crates/keystone/src/scim/group/patch.rs
+++ b/crates/keystone/src/scim/group/patch.rs
@@ -11,8 +11,11 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! `PUT /SCIM/v2/{domain_id}/Groups/{id}` — full-replace update (ADR 0024
-//! §3.C, §4, §5.C, §5.E, §7, §11).
+//! `PATCH /SCIM/v2/{domain_id}/Groups/{id}` (ADR 0024 §5.C, §7, §11).
+//!
+//! `members` is `add`/`remove` only -- the "push group" pattern -- not
+//! `replace`; reuses the `identity/scim/group/update` OPA policy, same as
+//! `PUT`.
 
 use std::collections::HashSet;
 
@@ -22,6 +25,7 @@ use serde_json::json;
 use openstack_keystone_core::api::KeystoneApiError;
 use openstack_keystone_core::api::api_key_auth::ScimRealmAuth;
 use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::identity::GroupUpdate;
 use openstack_keystone_core_types::scim::{
     ScimResourceIndexUpdate, ScimResourceProviderError, ScimResourceType,
 };
@@ -31,29 +35,31 @@ use crate::scim::error::ScimApiError;
 use crate::scim::etag::{etag_header, parse_if_match};
 use crate::scim::group::membership::validate_members_owned_by_realm;
 use crate::scim::group::show::fetch_owned;
-use crate::scim::types::{MAX_GROUP_MEMBERS, ScimGroup, ScimGroupWrite};
+use crate::scim::patch::{GROUP_PATCH_PATHS, PatchOp, ScimPatchRequest, validate_patch};
+use crate::scim::types::{MAX_GROUP_MEMBERS, ScimGroup, ScimGroupMember};
 
-pub(super) async fn update(
+fn member_ids(value: &serde_json::Value) -> Result<Vec<String>, ScimApiError> {
+    serde_json::from_value::<Vec<ScimGroupMember>>(value.clone())
+        .map(|members| members.into_iter().map(|m| m.value).collect())
+        .map_err(|_| {
+            ScimApiError::InvalidValue(
+                "members value must be an array of {\"value\": \"<id>\"} objects".to_string(),
+            )
+        })
+}
+
+pub(super) async fn patch(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     Path((_domain_id, id)): Path<(String, String)>,
     State(state): State<ServiceState>,
     headers: HeaderMap,
-    Json(req): Json<ScimGroupWrite>,
+    Json(req): Json<ScimPatchRequest>,
 ) -> Result<(HeaderMap, Json<ScimGroup>), ScimApiError> {
-    if req.display_name.trim().is_empty() {
-        return Err(KeystoneApiError::BadRequest("displayName is required".to_string()).into());
-    }
-
-    let new_member_ids = req.member_ids();
-    if new_member_ids.len() > MAX_GROUP_MEMBERS {
-        return Err(ScimApiError::InvalidValue(format!(
-            "members must not exceed {MAX_GROUP_MEMBERS} entries"
-        )));
-    }
+    let ops = validate_patch(&req, GROUP_PATCH_PATHS)?;
     let expected_version = parse_if_match(&headers)?;
 
     let exec = ExecutionContext::from_auth(&state, &ctx);
-    let (existing_group, existing_index) =
+    let (existing_group, _existing_index) =
         fetch_owned(&state, &exec, &realm.domain_id, &realm.provider_id, &id).await?;
 
     state
@@ -61,20 +67,70 @@ pub(super) async fn update(
         .enforce(
             "identity/scim/group/update",
             &ctx,
-            json!({"group": {"display_name": req.display_name}}),
+            serde_json::Value::Null,
             Some(json!({"group": existing_group})),
         )
         .await?;
 
-    // ADR 0024 §3.D: if `displayName` is changing, re-run the domain-wide
-    // collision check (a no-op rename doesn't need it). The lookup is
-    // case-insensitive, so exclude the resource's own id — otherwise a
-    // case-only rename would collide with itself.
-    if req.display_name != existing_group.name
+    let mut new_display_name = existing_group.name.clone();
+    let mut new_external_id: Option<Option<String>> = None;
+    let mut members_to_add: Vec<String> = Vec::new();
+    let mut members_to_remove: Vec<String> = Vec::new();
+
+    for validated in &ops {
+        match (validated.path.as_str(), validated.op) {
+            ("displayname", PatchOp::Remove) => {
+                return Err(ScimApiError::InvalidValue(
+                    "displayName is required and cannot be removed".to_string(),
+                ));
+            }
+            ("displayname", _) => {
+                let Some(s) = validated.value.as_str() else {
+                    return Err(ScimApiError::InvalidValue(
+                        "displayName must be a string".to_string(),
+                    ));
+                };
+                if s.trim().is_empty() {
+                    return Err(KeystoneApiError::BadRequest(
+                        "displayName is required".to_string(),
+                    )
+                    .into());
+                }
+                new_display_name = s.to_string();
+            }
+            ("externalid", PatchOp::Remove) => {
+                new_external_id = Some(None);
+            }
+            ("externalid", _) => {
+                let Some(s) = validated.value.as_str() else {
+                    return Err(ScimApiError::InvalidValue(
+                        "externalId must be a string".to_string(),
+                    ));
+                };
+                new_external_id = Some(Some(s.to_string()));
+            }
+            ("members", PatchOp::Add) => {
+                members_to_add.extend(member_ids(&validated.value)?);
+            }
+            ("members", PatchOp::Remove) => {
+                members_to_remove.extend(member_ids(&validated.value)?);
+            }
+            ("members", PatchOp::Replace) => {
+                return Err(ScimApiError::InvalidPath(
+                    "members supports add/remove only".to_string(),
+                ));
+            }
+            (other, _) => unreachable!(
+                "validate_patch already restricted paths to the allowlist, got `{other}`"
+            ),
+        }
+    }
+
+    if new_display_name != existing_group.name
         && let Some(matched_id) = state
             .provider
             .get_identity_provider()
-            .find_group_by_name_ci(&exec, &realm.domain_id, &req.display_name)
+            .find_group_by_name_ci(&exec, &realm.domain_id, &new_display_name)
             .await?
         && matched_id != id
     {
@@ -83,22 +139,42 @@ pub(super) async fn update(
         ));
     }
 
-    // ADR 0024 §7: every referenced member must already be owned by this
-    // same realm.
-    validate_members_owned_by_realm(
-        &state,
-        &exec,
-        &realm.domain_id,
-        &realm.provider_id,
-        &new_member_ids,
-    )
-    .await?;
+    // ADR 0024 §7: every added member must already be owned by this same
+    // realm, checked before any mutation.
+    if !members_to_add.is_empty() {
+        validate_members_owned_by_realm(
+            &state,
+            &exec,
+            &realm.domain_id,
+            &realm.provider_id,
+            &members_to_add,
+        )
+        .await?;
+    }
 
-    // ADR 0024 §5.E: the index write always happens (even when `externalId`
-    // is unchanged) so `version` bumps -- and the CAS below can be checked
-    // -- on every PUT. A rejected CAS means a concurrent writer won the
-    // race, so this request aborts before touching core Identity or
-    // membership.
+    let current_member_ids: HashSet<String> = state
+        .provider
+        .get_identity_provider()
+        .list_users_of_group(&exec, &id)
+        .await?
+        .into_iter()
+        .collect();
+    let mut resulting_member_ids = current_member_ids.clone();
+    for m in &members_to_add {
+        resulting_member_ids.insert(m.clone());
+    }
+    for m in &members_to_remove {
+        resulting_member_ids.remove(m);
+    }
+    // ADR 0024 §11: reject an oversized resulting membership before any
+    // storage mutation, not after partial application.
+    if resulting_member_ids.len() > MAX_GROUP_MEMBERS {
+        return Err(ScimApiError::InvalidValue(format!(
+            "members must not exceed {MAX_GROUP_MEMBERS} entries"
+        )));
+    }
+
+    // ADR 0024 §5.E: always bump the index version, mirroring `PUT`.
     let index = match state
         .provider
         .get_scim_resource_provider()
@@ -109,11 +185,7 @@ pub(super) async fn update(
             ScimResourceType::Group,
             &id,
             ScimResourceIndexUpdate {
-                external_id: if req.external_id != existing_index.external_id {
-                    Some(req.external_id.clone())
-                } else {
-                    None
-                },
+                external_id: new_external_id,
                 deprovisioned_at: None,
             },
             expected_version,
@@ -133,23 +205,20 @@ pub(super) async fn update(
     let group = state
         .provider
         .get_identity_provider()
-        .update_group(&exec, &id, req.to_group_update())
+        .update_group(
+            &exec,
+            &id,
+            GroupUpdate {
+                name: Some(new_display_name),
+                description: None,
+                extra: Default::default(),
+            },
+        )
         .await?;
 
-    // §5.C: `PUT` does a full membership resync against the target member set,
-    // not an incremental patch. Adds are attempted before removals so that a
-    // failure leaves the group unchanged rather than emptying it.
-    let current_member_ids: HashSet<String> = state
-        .provider
-        .get_identity_provider()
-        .list_users_of_group(&exec, &id)
-        .await?
-        .into_iter()
-        .collect();
-    let target_member_ids: HashSet<String> = new_member_ids.iter().cloned().collect();
-
-    let added: Vec<(&str, &str)> = target_member_ids
-        .difference(&current_member_ids)
+    let added: Vec<(&str, &str)> = members_to_add
+        .iter()
+        .filter(|uid| !current_member_ids.contains(uid.as_str()))
         .map(|uid| (uid.as_str(), id.as_str()))
         .collect();
     if !added.is_empty() {
@@ -159,7 +228,10 @@ pub(super) async fn update(
             .add_users_to_groups(&exec, added)
             .await?;
     }
-    for removed in current_member_ids.difference(&target_member_ids) {
+    for removed in members_to_remove
+        .iter()
+        .filter(|uid| current_member_ids.contains(uid.as_str()))
+    {
         state
             .provider
             .get_identity_provider()
@@ -167,6 +239,7 @@ pub(super) async fn update(
             .await?;
     }
 
+    let member_ids: Vec<String> = resulting_member_ids.into_iter().collect();
     let mut response_headers = HeaderMap::new();
     response_headers.insert(
         "etag",
@@ -176,13 +249,12 @@ pub(super) async fn update(
     );
     Ok((
         response_headers,
-        Json(ScimGroup::from_domain(&group, &index, &new_member_ids)),
+        Json(ScimGroup::from_domain(&group, &index, &member_ids)),
     ))
 }
 
 #[cfg(test)]
 mod tests {
-    use openstack_keystone_core::api::KeystoneApiError;
     use openstack_keystone_core::api::api_key_auth::ScimRealmContext;
     use openstack_keystone_core::auth::ValidatedSecurityContext;
     use openstack_keystone_core_types::auth::{
@@ -191,13 +263,14 @@ mod tests {
     };
     use openstack_keystone_core_types::identity::Group;
     use openstack_keystone_core_types::resource::Domain;
-    use openstack_keystone_core_types::scim::ScimResourceIndex;
+    use openstack_keystone_core_types::scim::{ScimResourceIndex, ScimResourceType};
+    use serde_json::Value;
 
     use super::*;
     use crate::api::tests::get_mocked_state;
     use crate::identity::MockIdentityProvider;
     use crate::provider::Provider;
-    use crate::scim::types::ScimGroupMember;
+    use crate::scim::patch::ScimPatchOperation;
     use crate::scim_resource::MockScimResourceProvider;
 
     fn domain_scoped_auth(domain_id: &str) -> ScimRealmAuth {
@@ -238,7 +311,7 @@ mod tests {
             provider_id: "okta-1".to_string(),
             resource_type: ScimResourceType::Group,
             keystone_id: keystone_id.to_string(),
-            external_id: Some("ext-old".to_string()),
+            external_id: Some("ext-1".to_string()),
             version: 0,
             deprovisioned_at: None,
             created_at: 1,
@@ -246,30 +319,18 @@ mod tests {
         }
     }
 
-    fn write_req(display_name: &str, members: Vec<&str>) -> ScimGroupWrite {
-        ScimGroupWrite {
+    fn patch_req(op: &str, path: &str, value: Value) -> ScimPatchRequest {
+        ScimPatchRequest {
             schemas: vec![],
-            external_id: Some("ext-old".to_string()),
-            display_name: display_name.to_string(),
-            members: members
-                .into_iter()
-                .map(|v| ScimGroupMember {
-                    value: v.to_string(),
-                })
-                .collect(),
+            operations: vec![ScimPatchOperation {
+                op: op.to_string(),
+                path: Some(path.to_string()),
+                value,
+            }],
         }
     }
 
-    #[tokio::test]
-    async fn test_update() {
-        let mut resource_mock = MockScimResourceProvider::default();
-        resource_mock
-            .expect_get_index()
-            .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
-        resource_mock
-            .expect_update_index()
-            .returning(|_, _, _, _, id, _, _| Ok(make_index(id)));
-
+    fn group_mock() -> MockIdentityProvider {
         let mut identity_mock = MockIdentityProvider::default();
         identity_mock.expect_get_group().returning(|_, id| {
             Ok(Some(Group {
@@ -280,6 +341,20 @@ mod tests {
                 extra: Default::default(),
             }))
         });
+        identity_mock
+    }
+
+    #[tokio::test]
+    async fn test_patch_display_name() {
+        let mut resource_mock = MockScimResourceProvider::default();
+        resource_mock
+            .expect_get_index()
+            .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
+        resource_mock
+            .expect_update_index()
+            .returning(|_, _, _, _, id, _, _| Ok(make_index(id)));
+
+        let mut identity_mock = group_mock();
         identity_mock
             .expect_find_group_by_name_ci()
             .returning(|_, _, _| Ok(None));
@@ -305,12 +380,16 @@ mod tests {
         )
         .await;
 
-        let (headers, Json(result)) = update(
+        let (headers, Json(result)) = patch(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("new_name", vec![])),
+            Json(patch_req(
+                "replace",
+                "displayName",
+                Value::String("new_name".to_string()),
+            )),
         )
         .await
         .unwrap();
@@ -319,28 +398,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_resyncs_membership() {
+    async fn test_patch_members_add() {
         let mut resource_mock = MockScimResourceProvider::default();
         resource_mock
             .expect_get_index()
+            .withf(|_, _, _, rt, id| *rt == ScimResourceType::Group && id == "group-1")
             .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
+        resource_mock
+            .expect_get_index()
+            .withf(|_, _, _, rt, _| *rt == ScimResourceType::User)
+            .returning(|_, domain_id, provider_id, _, id| {
+                Ok(Some(ScimResourceIndex {
+                    domain_id: domain_id.to_string(),
+                    provider_id: provider_id.to_string(),
+                    resource_type: ScimResourceType::User,
+                    keystone_id: id.to_string(),
+                    external_id: None,
+                    version: 0,
+                    deprovisioned_at: None,
+                    created_at: 1,
+                    updated_at: 1,
+                }))
+            });
         resource_mock
             .expect_update_index()
             .returning(|_, _, _, _, id, _, _| Ok(make_index(id)));
 
-        let mut identity_mock = MockIdentityProvider::default();
-        identity_mock.expect_get_group().returning(|_, id| {
-            Ok(Some(Group {
-                id: id.to_string(),
-                domain_id: "domain-1".to_string(),
-                name: "engineers".to_string(),
-                description: None,
-                extra: Default::default(),
-            }))
-        });
-        identity_mock
-            .expect_find_group_by_name_ci()
-            .returning(|_, _, _| Ok(None));
+        let mut identity_mock = group_mock();
         identity_mock.expect_update_group().returning(|_, id, req| {
             Ok(Group {
                 id: id.to_string(),
@@ -350,14 +434,63 @@ mod tests {
                 extra: Default::default(),
             })
         });
-        // Current membership: user-old. Desired: user-new.
         identity_mock
             .expect_list_users_of_group()
-            .returning(|_, _| Ok(vec!["user-old".to_string()]));
+            .returning(|_, _| Ok(vec![]));
         identity_mock
             .expect_add_users_to_groups()
             .withf(|_, memberships| memberships == &vec![("user-new", "group-1")])
             .returning(|_, _| Ok(()));
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_scim_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let (_, Json(result)) = patch(
+            domain_scoped_auth("domain-1"),
+            Path(("domain-1".to_string(), "group-1".to_string())),
+            State(state),
+            HeaderMap::new(),
+            Json(patch_req(
+                "add",
+                "members",
+                serde_json::json!([{"value": "user-new"}]),
+            )),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.members.len(), 1);
+        assert_eq!(result.members[0].value, "user-new");
+    }
+
+    #[tokio::test]
+    async fn test_patch_members_remove() {
+        let mut resource_mock = MockScimResourceProvider::default();
+        resource_mock
+            .expect_get_index()
+            .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
+        resource_mock
+            .expect_update_index()
+            .returning(|_, _, _, _, id, _, _| Ok(make_index(id)));
+
+        let mut identity_mock = group_mock();
+        identity_mock.expect_update_group().returning(|_, id, req| {
+            Ok(Group {
+                id: id.to_string(),
+                domain_id: "domain-1".to_string(),
+                name: req.name.clone().unwrap(),
+                description: None,
+                extra: Default::default(),
+            })
+        });
+        identity_mock
+            .expect_list_users_of_group()
+            .returning(|_, _| Ok(vec!["user-old".to_string()]));
         identity_mock
             .expect_remove_user_from_group()
             .withf(|_, uid, gid| uid == "user-old" && gid == "group-1")
@@ -372,65 +505,74 @@ mod tests {
         )
         .await;
 
-        let (_, Json(result)) = update(
+        let (_, Json(result)) = patch(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("engineers", vec!["user-new"])),
+            Json(patch_req(
+                "remove",
+                "members",
+                serde_json::json!([{"value": "user-old"}]),
+            )),
         )
         .await
         .unwrap();
-        assert_eq!(result.members.len(), 1);
-        assert_eq!(result.members[0].value, "user-new");
+        assert!(result.members.is_empty());
     }
 
     #[tokio::test]
-    async fn test_update_rejects_member_not_owned_by_realm() {
+    async fn test_patch_members_replace_rejected() {
         let mut resource_mock = MockScimResourceProvider::default();
         resource_mock
             .expect_get_index()
-            .withf(|_, _, _, rt, id| *rt == ScimResourceType::Group && id == "group-1")
             .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
-        resource_mock
-            .expect_get_index()
-            .withf(|_, _, _, rt, _| *rt == ScimResourceType::User)
-            .returning(|_, _, _, _, _| Ok(None));
-
-        let mut identity_mock = MockIdentityProvider::default();
-        identity_mock.expect_get_group().returning(|_, id| {
-            Ok(Some(Group {
-                id: id.to_string(),
-                domain_id: "domain-1".to_string(),
-                name: "engineers".to_string(),
-                description: None,
-                extra: Default::default(),
-            }))
-        });
-        identity_mock.expect_update_group().never();
 
         let state = get_mocked_state(
             Provider::mocked_builder()
-                .mock_identity(identity_mock)
+                .mock_identity(group_mock())
                 .mock_scim_resource(resource_mock),
             true,
             None,
         )
         .await;
 
-        let result = update(
+        let result = patch(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("engineers", vec!["user-from-elsewhere"])),
+            Json(patch_req(
+                "replace",
+                "members",
+                serde_json::json!([{"value": "user-new"}]),
+            )),
         )
         .await;
-        assert!(matches!(result, Err(ScimApiError::InvalidValue(_))));
+        assert!(matches!(result, Err(ScimApiError::InvalidPath(_))));
     }
 
     #[tokio::test]
-    async fn test_update_not_owned_returns_404() {
+    async fn test_patch_rejects_disallowed_path() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let result = patch(
+            domain_scoped_auth("domain-1"),
+            Path(("domain-1".to_string(), "group-1".to_string())),
+            State(state),
+            HeaderMap::new(),
+            Json(patch_req(
+                "replace",
+                r#"emails[type eq "work"].value"#,
+                Value::String("a@b.com".to_string()),
+            )),
+        )
+        .await;
+        assert!(matches!(result, Err(ScimApiError::InvalidPath(_))));
+    }
+
+    #[tokio::test]
+    async fn test_patch_not_owned_returns_404() {
         let mut resource_mock = MockScimResourceProvider::default();
         resource_mock
             .expect_get_index()
@@ -443,70 +585,23 @@ mod tests {
         )
         .await;
 
-        let result = update(
+        let result = patch(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("new_name", vec![])),
+            Json(patch_req(
+                "replace",
+                "displayName",
+                Value::String("x".to_string()),
+            )),
         )
         .await;
         assert!(matches!(
             result,
-            Err(ScimApiError::Api(KeystoneApiError::NotFound { .. }))
+            Err(ScimApiError::Api(
+                openstack_keystone_core::api::KeystoneApiError::NotFound { .. }
+            ))
         ));
-    }
-
-    #[tokio::test]
-    async fn test_update_stale_if_match_returns_412() {
-        let mut resource_mock = MockScimResourceProvider::default();
-        resource_mock
-            .expect_get_index()
-            .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
-        resource_mock
-            .expect_update_index()
-            .returning(|_, _, _, _, id, _, _| {
-                Err(
-                    openstack_keystone_core_types::scim::ScimResourceProviderError::VersionMismatch(
-                        format!("stale version for {id}"),
-                    ),
-                )
-            });
-
-        let mut identity_mock = MockIdentityProvider::default();
-        identity_mock.expect_get_group().returning(|_, id| {
-            Ok(Some(Group {
-                id: id.to_string(),
-                domain_id: "domain-1".to_string(),
-                name: "engineers".to_string(),
-                description: None,
-                extra: Default::default(),
-            }))
-        });
-        identity_mock
-            .expect_find_group_by_name_ci()
-            .returning(|_, _, _| Ok(None));
-
-        let state = get_mocked_state(
-            Provider::mocked_builder()
-                .mock_identity(identity_mock)
-                .mock_scim_resource(resource_mock),
-            true,
-            None,
-        )
-        .await;
-
-        let mut headers = HeaderMap::new();
-        headers.insert("if-match", r#"W/"5""#.parse().unwrap());
-
-        let result = update(
-            domain_scoped_auth("domain-1"),
-            Path(("domain-1".to_string(), "group-1".to_string())),
-            State(state),
-            headers,
-            Json(write_req("new_name", vec![])),
-        )
-        .await;
-        assert!(matches!(result, Err(ScimApiError::PreconditionFailed(_))));
     }
 }

--- a/crates/keystone/src/scim/group/show.rs
+++ b/crates/keystone/src/scim/group/show.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! `GET /SCIM/v2/{domain_id}/Groups/{id}` (ADR 0024 §3.C Ownership Fencing).
 
-use axum::{Json, extract::Path, extract::State};
+use axum::{Json, extract::Path, extract::State, http::HeaderMap};
 use serde_json::json;
 
 use openstack_keystone_core::api::KeystoneApiError;
@@ -23,6 +23,7 @@ use openstack_keystone_core_types::scim::ScimResourceType;
 
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
+use crate::scim::etag::etag_header;
 use crate::scim::types::ScimGroup;
 
 /// Fetch `(Group, ScimResourceIndex)` for `id` under the caller's own realm,
@@ -72,7 +73,7 @@ pub(super) async fn show(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     Path((_domain_id, id)): Path<(String, String)>,
     State(state): State<ServiceState>,
-) -> Result<Json<ScimGroup>, ScimApiError> {
+) -> Result<(HeaderMap, Json<ScimGroup>), ScimApiError> {
     let exec = ExecutionContext::from_auth(&state, &ctx);
     let (group, index) =
         fetch_owned(&state, &exec, &realm.domain_id, &realm.provider_id, &id).await?;
@@ -93,7 +94,17 @@ pub(super) async fn show(
         .list_users_of_group(&exec, &group.id)
         .await?;
 
-    Ok(Json(ScimGroup::from_domain(&group, &index, &member_ids)))
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "etag",
+        etag_header(index.version)
+            .parse()
+            .expect("weak etag is valid header value"),
+    );
+    Ok((
+        headers,
+        Json(ScimGroup::from_domain(&group, &index, &member_ids)),
+    ))
 }
 
 #[cfg(test)]
@@ -189,7 +200,7 @@ mod tests {
         )
         .await;
 
-        let result = show(
+        let (headers, Json(result)) = show(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
@@ -199,6 +210,7 @@ mod tests {
         assert_eq!(result.id, "group-1");
         assert_eq!(result.members.len(), 1);
         assert_eq!(result.members[0].value, "user-1");
+        assert_eq!(headers.get("etag").unwrap(), r#"W/"0""#);
     }
 
     #[tokio::test]

--- a/crates/keystone/src/scim/patch.rs
+++ b/crates/keystone/src/scim/patch.rs
@@ -1,0 +1,201 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # SCIM `PATCH` request shape and path validation (ADR 0024 §5.C)
+//!
+//! `Operations: [{op, path, value}]` is accepted only for a fixed,
+//! per-resource allowlist of top-level scalar `path` targets. Anything else
+//! -- a complex filter expression (`emails[type eq "work"].value`), an
+//! array-index path, or an omitted `path` -- is rejected with
+//! `400 Bad Request` (`scimType: "invalidPath"`) before any attribute is
+//! touched. Resource-specific application of a validated operation list
+//! lives in `scim::user::patch` / `scim::group::patch`.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::scim::error::ScimApiError;
+
+/// ADR 0024 §5.C User `path` allowlist (lowercased).
+pub const USER_PATCH_PATHS: &[&str] = &[
+    "active",
+    "username",
+    "displayname",
+    "externalid",
+    "name.givenname",
+    "name.familyname",
+];
+
+/// ADR 0024 §5.C Group `path` allowlist (lowercased). `members` is
+/// add/remove only -- enforced separately in `scim::group::patch`, not by
+/// this table.
+pub const GROUP_PATCH_PATHS: &[&str] = &["displayname", "externalid", "members"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatchOp {
+    Add,
+    Replace,
+    Remove,
+}
+
+impl PatchOp {
+    pub fn parse(token: &str) -> Option<Self> {
+        match token.to_ascii_lowercase().as_str() {
+            "add" => Some(Self::Add),
+            "replace" => Some(Self::Replace),
+            "remove" => Some(Self::Remove),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimPatchOperation {
+    pub op: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ScimPatchRequest {
+    #[serde(default)]
+    pub schemas: Vec<String>,
+    #[serde(rename = "Operations")]
+    pub operations: Vec<ScimPatchOperation>,
+}
+
+/// A validated `ScimPatchOperation`, its `path` lowercased and its `op`
+/// resolved to a [`PatchOp`].
+pub struct ValidatedPatchOp {
+    pub op: PatchOp,
+    pub path: String,
+    pub value: Value,
+}
+
+/// Validate `Operations[].{op,path}` against `allowed_paths`, in request
+/// order. Rejects the whole request on the first violation -- partial
+/// application of an otherwise-invalid PATCH would leave the resource in a
+/// state the client never asked for.
+pub fn validate_patch(
+    req: &ScimPatchRequest,
+    allowed_paths: &[&str],
+) -> Result<Vec<ValidatedPatchOp>, ScimApiError> {
+    if req.operations.is_empty() {
+        return Err(ScimApiError::InvalidPath(
+            "Operations must not be empty".to_string(),
+        ));
+    }
+    req.operations
+        .iter()
+        .map(|raw| {
+            let Some(path) = &raw.path else {
+                return Err(ScimApiError::InvalidPath(
+                    "path is required for every operation".to_string(),
+                ));
+            };
+            let path = path.to_ascii_lowercase();
+            if !allowed_paths.contains(&path.as_str()) {
+                return Err(ScimApiError::InvalidPath(format!(
+                    "path `{path}` is not patchable"
+                )));
+            }
+            let Some(op) = PatchOp::parse(&raw.op) else {
+                return Err(ScimApiError::InvalidPath(format!(
+                    "unsupported op `{}`",
+                    raw.op
+                )));
+            };
+            Ok(ValidatedPatchOp {
+                op,
+                path,
+                value: raw.value.clone(),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(op: &str, path: &str, value: Value) -> ScimPatchOperation {
+        ScimPatchOperation {
+            op: op.to_string(),
+            path: Some(path.to_string()),
+            value,
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_allowed_path() {
+        let req = ScimPatchRequest {
+            schemas: vec![],
+            operations: vec![op("replace", "active", Value::Bool(false))],
+        };
+        let validated = validate_patch(&req, USER_PATCH_PATHS).unwrap();
+        assert_eq!(validated.len(), 1);
+        assert_eq!(validated[0].path, "active");
+        assert!(matches!(validated[0].op, PatchOp::Replace));
+    }
+
+    #[test]
+    fn test_validate_rejects_missing_path() {
+        let req = ScimPatchRequest {
+            schemas: vec![],
+            operations: vec![ScimPatchOperation {
+                op: "replace".to_string(),
+                path: None,
+                value: Value::Null,
+            }],
+        };
+        let result = validate_patch(&req, USER_PATCH_PATHS);
+        assert!(matches!(result, Err(ScimApiError::InvalidPath(_))));
+    }
+
+    #[test]
+    fn test_validate_rejects_complex_filter_path() {
+        let req = ScimPatchRequest {
+            schemas: vec![],
+            operations: vec![op(
+                "replace",
+                r#"emails[type eq "work"].value"#,
+                Value::String("a@b.com".to_string()),
+            )],
+        };
+        let result = validate_patch(&req, USER_PATCH_PATHS);
+        assert!(matches!(result, Err(ScimApiError::InvalidPath(_))));
+    }
+
+    #[test]
+    fn test_validate_rejects_unsupported_op() {
+        let req = ScimPatchRequest {
+            schemas: vec![],
+            operations: vec![op("move", "active", Value::Bool(true))],
+        };
+        let result = validate_patch(&req, USER_PATCH_PATHS);
+        assert!(matches!(result, Err(ScimApiError::InvalidPath(_))));
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_operations() {
+        let req = ScimPatchRequest {
+            schemas: vec![],
+            operations: vec![],
+        };
+        let result = validate_patch(&req, USER_PATCH_PATHS);
+        assert!(matches!(result, Err(ScimApiError::InvalidPath(_))));
+    }
+}

--- a/crates/keystone/src/scim/types.rs
+++ b/crates/keystone/src/scim/types.rs
@@ -38,9 +38,9 @@ pub const LIST_RESPONSE_SCHEMA: &str = "urn:ietf:params:scim:api:messages:2.0:Li
 /// ADR 0024 §11 membership-graph-bomb cap: max `members` entries per request.
 pub const MAX_GROUP_MEMBERS: usize = 1000;
 
-const EXTRA_GIVEN_NAME: &str = "scim_given_name";
-const EXTRA_FAMILY_NAME: &str = "scim_family_name";
-const EXTRA_DISPLAY_NAME: &str = "scim_display_name";
+pub(crate) const EXTRA_GIVEN_NAME: &str = "scim_given_name";
+pub(crate) const EXTRA_FAMILY_NAME: &str = "scim_family_name";
+pub(crate) const EXTRA_DISPLAY_NAME: &str = "scim_display_name";
 const EXTRA_PRIMARY_EMAIL: &str = "scim_primary_email";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -339,7 +339,7 @@ pub struct ScimGroupListResponse {
     pub resources: Vec<ScimGroup>,
 }
 
-fn extra_str(extra: &HashMap<String, Value>, key: &str) -> Option<String> {
+pub(crate) fn extra_str(extra: &HashMap<String, Value>, key: &str) -> Option<String> {
     extra.get(key).and_then(|v| v.as_str()).map(String::from)
 }
 

--- a/crates/keystone/src/scim/user.rs
+++ b/crates/keystone/src/scim/user.rs
@@ -20,6 +20,7 @@ use openstack_keystone_core::keystone::ServiceState;
 mod create;
 mod delete;
 mod list;
+mod patch;
 mod show;
 mod update;
 
@@ -29,6 +30,9 @@ pub fn router() -> Router<ServiceState> {
         .route("/", get(list::list).post(create::create))
         .route(
             "/{id}",
-            get(show::show).put(update::update).delete(delete::delete),
+            get(show::show)
+                .put(update::update)
+                .patch(patch::patch)
+                .delete(delete::delete),
         )
 }

--- a/crates/keystone/src/scim/user/create.rs
+++ b/crates/keystone/src/scim/user/create.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! `POST /SCIM/v2/{domain_id}/Users` (ADR 0024 §3.C, §3.D, §4).
 
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{Json, extract::State, http::HeaderMap, http::StatusCode};
 use serde_json::json;
 
 use openstack_keystone_core::api::KeystoneApiError;
@@ -26,13 +26,14 @@ use openstack_keystone_core_types::scim::{
 
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
+use crate::scim::etag::etag_header;
 use crate::scim::types::{ScimUser, ScimUserWrite};
 
 pub(super) async fn create(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     State(state): State<ServiceState>,
     Json(req): Json<ScimUserWrite>,
-) -> Result<(StatusCode, Json<ScimUser>), ScimApiError> {
+) -> Result<(StatusCode, HeaderMap, Json<ScimUser>), ScimApiError> {
     if req.user_name.trim().is_empty() {
         return Err(KeystoneApiError::BadRequest("userName is required".to_string()).into());
     }
@@ -127,8 +128,16 @@ pub(super) async fn create(
         }
     };
 
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "etag",
+        etag_header(index.version)
+            .parse()
+            .expect("weak etag is valid header value"),
+    );
     Ok((
         StatusCode::CREATED,
+        headers,
         Json(ScimUser::from_domain(&user, &index)),
     ))
 }
@@ -239,13 +248,15 @@ mod tests {
             active: true,
         };
 
-        let (status, Json(body)) = create(domain_scoped_auth("domain-1"), State(state), Json(req))
-            .await
-            .unwrap();
+        let (status, headers, Json(body)) =
+            create(domain_scoped_auth("domain-1"), State(state), Json(req))
+                .await
+                .unwrap();
         assert_eq!(status, StatusCode::CREATED);
         assert_eq!(body.user_name, "alice");
         assert_eq!(body.id, "user-1");
         assert_eq!(body.external_id.as_deref(), Some("ext-1"));
+        assert_eq!(headers.get("etag").unwrap(), r#"W/"0""#);
     }
 
     #[tokio::test]

--- a/crates/keystone/src/scim/user/delete.rs
+++ b/crates/keystone/src/scim/user/delete.rs
@@ -80,6 +80,7 @@ pub(super) async fn delete(
                 external_id: None,
                 deprovisioned_at: Some(Some(now)),
             },
+            None,
         )
         .await?;
 
@@ -195,8 +196,8 @@ mod tests {
             });
         resource_mock
             .expect_update_index()
-            .withf(|_, _, _, _, _, update| matches!(update.deprovisioned_at, Some(Some(_))))
-            .returning(|_, _, _, _, id, _| {
+            .withf(|_, _, _, _, _, update, _| matches!(update.deprovisioned_at, Some(Some(_))))
+            .returning(|_, _, _, _, id, _, _| {
                 Ok(ScimResourceIndex {
                     domain_id: "domain-1".to_string(),
                     provider_id: "okta-1".to_string(),

--- a/crates/keystone/src/scim/user/list.rs
+++ b/crates/keystone/src/scim/user/list.rs
@@ -11,7 +11,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! `GET /SCIM/v2/{domain_id}/Users` (ADR 0024 §3, §5.D bare pagination).
+//! `GET /SCIM/v2/{domain_id}/Users` (ADR 0024 §3, §5.B filter, §5.D
+//! pagination).
 
 use axum::{Json, extract::Query, extract::State};
 use serde::Deserialize;
@@ -23,6 +24,7 @@ use openstack_keystone_core_types::scim::ScimResourceType;
 
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
+use crate::scim::filter::{USER_FILTER_ATTRS, parse_filter};
 use crate::scim::types::{LIST_RESPONSE_SCHEMA, ScimListResponse, ScimUser};
 
 #[derive(Debug, Deserialize, Default)]
@@ -31,6 +33,8 @@ pub(super) struct ListParams {
     start_index: Option<usize>,
     #[serde(default)]
     count: Option<usize>,
+    #[serde(default)]
+    filter: Option<String>,
 }
 
 pub(super) async fn list(
@@ -48,6 +52,12 @@ pub(super) async fn list(
         )
         .await?;
 
+    let parsed_filter = params
+        .filter
+        .as_deref()
+        .map(|f| parse_filter(f, USER_FILTER_ATTRS))
+        .transpose()?;
+
     let exec = ExecutionContext::from_auth(&state, &ctx);
 
     let indexes = state
@@ -63,30 +73,48 @@ pub(super) async fn list(
 
     let start_index = params.start_index.unwrap_or(1).max(1);
     let count = params.count.unwrap_or(200).min(200);
-    let total_results = indexes.len();
 
-    let mut resources = Vec::new();
-    for index in indexes
-        .into_iter()
-        .filter(|i| i.deprovisioned_at.is_none())
-        .skip(start_index.saturating_sub(1))
-        .take(count)
-    {
-        if let Some(user) = state
+    // A `filter` requires hydrating every active resource up front to
+    // evaluate it (userName/active aren't on the index) -- still bounded to
+    // this realm's own resource count (§5.D), just no longer deferrable to
+    // the paginated slice alone.
+    let mut matched = Vec::new();
+    for index in indexes.into_iter().filter(|i| i.deprovisioned_at.is_none()) {
+        let Some(user) = state
             .provider
             .get_identity_provider()
             .get_user(&exec, &index.keystone_id)
             .await?
-        {
-            resources.push(ScimUser::from_domain(&user, &index));
+        else {
+            continue;
+        };
+        let scim_user = ScimUser::from_domain(&user, &index);
+        let matches = parsed_filter.as_ref().is_none_or(|f| {
+            f.matches(|attr| match attr {
+                "username" => Some(scim_user.user_name.clone()),
+                "externalid" => scim_user.external_id.clone(),
+                "id" => Some(scim_user.id.clone()),
+                "active" => Some(scim_user.active.to_string()),
+                _ => None,
+            })
+        });
+        if matches {
+            matched.push(scim_user);
         }
     }
+
+    let total_results = matched.len();
+    let resources: Vec<ScimUser> = matched
+        .into_iter()
+        .skip(start_index.saturating_sub(1))
+        .take(count)
+        .collect();
 
     Ok(Json(ScimListResponse {
         schemas: vec![LIST_RESPONSE_SCHEMA.to_string()],
         total_results,
         start_index,
-        items_per_page: resources.len(),
+        items_per_page: count,
         resources,
     }))
 }
@@ -196,9 +224,7 @@ mod tests {
         .unwrap();
         assert_eq!(result.resources.len(), 1);
         assert_eq!(result.resources[0].id, "user-1");
-        // total_results counts everything the realm owns, deprovisioned
-        // included, matching the raw index count before filtering.
-        assert_eq!(result.total_results, 2);
+        assert_eq!(result.total_results, 1);
     }
 
     #[tokio::test]
@@ -212,5 +238,80 @@ mod tests {
         )
         .await;
         assert!(matches!(result, Err(ScimApiError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn test_list_applies_username_filter() {
+        let mut resource_mock = MockScimResourceProvider::default();
+        resource_mock.expect_list_index().returning(|_, _, _, _| {
+            Ok(vec![
+                make_index("user-1", false),
+                make_index("user-2", false),
+            ])
+        });
+
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock.expect_get_user().returning(|_, id| {
+            let name = if id == "user-1" { "alice" } else { "bob" };
+            Ok(Some(
+                UserResponseBuilder::default()
+                    .id(id)
+                    .domain_id("domain-1")
+                    .enabled(true)
+                    .name(name)
+                    .build()
+                    .unwrap(),
+            ))
+        });
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_scim_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let result = list(
+            domain_scoped_auth("domain-1"),
+            State(state),
+            Query(ListParams {
+                start_index: None,
+                count: None,
+                filter: Some(r#"userName eq "bob""#.to_string()),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.total_results, 1);
+        assert_eq!(result.resources[0].id, "user-2");
+    }
+
+    #[tokio::test]
+    async fn test_list_rejects_invalid_filter() {
+        let mut resource_mock = MockScimResourceProvider::default();
+        resource_mock
+            .expect_list_index()
+            .returning(|_, _, _, _| Ok(vec![]));
+
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_scim_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let result = list(
+            domain_scoped_auth("domain-1"),
+            State(state),
+            Query(ListParams {
+                start_index: None,
+                count: None,
+                filter: Some(r#"password eq "x""#.to_string()),
+            }),
+        )
+        .await;
+        assert!(matches!(result, Err(ScimApiError::InvalidFilter(_))));
     }
 }

--- a/crates/keystone/src/scim/user/patch.rs
+++ b/crates/keystone/src/scim/user/patch.rs
@@ -11,14 +11,20 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! `PUT /SCIM/v2/{domain_id}/Users/{id}` — full-replace update (ADR 0024
-//! §3.C, §4, §5.E).
+//! `PATCH /SCIM/v2/{domain_id}/Users/{id}` (ADR 0024 §5.C).
+//!
+//! Reuses the `identity/scim/user/update` OPA policy: PATCH is an
+//! alternate write mechanism for the same resource/authorization concern
+//! `PUT` already enforces, not a distinct one.
+
+use serde_json::{Value, json};
 
 use axum::{Json, extract::Path, extract::State, http::HeaderMap};
-use serde_json::json;
 
+use openstack_keystone_core::api::KeystoneApiError;
 use openstack_keystone_core::api::api_key_auth::ScimRealmAuth;
 use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::identity::UserUpdate;
 use openstack_keystone_core_types::scim::{
     ScimResourceIndexUpdate, ScimResourceProviderError, ScimResourceType,
 };
@@ -26,26 +32,29 @@ use openstack_keystone_core_types::scim::{
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::{etag_header, parse_if_match};
-use crate::scim::types::{ScimUser, ScimUserWrite};
+use crate::scim::patch::{PatchOp, ScimPatchRequest, USER_PATCH_PATHS, validate_patch};
+use crate::scim::types::{EXTRA_DISPLAY_NAME, EXTRA_FAMILY_NAME, EXTRA_GIVEN_NAME, ScimUser};
 use crate::scim::user::show::fetch_owned;
 
-pub(super) async fn update(
+fn str_value(value: &Value, path: &str) -> Result<String, ScimApiError> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| ScimApiError::InvalidValue(format!("`{path}` value must be a string")))
+}
+
+pub(super) async fn patch(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     Path((_domain_id, id)): Path<(String, String)>,
     State(state): State<ServiceState>,
     headers: HeaderMap,
-    Json(req): Json<ScimUserWrite>,
+    Json(req): Json<ScimPatchRequest>,
 ) -> Result<(HeaderMap, Json<ScimUser>), ScimApiError> {
-    if req.user_name.trim().is_empty() {
-        return Err(openstack_keystone_core::api::KeystoneApiError::BadRequest(
-            "userName is required".to_string(),
-        )
-        .into());
-    }
+    let ops = validate_patch(&req, USER_PATCH_PATHS)?;
     let expected_version = parse_if_match(&headers)?;
 
     let exec = ExecutionContext::from_auth(&state, &ctx);
-    let (existing_user, existing_index) =
+    let (existing_user, _existing_index) =
         fetch_owned(&state, &exec, &realm.domain_id, &realm.provider_id, &id).await?;
 
     state
@@ -53,20 +62,90 @@ pub(super) async fn update(
         .enforce(
             "identity/scim/user/update",
             &ctx,
-            json!({"user": {"user_name": req.user_name}}),
+            serde_json::Value::Null,
             Some(json!({"user": existing_user})),
         )
         .await?;
 
-    // ADR 0024 §3.D: if the `userName` is changing, re-run the domain-wide
-    // collision check (a no-op rename doesn't need it). The lookup is
-    // case-insensitive, so exclude the resource's own id — otherwise a
-    // case-only rename (e.g. `Bob` -> `BOB`) would collide with itself.
-    if req.user_name != existing_user.name
+    let mut new_user_name = existing_user.name.clone();
+    let mut new_enabled = existing_user.enabled;
+    let mut extra = existing_user.extra.clone();
+    let mut new_external_id: Option<Option<String>> = None;
+
+    for validated in &ops {
+        match (validated.path.as_str(), validated.op) {
+            ("active", PatchOp::Remove) => {
+                return Err(ScimApiError::InvalidValue(
+                    "active cannot be removed".to_string(),
+                ));
+            }
+            ("active", _) => {
+                new_enabled = validated.value.as_bool().ok_or_else(|| {
+                    ScimApiError::InvalidValue("active must be a boolean".to_string())
+                })?;
+            }
+            ("username", PatchOp::Remove) => {
+                return Err(ScimApiError::InvalidValue(
+                    "userName cannot be removed".to_string(),
+                ));
+            }
+            ("username", _) => {
+                let value = str_value(&validated.value, "userName")?;
+                if value.trim().is_empty() {
+                    return Err(
+                        KeystoneApiError::BadRequest("userName is required".to_string()).into(),
+                    );
+                }
+                new_user_name = value;
+            }
+            ("externalid", PatchOp::Remove) => {
+                return Err(ScimApiError::InvalidValue(
+                    "externalId is required and cannot be removed".to_string(),
+                ));
+            }
+            ("externalid", _) => {
+                new_external_id = Some(Some(str_value(&validated.value, "externalId")?));
+            }
+            ("displayname", PatchOp::Remove) => {
+                extra.remove(EXTRA_DISPLAY_NAME);
+            }
+            ("displayname", _) => {
+                extra.insert(
+                    EXTRA_DISPLAY_NAME.to_string(),
+                    Value::String(str_value(&validated.value, "displayName")?),
+                );
+            }
+            ("name.givenname", PatchOp::Remove) => {
+                extra.remove(EXTRA_GIVEN_NAME);
+            }
+            ("name.givenname", _) => {
+                extra.insert(
+                    EXTRA_GIVEN_NAME.to_string(),
+                    Value::String(str_value(&validated.value, "name.givenName")?),
+                );
+            }
+            ("name.familyname", PatchOp::Remove) => {
+                extra.remove(EXTRA_FAMILY_NAME);
+            }
+            ("name.familyname", _) => {
+                extra.insert(
+                    EXTRA_FAMILY_NAME.to_string(),
+                    Value::String(str_value(&validated.value, "name.familyName")?),
+                );
+            }
+            (other, _) => unreachable!(
+                "validate_patch already restricted paths to the allowlist, got `{other}`"
+            ),
+        }
+    }
+
+    // ADR 0024 §3.D: re-run the domain-wide collision check if `userName`
+    // is actually changing (mirrors `PUT`'s equivalent check).
+    if new_user_name != existing_user.name
         && let Some(matched_id) = state
             .provider
             .get_identity_provider()
-            .find_user_by_name_ci(&exec, &realm.domain_id, &req.user_name)
+            .find_user_by_name_ci(&exec, &realm.domain_id, &new_user_name)
             .await?
         && matched_id != id
     {
@@ -75,11 +154,7 @@ pub(super) async fn update(
         ));
     }
 
-    // ADR 0024 §5.E: the index write always happens (even when `externalId`
-    // is unchanged) so `version` bumps -- and the CAS below can be checked
-    // -- on every PUT, not just ones that touch `externalId`. A rejected
-    // CAS here means a concurrent writer won the race, so this request
-    // aborts before ever touching core Identity.
+    // ADR 0024 §5.E: always bump the index version, mirroring `PUT`.
     let index = match state
         .provider
         .get_scim_resource_provider()
@@ -90,11 +165,7 @@ pub(super) async fn update(
             ScimResourceType::User,
             &id,
             ScimResourceIndexUpdate {
-                external_id: if req.external_id != existing_index.external_id {
-                    Some(req.external_id.clone())
-                } else {
-                    None
-                },
+                external_id: new_external_id,
                 deprovisioned_at: None,
             },
             expected_version,
@@ -114,7 +185,16 @@ pub(super) async fn update(
     let user = state
         .provider
         .get_identity_provider()
-        .update_user(&exec, &id, req.to_user_update())
+        .update_user(
+            &exec,
+            &id,
+            UserUpdate {
+                enabled: Some(new_enabled),
+                extra,
+                name: Some(new_user_name),
+                ..Default::default()
+            },
+        )
         .await?;
 
     let mut response_headers = HeaderMap::new();
@@ -129,7 +209,6 @@ pub(super) async fn update(
 
 #[cfg(test)]
 mod tests {
-    use openstack_keystone_core::api::KeystoneApiError;
     use openstack_keystone_core::api::api_key_auth::ScimRealmContext;
     use openstack_keystone_core::auth::ValidatedSecurityContext;
     use openstack_keystone_core_types::auth::{
@@ -144,6 +223,7 @@ mod tests {
     use crate::api::tests::get_mocked_state;
     use crate::identity::MockIdentityProvider;
     use crate::provider::Provider;
+    use crate::scim::patch::ScimPatchOperation;
     use crate::scim_resource::MockScimResourceProvider;
 
     fn domain_scoped_auth(domain_id: &str) -> ScimRealmAuth {
@@ -184,7 +264,7 @@ mod tests {
             provider_id: "okta-1".to_string(),
             resource_type: openstack_keystone_core_types::scim::ScimResourceType::User,
             keystone_id: keystone_id.to_string(),
-            external_id: Some("ext-old".to_string()),
+            external_id: Some("ext-1".to_string()),
             version: 0,
             deprovisioned_at: None,
             created_at: 1,
@@ -192,20 +272,19 @@ mod tests {
         }
     }
 
-    fn write_req(user_name: &str, external_id: Option<&str>) -> ScimUserWrite {
-        ScimUserWrite {
+    fn patch_req(op: &str, path: &str, value: Value) -> ScimPatchRequest {
+        ScimPatchRequest {
             schemas: vec![],
-            external_id: external_id.map(str::to_string),
-            user_name: user_name.to_string(),
-            name: None,
-            display_name: None,
-            emails: vec![],
-            active: true,
+            operations: vec![ScimPatchOperation {
+                op: op.to_string(),
+                path: Some(path.to_string()),
+                value,
+            }],
         }
     }
 
     #[tokio::test]
-    async fn test_update() {
+    async fn test_patch_active() {
         let mut resource_mock = MockScimResourceProvider::default();
         resource_mock
             .expect_get_index()
@@ -221,7 +300,62 @@ mod tests {
                     .id(id)
                     .domain_id("domain-1")
                     .enabled(true)
-                    .name("old_name")
+                    .name("alice")
+                    .build()
+                    .unwrap(),
+            ))
+        });
+        identity_mock.expect_update_user().returning(|_, id, req| {
+            assert_eq!(req.enabled, Some(false));
+            Ok(UserResponseBuilder::default()
+                .id(id)
+                .domain_id("domain-1")
+                .enabled(false)
+                .name("alice")
+                .build()
+                .unwrap())
+        });
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_scim_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let (headers, Json(result)) = patch(
+            domain_scoped_auth("domain-1"),
+            Path(("domain-1".to_string(), "user-1".to_string())),
+            State(state),
+            HeaderMap::new(),
+            Json(patch_req("replace", "active", Value::Bool(false))),
+        )
+        .await
+        .unwrap();
+        assert!(!result.active);
+        assert_eq!(headers.get("etag").unwrap(), r#"W/"0""#);
+    }
+
+    #[tokio::test]
+    async fn test_patch_username() {
+        let mut resource_mock = MockScimResourceProvider::default();
+        resource_mock
+            .expect_get_index()
+            .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
+        resource_mock
+            .expect_update_index()
+            .returning(|_, _, _, _, id, _, _| Ok(make_index(id)));
+
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock.expect_get_user().returning(|_, id| {
+            Ok(Some(
+                UserResponseBuilder::default()
+                    .id(id)
+                    .domain_id("domain-1")
+                    .enabled(true)
+                    .name("alice")
                     .build()
                     .unwrap(),
             ))
@@ -248,21 +382,24 @@ mod tests {
         )
         .await;
 
-        let (headers, Json(result)) = update(
+        let (_, Json(result)) = patch(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("new_name", Some("ext-old"))),
+            Json(patch_req(
+                "replace",
+                "userName",
+                Value::String("bob".to_string()),
+            )),
         )
         .await
         .unwrap();
-        assert_eq!(result.user_name, "new_name");
-        assert_eq!(headers.get("etag").unwrap(), r#"W/"0""#);
+        assert_eq!(result.user_name, "bob");
     }
 
     #[tokio::test]
-    async fn test_update_case_only_rename_does_not_self_conflict() {
+    async fn test_patch_display_name_and_given_name() {
         let mut resource_mock = MockScimResourceProvider::default();
         resource_mock
             .expect_get_index()
@@ -278,22 +415,18 @@ mod tests {
                     .id(id)
                     .domain_id("domain-1")
                     .enabled(true)
-                    .name("Bob")
+                    .name("alice")
                     .build()
                     .unwrap(),
             ))
         });
-        // Case-insensitive lookup matches the resource's own id -- must not
-        // be treated as a collision with another user.
-        identity_mock
-            .expect_find_user_by_name_ci()
-            .returning(|_, _, _| Ok(Some("user-1".to_string())));
         identity_mock.expect_update_user().returning(|_, id, req| {
             Ok(UserResponseBuilder::default()
                 .id(id)
                 .domain_id("domain-1")
                 .enabled(true)
-                .name(req.name.clone().unwrap())
+                .name("alice")
+                .extra(req.extra.clone())
                 .build()
                 .unwrap())
         });
@@ -307,20 +440,106 @@ mod tests {
         )
         .await;
 
-        let (_, Json(result)) = update(
+        let (_, Json(result)) = patch(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("BOB", Some("ext-old"))),
+            Json(ScimPatchRequest {
+                schemas: vec![],
+                operations: vec![
+                    ScimPatchOperation {
+                        op: "replace".to_string(),
+                        path: Some("displayName".to_string()),
+                        value: Value::String("Alice A.".to_string()),
+                    },
+                    ScimPatchOperation {
+                        op: "replace".to_string(),
+                        path: Some("name.givenName".to_string()),
+                        value: Value::String("Alice".to_string()),
+                    },
+                    ScimPatchOperation {
+                        op: "replace".to_string(),
+                        path: Some("name.familyName".to_string()),
+                        value: Value::String("Anderson".to_string()),
+                    },
+                ],
+            }),
         )
         .await
         .unwrap();
-        assert_eq!(result.user_name, "BOB");
+        assert_eq!(result.display_name.as_deref(), Some("Alice A."));
+        assert_eq!(
+            result.name.as_ref().and_then(|n| n.given_name.as_deref()),
+            Some("Alice")
+        );
+        assert_eq!(
+            result.name.as_ref().and_then(|n| n.family_name.as_deref()),
+            Some("Anderson")
+        );
     }
 
     #[tokio::test]
-    async fn test_update_not_owned_returns_404() {
+    async fn test_patch_external_id_remove_rejected() {
+        let mut resource_mock = MockScimResourceProvider::default();
+        resource_mock
+            .expect_get_index()
+            .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
+
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock.expect_get_user().returning(|_, id| {
+            Ok(Some(
+                UserResponseBuilder::default()
+                    .id(id)
+                    .domain_id("domain-1")
+                    .enabled(true)
+                    .name("alice")
+                    .build()
+                    .unwrap(),
+            ))
+        });
+
+        let state = get_mocked_state(
+            Provider::mocked_builder()
+                .mock_identity(identity_mock)
+                .mock_scim_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let result = patch(
+            domain_scoped_auth("domain-1"),
+            Path(("domain-1".to_string(), "user-1".to_string())),
+            State(state),
+            HeaderMap::new(),
+            Json(patch_req("remove", "externalId", Value::Null)),
+        )
+        .await;
+        assert!(matches!(result, Err(ScimApiError::InvalidValue(_))));
+    }
+
+    #[tokio::test]
+    async fn test_patch_rejects_disallowed_path() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let result = patch(
+            domain_scoped_auth("domain-1"),
+            Path(("domain-1".to_string(), "user-1".to_string())),
+            State(state),
+            HeaderMap::new(),
+            Json(patch_req(
+                "replace",
+                r#"emails[type eq "work"].value"#,
+                Value::String("a@b.com".to_string()),
+            )),
+        )
+        .await;
+        assert!(matches!(result, Err(ScimApiError::InvalidPath(_))));
+    }
+
+    #[tokio::test]
+    async fn test_patch_not_owned_returns_404() {
         let mut resource_mock = MockScimResourceProvider::default();
         resource_mock
             .expect_get_index()
@@ -333,72 +552,19 @@ mod tests {
         )
         .await;
 
-        let result = update(
+        let result = patch(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("new_name", None)),
+            Json(patch_req("replace", "active", Value::Bool(false))),
         )
         .await;
         assert!(matches!(
             result,
-            Err(ScimApiError::Api(KeystoneApiError::NotFound { .. }))
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_update_stale_if_match_returns_412() {
-        let mut resource_mock = MockScimResourceProvider::default();
-        resource_mock
-            .expect_get_index()
-            .returning(|_, _, _, _, id| Ok(Some(make_index(id))));
-        resource_mock
-            .expect_update_index()
-            .returning(|_, _, _, _, id, _, _| {
-                Err(
-                    openstack_keystone_core_types::scim::ScimResourceProviderError::VersionMismatch(
-                        format!("stale version for {id}"),
-                    ),
-                )
-            });
-
-        let mut identity_mock = MockIdentityProvider::default();
-        identity_mock.expect_get_user().returning(|_, id| {
-            Ok(Some(
-                UserResponseBuilder::default()
-                    .id(id)
-                    .domain_id("domain-1")
-                    .enabled(true)
-                    .name("old_name")
-                    .build()
-                    .unwrap(),
+            Err(ScimApiError::Api(
+                openstack_keystone_core::api::KeystoneApiError::NotFound { .. }
             ))
-        });
-        identity_mock
-            .expect_find_user_by_name_ci()
-            .returning(|_, _, _| Ok(None));
-
-        let state = get_mocked_state(
-            Provider::mocked_builder()
-                .mock_identity(identity_mock)
-                .mock_scim_resource(resource_mock),
-            true,
-            None,
-        )
-        .await;
-
-        let mut headers = HeaderMap::new();
-        headers.insert("if-match", r#"W/"5""#.parse().unwrap());
-
-        let result = update(
-            domain_scoped_auth("domain-1"),
-            Path(("domain-1".to_string(), "user-1".to_string())),
-            State(state),
-            headers,
-            Json(write_req("new_name", Some("ext-old"))),
-        )
-        .await;
-        assert!(matches!(result, Err(ScimApiError::PreconditionFailed(_))));
+        ));
     }
 }

--- a/crates/keystone/src/scim/user/show.rs
+++ b/crates/keystone/src/scim/user/show.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! `GET /SCIM/v2/{domain_id}/Users/{id}` (ADR 0024 §3.C Ownership Fencing).
 
-use axum::{Json, extract::Path, extract::State};
+use axum::{Json, extract::Path, extract::State, http::HeaderMap};
 use serde_json::json;
 
 use openstack_keystone_core::api::KeystoneApiError;
@@ -23,6 +23,7 @@ use openstack_keystone_core_types::scim::ScimResourceType;
 
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
+use crate::scim::etag::etag_header;
 use crate::scim::types::ScimUser;
 
 /// Fetch `(UserResponse, ScimResourceIndex)` for `id` under the caller's own
@@ -72,7 +73,7 @@ pub(super) async fn show(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     Path((_domain_id, id)): Path<(String, String)>,
     State(state): State<ServiceState>,
-) -> Result<Json<ScimUser>, ScimApiError> {
+) -> Result<(HeaderMap, Json<ScimUser>), ScimApiError> {
     let exec = ExecutionContext::from_auth(&state, &ctx);
     let (user, index) =
         fetch_owned(&state, &exec, &realm.domain_id, &realm.provider_id, &id).await?;
@@ -87,7 +88,14 @@ pub(super) async fn show(
         )
         .await?;
 
-    Ok(Json(ScimUser::from_domain(&user, &index)))
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "etag",
+        etag_header(index.version)
+            .parse()
+            .expect("weak etag is valid header value"),
+    );
+    Ok((headers, Json(ScimUser::from_domain(&user, &index))))
 }
 
 #[cfg(test)]
@@ -180,7 +188,7 @@ mod tests {
         )
         .await;
 
-        let result = show(
+        let (headers, Json(result)) = show(
             domain_scoped_auth("domain-1"),
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
@@ -188,6 +196,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(result.id, "user-1");
+        assert_eq!(headers.get("etag").unwrap(), r#"W/"0""#);
     }
 
     #[tokio::test]

--- a/crates/scim-driver-raft/src/lib.rs
+++ b/crates/scim-driver-raft/src/lib.rs
@@ -449,6 +449,7 @@ impl RaftBackend {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(clippy::too_many_arguments)]
     async fn update_resource_impl(
         &self,
         storage: &dyn StorageApi,
@@ -457,6 +458,7 @@ impl RaftBackend {
         resource_type: ScimResourceType,
         keystone_id: &str,
         data: ScimResourceIndexUpdate,
+        expected_version: Option<u64>,
     ) -> Result<ScimResourceIndex, StoreError> {
         let key = self.get_resource_key_name(domain_id, provider_id, resource_type, keystone_id);
         let curr: StoreDataEnvelope<ScimResourceIndex> = storage
@@ -466,6 +468,20 @@ impl RaftBackend {
                 source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
             })?
             .try_deserialize()?;
+
+        // ADR 0024 §5.E: reject up front if the caller's `If-Match` version
+        // is already stale. This alone doesn't close the race (a concurrent
+        // writer could still land between this check and the CAS write
+        // below) -- the `set_value` violation check after the write is what
+        // actually closes it; this is just the fast, common-case rejection.
+        if let Some(expected) = expected_version
+            && curr.data.version != expected
+        {
+            return Err(StoreError::Conflict {
+                subject: key,
+                description: "ETag precondition failed: version mismatch".to_string(),
+            });
+        }
 
         // Re-claim `externalId` before persisting, if it changed: release
         // the old claim (if any) and atomically claim the new one so two
@@ -507,9 +523,9 @@ impl RaftBackend {
 
         let new = curr.data.with_update(data, Utc::now().timestamp());
         let new_meta = curr.metadata.new_revision();
-        storage
+        let response = storage
             .set_value(
-                key,
+                key.clone(),
                 StoreDataEnvelope {
                     data: rmp_serde::to_vec(&new)?,
                     metadata: new_meta,
@@ -518,6 +534,19 @@ impl RaftBackend {
                 Some(curr.metadata.revision),
             )
             .await?;
+        // `set_value`'s CAS mismatch surfaces as a `violations` entry on an
+        // `Ok` response, not an `Err` -- a concurrent writer that landed
+        // between our read above and this write must be treated the same as
+        // the up-front `expected_version` check, closing the race window
+        // ADR 0024 §5.E requires (this is what actually decides the race;
+        // the up-front check above only rejects the common, already-stale
+        // case cheaply).
+        if !response.violations.is_empty() {
+            return Err(StoreError::Conflict {
+                subject: key,
+                description: "ETag precondition failed: version mismatch".to_string(),
+            });
+        }
         Ok(new)
     }
 }
@@ -606,6 +635,7 @@ impl ScimResourceBackend for RaftBackend {
         resource_type: ScimResourceType,
         keystone_id: &'a str,
         data: ScimResourceIndexUpdate,
+        expected_version: Option<u64>,
     ) -> Result<ScimResourceIndex, ScimResourceProviderError> {
         let raft = state
             .storage
@@ -619,10 +649,14 @@ impl ScimResourceBackend for RaftBackend {
                 resource_type,
                 keystone_id,
                 data,
+                expected_version,
             )
             .await
         {
             Ok(obj) => Ok(obj),
+            Err(StoreError::Conflict { description, .. }) if description.contains("ETag") => {
+                Err(ScimResourceProviderError::VersionMismatch(description))
+            }
             Err(StoreError::Conflict { description, .. }) => {
                 Err(ScimResourceProviderError::Conflict(description))
             }
@@ -1165,11 +1199,89 @@ mod tests {
                     external_id: None,
                     deprovisioned_at: Some(Some(12345)),
                 },
+                None,
             )
             .await
             .unwrap();
         assert_eq!(updated.deprovisioned_at, Some(12345));
         assert_eq!(updated.version, 1);
+    }
+
+    #[tokio::test]
+    async fn test_update_resource_matching_expected_version_succeeds() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_resource_impl(
+                &storage,
+                make_resource_create("domain-1", "provider-1", "user-1", None),
+            )
+            .await
+            .unwrap();
+
+        let updated = backend
+            .update_resource_impl(
+                &storage,
+                "domain-1",
+                "provider-1",
+                ScimResourceType::User,
+                "user-1",
+                ScimResourceIndexUpdate {
+                    external_id: None,
+                    deprovisioned_at: Some(Some(12345)),
+                },
+                Some(0),
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated.version, 1);
+    }
+
+    #[tokio::test]
+    async fn test_update_resource_stale_expected_version_conflicts() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_resource_impl(
+                &storage,
+                make_resource_create("domain-1", "provider-1", "user-1", None),
+            )
+            .await
+            .unwrap();
+
+        // Caller observed version 0, but pass a stale expectation of 7.
+        let result = backend
+            .update_resource_impl(
+                &storage,
+                "domain-1",
+                "provider-1",
+                ScimResourceType::User,
+                "user-1",
+                ScimResourceIndexUpdate {
+                    external_id: None,
+                    deprovisioned_at: Some(Some(12345)),
+                },
+                Some(7),
+            )
+            .await;
+        assert!(matches!(result, Err(StoreError::Conflict { .. })));
+
+        // The row must be untouched by the rejected write.
+        let fetched = backend
+            .get_resource_impl(
+                &storage,
+                "domain-1",
+                "provider-1",
+                ScimResourceType::User,
+                "user-1",
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(fetched.version, 0);
+        assert!(fetched.deprovisioned_at.is_none());
     }
 
     #[tokio::test]
@@ -1196,6 +1308,7 @@ mod tests {
                     external_id: Some(Some("ext-new".to_string())),
                     deprovisioned_at: None,
                 },
+                None,
             )
             .await
             .unwrap();
@@ -1240,6 +1353,7 @@ mod tests {
                     external_id: None,
                     deprovisioned_at: Some(Some(1)),
                 },
+                None,
             )
             .await;
         assert!(result.is_err());

--- a/doc/src/adr/0024-scim-v2-provisioning.md
+++ b/doc/src/adr/0024-scim-v2-provisioning.md
@@ -2,26 +2,33 @@
 
 **Date:** 2026-07-01
 
-**Last-revised:** 2026-07-06 (PR1+PR2+PR3 implementation note)
+**Last-revised:** 2026-07-06 (PR1+PR2+PR3+PR4 implementation note)
 
 ## Status
 
 Proposed
 
 **Implementation note (2026-07-06):** PR1 (Realm Foundation), PR2 (Users
-vertical slice), and PR3 (Groups + membership isolation) have landed. During
-implementation, the realm/user identity design was refined beyond what this
-ADR originally specified: `ScimRealmResource` gained a mandatory `idp_id` link
-to a federation `IdentityProvider`, and a SCIM-provisioned `User`'s `id` is
-derived deterministically rather than server-assigned, so it converges with a
-later federated JIT login for the same person instead of producing a
-duplicate account. §2.A and §4 below have been updated to match the as-built
-behavior; the "Rejected alternative" callout in §4 is revised accordingly.
-`Group`, by contrast, keeps a normal server-assigned `id` and an optional
-`externalId` — nothing federates in *as* a Group, so there is no convergence
-hazard a deterministic id would solve. The filter/PATCH/ETag protocol surface
-(§5.B–E), the janitor purge phase (§6.C), and CLI parity (§12) remain
-unimplemented — this ADR stays `Proposed` until all of it lands.
+vertical slice), PR3 (Groups + membership isolation), and PR4 (Protocol
+Surface Completion — filter grammar, `PATCH`, ETags, discovery endpoints)
+have landed. During implementation, the realm/user identity design was
+refined beyond what this ADR originally specified: `ScimRealmResource` gained
+a mandatory `idp_id` link to a federation `IdentityProvider`, and a
+SCIM-provisioned `User`'s `id` is derived deterministically rather than
+server-assigned, so it converges with a later federated JIT login for the
+same person instead of producing a duplicate account. §2.A and §4 below have
+been updated to match the as-built behavior; the "Rejected alternative"
+callout in §4 is revised accordingly. `Group`, by contrast, keeps a normal
+server-assigned `id` and an optional `externalId` — nothing federates in *as*
+a Group, so there is no convergence hazard a deterministic id would solve.
+§5's filter/PATCH/ETag design matches the as-built PR4 behavior as written,
+with one addition worth noting here: closing the ETag CAS guarantee (§5.E)
+required fixing a latent bug in the storage driver's compare-and-swap path
+that predates PR4 (a concurrent-write violation was detected by the store but
+never surfaced to the caller) — `ScimResourceIndex.version` now bumps on
+every `PUT`/`PATCH`, not only ones that change `externalId`, so the ETag is
+meaningful on every write. The janitor purge phase (§6.C) and CLI parity
+(§12) remain unimplemented — this ADR stays `Proposed` until both land.
 
 ## Reference
 


### PR DESCRIPTION
Bring Users and Groups up to the ADR 0024 §5 pragmatic RFC 7644 subset:
filter grammar, PATCH, ETags/If-Match, and discovery endpoints. This is
the first PR where Users and Groups share infrastructure directly.

Filter grammar (scim/filter.rs): homogeneous and/or chains,
eq/ne/co/sw/pr operators, 512-byte/8-term caps, separate User/Group
attribute allowlists.  Invalid filters reject with 400/invalidFilter
before any resource lookup.  Wired into both list.rs handlers;
evaluating co/sw against userName or displayName requires hydrating the
realm's whole active resource set up front (those attributes live on the
core Identity row, not the index), still bounded to one realm's resource
count per §5.D.

PATCH (scim/patch.rs + user|group/patch.rs): Operations[].path validated
against a fixed per-resource allowlist, rejecting complex
filter/array-index expressions with 400/invalidPath. Group members PATCH
is add/remove only, not replace. Reuses the existing
identity/scim/{user,group}/update OPA policies rather than adding new
ones, since PATCH is an alternate write mechanism for the same
authorization concern PUT already enforces.

ETags/If-Match (scim/etag.rs, ADR §5.E): ScimResourceIndex.version now
bumps on every PUT/PATCH unconditionally, not only writes touching
externalId, so the ETag means something on every write. Fixed a latent
bug in the storage driver along the way: update_resource_impl called
set_value with an expected_revision CAS but never checked the returned
violations, so a concurrent writer landing between read and write would
silently "succeed" from the caller's perspective despite losing the
race.  ScimResourceBackend::update/ScimResourceApi::update_index gained
an expected_version parameter; a new VersionMismatch error variant maps
to 412 Precondition Failed.

Discovery endpoints (scim/discovery.rs): static ServiceProviderConfig,
Schemas, and ResourceTypes documents, mounted without ScimRealmAuth
since they're protocol metadata Okta/Entra probe before presenting
credentials.

Also fixes a parity bug: Users' list.rs had the same total_results/
items_per_page miscount PR3's Groups list.rs had already fixed
independently; both now agree.

Assisted--by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
