### PR TITLE
fix: unify ApiClient scope validation, fix nextest filter

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,8 +1,8 @@
 experimental = ["setup-scripts"]
 
 [profile.default]
-# exclude raft-only tests
-default-filter = 'not test(/spiffe/) and not test(/mapping/) and not test(/test_cluster/) and not test(/api_key/)'
+# exclude raft-only tests from the integration test binary only
+default-filter = 'not (binary(integration) and (test(/spiffe/) or test(/mapping/) or test(/test_cluster/) or test(/api_key/)))'
 # Global default settings
 #
 [scripts.setup.setup-pg]

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -330,11 +330,6 @@ impl From<MappingProviderError> for KeystoneApiError {
             MappingProviderError::ApiClientNonDomainScopeForbidden(x) => Self::BadRequest(format!(
                 "rule '{x}' grants a non-domain scope, which is forbidden for API Key (ApiClient) mapping rulesets (only domain scope is accepted)"
             )),
-            MappingProviderError::ScimRealmProjectScopeForbidden(x) => {
-                Self::UnprocessableEntity(format!(
-                    "rule '{x}' grants project scope, which is forbidden for a mapping ruleset bound to an active SCIM realm"
-                ))
-            }
             MappingProviderError::RoleNotFound(x) => Self::UnprocessableEntity(format!(
                 "rule references role '{x}' which does not exist"
             )),

--- a/crates/core-types/src/mapping/error.rs
+++ b/crates/core-types/src/mapping/error.rs
@@ -159,16 +159,6 @@ pub enum MappingProviderError {
         "rule '{0}' grants a non-domain scope, which is forbidden for API Key (ApiClient) mapping rulesets (only domain scope is accepted)"
     )]
     ApiClientNonDomainScopeForbidden(String),
-    /// A ruleset whose `provider_id` has an active SCIM realm (ADR 0024)
-    /// granted `Authorization::Project`, which is prohibited at write-time:
-    /// a SCIM realm's `ScimRealmAuth` extractor requires Domain-only scope
-    /// (ADR 0024 §2.C), so a Project-scoped rule sharing the same
-    /// `provider_id` would make realm authorization flap unpredictably
-    /// between pass/403 depending on which rule matched.
-    #[error(
-        "rule '{0}' grants project scope, which is forbidden for a mapping ruleset bound to an active SCIM realm (ADR 0024 \u{a7}2.C)"
-    )]
-    ScimRealmProjectScopeForbidden(String),
 
     /// A rule's `Authorization` granted a `RoleRef` whose `id` does not
     /// correspond to any existing `Role`. `RoleRef.id` is mandatory (unlike

--- a/crates/core/src/mapping/service.rs
+++ b/crates/core/src/mapping/service.rs
@@ -45,56 +45,6 @@ use crate::mapping::{
 };
 use crate::plugin_manager::PluginManagerApi;
 
-/// Reject `Authorization::Project` entries in a ruleset whose `source` is
-/// `IdentitySource::ApiClient` and whose `provider_id` has an active
-/// `ScimRealmResource` (ADR 0024 §2.C write-time ruleset constraint).
-///
-/// Mirrors `validate_api_client_no_system_scope`'s defense-in-depth
-/// rationale (ADR 0021 §6.C): `ScimRealmAuth` already enforces Domain-only
-/// scope at authentication time, but nothing stops an operator from adding a
-/// `Project`-scoped rule to the same ruleset for an unrelated claim match,
-/// which would make that enforcement flap unpredictably per-request. A
-/// realm lookup is required (async), so this check lives here rather than
-/// in the synchronous `validation` module.
-async fn validate_scim_realm_no_project_scope<'a>(
-    ctx: &ExecutionContext<'a>,
-    domain_id: Option<&str>,
-    source: &IdentitySource,
-    rules: &[MappingRule],
-) -> Result<(), MappingProviderError> {
-    let IdentitySource::ApiClient { provider_id } = source else {
-        return Ok(());
-    };
-    let Some(domain_id) = domain_id else {
-        return Ok(());
-    };
-    let realm = ctx
-        .state()
-        .provider
-        .get_scim_realm_provider()
-        .get_realm(ctx, domain_id, provider_id)
-        .await
-        .map_err(MappingProviderError::driver)?;
-    let Some(realm) = realm else {
-        return Ok(());
-    };
-    if !realm.enabled {
-        return Ok(());
-    }
-    for rule in rules {
-        if rule
-            .authorizations
-            .iter()
-            .any(|auth| matches!(auth, Authorization::Project { .. }))
-        {
-            return Err(MappingProviderError::ScimRealmProjectScopeForbidden(
-                rule.name.clone(),
-            ));
-        }
-    }
-    Ok(())
-}
-
 /// Reject any `RoleRef` in a rule's
 /// `Authorization::{Project,Domain,System}.roles` whose `id` does not
 /// correspond to an existing `Role`.
@@ -714,13 +664,7 @@ impl MappingApi for MappingService {
         mut ruleset: MappingRuleSetCreate,
     ) -> Result<MappingRuleSet, MappingProviderError> {
         validation::validate_ruleset_create(&ruleset)?;
-        validate_scim_realm_no_project_scope(
-            ctx,
-            ruleset.domain_id.as_deref(),
-            &ruleset.source,
-            &ruleset.rules,
-        )
-        .await?;
+        validation::validate_api_client_domain_scope(&ruleset.source, &ruleset.rules)?;
         validate_roles_exist(ctx, &ruleset.rules).await?;
         let mapping_id = ruleset
             .mapping_id
@@ -1074,7 +1018,7 @@ impl MappingApi for MappingService {
 
         // 4. Re-validate the resulting ruleset
         let create_payload = MappingRuleSetCreate {
-            mapping_id: Some(existing.mapping_id.clone()),
+            mapping_id: Some(mapping_id.to_string()),
             domain_id: existing.domain_id.clone(),
             source: existing.source.clone(),
             domain_resolution_mode: existing.domain_resolution_mode.clone(),
@@ -1083,13 +1027,7 @@ impl MappingApi for MappingService {
         };
         validation::validate_ruleset_create(&create_payload)?;
 
-        validate_scim_realm_no_project_scope(
-            ctx,
-            existing.domain_id.as_deref(),
-            &existing.source,
-            &create_payload.rules,
-        )
-        .await?;
+        validation::validate_api_client_domain_scope(&existing.source, &create_payload.rules)?;
         validate_roles_exist(ctx, &create_payload.rules).await?;
 
         // 5. Compute new version
@@ -1171,13 +1109,7 @@ impl MappingApi for MappingService {
 
         let merged_rules = data.rules.clone().unwrap_or(existing.rules.clone());
 
-        validate_scim_realm_no_project_scope(
-            ctx,
-            existing.domain_id.as_deref(),
-            &existing.source,
-            &merged_rules,
-        )
-        .await?;
+        validation::validate_api_client_domain_scope(&existing.source, &merged_rules)?;
         validate_roles_exist(ctx, &merged_rules).await?;
 
         let new_version = version::compute_ruleset_version_from_parts(
@@ -1559,29 +1491,8 @@ mod tests {
     // ---------------------------------------------------------------------
 
     #[tokio::test]
-    async fn test_create_ruleset_rejects_project_scope_for_active_scim_realm() {
-        let mut scim_realm_mock = crate::scim_realm::MockScimRealmProvider::default();
-        scim_realm_mock
-            .expect_get_realm()
-            .withf(|_, domain_id, provider_id| {
-                domain_id == "domain-1" && provider_id == "provider-1"
-            })
-            .returning(|_, _, _| {
-                Ok(Some(
-                    openstack_keystone_core_types::scim::ScimRealmResource {
-                        domain_id: "domain-1".to_string(),
-                        provider_id: "provider-1".to_string(),
-                        idp_id: "idp-1".to_string(),
-                        display_name: "Okta".to_string(),
-                        enabled: true,
-                        created_at: 0,
-                        updated_at: 0,
-                    },
-                ))
-            });
-        let provider = crate::provider::Provider::mocked_builder().mock_scim_realm(scim_realm_mock);
-        let state = get_mocked_state(None, Some(provider)).await;
-
+    async fn test_create_ruleset_rejects_project_scope_for_api_client() {
+        let state = get_mocked_state(None, None).await;
         let mock_backend = MockMappingBackend::new();
         let service = MappingService::from_driver(mock_backend);
 
@@ -1602,72 +1513,14 @@ mod tests {
 
         assert!(matches!(
             result.unwrap_err(),
-            MappingProviderError::ScimRealmProjectScopeForbidden(name) if name == "grant-project"
+            MappingProviderError::ApiClientNonDomainScopeForbidden(name) if name == "grant-project"
         ));
     }
 
     #[tokio::test]
-    async fn test_create_ruleset_allows_project_scope_when_realm_disabled() {
-        let mut scim_realm_mock = crate::scim_realm::MockScimRealmProvider::default();
-        scim_realm_mock.expect_get_realm().returning(|_, _, _| {
-            Ok(Some(
-                openstack_keystone_core_types::scim::ScimRealmResource {
-                    domain_id: "domain-1".to_string(),
-                    provider_id: "provider-1".to_string(),
-                    idp_id: "idp-1".to_string(),
-                    display_name: "Okta".to_string(),
-                    enabled: false,
-                    created_at: 0,
-                    updated_at: 0,
-                },
-            ))
-        });
-        let provider = crate::provider::Provider::mocked_builder().mock_scim_realm(scim_realm_mock);
-        let state = get_mocked_state(None, Some(provider)).await;
-
-        let mut mock_backend = MockMappingBackend::new();
-        let ruleset_create = MappingRuleSetCreate {
-            mapping_id: None,
-            domain_id: Some("domain-1".to_string()),
-            source: IdentitySource::ApiClient {
-                provider_id: "provider-1".to_string(),
-            },
-            domain_resolution_mode: DomainResolutionMode::Fixed,
-            enabled: true,
-            rules: vec![project_scope_rule()],
-        };
-        let expected = MappingRuleSet {
-            mapping_id: "generated-id".to_string(),
-            domain_id: ruleset_create.domain_id.clone(),
-            source: ruleset_create.source.clone(),
-            domain_resolution_mode: ruleset_create.domain_resolution_mode.clone(),
-            enabled: ruleset_create.enabled,
-            rules: ruleset_create.rules.clone(),
-            ruleset_version: 1,
-        };
-        let expected_clone = expected.clone();
-        mock_backend
-            .expect_create_ruleset()
-            .returning(move |_, _| Ok(expected_clone.clone()));
-
-        let service = MappingService::from_driver(mock_backend);
-
-        let result = service
-            .create_ruleset(&ExecutionContext::internal(&state), ruleset_create)
-            .await;
-
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
     async fn test_create_ruleset_allows_project_scope_for_federation_source() {
-        // Non-ApiClient sources are never subject to the SCIM realm
-        // constraint — the realm provider must not even be consulted.
-        let mut scim_realm_mock = crate::scim_realm::MockScimRealmProvider::default();
-        scim_realm_mock.expect_get_realm().never();
-        let provider = crate::provider::Provider::mocked_builder().mock_scim_realm(scim_realm_mock);
-        let state = get_mocked_state(None, Some(provider)).await;
-
+        // Non-ApiClient sources are not subject to domain-scope constraints.
+        let state = get_mocked_state(None, None).await;
         let mut mock_backend = MockMappingBackend::new();
         let ruleset_create = MappingRuleSetCreate {
             mapping_id: None,
@@ -1703,23 +1556,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_ruleset_rejects_project_scope_for_active_scim_realm() {
-        let mut scim_realm_mock = crate::scim_realm::MockScimRealmProvider::default();
-        scim_realm_mock.expect_get_realm().returning(|_, _, _| {
-            Ok(Some(
-                openstack_keystone_core_types::scim::ScimRealmResource {
-                    domain_id: "domain-1".to_string(),
-                    provider_id: "provider-1".to_string(),
-                    idp_id: "idp-1".to_string(),
-                    display_name: "Okta".to_string(),
-                    enabled: true,
-                    created_at: 0,
-                    updated_at: 0,
-                },
-            ))
-        });
-        let provider = crate::provider::Provider::mocked_builder().mock_scim_realm(scim_realm_mock);
-        let state = get_mocked_state(None, Some(provider)).await;
+    async fn test_update_ruleset_rejects_project_scope_for_api_client() {
+        let state = get_mocked_state(None, None).await;
 
         let mapping_id = "test-id";
         let mut mock_backend = MockMappingBackend::new();
@@ -1754,7 +1592,7 @@ mod tests {
 
         assert!(matches!(
             result.unwrap_err(),
-            MappingProviderError::ScimRealmProjectScopeForbidden(name) if name == "grant-project"
+            MappingProviderError::ApiClientNonDomainScopeForbidden(name) if name == "grant-project"
         ));
     }
 

--- a/crates/core/src/mapping/validation.rs
+++ b/crates/core/src/mapping/validation.rs
@@ -62,11 +62,7 @@ pub fn validate_ruleset_create(ruleset: &MappingRuleSetCreate) -> Result<(), Map
     // 1. Rule name uniqueness and format
     validate_rules(&ruleset.rules)?;
 
-    // API Key (ApiClient) rulesets must never grant system scope (ADR 0021
-    // §6.C, Invariant 3 defense-in-depth).
-    validate_api_client_no_system_scope(&ruleset.source, &ruleset.rules)?;
-
-    // 2. Regex safety for all `MatchesRegex` conditions
+    // Regex safety for all `MatchesRegex` conditions
     let all_conditions = collect_all_claim_conditions(&ruleset.rules);
     for cc in &all_conditions {
         if let Some(pattern) = cc.regex_pattern() {
@@ -74,10 +70,10 @@ pub fn validate_ruleset_create(ruleset: &MappingRuleSetCreate) -> Result<(), Map
         }
     }
 
-    // 3. Template safety — no `enclosing_domain_id` shadowing
+    // Template safety — no `enclosing_domain_id` shadowing
     validate_identity_templates(&ruleset.rules, &ruleset.domain_resolution_mode)?;
 
-    // 4. Domain resolution mode consistency
+    // Domain resolution mode consistency
     validate_domain_resolution_mode(
         &ruleset.domain_resolution_mode,
         &ruleset.rules,
@@ -105,11 +101,6 @@ pub fn validate_ruleset_update(
     // If new rules are supplied, validate them
     if let Some(ref rules) = update.rules {
         validate_rules(rules)?;
-
-        // API Key (ApiClient) rulesets must never grant system scope (ADR
-        // 0021 §6.C, Invariant 3 defense-in-depth). `source` is immutable, so
-        // always validated against `existing.source`.
-        validate_api_client_no_system_scope(&existing.source, rules)?;
 
         // Regex safety
         let all_conditions = collect_all_claim_conditions(rules);
@@ -220,19 +211,13 @@ fn validate_rules(rules: &[MappingRule]) -> Result<(), MappingProviderError> {
     Ok(())
 }
 
-/// Reject `is_system`/`Authorization::System` grants, and enforce a
-/// domain-scope-only allowlist for every other authorization, in any rule of
-/// a ruleset sourced from an API Key (`IdentitySource::ApiClient`) provider.
+/// Enforce that ApiClient-sourced rulesets only grant Domain scope.
 ///
-/// Per ADR 0021 §6.C, allowing an API Key to hold system scope is dangerous
-/// enough that the prohibition is enforced at both write-time (here) and at
-/// authentication time (`hydrate_ephemeral_context`); this check is
-/// defense-in-depth, not a substitute for the runtime guard. By design, API
-/// Keys are domain-owned machine identities (§2), so once system scope is
-/// excluded, every remaining authorization MUST be `Authorization::Domain`
-/// -- this is an allowlist, not a denylist naming each forbidden variant, so
-/// it also covers any authorization type added in the future.
-fn validate_api_client_no_system_scope(
+/// Per ADR 0021 §6.C, allowing an API Key to hold system scope is dangerous.
+/// Per ADR 0021 §2, API Keys are domain-owned machine identities, so only
+/// `Authorization::Domain` is allowed. Both checks are combined in a single
+/// pass and return the most specific error.
+pub fn validate_api_client_domain_scope(
     source: &IdentitySource,
     rules: &[MappingRule],
 ) -> Result<(), MappingProviderError> {
@@ -1461,7 +1446,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // validate_api_client_no_system_scope tests (ADR 0021 §6.C)
+    // validate_api_client_domain_scope tests (ADR 0021 §6.C)
     // -----------------------------------------------------------------------
 
     fn api_client_source() -> IdentitySource {
@@ -1487,12 +1472,8 @@ mod tests {
 
     #[test]
     fn api_client_ruleset_rejects_is_system() {
-        let ruleset = MappingRuleSetCreate {
-            source: api_client_source(),
-            rules: vec![rule_with_is_system("system-rule")],
-            ..sample_ruleset_create()
-        };
-        let result = validate_ruleset_create(&ruleset);
+        let rules = vec![rule_with_is_system("system-rule")];
+        let result = validate_api_client_domain_scope(&api_client_source(), &rules);
         assert!(matches!(
             result,
             Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "system-rule"
@@ -1501,12 +1482,8 @@ mod tests {
 
     #[test]
     fn api_client_ruleset_rejects_system_authorization() {
-        let ruleset = MappingRuleSetCreate {
-            source: api_client_source(),
-            rules: vec![rule_with_system_authorization("system-auth-rule")],
-            ..sample_ruleset_create()
-        };
-        let result = validate_ruleset_create(&ruleset);
+        let rules = vec![rule_with_system_authorization("system-auth-rule")];
+        let result = validate_api_client_domain_scope(&api_client_source(), &rules);
         assert!(matches!(
             result,
             Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "system-auth-rule"
@@ -1526,21 +1503,8 @@ mod tests {
 
     #[test]
     fn api_client_ruleset_update_rejects_is_system() {
-        let existing = MappingRuleSet {
-            mapping_id: "test-123".to_string(),
-            domain_id: Some("test-domain".to_string()),
-            source: api_client_source(),
-            domain_resolution_mode: DomainResolutionMode::Fixed,
-            enabled: true,
-            rules: vec![simple_rule("existing-rule", "user-exists")],
-            ruleset_version: 0,
-        };
-        let update = MappingRuleSetUpdate {
-            rules: Some(vec![rule_with_is_system("new-system-rule")]),
-            enabled: None,
-            allowed_domains: None,
-        };
-        let result = validate_ruleset_update(&existing, &update);
+        let rules = vec![rule_with_is_system("new-system-rule")];
+        let result = validate_api_client_domain_scope(&api_client_source(), &rules);
         assert!(matches!(
             result,
             Err(MappingProviderError::ApiClientSystemScopeForbidden(ref name)) if name == "new-system-rule"
@@ -1563,12 +1527,8 @@ mod tests {
         // domain-scoped authorization is accepted (allowlist, not a denylist
         // naming each forbidden variant). Exercised here with Project, but
         // the guard applies to any non-Domain authorization.
-        let ruleset = MappingRuleSetCreate {
-            source: api_client_source(),
-            rules: vec![rule_with_project_authorization("project-auth-rule")],
-            ..sample_ruleset_create()
-        };
-        let result = validate_ruleset_create(&ruleset);
+        let rules = vec![rule_with_project_authorization("project-auth-rule")];
+        let result = validate_api_client_domain_scope(&api_client_source(), &rules);
         assert!(matches!(
             result,
             Err(MappingProviderError::ApiClientNonDomainScopeForbidden(ref name)) if name == "project-auth-rule"
@@ -1588,21 +1548,8 @@ mod tests {
 
     #[test]
     fn api_client_ruleset_update_rejects_non_domain_scope() {
-        let existing = MappingRuleSet {
-            mapping_id: "test-123".to_string(),
-            domain_id: Some("test-domain".to_string()),
-            source: api_client_source(),
-            domain_resolution_mode: DomainResolutionMode::Fixed,
-            enabled: true,
-            rules: vec![simple_rule("existing-rule", "user-exists")],
-            ruleset_version: 0,
-        };
-        let update = MappingRuleSetUpdate {
-            rules: Some(vec![rule_with_project_authorization("new-project-rule")]),
-            enabled: None,
-            allowed_domains: None,
-        };
-        let result = validate_ruleset_update(&existing, &update);
+        let rules = vec![rule_with_project_authorization("new-project-rule")];
+        let result = validate_api_client_domain_scope(&api_client_source(), &rules);
         assert!(matches!(
             result,
             Err(MappingProviderError::ApiClientNonDomainScopeForbidden(ref name)) if name == "new-project-rule"


### PR DESCRIPTION
ApiClient-sourced rulesets must only grant Domain scope. Unify
validate_api_client_no_system_scope and
validate_api_client_no_non_domain_ scope into a single
validate_api_client_domain_scope function that checks both in one pass.
System scope and all non-Domain scopes (project, etc.) are always
rejected regardless of SCIM realm state.

Remove the SCIM realm-aware async validation path from the service layer
and replace with the synchronous unified validator.

Also fix nextest default-filter to scope exclusions to the integration
test binary only, preventing workspace-wide test filtering. This filter
was causing mapping tests to be silently not selected unless a package
test was requested.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
