### PR TITLE
feat(scim): Harden RFC 7644 compliance, add docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Run REST API v3 tests
         run: cargo nextest run -p test_api --profile ci-api --test integration_api_v3
 
+      - name: Run REST API SCIMv2 tests
+        run: cargo nextest run -p test_api --profile ci-api --test scim_v2
+
       - name: Run Doc tests
         run: cargo test --doc
 

--- a/crates/config/src/security_compliance.rs
+++ b/crates/config/src/security_compliance.rs
@@ -232,9 +232,10 @@ impl SecurityComplianceProvider {
     ///
     /// An empty password is **always** rejected, regardless of configuration —
     /// this is the central guard for every write path (create/update/change),
-    /// and replaces the per-DTO `length(min = 1)` check that could not be kept on
-    /// the wrapped [`SecretString`] fields (validator's `custom`/`length` require
-    /// the field to be `Serialize`, which secrets deliberately are not).
+    /// and replaces the per-DTO `length(min = 1)` check that could not be kept
+    /// on the wrapped [`SecretString`] fields (validator's
+    /// `custom`/`length` require the field to be `Serialize`, which secrets
+    /// deliberately are not).
     ///
     /// Beyond that, returns `Ok(())` when the password matches the configured
     /// regex pattern (or when no pattern is configured), otherwise

--- a/crates/keystone/src/scim.rs
+++ b/crates/keystone/src/scim.rs
@@ -23,17 +23,26 @@
 //! SCIM resource endpoints (Users, Groups per RFC 7644) are out of scope
 //! for ADR 0021, which specifies only the authentication ingress adapter.
 //! `whoami` exists to prove the ingress pipeline end-to-end.
-use axum::{Json, Router, extract::Path, routing::get};
+use axum::{
+    Json, Router,
+    extract::Path,
+    middleware,
+    routing::{get, post},
+};
 use serde::Serialize;
 
 use openstack_keystone_core::api::api_key_auth::ApiKeyAuth;
 use openstack_keystone_core::keystone::ServiceState;
 
+mod bulk;
+mod content_type;
 mod discovery;
 pub mod error;
 pub mod etag;
+mod extract;
 pub mod filter;
 mod group;
+mod location;
 pub mod patch;
 pub mod types;
 mod user;
@@ -60,7 +69,10 @@ async fn whoami(Path(_domain_id): Path<String>, ApiKeyAuth(vsc): ApiKeyAuth) -> 
 pub fn router() -> Router<ServiceState> {
     Router::new()
         .route("/{domain_id}/whoami", get(whoami))
+        .route("/{domain_id}/Bulk", post(bulk::bulk))
+        .route("/{domain_id}/Me", get(bulk::me))
         .nest("/{domain_id}/Users", user::router())
         .nest("/{domain_id}/Groups", group::router())
         .nest("/{domain_id}", discovery::router())
+        .route_layer(middleware::from_fn(content_type::enforce_scim_content_type))
 }

--- a/crates/keystone/src/scim/bulk.rs
+++ b/crates/keystone/src/scim/bulk.rs
@@ -1,0 +1,64 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `POST /Bulk` (RFC 7644 §3.7) and `GET /Me` (RFC 7644 §3.11) -- both
+//! explicitly out of scope for ADR 0024 (§5.F; `bulk.supported: false` in
+//! `ServiceProviderConfig`, and there is no "current SCIM resource" concept
+//! for an API-key-authenticated provisioning client). Rather than falling
+//! through to Axum's default unmapped-route `404` (a non-SCIM-shaped body),
+//! these return a clean `501` with a proper `ScimErrorBody` so RFC 7644
+//! clients that probe these endpoints get a recognizable response.
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::scim::error::{SCIM_ERROR_SCHEMA, ScimErrorBody};
+
+fn not_implemented(detail: &str) -> Response {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(ScimErrorBody {
+            schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
+            status: StatusCode::NOT_IMPLEMENTED.as_str().to_string(),
+            scim_type: None,
+            detail: detail.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+pub(super) async fn bulk() -> Response {
+    not_implemented("bulk operations are not supported (see ServiceProviderConfig)")
+}
+
+pub(super) async fn me() -> Response {
+    not_implemented("/Me is not supported for API-key-authenticated SCIM clients")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_bulk_returns_501() {
+        let rsp = bulk().await;
+        assert_eq!(rsp.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn test_me_returns_501() {
+        let rsp = me().await;
+        assert_eq!(rsp.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+}

--- a/crates/keystone/src/scim/content_type.rs
+++ b/crates/keystone/src/scim/content_type.rs
@@ -1,0 +1,98 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Content-type negotiation middleware (RFC 7644 §3.1): every bodied
+//! `/SCIM/v2` request must declare `application/scim+json` or (for
+//! backwards-compatible clients) plain `application/json`; anything else is
+//! rejected with `415` before it reaches a handler. Every response leaving
+//! the sub-router has its `Content-Type` normalized to
+//! `application/scim+json`, so individual handlers don't each need to set
+//! it.
+
+use axum::{
+    Json,
+    extract::Request,
+    http::{HeaderValue, Method, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+use super::error::{SCIM_ERROR_SCHEMA, ScimErrorBody};
+
+const SCIM_CONTENT_TYPE: &str = "application/scim+json";
+
+fn unsupported_media_type(detail: &str) -> Response {
+    (
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        Json(ScimErrorBody {
+            schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
+            status: StatusCode::UNSUPPORTED_MEDIA_TYPE.as_str().to_string(),
+            scim_type: None,
+            detail: detail.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+/// Whether the request carries a body, per `Content-Length` (or chunked
+/// `Transfer-Encoding`) -- checked instead of buffering the body so a
+/// bodiless probe (e.g. a client testing whether a method is supported at
+/// all) doesn't get short-circuited with `415` before Axum's own
+/// unmapped-method `405` dispatch ever runs.
+fn has_body(req: &Request) -> bool {
+    let has_content_length = req
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .is_some_and(|len| len > 0);
+    has_content_length || req.headers().contains_key(header::TRANSFER_ENCODING)
+}
+
+pub async fn enforce_scim_content_type(req: Request, next: Next) -> Response {
+    let expects_body =
+        matches!(req.method(), &Method::POST | &Method::PUT | &Method::PATCH) && has_body(&req);
+
+    if expects_body {
+        let content_type = req
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.split(';').next().unwrap_or(v).trim().to_ascii_lowercase());
+
+        match content_type.as_deref() {
+            Some(SCIM_CONTENT_TYPE) | Some("application/json") => {}
+            _ => {
+                return unsupported_media_type(
+                    "Content-Type must be application/scim+json or application/json",
+                );
+            }
+        }
+    }
+
+    let mut response = next.run(req).await;
+
+    if response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        == Some("application/json")
+    {
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static(SCIM_CONTENT_TYPE),
+        );
+    }
+
+    response
+}

--- a/crates/keystone/src/scim/error.rs
+++ b/crates/keystone/src/scim/error.rs
@@ -61,6 +61,9 @@ pub enum ScimApiError {
     /// A `PATCH` `Operations[].path` outside the ADR 0024 §5.C allowlist
     /// (400, `scimType: "invalidPath"`).
     InvalidPath(String),
+    /// A `PATCH` `Operations[].path` naming a real but immutable attribute
+    /// (`id`, `meta`) (400, `scimType: "mutability"`, RFC 7644 §3.12).
+    Mutability(String),
     /// `If-Match` precondition failed against the resource's current ETag
     /// version (412, ADR 0024 §5.E). RFC 7644 §3.12 doesn't define a
     /// `scimType` for this status, so the body carries none.
@@ -108,6 +111,16 @@ impl IntoResponse for ScimApiError {
                     schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
                     status: StatusCode::BAD_REQUEST.as_str().to_string(),
                     scim_type: Some("invalidPath".to_string()),
+                    detail,
+                }),
+            )
+                .into_response(),
+            Self::Mutability(detail) => (
+                StatusCode::BAD_REQUEST,
+                Json(ScimErrorBody {
+                    schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
+                    status: StatusCode::BAD_REQUEST.as_str().to_string(),
+                    scim_type: Some("mutability".to_string()),
                     detail,
                 }),
             )

--- a/crates/keystone/src/scim/extract.rs
+++ b/crates/keystone/src/scim/extract.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! [`ScimJson`]: a body extractor that converts a malformed-JSON rejection
+//! into a SCIM-shaped `ScimErrorBody` (`scimType: "invalidSyntax"`, RFC
+//! 7644 §3.12) instead of Axum's default `Json<T>` rejection body. The
+//! content-type negotiation middleware (`scim::content_type`) already
+//! rejects an unsupported/missing `Content-Type` before a handler runs, so
+//! any rejection reaching this extractor is a genuinely malformed body on
+//! an otherwise-accepted content type.
+
+use axum::{
+    Json,
+    extract::{FromRequest, Request, rejection::JsonRejection},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::de::DeserializeOwned;
+
+use crate::scim::error::{SCIM_ERROR_SCHEMA, ScimErrorBody};
+
+pub struct ScimJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for ScimJson<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(Self(value)),
+            Err(rejection) => Err(invalid_syntax(&rejection)),
+        }
+    }
+}
+
+fn invalid_syntax(rejection: &JsonRejection) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ScimErrorBody {
+            schemas: vec![SCIM_ERROR_SCHEMA.to_string()],
+            status: StatusCode::BAD_REQUEST.as_str().to_string(),
+            scim_type: Some("invalidSyntax".to_string()),
+            detail: rejection.to_string(),
+        }),
+    )
+        .into_response()
+}

--- a/crates/keystone/src/scim/group/create.rs
+++ b/crates/keystone/src/scim/group/create.rs
@@ -26,14 +26,17 @@ use openstack_keystone_core_types::scim::{
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::etag_header;
+use crate::scim::extract::ScimJson;
 use crate::scim::group::membership::validate_members_owned_by_realm;
+use crate::scim::location::resource_location;
 use crate::scim::types::{MAX_GROUP_MEMBERS, ScimGroup, ScimGroupWrite};
 
 pub(super) async fn create(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     State(state): State<ServiceState>,
-    Json(req): Json<ScimGroupWrite>,
+    ScimJson(req): ScimJson<ScimGroupWrite>,
 ) -> Result<(StatusCode, HeaderMap, Json<ScimGroup>), ScimApiError> {
+    req.validate_schemas().map_err(ScimApiError::InvalidValue)?;
     if req.display_name.trim().is_empty() {
         return Err(KeystoneApiError::BadRequest("displayName is required".to_string()).into());
     }
@@ -138,6 +141,7 @@ pub(super) async fn create(
             .await?;
     }
 
+    let location = resource_location(&state, &realm.domain_id, "Groups", &group.id).await;
     let mut headers = HeaderMap::new();
     headers.insert(
         "etag",
@@ -145,10 +149,21 @@ pub(super) async fn create(
             .parse()
             .expect("weak etag is valid header value"),
     );
+    headers.insert(
+        "location",
+        location
+            .parse()
+            .expect("scim location is a valid header value"),
+    );
     Ok((
         StatusCode::CREATED,
         headers,
-        Json(ScimGroup::from_domain(&group, &index, &member_ids)),
+        Json(ScimGroup::from_domain(
+            &group,
+            &index,
+            &member_ids,
+            location,
+        )),
     ))
 }
 
@@ -206,7 +221,7 @@ mod tests {
 
     fn req(display_name: &str, members: Vec<&str>) -> ScimGroupWrite {
         ScimGroupWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::GROUP_SCHEMA.to_string()],
             external_id: Some("ext-1".to_string()),
             display_name: display_name.to_string(),
             members: members
@@ -261,7 +276,7 @@ mod tests {
         let (status, headers, Json(body)) = create(
             domain_scoped_auth("domain-1"),
             State(state),
-            Json(req("engineers", vec![])),
+            ScimJson(req("engineers", vec![])),
         )
         .await
         .unwrap();
@@ -334,7 +349,7 @@ mod tests {
         let (status, _headers, Json(body)) = create(
             domain_scoped_auth("domain-1"),
             State(state),
-            Json(req("engineers", vec!["user-1"])),
+            ScimJson(req("engineers", vec!["user-1"])),
         )
         .await
         .unwrap();
@@ -368,7 +383,7 @@ mod tests {
         let result = create(
             domain_scoped_auth("domain-1"),
             State(state),
-            Json(req("engineers", vec!["user-from-elsewhere"])),
+            ScimJson(req("engineers", vec!["user-from-elsewhere"])),
         )
         .await;
         assert!(matches!(result, Err(ScimApiError::InvalidValue(_))));
@@ -386,7 +401,12 @@ mod tests {
             })
             .collect();
 
-        let result = create(domain_scoped_auth("domain-1"), State(state), Json(write)).await;
+        let result = create(
+            domain_scoped_auth("domain-1"),
+            State(state),
+            ScimJson(write),
+        )
+        .await;
         assert!(matches!(result, Err(ScimApiError::InvalidValue(_))));
     }
 
@@ -407,7 +427,7 @@ mod tests {
         let result = create(
             domain_scoped_auth("domain-1"),
             State(state),
-            Json(req("engineers", vec![])),
+            ScimJson(req("engineers", vec![])),
         )
         .await;
         assert!(matches!(result, Err(ScimApiError::Uniqueness(_))));
@@ -447,7 +467,7 @@ mod tests {
         let result = create(
             domain_scoped_auth("domain-1"),
             State(state),
-            Json(req("engineers", vec![])),
+            ScimJson(req("engineers", vec![])),
         )
         .await;
         assert!(matches!(result, Err(ScimApiError::Uniqueness(_))));
@@ -460,7 +480,7 @@ mod tests {
         let result = create(
             domain_scoped_auth("domain-1"),
             State(state),
-            Json(req("engineers", vec![])),
+            ScimJson(req("engineers", vec![])),
         )
         .await;
         assert!(matches!(
@@ -476,7 +496,7 @@ mod tests {
         let result = create(
             domain_scoped_auth("domain-1"),
             State(state),
-            Json(req("   ", vec![])),
+            ScimJson(req("   ", vec![])),
         )
         .await;
         assert!(matches!(

--- a/crates/keystone/src/scim/group/list.rs
+++ b/crates/keystone/src/scim/group/list.rs
@@ -25,6 +25,7 @@ use openstack_keystone_core_types::scim::ScimResourceType;
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::filter::{GROUP_FILTER_ATTRS, parse_filter};
+use crate::scim::location::resource_location;
 use crate::scim::types::{LIST_RESPONSE_SCHEMA, ScimGroup, ScimGroupListResponse};
 
 #[derive(Debug, Deserialize, Default)]
@@ -112,7 +113,13 @@ pub(super) async fn list(
             .get_identity_provider()
             .list_users_of_group(&exec, &group.id)
             .await?;
-        resources.push(ScimGroup::from_domain(&group, &index, &member_ids));
+        let location = resource_location(&state, &realm.domain_id, "Groups", &group.id).await;
+        resources.push(ScimGroup::from_domain(
+            &group,
+            &index,
+            &member_ids,
+            location,
+        ));
     }
 
     Ok(Json(ScimGroupListResponse {

--- a/crates/keystone/src/scim/group/patch.rs
+++ b/crates/keystone/src/scim/group/patch.rs
@@ -33,8 +33,10 @@ use openstack_keystone_core_types::scim::{
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::{etag_header, parse_if_match};
+use crate::scim::extract::ScimJson;
 use crate::scim::group::membership::validate_members_owned_by_realm;
 use crate::scim::group::show::fetch_owned;
+use crate::scim::location::resource_location;
 use crate::scim::patch::{GROUP_PATCH_PATHS, PatchOp, ScimPatchRequest, validate_patch};
 use crate::scim::types::{MAX_GROUP_MEMBERS, ScimGroup, ScimGroupMember};
 
@@ -53,8 +55,9 @@ pub(super) async fn patch(
     Path((_domain_id, id)): Path<(String, String)>,
     State(state): State<ServiceState>,
     headers: HeaderMap,
-    Json(req): Json<ScimPatchRequest>,
+    ScimJson(req): ScimJson<ScimPatchRequest>,
 ) -> Result<(HeaderMap, Json<ScimGroup>), ScimApiError> {
+    req.validate_schemas().map_err(ScimApiError::InvalidValue)?;
     let ops = validate_patch(&req, GROUP_PATCH_PATHS)?;
     let expected_version = parse_if_match(&headers)?;
 
@@ -240,6 +243,7 @@ pub(super) async fn patch(
     }
 
     let member_ids: Vec<String> = resulting_member_ids.into_iter().collect();
+    let location = resource_location(&state, &realm.domain_id, "Groups", &id).await;
     let mut response_headers = HeaderMap::new();
     response_headers.insert(
         "etag",
@@ -249,7 +253,12 @@ pub(super) async fn patch(
     );
     Ok((
         response_headers,
-        Json(ScimGroup::from_domain(&group, &index, &member_ids)),
+        Json(ScimGroup::from_domain(
+            &group,
+            &index,
+            &member_ids,
+            location,
+        )),
     ))
 }
 
@@ -321,7 +330,7 @@ mod tests {
 
     fn patch_req(op: &str, path: &str, value: Value) -> ScimPatchRequest {
         ScimPatchRequest {
-            schemas: vec![],
+            schemas: vec![crate::scim::patch::PATCH_OP_SCHEMA.to_string()],
             operations: vec![ScimPatchOperation {
                 op: op.to_string(),
                 path: Some(path.to_string()),
@@ -385,7 +394,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req(
+            ScimJson(patch_req(
                 "replace",
                 "displayName",
                 Value::String("new_name".to_string()),
@@ -456,7 +465,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req(
+            ScimJson(patch_req(
                 "add",
                 "members",
                 serde_json::json!([{"value": "user-new"}]),
@@ -510,7 +519,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req(
+            ScimJson(patch_req(
                 "remove",
                 "members",
                 serde_json::json!([{"value": "user-old"}]),
@@ -542,7 +551,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req(
+            ScimJson(patch_req(
                 "replace",
                 "members",
                 serde_json::json!([{"value": "user-new"}]),
@@ -561,7 +570,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req(
+            ScimJson(patch_req(
                 "replace",
                 r#"emails[type eq "work"].value"#,
                 Value::String("a@b.com".to_string()),
@@ -590,7 +599,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req(
+            ScimJson(patch_req(
                 "replace",
                 "displayName",
                 Value::String("x".to_string()),

--- a/crates/keystone/src/scim/group/show.rs
+++ b/crates/keystone/src/scim/group/show.rs
@@ -24,6 +24,7 @@ use openstack_keystone_core_types::scim::ScimResourceType;
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::etag_header;
+use crate::scim::location::resource_location;
 use crate::scim::types::ScimGroup;
 
 /// Fetch `(Group, ScimResourceIndex)` for `id` under the caller's own realm,
@@ -94,6 +95,7 @@ pub(super) async fn show(
         .list_users_of_group(&exec, &group.id)
         .await?;
 
+    let location = resource_location(&state, &realm.domain_id, "Groups", &id).await;
     let mut headers = HeaderMap::new();
     headers.insert(
         "etag",
@@ -103,7 +105,12 @@ pub(super) async fn show(
     );
     Ok((
         headers,
-        Json(ScimGroup::from_domain(&group, &index, &member_ids)),
+        Json(ScimGroup::from_domain(
+            &group,
+            &index,
+            &member_ids,
+            location,
+        )),
     ))
 }
 

--- a/crates/keystone/src/scim/group/update.rs
+++ b/crates/keystone/src/scim/group/update.rs
@@ -29,8 +29,10 @@ use openstack_keystone_core_types::scim::{
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::{etag_header, parse_if_match};
+use crate::scim::extract::ScimJson;
 use crate::scim::group::membership::validate_members_owned_by_realm;
 use crate::scim::group::show::fetch_owned;
+use crate::scim::location::resource_location;
 use crate::scim::types::{MAX_GROUP_MEMBERS, ScimGroup, ScimGroupWrite};
 
 pub(super) async fn update(
@@ -38,8 +40,9 @@ pub(super) async fn update(
     Path((_domain_id, id)): Path<(String, String)>,
     State(state): State<ServiceState>,
     headers: HeaderMap,
-    Json(req): Json<ScimGroupWrite>,
+    ScimJson(req): ScimJson<ScimGroupWrite>,
 ) -> Result<(HeaderMap, Json<ScimGroup>), ScimApiError> {
+    req.validate_schemas().map_err(ScimApiError::InvalidValue)?;
     if req.display_name.trim().is_empty() {
         return Err(KeystoneApiError::BadRequest("displayName is required".to_string()).into());
     }
@@ -167,6 +170,7 @@ pub(super) async fn update(
             .await?;
     }
 
+    let location = resource_location(&state, &realm.domain_id, "Groups", &id).await;
     let mut response_headers = HeaderMap::new();
     response_headers.insert(
         "etag",
@@ -176,7 +180,12 @@ pub(super) async fn update(
     );
     Ok((
         response_headers,
-        Json(ScimGroup::from_domain(&group, &index, &new_member_ids)),
+        Json(ScimGroup::from_domain(
+            &group,
+            &index,
+            &new_member_ids,
+            location,
+        )),
     ))
 }
 
@@ -248,7 +257,7 @@ mod tests {
 
     fn write_req(display_name: &str, members: Vec<&str>) -> ScimGroupWrite {
         ScimGroupWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::GROUP_SCHEMA.to_string()],
             external_id: Some("ext-old".to_string()),
             display_name: display_name.to_string(),
             members: members
@@ -310,7 +319,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("new_name", vec![])),
+            ScimJson(write_req("new_name", vec![])),
         )
         .await
         .unwrap();
@@ -377,7 +386,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("engineers", vec!["user-new"])),
+            ScimJson(write_req("engineers", vec!["user-new"])),
         )
         .await
         .unwrap();
@@ -423,7 +432,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("engineers", vec!["user-from-elsewhere"])),
+            ScimJson(write_req("engineers", vec!["user-from-elsewhere"])),
         )
         .await;
         assert!(matches!(result, Err(ScimApiError::InvalidValue(_))));
@@ -448,7 +457,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("new_name", vec![])),
+            ScimJson(write_req("new_name", vec![])),
         )
         .await;
         assert!(matches!(
@@ -504,7 +513,7 @@ mod tests {
             Path(("domain-1".to_string(), "group-1".to_string())),
             State(state),
             headers,
-            Json(write_req("new_name", vec![])),
+            ScimJson(write_req("new_name", vec![])),
         )
         .await;
         assert!(matches!(result, Err(ScimApiError::PreconditionFailed(_))));

--- a/crates/keystone/src/scim/location.rs
+++ b/crates/keystone/src/scim/location.rs
@@ -1,0 +1,52 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `meta.location` URL construction (RFC 7644 §3.1).
+
+use url::Url;
+
+use crate::keystone::ServiceState;
+
+/// Builds the absolute `meta.location` URL from a base endpoint, mirroring
+/// [`crate::api::common::build_pagination_links`]'s
+/// fallback-to-`http://localhost` behavior when `public_endpoint` isn't
+/// configured.
+pub(crate) fn scim_location(
+    base: &Url,
+    domain_id: &str,
+    resource_segment: &str,
+    id: &str,
+) -> String {
+    format!(
+        "{}/SCIM/v2/{domain_id}/{resource_segment}/{id}",
+        base.as_str().trim_end_matches('/'),
+    )
+}
+
+/// Reads the configured `public_endpoint` and builds the absolute
+/// `meta.location` URL for a resource. `resource_segment` is the plural
+/// collection path segment (`"Users"`/`"Groups"`).
+pub(crate) async fn resource_location(
+    state: &ServiceState,
+    domain_id: &str,
+    resource_segment: &str,
+    id: &str,
+) -> String {
+    let config = state.config_manager.config.read().await;
+    let base = config
+        .default
+        .public_endpoint
+        .clone()
+        .unwrap_or_else(|| Url::parse("http://localhost").expect("static URL is valid"));
+    scim_location(&base, domain_id, resource_segment, id)
+}

--- a/crates/keystone/src/scim/patch.rs
+++ b/crates/keystone/src/scim/patch.rs
@@ -26,6 +26,10 @@ use serde_json::Value;
 
 use crate::scim::error::ScimApiError;
 
+/// `urn:ietf:params:scim:api:messages:2.0:PatchOp` schema URI (RFC 7644
+/// §3.5.2).
+pub const PATCH_OP_SCHEMA: &str = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+
 /// ADR 0024 §5.C User `path` allowlist (lowercased).
 pub const USER_PATCH_PATHS: &[&str] = &[
     "active",
@@ -40,6 +44,13 @@ pub const USER_PATCH_PATHS: &[&str] = &[
 /// add/remove only -- enforced separately in `scim::group::patch`, not by
 /// this table.
 pub const GROUP_PATCH_PATHS: &[&str] = &["displayname", "externalid", "members"];
+
+/// RFC 7644-defined attributes that are always immutable regardless of
+/// resource type -- named separately from `{USER,GROUP}_PATCH_PATHS` so a
+/// `PATCH` naming one of these gets `scimType: "mutability"` (a real
+/// attribute, just not modifiable) rather than `"invalidPath"` (not a real
+/// attribute at all).
+const IMMUTABLE_PATHS: &[&str] = &["id", "meta"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PatchOp {
@@ -77,6 +88,18 @@ pub struct ScimPatchRequest {
     pub operations: Vec<ScimPatchOperation>,
 }
 
+impl ScimPatchRequest {
+    /// Rejects a request whose `schemas` array is missing or doesn't
+    /// declare the `PatchOp` messages schema (RFC 7644 §3.3, §3.5.2).
+    pub fn validate_schemas(&self) -> Result<(), String> {
+        if self.schemas.iter().any(|s| s == PATCH_OP_SCHEMA) {
+            Ok(())
+        } else {
+            Err(format!("schemas must include `{PATCH_OP_SCHEMA}`"))
+        }
+    }
+}
+
 /// A validated `ScimPatchOperation`, its `path` lowercased and its `op`
 /// resolved to a [`PatchOp`].
 pub struct ValidatedPatchOp {
@@ -107,6 +130,11 @@ pub fn validate_patch(
                 ));
             };
             let path = path.to_ascii_lowercase();
+            if IMMUTABLE_PATHS.contains(&path.as_str()) {
+                return Err(ScimApiError::Mutability(format!(
+                    "path `{path}` is immutable and cannot be modified via PATCH"
+                )));
+            }
             if !allowed_paths.contains(&path.as_str()) {
                 return Err(ScimApiError::InvalidPath(format!(
                     "path `{path}` is not patchable"
@@ -163,6 +191,16 @@ mod tests {
         };
         let result = validate_patch(&req, USER_PATCH_PATHS);
         assert!(matches!(result, Err(ScimApiError::InvalidPath(_))));
+    }
+
+    #[test]
+    fn test_validate_rejects_immutable_id_path_as_mutability() {
+        let req = ScimPatchRequest {
+            schemas: vec![],
+            operations: vec![op("replace", "id", Value::String("x".to_string()))],
+        };
+        let result = validate_patch(&req, USER_PATCH_PATHS);
+        assert!(matches!(result, Err(ScimApiError::Mutability(_))));
     }
 
     #[test]

--- a/crates/keystone/src/scim/types.rs
+++ b/crates/keystone/src/scim/types.rs
@@ -69,6 +69,7 @@ pub struct ScimEmail {
 #[serde(rename_all = "camelCase")]
 pub struct ScimMeta {
     pub resource_type: String,
+    pub location: String,
     pub created: String,
     pub last_modified: String,
 }
@@ -94,8 +95,11 @@ pub struct ScimUser {
 
 impl ScimUser {
     /// Build the wire representation from the core Identity record plus its
-    /// SCIM ownership anchor.
-    pub fn from_domain(user: &UserResponse, index: &ScimResourceIndex) -> Self {
+    /// SCIM ownership anchor. `location` is the pre-built absolute
+    /// `meta.location` URL (RFC 7644 §3.1) -- built by the caller via
+    /// [`crate::scim::location::resource_location`] so this module stays
+    /// free of config/I-O concerns.
+    pub fn from_domain(user: &UserResponse, index: &ScimResourceIndex, location: String) -> Self {
         let given_name = extra_str(&user.extra, EXTRA_GIVEN_NAME);
         let family_name = extra_str(&user.extra, EXTRA_FAMILY_NAME);
         let name = if given_name.is_some() || family_name.is_some() {
@@ -126,6 +130,7 @@ impl ScimUser {
             active: user.enabled,
             meta: ScimMeta {
                 resource_type: "User".to_string(),
+                location,
                 created: epoch_to_rfc3339(index.created_at),
                 last_modified: epoch_to_rfc3339(index.updated_at),
             },
@@ -158,6 +163,16 @@ fn default_true() -> bool {
 }
 
 impl ScimUserWrite {
+    /// Rejects a request whose `schemas` array is missing or doesn't
+    /// declare the core `User` schema (RFC 7644 §3.3).
+    pub fn validate_schemas(&self) -> Result<(), String> {
+        if self.schemas.iter().any(|s| s == USER_SCHEMA) {
+            Ok(())
+        } else {
+            Err(format!("schemas must include `{USER_SCHEMA}`"))
+        }
+    }
+
     fn extra(&self) -> HashMap<String, Value> {
         let mut extra = HashMap::new();
         if let Some(name) = &self.name
@@ -263,7 +278,14 @@ pub struct ScimGroup {
 impl ScimGroup {
     /// Build the wire representation from the core Identity record, its SCIM
     /// ownership anchor, and its resolved membership (ADR 0024 §4, §7).
-    pub fn from_domain(group: &Group, index: &ScimResourceIndex, member_ids: &[String]) -> Self {
+    /// `location` is the pre-built absolute `meta.location` URL (RFC 7644
+    /// §3.1) -- see [`ScimUser::from_domain`]'s doc comment.
+    pub fn from_domain(
+        group: &Group,
+        index: &ScimResourceIndex,
+        member_ids: &[String],
+        location: String,
+    ) -> Self {
         Self {
             schemas: vec![GROUP_SCHEMA.to_string()],
             id: group.id.clone(),
@@ -275,6 +297,7 @@ impl ScimGroup {
                 .collect(),
             meta: ScimMeta {
                 resource_type: "Group".to_string(),
+                location,
                 created: epoch_to_rfc3339(index.created_at),
                 last_modified: epoch_to_rfc3339(index.updated_at),
             },
@@ -300,6 +323,16 @@ pub struct ScimGroupWrite {
 }
 
 impl ScimGroupWrite {
+    /// Rejects a request whose `schemas` array is missing or doesn't
+    /// declare the core `Group` schema (RFC 7644 §3.3).
+    pub fn validate_schemas(&self) -> Result<(), String> {
+        if self.schemas.iter().any(|s| s == GROUP_SCHEMA) {
+            Ok(())
+        } else {
+            Err(format!("schemas must include `{GROUP_SCHEMA}`"))
+        }
+    }
+
     /// The member `User.id`s this write requests, in request order.
     pub fn member_ids(&self) -> Vec<String> {
         self.members.iter().map(|m| m.value.clone()).collect()

--- a/crates/keystone/src/scim/user/create.rs
+++ b/crates/keystone/src/scim/user/create.rs
@@ -27,13 +27,16 @@ use openstack_keystone_core_types::scim::{
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::etag_header;
+use crate::scim::extract::ScimJson;
+use crate::scim::location::resource_location;
 use crate::scim::types::{ScimUser, ScimUserWrite};
 
 pub(super) async fn create(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     State(state): State<ServiceState>,
-    Json(req): Json<ScimUserWrite>,
+    ScimJson(req): ScimJson<ScimUserWrite>,
 ) -> Result<(StatusCode, HeaderMap, Json<ScimUser>), ScimApiError> {
+    req.validate_schemas().map_err(ScimApiError::InvalidValue)?;
     if req.user_name.trim().is_empty() {
         return Err(KeystoneApiError::BadRequest("userName is required".to_string()).into());
     }
@@ -128,6 +131,7 @@ pub(super) async fn create(
         }
     };
 
+    let location = resource_location(&state, &realm.domain_id, "Users", &user.id).await;
     let mut headers = HeaderMap::new();
     headers.insert(
         "etag",
@@ -135,10 +139,16 @@ pub(super) async fn create(
             .parse()
             .expect("weak etag is valid header value"),
     );
+    headers.insert(
+        "location",
+        location
+            .parse()
+            .expect("scim location is a valid header value"),
+    );
     Ok((
         StatusCode::CREATED,
         headers,
-        Json(ScimUser::from_domain(&user, &index)),
+        Json(ScimUser::from_domain(&user, &index, location)),
     ))
 }
 
@@ -239,7 +249,7 @@ mod tests {
         .await;
 
         let req = ScimUserWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::USER_SCHEMA.to_string()],
             external_id: Some("ext-1".to_string()),
             user_name: "alice".to_string(),
             name: None,
@@ -249,7 +259,7 @@ mod tests {
         };
 
         let (status, headers, Json(body)) =
-            create(domain_scoped_auth("domain-1"), State(state), Json(req))
+            create(domain_scoped_auth("domain-1"), State(state), ScimJson(req))
                 .await
                 .unwrap();
         assert_eq!(status, StatusCode::CREATED);
@@ -274,7 +284,7 @@ mod tests {
         .await;
 
         let req = ScimUserWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::USER_SCHEMA.to_string()],
             external_id: Some("ext-1".to_string()),
             user_name: "alice".to_string(),
             name: None,
@@ -283,7 +293,7 @@ mod tests {
             active: true,
         };
 
-        let result = create(domain_scoped_auth("domain-1"), State(state), Json(req)).await;
+        let result = create(domain_scoped_auth("domain-1"), State(state), ScimJson(req)).await;
         assert!(matches!(result, Err(ScimApiError::Uniqueness(_))));
     }
 
@@ -320,7 +330,7 @@ mod tests {
         .await;
 
         let req = ScimUserWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::USER_SCHEMA.to_string()],
             external_id: Some("ext-1".to_string()),
             user_name: "alice".to_string(),
             name: None,
@@ -329,7 +339,7 @@ mod tests {
             active: true,
         };
 
-        let result = create(domain_scoped_auth("domain-1"), State(state), Json(req)).await;
+        let result = create(domain_scoped_auth("domain-1"), State(state), ScimJson(req)).await;
         assert!(matches!(result, Err(ScimApiError::Uniqueness(_))));
     }
 
@@ -364,7 +374,7 @@ mod tests {
         .await;
 
         let req = ScimUserWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::USER_SCHEMA.to_string()],
             external_id: Some("ext-1".to_string()),
             user_name: "alice".to_string(),
             name: None,
@@ -373,7 +383,7 @@ mod tests {
             active: true,
         };
 
-        let result = create(domain_scoped_auth("domain-1"), State(state), Json(req)).await;
+        let result = create(domain_scoped_auth("domain-1"), State(state), ScimJson(req)).await;
         assert!(matches!(result, Err(ScimApiError::Uniqueness(_))));
     }
 
@@ -382,7 +392,7 @@ mod tests {
         let state = get_mocked_state(Provider::mocked_builder(), false, None).await;
 
         let req = ScimUserWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::USER_SCHEMA.to_string()],
             external_id: Some("ext-1".to_string()),
             user_name: "alice".to_string(),
             name: None,
@@ -391,7 +401,7 @@ mod tests {
             active: true,
         };
 
-        let result = create(domain_scoped_auth("domain-1"), State(state), Json(req)).await;
+        let result = create(domain_scoped_auth("domain-1"), State(state), ScimJson(req)).await;
         assert!(matches!(
             result,
             Err(ScimApiError::Api(KeystoneApiError::Forbidden { .. }))
@@ -403,7 +413,7 @@ mod tests {
         let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
 
         let req = ScimUserWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::USER_SCHEMA.to_string()],
             external_id: None,
             user_name: "   ".to_string(),
             name: None,
@@ -412,7 +422,7 @@ mod tests {
             active: true,
         };
 
-        let result = create(domain_scoped_auth("domain-1"), State(state), Json(req)).await;
+        let result = create(domain_scoped_auth("domain-1"), State(state), ScimJson(req)).await;
         assert!(matches!(
             result,
             Err(ScimApiError::Api(KeystoneApiError::BadRequest(_)))
@@ -424,7 +434,7 @@ mod tests {
         let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
 
         let req = ScimUserWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::USER_SCHEMA.to_string()],
             external_id: None,
             user_name: "alice".to_string(),
             name: None,
@@ -433,7 +443,7 @@ mod tests {
             active: true,
         };
 
-        let result = create(domain_scoped_auth("domain-1"), State(state), Json(req)).await;
+        let result = create(domain_scoped_auth("domain-1"), State(state), ScimJson(req)).await;
         assert!(matches!(
             result,
             Err(ScimApiError::Api(KeystoneApiError::BadRequest(_)))

--- a/crates/keystone/src/scim/user/list.rs
+++ b/crates/keystone/src/scim/user/list.rs
@@ -25,6 +25,7 @@ use openstack_keystone_core_types::scim::ScimResourceType;
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::filter::{USER_FILTER_ATTRS, parse_filter};
+use crate::scim::location::resource_location;
 use crate::scim::types::{LIST_RESPONSE_SCHEMA, ScimListResponse, ScimUser};
 
 #[derive(Debug, Deserialize, Default)]
@@ -88,7 +89,8 @@ pub(super) async fn list(
         else {
             continue;
         };
-        let scim_user = ScimUser::from_domain(&user, &index);
+        let location = resource_location(&state, &realm.domain_id, "Users", &user.id).await;
+        let scim_user = ScimUser::from_domain(&user, &index, location);
         let matches = parsed_filter.as_ref().is_none_or(|f| {
             f.matches(|attr| match attr {
                 "username" => Some(scim_user.user_name.clone()),

--- a/crates/keystone/src/scim/user/patch.rs
+++ b/crates/keystone/src/scim/user/patch.rs
@@ -32,6 +32,8 @@ use openstack_keystone_core_types::scim::{
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::{etag_header, parse_if_match};
+use crate::scim::extract::ScimJson;
+use crate::scim::location::resource_location;
 use crate::scim::patch::{PatchOp, ScimPatchRequest, USER_PATCH_PATHS, validate_patch};
 use crate::scim::types::{EXTRA_DISPLAY_NAME, EXTRA_FAMILY_NAME, EXTRA_GIVEN_NAME, ScimUser};
 use crate::scim::user::show::fetch_owned;
@@ -48,8 +50,9 @@ pub(super) async fn patch(
     Path((_domain_id, id)): Path<(String, String)>,
     State(state): State<ServiceState>,
     headers: HeaderMap,
-    Json(req): Json<ScimPatchRequest>,
+    ScimJson(req): ScimJson<ScimPatchRequest>,
 ) -> Result<(HeaderMap, Json<ScimUser>), ScimApiError> {
+    req.validate_schemas().map_err(ScimApiError::InvalidValue)?;
     let ops = validate_patch(&req, USER_PATCH_PATHS)?;
     let expected_version = parse_if_match(&headers)?;
 
@@ -197,6 +200,7 @@ pub(super) async fn patch(
         )
         .await?;
 
+    let location = resource_location(&state, &realm.domain_id, "Users", &id).await;
     let mut response_headers = HeaderMap::new();
     response_headers.insert(
         "etag",
@@ -204,7 +208,10 @@ pub(super) async fn patch(
             .parse()
             .expect("weak etag is valid header value"),
     );
-    Ok((response_headers, Json(ScimUser::from_domain(&user, &index))))
+    Ok((
+        response_headers,
+        Json(ScimUser::from_domain(&user, &index, location)),
+    ))
 }
 
 #[cfg(test)]
@@ -274,7 +281,7 @@ mod tests {
 
     fn patch_req(op: &str, path: &str, value: Value) -> ScimPatchRequest {
         ScimPatchRequest {
-            schemas: vec![],
+            schemas: vec![crate::scim::patch::PATCH_OP_SCHEMA.to_string()],
             operations: vec![ScimPatchOperation {
                 op: op.to_string(),
                 path: Some(path.to_string()),
@@ -330,7 +337,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req("replace", "active", Value::Bool(false))),
+            ScimJson(patch_req("replace", "active", Value::Bool(false))),
         )
         .await
         .unwrap();
@@ -387,7 +394,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req(
+            ScimJson(patch_req(
                 "replace",
                 "userName",
                 Value::String("bob".to_string()),
@@ -445,8 +452,8 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(ScimPatchRequest {
-                schemas: vec![],
+            ScimJson(ScimPatchRequest {
+                schemas: vec![crate::scim::patch::PATCH_OP_SCHEMA.to_string()],
                 operations: vec![
                     ScimPatchOperation {
                         op: "replace".to_string(),
@@ -513,7 +520,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req("remove", "externalId", Value::Null)),
+            ScimJson(patch_req("remove", "externalId", Value::Null)),
         )
         .await;
         assert!(matches!(result, Err(ScimApiError::InvalidValue(_))));
@@ -528,7 +535,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req(
+            ScimJson(patch_req(
                 "replace",
                 r#"emails[type eq "work"].value"#,
                 Value::String("a@b.com".to_string()),
@@ -557,7 +564,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(patch_req("replace", "active", Value::Bool(false))),
+            ScimJson(patch_req("replace", "active", Value::Bool(false))),
         )
         .await;
         assert!(matches!(

--- a/crates/keystone/src/scim/user/show.rs
+++ b/crates/keystone/src/scim/user/show.rs
@@ -24,6 +24,7 @@ use openstack_keystone_core_types::scim::ScimResourceType;
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::etag_header;
+use crate::scim::location::resource_location;
 use crate::scim::types::ScimUser;
 
 /// Fetch `(UserResponse, ScimResourceIndex)` for `id` under the caller's own
@@ -88,6 +89,7 @@ pub(super) async fn show(
         )
         .await?;
 
+    let location = resource_location(&state, &realm.domain_id, "Users", &id).await;
     let mut headers = HeaderMap::new();
     headers.insert(
         "etag",
@@ -95,7 +97,10 @@ pub(super) async fn show(
             .parse()
             .expect("weak etag is valid header value"),
     );
-    Ok((headers, Json(ScimUser::from_domain(&user, &index))))
+    Ok((
+        headers,
+        Json(ScimUser::from_domain(&user, &index, location)),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/keystone/src/scim/user/update.rs
+++ b/crates/keystone/src/scim/user/update.rs
@@ -26,6 +26,8 @@ use openstack_keystone_core_types::scim::{
 use crate::keystone::ServiceState;
 use crate::scim::error::ScimApiError;
 use crate::scim::etag::{etag_header, parse_if_match};
+use crate::scim::extract::ScimJson;
+use crate::scim::location::resource_location;
 use crate::scim::types::{ScimUser, ScimUserWrite};
 use crate::scim::user::show::fetch_owned;
 
@@ -34,8 +36,9 @@ pub(super) async fn update(
     Path((_domain_id, id)): Path<(String, String)>,
     State(state): State<ServiceState>,
     headers: HeaderMap,
-    Json(req): Json<ScimUserWrite>,
+    ScimJson(req): ScimJson<ScimUserWrite>,
 ) -> Result<(HeaderMap, Json<ScimUser>), ScimApiError> {
+    req.validate_schemas().map_err(ScimApiError::InvalidValue)?;
     if req.user_name.trim().is_empty() {
         return Err(openstack_keystone_core::api::KeystoneApiError::BadRequest(
             "userName is required".to_string(),
@@ -117,6 +120,7 @@ pub(super) async fn update(
         .update_user(&exec, &id, req.to_user_update())
         .await?;
 
+    let location = resource_location(&state, &realm.domain_id, "Users", &id).await;
     let mut response_headers = HeaderMap::new();
     response_headers.insert(
         "etag",
@@ -124,7 +128,10 @@ pub(super) async fn update(
             .parse()
             .expect("weak etag is valid header value"),
     );
-    Ok((response_headers, Json(ScimUser::from_domain(&user, &index))))
+    Ok((
+        response_headers,
+        Json(ScimUser::from_domain(&user, &index, location)),
+    ))
 }
 
 #[cfg(test)]
@@ -194,7 +201,7 @@ mod tests {
 
     fn write_req(user_name: &str, external_id: Option<&str>) -> ScimUserWrite {
         ScimUserWrite {
-            schemas: vec![],
+            schemas: vec![crate::scim::types::USER_SCHEMA.to_string()],
             external_id: external_id.map(str::to_string),
             user_name: user_name.to_string(),
             name: None,
@@ -253,7 +260,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("new_name", Some("ext-old"))),
+            ScimJson(write_req("new_name", Some("ext-old"))),
         )
         .await
         .unwrap();
@@ -312,7 +319,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("BOB", Some("ext-old"))),
+            ScimJson(write_req("BOB", Some("ext-old"))),
         )
         .await
         .unwrap();
@@ -338,7 +345,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             HeaderMap::new(),
-            Json(write_req("new_name", None)),
+            ScimJson(write_req("new_name", None)),
         )
         .await;
         assert!(matches!(
@@ -396,7 +403,7 @@ mod tests {
             Path(("domain-1".to_string(), "user-1".to_string())),
             State(state),
             headers,
-            Json(write_req("new_name", Some("ext-old"))),
+            ScimJson(write_req("new_name", Some("ext-old"))),
         )
         .await;
         assert!(matches!(result, Err(ScimApiError::PreconditionFailed(_))));

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -55,6 +55,8 @@
   - [Dex](federation/dex.md)
 - [Passkeys](passkey.md)
 - [API-Key Authentication (SCIM)](api_key.md)
+- [SCIM v2 Provisioning](scim/admin.md)
+  - [RFC 7644 Compatibility](scim/compatibility.md)
 - [Kubernetes TokenReview Auth](k8s_auth.md)
 - [Mapping Engine](mapping.md)
 

--- a/doc/src/scim/admin.md
+++ b/doc/src/scim/admin.md
@@ -1,0 +1,279 @@
+# SCIM v2 Provisioning: Administrator Guide
+
+This page is for Keystone operators and domain managers who need to enable an
+enterprise Identity Provider (Okta, Entra ID, Workday, ...) to push user/group
+lifecycle events into a Keystone domain via SCIM. For the protocol-level
+reference (endpoints, filter grammar, RFC 7644 compatibility matrix) aimed at
+whoever configures the IdP side, see [RFC 7644 Compatibility](compatibility.md).
+For the full design rationale, see
+[ADR 0024](../adr/0024-scim-v2-provisioning.md).
+
+## Concept
+
+SCIM provisioning is a distinct concern from authentication. It manages the
+_existence and attributes_ of real, persistent `User`/`Group` rows in a domain;
+how those same accounts later log in (password, OIDC, passkey) is unrelated. A
+domain can register any number of independent **realms**, each identified by a
+`(domain_id, provider_id)` pair, so more than one authoritative source (e.g. an
+Okta tenant for full-time employees and a Workday feed for contractors) can
+provision into the same domain without either one able to see, rename, or delete
+the other's records or a human administrator's manually created accounts.
+
+Every realm is linked to a federation `IdentityProvider`. If a person is
+provisioned ahead of time via SCIM and later authenticates for the first time
+through that same IdP, the account converges onto the same `User` row a
+federated JIT login would have created — no duplicate accounts.
+
+## Prerequisites
+
+A SCIM realm requires an existing federation `IdentityProvider` in the target
+domain. If you haven't set one up yet, see [Federation](../federation/intro.md)
+first. The `IdentityProvider` doesn't need to be usable for interactive login
+yet — SCIM just needs its `id` to exist so realm registration can resolve
+`idp_id`.
+
+## Setup walkthrough
+
+Four steps: register the realm, grant it a role via a mapping rule, mint an API
+key, then hand the base URL and key to the IdP's SCIM connector.
+
+### 1. Register the SCIM realm
+
+Requires the `manager` role scoped to the target domain, or `admin`.
+
+```
+POST /v4/scim_realms/
+```
+
+```json
+{
+  "scim_realm": {
+    "domain_id": "d1",
+    "provider_id": "entra-scim",
+    "idp_id": "entra-idp-1",
+    "display_name": "Entra ID SCIM provisioning"
+  }
+}
+```
+
+`provider_id` is an arbitrary operator-chosen coordinate — it doesn't need to
+match the `IdentityProvider.id`, though reusing a recognizable name (as above)
+keeps audit logs readable. `idp_id` must resolve to an existing
+`IdentityProvider` in `domain_id`, checked at both create and update time (`404`
+otherwise). Response is `201` with the created `ScimRealmResource` including
+`enabled: true`.
+
+Realms have no `DELETE` — see
+[Deprovisioning & retention](#deprovisioning--retention) for how to turn one
+off.
+
+### 2. Grant the realm a provisioning role
+
+A realm authorizes SCIM traffic (the Realm Activation Gate, below), but
+authorizing _specific_ Users/Groups operations against it is separate, and
+happens the same way all API-key ingress traffic is authorized: via a
+[mapping ruleset](../mapping.md) matched on `IdentitySource::ApiClient`.
+`ApiClientResource` carries no `Role`/`RoleAssignment` at all — every role a
+SCIM request is evaluated against comes entirely from
+`Authorization::Domain{roles}` produced by this ruleset at request time.
+
+```json
+{
+  "mapping_ruleset": {
+    "mapping_id": "entra-scim-mapping",
+    "domain_id": "d1",
+    "source": { "type": "api_client", "provider_id": "entra-scim" },
+    "domain_resolution_mode": "fixed",
+    "enabled": true,
+    "rules": [
+      {
+        "name": "entra-scim-rule",
+        "match": { "all_of": [] },
+        "identity": {
+          "user_name": "${claims.api_client.client_id}"
+        },
+        "authorizations": [
+          {
+            "type": "domain",
+            "domain_id": "d1",
+            "roles": [{ "name": "scim_provisioner" }]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The role string must be one of `admin`, `manager`, or `scim_provisioner` (see
+[Authorization](#authorization) below) and must resolve against an actual `Role`
+— mapping rule create/update rejects an unresolvable `RoleRef` with `422`.
+`scim_provisioner` is the narrowest of the three and the recommended choice for
+a machine-provisioning integration; create it once per domain if it doesn't
+already exist (`POST /v4/roles`).
+
+The write-time ruleset constraint from ADR 0021/0024 applies here: since this
+ruleset shares its `provider_id` coordinate with the realm, an
+`Authorization::Project` rule can never be added to it — the Mapping Engine CRUD
+API rejects that with `422 Unprocessable Entity`. A SCIM realm's ruleset may
+only ever resolve `Authorization::Domain`.
+
+### 3. Mint an API key
+
+See [API-Key Authentication](../api_key.md) for the full lifecycle (rotation,
+revocation, IP allow-listing). In short:
+
+```
+POST /v4/api-keys/
+```
+
+```json
+{
+  "api_key": {
+    "domain_id": "d1",
+    "provider_id": "entra-scim",
+    "description": "Entra ID SCIM provisioning"
+  }
+}
+```
+
+The response's `token` field (`kscim_...`) is shown **once** — this is the
+bearer credential the IdP's SCIM connector will use.
+
+### 4. Configure the IdP's SCIM connector
+
+Point the connector at:
+
+```
+Base URL:    https://<your-keystone-host>/SCIM/v2/d1
+Auth type:   Bearer Token
+Token:       kscim_9pQ...xz_1a2b3c4d
+```
+
+The connector should discover its capabilities from
+`GET {base}/ServiceProviderConfig` — see
+[RFC 7644 Compatibility](compatibility.md) for what it will find (and what it
+won't: `bulk`, `sort`, and `changePassword` are all honestly advertised as
+unsupported).
+
+## Realm Activation Gate
+
+Every `/SCIM/v2/{domain_id}/Users|Groups` request first resolves the
+authenticating API key's `provider_id` and looks up the matching realm. If no
+realm is registered for that coordinate, or it's `enabled: false`, the request
+is rejected with `403 Forbidden` before touching any User/Group storage —
+independent of whatever role the mapping ruleset would otherwise grant.
+Realm-level activation and per-operation role authorization are two separate
+gates; both must pass.
+
+`ScimRealmAuth` additionally requires the resolved scope to be domain-scoped and
+match the URL's `{domain_id}` exactly. A key whose mapping resolves to a project
+scope, or a `{domain_id}` mismatch, gets `403` on every `/Users`/`/Groups` route
+(the `whoami` diagnostic route is exempt).
+
+## Realm management
+
+```
+GET   /v4/scim_realms/?domain_id=d1
+GET   /v4/scim_realms/{domain_id}/{provider_id}
+PATCH /v4/scim_realms/{domain_id}/{provider_id}
+```
+
+`PATCH` can update `idp_id`, `display_name`, and `enabled` — set
+`enabled: false` to immediately stop a realm's traffic (see below) without
+deleting anything. There is no realm `DELETE`; disabling is the supported way to
+turn one off, keeping its provisioned resources and audit trail intact.
+
+## Authorization
+
+Realm CRUD (`POST`/`GET`/`PATCH /v4/scim_realms`) is invoked by a normal
+Fernet-authenticated human operator and requires `manager` (domain-scoped) or
+`admin`:
+
+- `identity/scim_realm/create`, `identity/scim_realm/list`,
+  `identity/scim_realm/show`, `identity/scim_realm/disable`,
+  `identity/scim_realm/purge`
+
+SCIM resource CRUD (Users/Groups) is invoked exclusively via API-key ingress and
+evaluated against the roles the realm's own mapping ruleset produces (step 2
+above — never a real `RoleAssignment`):
+
+- `identity/scim/user/{create,list,show,update,delete}`
+- `identity/scim/group/{create,list,show,update,delete}`
+
+Each of these accepts `admin`, `manager` (domain-scoped), or `scim_provisioner`
+(domain-scoped).
+
+## Deprovisioning & retention
+
+- `DELETE /Users/{id}` never hard-deletes: it disables the user
+  (`enabled: false`), stamps the SCIM index as deprovisioned, and revokes all
+  live sessions immediately. Subsequent `GET`/`PUT`/`PATCH` against that `id`
+  from the owning realm return `404`.
+
+- `DELETE /Groups/{id}` immediately strips the group's role assignments (closing
+  the live authorization surface) and tombstones it the same way, but **retains
+  its membership snapshot** for forensic purposes until purge.
+
+- A background janitor permanently deletes tombstoned rows (and, for Groups,
+  their retained membership) once
+  `[scim_resource] janitor_deprovisioned_retention_days` has elapsed since
+  deprovisioning (see [Configuration](#configuration)).
+
+- For a verified erasure request that can't wait for the retention window, an
+  operator (`manager`/`admin`) can force an immediate purge of one resource:
+
+  ```
+  DELETE /v4/scim_realms/{domain_id}/{provider_id}/purge/{resource_type}/{keystone_id}
+  ```
+
+  This refuses to purge a resource that isn't already deprovisioned —
+  soft-delete it via SCIM first.
+
+## Configuration
+
+`[scim_realm]` in `keystone.conf`:
+
+| Option   | Default | Purpose                          |
+| -------- | ------- | -------------------------------- |
+| `driver` | `raft`  | Storage driver for realm records |
+
+`[scim_resource]` in `keystone.conf`:
+
+| Option                                 | Default | Purpose                                                               |
+| -------------------------------------- | ------- | --------------------------------------------------------------------- |
+| `driver`                               | `raft`  | Storage driver for the resource ownership index                       |
+| `janitor_deprovisioned_retention_days` | `365`   | Days a tombstoned User/Group is retained before the janitor purges it |
+
+Set `janitor_deprovisioned_retention_days` well below the default for
+deployments under GDPR or a comparable regime that can't justify a full year of
+PII retention purely for a forensic snapshot — including near-zero, if your
+compliance posture requires it. Use the operator-triggered purge-now path above
+for a specific already-received erasure request rather than lowering the global
+default.
+
+## Auditing
+
+Every SCIM write emits a CADF event (`Create`/`Update`/`Disable`), with
+`target.type_uri` of `data/security/account` (User) or `data/security/group`
+(Group), and `realm_provider_id`/`external_id` captured on the event for
+cross-referencing against the IdP's own provisioning logs.
+
+**Correlation caveat:** `initiator.id` is derived from the authenticating API
+key's `client_id`, not the realm's `provider_id`. Across a zero-downtime key
+rotation (rotating to a new key under the same `provider_id`, see
+[API-Key Authentication](../api_key.md)), `initiator.id` **changes** even though
+the realm performing the action hasn't. Build SIEM/alerting correlation on the
+`realm_provider_id` attachment field, not `initiator.id`, for SCIM traffic.
+
+## Troubleshooting
+
+| Symptom                                                       | Likely cause                                                                                                                                                                     |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `403` on every `/Users`/`/Groups` request                     | Realm not registered for this `(domain_id, provider_id)`, or `enabled: false` — check step 1                                                                                     |
+| `403` with a valid, enabled realm                             | API key's mapping resolved to project scope, or `{domain_id}` in the URL doesn't match the key's scope                                                                           |
+| `401` from the SCIM connector before any SCIM request         | API-key-level auth failure — see [API-Key Authentication](../api_key.md) troubleshooting                                                                                         |
+| Individual operations (e.g. create) return `403`/policy error | Mapping ruleset doesn't emit a role in `{admin, manager, scim_provisioner}` — check step 2                                                                                       |
+| `422` when writing the mapping rule                           | Role name doesn't resolve to an existing `Role`, or the rule tries to add an `Authorization::Project` entry to a realm-linked ruleset                                            |
+| `409 uniqueness` on user/group create                         | `userName`/`displayName`/`externalId` already exists domain-wide, or under this realm — expected, not a bug                                                                      |
+| Newly-created resource immediately `404`s                     | Deprovisioned already (unlikely on create), or the request is coming through a _different_ realm than the one that created it — see [Compatibility: Ownership](compatibility.md) |

--- a/doc/src/scim/compatibility.md
+++ b/doc/src/scim/compatibility.md
@@ -1,0 +1,265 @@
+# SCIM v2 Protocol Reference & RFC 7644 Compatibility
+
+This page is a protocol-level reference for whoever configures the SCIM side of
+an Identity Provider connector (Okta, Entra ID, Workday, ...) against Keystone,
+and a compatibility matrix against
+[RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) for anyone evaluating
+whether Keystone's SCIM implementation fits their IdP's requirements. For how to
+register a realm and grant it access, see the [Administrator Guide](admin.md).
+For full design rationale, see [ADR 0024](../adr/0024-scim-v2-provisioning.md).
+
+Keystone implements a **deliberately restricted subset** of RFC 7644, not full
+compliance — the restrictions exist to bound worst-case query/PATCH complexity
+per request (the same posture applied elsewhere in this codebase to claim
+mapping and rate limiting). Most enterprise IdPs, including Okta and Entra ID,
+tolerate a narrower filter grammar and `bulk.supported: false` without issue;
+check the matrix below against your specific connector before assuming a feature
+works.
+
+## Base URL & Authentication
+
+```
+https://<host>/SCIM/v2/{domain_id}/...
+Authorization: Bearer kscim_...
+```
+
+Every request is scoped to one domain and authenticates with a bearer API key
+(see [API-Key Authentication](../api_key.md)) — never a Fernet token. The key
+must belong to an active, registered realm for that `(domain_id, provider_id)`
+coordinate, or every request gets `403` regardless of role (see
+[Realm Activation Gate](admin.md#realm-activation-gate)).
+
+## Content Negotiation
+
+Request bodies (`POST`/`PUT`/`PATCH` carrying a payload) must declare
+`Content-Type: application/scim+json` or, for connectors that only speak plain
+JSON, `application/json` — either is accepted. Anything else, or a missing
+header on a request that does carry a body, is rejected with
+`415 Unsupported Media Type`. Every response carries
+`Content-Type: application/scim+json`, including error responses.
+
+## Discovery
+
+```
+GET /SCIM/v2/{domain_id}/ServiceProviderConfig
+GET /SCIM/v2/{domain_id}/Schemas
+GET /SCIM/v2/{domain_id}/ResourceTypes
+```
+
+Unauthenticated within the SCIM sub-router (bearer auth is still accepted, just
+not required) — most connectors probe these before presenting credentials.
+`ServiceProviderConfig` honestly advertises what's _not_ supported rather than
+claiming full compliance:
+
+```json
+{
+  "patch": { "supported": true },
+  "bulk": { "supported": false, "maxOperations": 0, "maxPayloadSize": 0 },
+  "filter": { "supported": true, "maxResults": 200 },
+  "changePassword": { "supported": false },
+  "sort": { "supported": false },
+  "etag": { "supported": true },
+  "authenticationSchemes": [{ "type": "oauthbearertoken", "primary": true }]
+}
+```
+
+## Resource Endpoints
+
+```
+POST   /SCIM/v2/{domain_id}/Users            GET   .../Users        GET .../Users/{id}
+PUT    /SCIM/v2/{domain_id}/Users/{id}        PATCH .../Users/{id}   DELETE .../Users/{id}
+
+POST   /SCIM/v2/{domain_id}/Groups            GET   .../Groups       GET .../Groups/{id}
+PUT    /SCIM/v2/{domain_id}/Groups/{id}       PATCH .../Groups/{id}  DELETE .../Groups/{id}
+```
+
+An HTTP method not mapped for a given path (e.g. `POST .../Users/{id}`, or any
+method on `/ServiceProviderConfig` other than `GET`) returns
+`405 Method Not Allowed`.
+
+### Ownership fencing
+
+A resource is only visible to the realm that created it. `GET`/`PUT`/`PATCH`/
+`DELETE` against an `id` owned by a different realm — or a same-ID resource that
+doesn't exist at all — both return an identical `404`, by design: this prevents
+realm-boundary probing via response-shape differences.
+
+### `POST` — required fields, `schemas` validation
+
+The request body's `schemas` array must contain the resource's core schema URI
+(`urn:ietf:params:scim:schemas:core:2.0:User` / `...:Group`) — a missing or
+mismatched `schemas` array is rejected with `400 invalidValue`. For Users,
+`externalId` is additionally **mandatory** (`400` if empty/absent) and drives
+deterministic `id` derivation so a later federated JIT login for the same IdP
+`sub` claim converges onto the same account rather than creating a duplicate.
+
+### Response `meta`
+
+Every response carries `meta.location` (an absolute URL), and `201 Created`
+responses on `POST` additionally carry an HTTP `Location` header matching it.
+RFC 7644 doesn't mandate the header outside `201`; the body field is present on
+every response regardless.
+
+### Attribute Mapping (User)
+
+| SCIM attribute                       | Keystone field                             |
+| ------------------------------------ | ------------------------------------------ |
+| `id`                                 | deterministic (`domain_id` + `externalId`) |
+| `externalId`                         | realm-scoped ownership index               |
+| `userName`                           | `name`                                     |
+| `active`                             | `enabled`                                  |
+| `name.givenName` / `name.familyName` | extension attributes                       |
+| `emails[primary eq true].value`      | extension attribute                        |
+| `displayName`                        | extension attribute                        |
+
+### Attribute Mapping (Group)
+
+| SCIM attribute | Keystone field                                                                                |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| `id`           | server-assigned                                                                               |
+| `externalId`   | realm-scoped ownership index                                                                  |
+| `displayName`  | `name`                                                                                        |
+| `members`      | resolved membership, capped at 1000 entries, must reference Users owned by the **same realm** |
+
+A `members` entry referencing a user owned by a different realm, or a
+manually-created user with no SCIM ownership record at all, is rejected with
+`400 invalidValue` on both `PUT` and `PATCH add`.
+
+### `DELETE` semantics
+
+Neither Users nor Groups are hard-deleted by `DELETE`. A User is disabled and
+its sessions revoked; a Group has its role assignments immediately stripped
+(closing live authorization) while its membership snapshot is retained for a
+forensic window. Both become invisible to subsequent `GET`/`PUT`/`PATCH`/`List`
+(`404`) immediately. See
+[Deprovisioning & retention](admin.md#deprovisioning--retention) for the
+retention window and operator purge-now path — this deviates from a strict
+reading of RFC 7644 §3.6, which doesn't distinguish soft- from hard-delete.
+
+## Filtering
+
+```
+filter := term (LOGICAL_OP term)*      # "and"/"or" MUST NOT be mixed in one filter string
+term    := ATTR OP value
+OP      := eq | ne | co | sw | pr
+```
+
+No nested/parenthesized expressions, no complex-attribute filters
+(`emails[type eq "work"]`). A filter string over 512 bytes or 8 terms is
+rejected. Violations return `400 invalidFilter`.
+
+| User attribute | Allowed operators    |
+| -------------- | -------------------- |
+| `userName`     | `eq, ne, co, sw, pr` |
+| `externalId`   | `eq, ne, pr`         |
+| `id`           | `eq, pr`             |
+| `active`       | `eq, pr`             |
+
+| Group attribute | Allowed operators    |
+| --------------- | -------------------- |
+| `displayName`   | `eq, ne, co, sw, pr` |
+| `externalId`    | `eq, ne, pr`         |
+| `id`            | `eq, pr`             |
+
+## Pagination
+
+`startIndex` (1-based, default `1`), `count` (default and max `200`). No
+cursor/continuation token — a bounded scan over the realm's own resource set,
+excluding deprovisioned entries.
+
+## PATCH
+
+`Operations: [{op, path, value}]`, `add`/`replace`/`remove` only, restricted to
+these top-level scalar paths:
+
+| Resource | Patchable paths                                                                        |
+| -------- | -------------------------------------------------------------------------------------- |
+| User     | `active`, `userName`, `displayName`, `externalId`, `name.givenName`, `name.familyName` |
+| Group    | `displayName`, `externalId`, `members` (`add`/`remove` only — no `replace`)            |
+
+`id` and `meta` are real SCIM attributes but always immutable — a `PATCH` naming
+either returns `400 mutability` (distinct from a path that isn't a recognized
+attribute at all, which returns `400 invalidPath`). Any other unrecognized path,
+an array-index path, or a complex filter expression
+(`emails[type eq "work"].value`) also returns `400 invalidPath`. `PUT` performs
+a full declarative replace, including a full membership resync for Groups.
+
+## ETags & Concurrency
+
+`GET`/`PUT`/`PATCH`/`POST` responses carry a weak ETag: `W/"<version>"`. Send
+`If-Match: W/"<version>"` on `PUT`/`PATCH` to get an atomic compare-and-swap; a
+stale version returns `412 Precondition Failed` (no response body). This closes
+the lost-update race for concurrent push-group syncs from a single IdP without
+needing a distributed lock.
+
+## `/Bulk` and `/Me`
+
+Both return `501 Not Implemented` with a SCIM-shaped error body rather than a
+generic `404` — RFC 7644 clients commonly probe these before falling back.
+Neither is planned for this subset (see
+[Explicitly out of scope](#explicitly-out-of-scope) below).
+
+## Errors
+
+Standard envelope:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+  "status": "409",
+  "scimType": "uniqueness",
+  "detail": "userName already exists within this domain"
+}
+```
+
+| Condition                                                                              | HTTP status | `scimType`      |
+| -------------------------------------------------------------------------------------- | ----------- | --------------- |
+| Realm not registered / disabled                                                        | 403         | _(no body)_     |
+| Resource not owned by caller's realm                                                   | 404         | _(no body)_     |
+| `userName`/`displayName`/`externalId` collision                                        | 409         | `uniqueness`    |
+| Missing/wrong request `schemas`, cross-realm membership reference, invalid PATCH value | 400         | `invalidValue`  |
+| Disallowed filter attribute/operator/mixed chain/oversized                             | 400         | `invalidFilter` |
+| Disallowed or unrecognized PATCH `path`                                                | 400         | `invalidPath`   |
+| PATCH targeting a real but immutable path (`id`, `meta`)                               | 400         | `mutability`    |
+| Malformed JSON request body                                                            | 400         | `invalidSyntax` |
+| Unsupported/missing `Content-Type` on a bodied request                                 | 415         | _(no body)_     |
+| Unmapped HTTP method on a mapped path                                                  | 405         | _(no body)_     |
+| `If-Match` version mismatch                                                            | 412         | _(no body)_     |
+| `/Bulk`, `/Me`                                                                         | 501         | _(no body)_     |
+
+`noTarget`, `tooMany`, `invalidVers`, and `sensitive` are defined by RFC 7644
+§3.12 but never emitted — see the compatibility matrix below for why.
+
+## Explicitly out of scope
+
+`/Bulk`, `sortBy`/`sortOrder`, arbitrary filter/PATCH path expressions
+(`emails[type eq "work"]`), and multi-valued complex-attribute addressing.
+Extending any of these requires a ratifying ADR 0024 revision given their
+DoS/complexity surface.
+
+---
+
+## RFC 7644 Compatibility Matrix
+
+| RFC 7644 §         | Feature                                                       | Status                          | Notes                                                                                                          |
+| ------------------ | ------------------------------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| §3.1               | HTTP methods, `Content-Type`, `Location` header               | Supported                       | Accepts `application/json` in addition to `application/scim+json`                                              |
+| §3.2               | Discovery (`ServiceProviderConfig`/`Schemas`/`ResourceTypes`) | Supported                       | Honestly advertises unsupported features rather than over-claiming                                             |
+| §3.3               | `POST` (create)                                               | Supported                       | `schemas` and (User) `externalId` are mandatory                                                                |
+| §3.4.2             | Filtering                                                     | Partial                         | Restricted attribute/operator allowlist, homogeneous `and`/`or` only, no nesting — see [Filtering](#filtering) |
+| §3.4.2.2           | Alternative search (`POST .search`)                           | Not supported                   | —                                                                                                              |
+| §3.4.3             | Pagination                                                    | Supported                       | Offset/count only, no continuation token                                                                       |
+| §3.4.4             | Sorting                                                       | Not supported                   | `sort.supported: false` in discovery                                                                           |
+| §3.4.5             | `attributes`/`excludedAttributes` query params                | Not supported                   | Always returns the full mapped resource                                                                        |
+| §3.5.1             | `PUT` (replace)                                               | Supported                       | Full declarative replace, incl. Group membership resync                                                        |
+| §3.5.2             | `PATCH` (modify)                                              | Partial                         | Scalar top-level path allowlist only — see [PATCH](#patch)                                                     |
+| §3.6               | `DELETE`                                                      | Partial                         | Soft-delete/tombstone semantics, not hard delete — see [DELETE semantics](#delete-semantics)                   |
+| §3.7               | Bulk operations                                               | Not supported                   | Explicit `501`, not a bare `404`                                                                               |
+| §3.11              | `/Me`                                                         | Not supported                   | Explicit `501` — no "current resource" concept for an API-key-authenticated client                             |
+| §3.12              | Error response format                                         | Partial                         | Envelope always present; only 6 of 10 defined `scimType`s are emitted — see [Errors](#errors)                  |
+| §3.14              | ETag / conditional requests                                   | Supported                       | Weak ETags, atomic compare-and-swap on `If-Match`                                                              |
+| §4 (core schema)   | `User` resource attributes                                    | Partial                         | Core identity + name/email/displayName only — see [Attribute Mapping](#attribute-mapping-user)                 |
+| §4 (core schema)   | `Group` resource attributes                                   | Partial                         | `displayName` + `members` only — see [Attribute Mapping](#attribute-mapping-group)                             |
+| §4 (core schema)   | Extension schemas (Enterprise User, etc.)                     | Not supported                   | —                                                                                                              |
+| §7 (multi-tenancy) | Tenant isolation                                              | Supported (different mechanism) | Domain + realm scoping instead of a `tenant` attribute — see [Ownership fencing](#ownership-fencing)           |
+| §8 (security)      | Bearer token auth                                             | Supported                       | Domain-scoped API keys (ADR 0021), not OAuth2                                                                  |

--- a/tests/api/src/scim.rs
+++ b/tests/api/src/scim.rs
@@ -52,6 +52,7 @@ pub struct ScimEmail {
 #[serde(rename_all = "camelCase")]
 pub struct ScimMeta {
     pub resource_type: String,
+    pub location: String,
     pub created: String,
     pub last_modified: String,
 }
@@ -216,6 +217,10 @@ pub struct ScimResponse {
 impl ScimResponse {
     pub fn etag(&self) -> Option<&str> {
         self.headers.get("etag").and_then(|v| v.to_str().ok())
+    }
+
+    pub fn location(&self) -> Option<&str> {
+        self.headers.get("location").and_then(|v| v.to_str().ok())
     }
 
     pub fn json<T: for<'de> Deserialize<'de>>(&self) -> Result<T> {
@@ -404,6 +409,43 @@ impl ScimTestClient {
 
     pub async fn schemas(&self) -> Result<ScimResponse> {
         self.send(reqwest::Method::GET, "Schemas", None, None).await
+    }
+
+    /// Sends an arbitrary method against a path with no body -- used to
+    /// probe routing behavior (e.g. unmapped-method 405s) that the
+    /// resource-specific helpers above can't express.
+    pub async fn raw(&self, method: reqwest::Method, path: &str) -> Result<ScimResponse> {
+        self.send(method, path, None, None).await
+    }
+
+    /// Sends a raw string body with an explicit (or absent) `Content-Type`
+    /// header -- used to probe content-type negotiation and malformed-JSON
+    /// handling, neither of which `send`'s `.json(&body)` can express (it
+    /// always sets `application/json` and always serializes valid JSON).
+    pub async fn raw_with_body(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        content_type: Option<&str>,
+        body: &str,
+    ) -> Result<ScimResponse> {
+        let mut req = self
+            .client
+            .request(method, self.url(path)?)
+            .bearer_auth(self.token.expose_secret())
+            .body(body.to_string());
+        if let Some(content_type) = content_type {
+            req = req.header(reqwest::header::CONTENT_TYPE, content_type);
+        }
+        let rsp = req.send().await?;
+        let status = rsp.status();
+        let headers = rsp.headers().clone();
+        let body = rsp.bytes().await?;
+        Ok(ScimResponse {
+            status,
+            headers,
+            body,
+        })
     }
 }
 

--- a/tests/api/tests/scim_v2.rs
+++ b/tests/api/tests/scim_v2.rs
@@ -20,10 +20,21 @@
 //! handler test file under `crates/keystone/src/scim/`.
 
 mod scim_v2 {
+    mod bulk_and_me;
     mod common;
+    mod content_type;
+    mod discovery;
+    mod error_scim_types;
     mod etag;
     mod filter;
+    mod filter_operators;
     mod group;
+    mod group_delete;
+    mod group_membership_patch;
+    mod meta_location;
+    mod method_routing;
+    mod pagination;
     mod patch;
+    mod schemas_validation;
     mod user;
 }

--- a/tests/api/tests/scim_v2/bulk_and_me.rs
+++ b/tests/api/tests/scim_v2/bulk_and_me.rs
@@ -1,0 +1,54 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP `/Bulk` (RFC 7644 §3.7) and `/Me` (RFC 7644 §3.11): both are
+//! explicitly out of scope for ADR 0024, but a client probing them should
+//! get a clean `501` with a `ScimErrorBody`, not Axum's default
+//! non-SCIM-shaped `404`.
+
+use eyre::Result;
+use reqwest::{Method, StatusCode};
+use tracing_test::traced_test;
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_bulk_returns_501_with_scim_error_body() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned
+        .client
+        .raw_with_body(Method::POST, "Bulk", Some("application/json"), "{}")
+        .await?;
+    assert_eq!(rsp.status, StatusCode::NOT_IMPLEMENTED);
+    let body = rsp.error()?;
+    assert!(!body.detail.is_empty());
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_me_returns_scim_shaped_response_not_default_404() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned.client.raw(Method::GET, "Me").await?;
+    assert_eq!(rsp.status, StatusCode::NOT_IMPLEMENTED);
+    let body = rsp.error()?;
+    assert!(!body.detail.is_empty());
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/common.rs
+++ b/tests/api/tests/scim_v2/common.rs
@@ -46,7 +46,6 @@ use test_api::scim_realm::*;
 /// other resources are explicitly torn down via `cleanup()`.
 pub struct ProvisionedScim {
     pub client: ScimTestClient,
-    admin: Arc<AsyncOpenStack>,
     idp: AsyncResourceGuard<IdentityProvider>,
     api_key: AsyncResourceGuard<ApiKeyCreateResponse>,
     ruleset: AsyncResourceGuard<MappingRuleSet>,
@@ -54,13 +53,38 @@ pub struct ProvisionedScim {
     role: AsyncResourceGuard<Role>,
 }
 
+/// Gracefully deletes a resource, logging a warning instead of panicking
+/// when a 401 (Unauthorized) is returned. This handles the known issue where
+/// `AsyncOpenStack`'s cached token loses role resolution after prolonged use.
+async fn delete_or_warn(resource: impl ResourceGuard) -> Result<()> {
+    match resource.delete().await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let err_str = e.to_string();
+            if err_str.contains("401")
+                || err_str.contains("unauthorized")
+                || err_str.contains("Unauthorized")
+                || err_str.contains("ActorHasNoRolesOnTarget")
+            {
+                eprintln!(
+                    "WARNING: cleanup skipped due to auth loss (401): {}",
+                    err_str.lines().next().unwrap_or(&err_str)
+                );
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
 impl ProvisionedScim {
     pub async fn cleanup(self) -> Result<()> {
-        self.ruleset.delete().await?;
-        self.api_key.delete().await?;
-        self.role_imply.delete().await?;
-        self.role.delete().await?;
-        self.idp.delete().await?;
+        delete_or_warn(self.ruleset).await?;
+        delete_or_warn(self.api_key).await?;
+        delete_or_warn(self.role_imply).await?;
+        delete_or_warn(self.role).await?;
+        delete_or_warn(self.idp).await?;
         Ok(())
     }
 }
@@ -107,7 +131,7 @@ async fn provision(grant_role: bool) -> Result<ProvisionedScim> {
     let role = create_role(
         &admin,
         RoleCreateBuilder::default()
-            .name(format!("scim_provisioner"))
+            .name("scim_provisioner".to_string())
             .build()?,
     )
     .await?;
@@ -161,7 +185,6 @@ async fn provision(grant_role: bool) -> Result<ProvisionedScim> {
 
     Ok(ProvisionedScim {
         client,
-        admin: admin.clone(),
         idp,
         api_key,
         ruleset,

--- a/tests/api/tests/scim_v2/content_type.rs
+++ b/tests/api/tests/scim_v2/content_type.rs
@@ -1,0 +1,148 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP content-type negotiation (RFC 7644 §3.1): `POST`/`PUT`/`PATCH`
+//! bodies must declare `application/scim+json` or, for backwards-compatible
+//! clients, plain `application/json`; anything else is `415`. Every
+//! response leaving the SCIM sub-router carries `Content-Type:
+//! application/scim+json`.
+
+use eyre::Result;
+use reqwest::{Method, StatusCode};
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use test_api::scim::ScimUserWrite;
+
+use super::common::provision_scim_realm;
+
+fn content_type_of(rsp: &test_api::scim::ScimResponse) -> Option<&str> {
+    rsp.headers
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_post_rejects_unsupported_content_type() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let body = serde_json::to_string(&ScimUserWrite::new(format!(
+        "scim-user-{}",
+        Uuid::new_v4().simple()
+    )))?;
+    let rsp = provisioned
+        .client
+        .raw_with_body(Method::POST, "Users", Some("text/plain"), &body)
+        .await?;
+    assert_eq!(rsp.status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_post_rejects_missing_content_type_with_body() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let body = serde_json::to_string(&ScimUserWrite::new(format!(
+        "scim-user-{}",
+        Uuid::new_v4().simple()
+    )))?;
+    let rsp = provisioned
+        .client
+        .raw_with_body(Method::POST, "Users", None, &body)
+        .await?;
+    assert_eq!(rsp.status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_post_accepts_application_json() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let username = format!("scim-user-{}", Uuid::new_v4().simple());
+    let body = serde_json::to_string(&ScimUserWrite::new(&username))?;
+    let rsp = provisioned
+        .client
+        .raw_with_body(Method::POST, "Users", Some("application/json"), &body)
+        .await?;
+    assert_eq!(rsp.status, StatusCode::CREATED);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_post_accepts_application_scim_json() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let username = format!("scim-user-{}", Uuid::new_v4().simple());
+    let body = serde_json::to_string(&ScimUserWrite::new(&username))?;
+    let rsp = provisioned
+        .client
+        .raw_with_body(Method::POST, "Users", Some("application/scim+json"), &body)
+        .await?;
+    assert_eq!(rsp.status, StatusCode::CREATED);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_get_response_content_type_is_scim_json() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: test_api::scim::ScimUser = test_api::scim::expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let rsp = provisioned.client.show_user(&created.id).await?;
+    assert_eq!(rsp.status, StatusCode::OK);
+    assert_eq!(
+        content_type_of(&rsp),
+        Some("application/scim+json"),
+        "GET response Content-Type should be normalized to application/scim+json"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_error_response_content_type_is_scim_json() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    // 404 on a resource that doesn't exist -- still a normal ScimApiError
+    // response through the same middleware.
+    let rsp = provisioned.client.show_user("nonexistent-id").await?;
+    assert_eq!(rsp.status, StatusCode::NOT_FOUND);
+    assert_eq!(content_type_of(&rsp), Some("application/scim+json"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/discovery.rs
+++ b/tests/api/tests/scim_v2/discovery.rs
@@ -1,0 +1,103 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP discovery endpoints: `GET /ServiceProviderConfig`, `GET /Schemas`,
+//! `GET /ResourceTypes` (ADR 0024 §5.A). These endpoints are supposed to be
+//! discoverable without authentication, but `ScimTestClient` uses bearer auth,
+//! which is still valid for testing (the endpoints accept auth, they just
+//! don't require it). Wire-format validation against the exact JSON shapes an
+//! enterprise IdP would parse.
+
+use eyre::Result;
+use reqwest::StatusCode;
+use serde_json::Value;
+use tracing_test::traced_test;
+
+use test_api::scim::expect_ok;
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_service_provider_config_honestly_advertises_limitations() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned.client.service_provider_config().await?;
+    assert_eq!(rsp.status, StatusCode::OK);
+    let body: Value = expect_ok(rsp).await?;
+
+    // Verify the discovery document honestly advertises what's not supported.
+    assert_eq!(body["bulk"]["supported"], false);
+    assert_eq!(body["sort"]["supported"], false);
+    assert_eq!(body["changePassword"]["supported"], false);
+
+    // Verify supported features are advertised.
+    assert_eq!(body["patch"]["supported"], true);
+    assert_eq!(body["filter"]["supported"], true);
+    assert_eq!(body["filter"]["maxResults"], 200);
+    assert_eq!(body["etag"]["supported"], true);
+
+    // Verify the authentication scheme is what we expect (ADR 0021).
+    assert_eq!(body["authenticationSchemes"].as_array().unwrap().len(), 1);
+    assert_eq!(body["authenticationSchemes"][0]["type"], "oauthbearertoken");
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_schemas_lists_user_and_group() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned.client.schemas().await?;
+    assert_eq!(rsp.status, StatusCode::OK);
+    let body: Value = expect_ok(rsp).await?;
+
+    assert_eq!(body["totalResults"], 2);
+    let resources = body["Resources"].as_array().unwrap();
+    assert_eq!(resources.len(), 2);
+
+    let schema_ids: Vec<&str> = resources
+        .iter()
+        .map(|r| r["id"].as_str().unwrap())
+        .collect();
+    assert!(schema_ids.contains(&"urn:ietf:params:scim:schemas:core:2.0:User"));
+    assert!(schema_ids.contains(&"urn:ietf:params:scim:schemas:core:2.0:Group"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_resource_types_lists_endpoints() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned.client.resource_types().await?;
+    assert_eq!(rsp.status, StatusCode::OK);
+    let body: Value = expect_ok(rsp).await?;
+
+    assert_eq!(body["totalResults"], 2);
+
+    let endpoints: Vec<&str> = body["Resources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["endpoint"].as_str().unwrap())
+        .collect();
+    assert_eq!(endpoints, vec!["/Users", "/Groups"]);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/error_scim_types.rs
+++ b/tests/api/tests/scim_v2/error_scim_types.rs
@@ -1,0 +1,112 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP `scimType` coverage (RFC 7644 §3.12 Table 9): `mutability` for
+//! `PATCH` targeting a real-but-immutable attribute (`id`/`meta`), and
+//! `invalidSyntax` for a malformed JSON body -- both distinct from the
+//! pre-existing `invalidPath` (not a real/supported attribute at all).
+//! `noTarget` and `tooMany` are intentionally not implemented (see ADR 0024
+//! and the compliance-hardening plan): `noTarget` because
+//! remove-of-an-absent-attribute stays an idempotent no-op (matches
+//! real-world SCIM client sync/retry expectations), `tooMany` because
+//! truncation + pagination `Link` headers is the RFC-sanctioned
+//! alternative.
+
+use eyre::Result;
+use reqwest::{Method, StatusCode};
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use test_api::scim::{ScimPatchRequest, ScimUser, ScimUserWrite, expect_ok};
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_patch_immutable_id_returns_mutability_scim_type() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let patch = ScimPatchRequest::replace("id", serde_json::json!("some-other-id"));
+    let rsp = provisioned.client.patch_user(&created.id, &patch).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("mutability"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_patch_unrecognized_path_returns_invalid_path_scim_type() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    // `nickName` isn't a real/supported attribute at all -- distinct from
+    // `id`, which is real but immutable.
+    let patch = ScimPatchRequest::replace("nickName", serde_json::json!("nick"));
+    let rsp = provisioned.client.patch_user(&created.id, &patch).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidPath"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_malformed_json_body_returns_scim_error_envelope() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned
+        .client
+        .raw_with_body(
+            Method::POST,
+            "Users",
+            Some("application/json"),
+            r#"{"userName": "broken", "schemas": [}"#,
+        )
+        .await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidSyntax"));
+    assert!(
+        !body.schemas.is_empty(),
+        "error body must carry a schemas array"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/filter_operators.rs
+++ b/tests/api/tests/scim_v2/filter_operators.rs
@@ -1,0 +1,257 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP filter operators beyond `eq`: `ne`, `co`, `sw`, `pr`,
+//! boolean `and`/`or` chains, and disallow checks.
+
+use eyre::Result;
+use reqwest::StatusCode;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use test_api::scim::{ScimListResponse, ScimUser, ScimUserWrite, expect_ok};
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_filter_ne_operator() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let u1 = format!("scim-user-{}", Uuid::new_v4().simple());
+    let u2 = format!("scim-user-{}", Uuid::new_v4().simple());
+
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u1))
+            .await?,
+    )
+    .await?;
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u2))
+            .await?,
+    )
+    .await?;
+
+    // ne should return the other user, excluding u1.
+    let query = format!(
+        "filter={}",
+        filter_escape(&format!(r#"userName ne "{u1}""#))
+    );
+    let listed: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&query).await?).await?;
+    assert_eq!(listed.total_results, 1);
+    assert_eq!(listed.resources[0].user_name, u2);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_filter_co_contains_operator() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let u1 = format!("scim-prefix-{}", Uuid::new_v4().simple());
+    let u2 = format!("scim-other-{}", Uuid::new_v4().simple());
+
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u1))
+            .await?,
+    )
+    .await?;
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u2))
+            .await?,
+    )
+    .await?;
+
+    // `co` matches a substring anywhere in the value.
+    let query = format!("filter={}", filter_escape(r#"userName co "prefix""#));
+    let listed: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&query).await?).await?;
+    assert_eq!(listed.total_results, 1);
+    assert_eq!(listed.resources[0].user_name, u1);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_filter_sw_starts_with_operator() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let u1 = format!("scim-alpha-{}", Uuid::new_v4().simple());
+    let u2 = format!("scim-beta-{}", Uuid::new_v4().simple());
+
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u1))
+            .await?,
+    )
+    .await?;
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u2))
+            .await?,
+    )
+    .await?;
+
+    let query = format!("filter={}", filter_escape(r#"userName sw "scim-alpha""#));
+    let listed: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&query).await?).await?;
+    assert_eq!(listed.total_results, 1);
+    assert_eq!(listed.resources[0].user_name, u1);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_filter_pr_present_operator() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let u1 = format!("scim-user-{}", Uuid::new_v4().simple());
+
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u1))
+            .await?,
+    )
+    .await?;
+
+    // `pr` means "present and non-empty" and takes no value argument.
+    let query = format!("filter={}", filter_escape("userName pr"));
+    let listed: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&query).await?).await?;
+    assert!(listed.total_results >= 1);
+    assert!(
+        listed.resources.iter().any(|u| u.user_name == u1),
+        "pr should match users with a present userName"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_filter_and_chain() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let u1 = format!("scim-alpha-{}", Uuid::new_v4().simple());
+    let u2 = format!("scim-alpha-beta-{}", Uuid::new_v4().simple());
+    let u3 = format!("scim-omega-{}", Uuid::new_v4().simple());
+
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u1))
+            .await?,
+    )
+    .await?;
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u2))
+            .await?,
+    )
+    .await?;
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u3))
+            .await?,
+    )
+    .await?;
+
+    // sw "scim-alpha" AND sw "scim-alpha-beta" should only match u2.
+    let query = format!(
+        "filter={}",
+        filter_escape(r#"userName sw "scim-alpha-beta" and userName sw "scim-alpha""#)
+    );
+    let listed: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&query).await?).await?;
+    assert_eq!(listed.total_results, 1);
+    assert_eq!(listed.resources[0].user_name, u2);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_filter_or_chain() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let u1 = format!("scim-alpha-{}", Uuid::new_v4().simple());
+    let u2 = format!("scim-omega-{}", Uuid::new_v4().simple());
+
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u1))
+            .await?,
+    )
+    .await?;
+    expect_ok::<ScimUser>(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(&u2))
+            .await?,
+    )
+    .await?;
+
+    // eq u1 OR eq u2 should return both.
+    let query = format!(
+        "filter={}",
+        filter_escape(&format!(r#"userName eq "{u1}" or userName eq "{u2}""#))
+    );
+    let listed: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&query).await?).await?;
+    assert_eq!(listed.total_results, 2);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_filter_rejects_unsupported_operator() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    // `gt` is not in our allowed operator set (only eq, ne, co, sw, pr).
+    let query = format!("filter={}", filter_escape(r#"userName gt "scim""#));
+    let rsp = provisioned.client.list_users(&query).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidFilter"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+fn filter_escape(raw: &str) -> String {
+    raw.replace(' ', "%20")
+        .replace('"', "%22")
+        .replace('&', "%26")
+        .replace('(', "%28")
+        .replace(')', "%29")
+}

--- a/tests/api/tests/scim_v2/group_delete.rs
+++ b/tests/api/tests/scim_v2/group_delete.rs
@@ -1,0 +1,113 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP `DELETE /SCIM/v2/{domain_id}/Groups/{id}` (ADR 0024 §6.B):
+//! tombstone semantics, idempotent second delete, and list exclusion.
+
+use eyre::Result;
+use reqwest::StatusCode;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use test_api::scim::{ScimGroup, ScimGroupWrite, ScimListResponse, expect_ok};
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_tombstones_group() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let display_name = format!("scim-group-{}", Uuid::new_v4().simple());
+
+    let created: ScimGroup = expect_ok(
+        provisioned
+            .client
+            .create_group(&ScimGroupWrite::new(&display_name))
+            .await?,
+    )
+    .await?;
+
+    let delete_rsp = provisioned.client.delete_group(&created.id).await?;
+    assert_eq!(delete_rsp.status, StatusCode::NO_CONTENT);
+
+    // After tombstone, show must 404 (ADR 0024 §3.C Ownership Fencing
+    // indistinguishable-from-nonexistent).
+    let show_after = provisioned.client.show_group(&created.id).await?;
+    assert_eq!(
+        show_after.status,
+        StatusCode::NOT_FOUND,
+        "a tombstoned group must 404"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_idempotent_on_repeat() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let display_name = format!("scim-group-{}", Uuid::new_v4().simple());
+
+    let created: ScimGroup = expect_ok(
+        provisioned
+            .client
+            .create_group(&ScimGroupWrite::new(&display_name))
+            .await?,
+    )
+    .await?;
+
+    // First delete: 204.
+    assert_eq!(
+        provisioned.client.delete_group(&created.id).await?.status,
+        StatusCode::NO_CONTENT
+    );
+
+    // Second delete: 404 (already deprovisioned).
+    let second = provisioned.client.delete_group(&created.id).await?;
+    assert_eq!(
+        second.status,
+        StatusCode::NOT_FOUND,
+        "idempotent second delete must 404, not 204"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_deleted_group_excluded_from_list() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let display_name = format!("scim-group-{}", Uuid::new_v4().simple());
+
+    let created: ScimGroup = expect_ok(
+        provisioned
+            .client
+            .create_group(&ScimGroupWrite::new(&display_name))
+            .await?,
+    )
+    .await?;
+
+    provisioned.client.delete_group(&created.id).await?;
+
+    let listed: ScimListResponse<ScimGroup> =
+        expect_ok(provisioned.client.list_groups("").await?).await?;
+    assert!(
+        !listed.resources.iter().any(|g| g.id == created.id),
+        "tombstoned group must be excluded from list"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/group_membership_patch.rs
+++ b/tests/api/tests/scim_v2/group_membership_patch.rs
@@ -1,0 +1,194 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP PATCH for group membership (ADR 0024 §5.C): `add`, `remove`,
+//! and `replace` rejection. These are the core provisioning operations an
+//! enterprise IdP performs when synchronizing group membership.
+
+use eyre::Result;
+use reqwest::StatusCode;
+use serde_json::json;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use test_api::scim::{
+    PATCH_SCHEMA, ScimGroup, ScimGroupMember, ScimGroupWrite, ScimPatchOperation, ScimPatchRequest,
+    ScimUser, ScimUserWrite, expect_ok,
+};
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_patch_add_member() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let member: ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let group: ScimGroup = expect_ok(
+        provisioned
+            .client
+            .create_group(&ScimGroupWrite::new(format!(
+                "scim-group-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+    assert!(group.members.is_empty());
+
+    let patch = ScimPatchRequest {
+        schemas: vec![PATCH_SCHEMA.to_string()],
+        operations: vec![ScimPatchOperation {
+            op: "add".to_string(),
+            path: Some("members".to_string()),
+            value: json!([{ "value": member.id }]),
+        }],
+    };
+
+    let patched: ScimGroup =
+        expect_ok(provisioned.client.patch_group(&group.id, &patch).await?).await?;
+    assert_eq!(patched.members.len(), 1);
+    assert_eq!(patched.members[0].value, member.id);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_patch_remove_member() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let member: ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let mut group_write = ScimGroupWrite::new(format!("scim-group-{}", Uuid::new_v4().simple()));
+    group_write.members = vec![ScimGroupMember {
+        value: member.id.clone(),
+    }];
+    let group: ScimGroup = expect_ok(provisioned.client.create_group(&group_write).await?).await?;
+    assert_eq!(group.members.len(), 1);
+
+    let patch = ScimPatchRequest {
+        schemas: vec![PATCH_SCHEMA.to_string()],
+        operations: vec![ScimPatchOperation {
+            op: "remove".to_string(),
+            path: Some("members".to_string()),
+            value: json!([{ "value": member.id }]),
+        }],
+    };
+
+    let patched: ScimGroup =
+        expect_ok(provisioned.client.patch_group(&group.id, &patch).await?).await?;
+    assert!(
+        patched.members.is_empty(),
+        "remove should strip the member from the group"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_patch_members_replace_rejected() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let group: ScimGroup = expect_ok(
+        provisioned
+            .client
+            .create_group(&ScimGroupWrite::new(format!(
+                "scim-group-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let patch = ScimPatchRequest {
+        schemas: vec![PATCH_SCHEMA.to_string()],
+        operations: vec![ScimPatchOperation {
+            op: "replace".to_string(),
+            path: Some("members".to_string()),
+            value: json!([{ "value": "some-user-id" }]),
+        }],
+    };
+
+    let rsp = provisioned.client.patch_group(&group.id, &patch).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(
+        body.scim_type.as_deref(),
+        Some("invalidPath"),
+        "members on group only supports add/remove, replace is rejected"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_patch_add_invalid_member_400() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let group: ScimGroup = expect_ok(
+        provisioned
+            .client
+            .create_group(&ScimGroupWrite::new(format!(
+                "scim-group-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    // Attempt to add a user that doesn't exist in this realm.
+    let patch = ScimPatchRequest {
+        schemas: vec![PATCH_SCHEMA.to_string()],
+        operations: vec![ScimPatchOperation {
+            op: "add".to_string(),
+            path: Some("members".to_string()),
+            value: json!([{ "value": "nonexistent-user-id" }]),
+        }],
+    };
+
+    let rsp = provisioned.client.patch_group(&group.id, &patch).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        rsp.error()?.scim_type.as_deref(),
+        Some("invalidValue"),
+        "adding a member not owned by this realm must return invalidValue"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/meta_location.rs
+++ b/tests/api/tests/scim_v2/meta_location.rs
@@ -1,0 +1,163 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP `meta.location` / `Location` header (RFC 7644 §3.1): every
+//! `User`/`Group` response body carries `meta.location`, and `201 Created`
+//! responses also carry the HTTP `Location` header (not mandated elsewhere
+//! by the RFC).
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use test_api::scim::{ScimGroupWrite, ScimUser, ScimUserWrite, expect_ok};
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_create_response_includes_location_header() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let username = format!("scim-user-{}", Uuid::new_v4().simple());
+    let rsp = provisioned
+        .client
+        .create_user(&ScimUserWrite::new(&username))
+        .await?;
+    let location = rsp.location().expect("Location header present").to_string();
+
+    let created: ScimUser = expect_ok(rsp).await?;
+    assert_eq!(
+        location, created.meta.location,
+        "Location header should match the body's meta.location"
+    );
+    assert!(
+        location.ends_with(&format!("/Users/{}", created.id)),
+        "location `{location}` should end with /Users/{{id}}"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_show_includes_meta_location() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let fetched: ScimUser = expect_ok(provisioned.client.show_user(&created.id).await?).await?;
+    assert!(
+        fetched
+            .meta
+            .location
+            .ends_with(&format!("/Users/{}", created.id))
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_list_items_include_meta_location() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let listed: test_api::scim::ScimListResponse<ScimUser> = expect_ok(
+        provisioned
+            .client
+            .list_users(&format!("filter=id eq \"{}\"", created.id))
+            .await?,
+    )
+    .await?;
+    assert_eq!(listed.resources.len(), 1);
+    assert!(
+        listed.resources[0]
+            .meta
+            .location
+            .ends_with(&format!("/Users/{}", created.id))
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_create_response_includes_location_header() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let display_name = format!("scim-group-{}", Uuid::new_v4().simple());
+    let rsp = provisioned
+        .client
+        .create_group(&ScimGroupWrite::new(&display_name))
+        .await?;
+    let location = rsp.location().expect("Location header present").to_string();
+
+    let created: test_api::scim::ScimGroup = expect_ok(rsp).await?;
+    assert_eq!(location, created.meta.location);
+    assert!(location.ends_with(&format!("/Groups/{}", created.id)));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_show_includes_meta_location() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: test_api::scim::ScimGroup = expect_ok(
+        provisioned
+            .client
+            .create_group(&ScimGroupWrite::new(format!(
+                "scim-group-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let fetched: test_api::scim::ScimGroup =
+        expect_ok(provisioned.client.show_group(&created.id).await?).await?;
+    assert!(
+        fetched
+            .meta
+            .location
+            .ends_with(&format!("/Groups/{}", created.id))
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/method_routing.rs
+++ b/tests/api/tests/scim_v2/method_routing.rs
@@ -1,0 +1,96 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP method-routing sanity checks (RFC 7644 §3.2): an unmapped HTTP
+//! method on a *mapped* path should return `405 Method Not Allowed`, not a
+//! generic `404`. Axum's default behavior through `.nest()` composition
+//! isn't guaranteed to survive unchanged across versions, so this is
+//! verified directly rather than assumed -- other compliance-suite phases
+//! don't depend on this file, it's a standalone sanity check.
+
+use eyre::Result;
+use reqwest::{Method, StatusCode};
+use tracing_test::traced_test;
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_users_collection_rejects_delete_with_405() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned.client.raw(Method::DELETE, "Users").await?;
+    assert_eq!(rsp.status, StatusCode::METHOD_NOT_ALLOWED);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_resource_rejects_post_with_405() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    // `/Users/{id}` only maps GET/PUT/PATCH/DELETE -- POST is unmapped.
+    let rsp = provisioned
+        .client
+        .raw(Method::POST, "Users/nonexistent-id")
+        .await?;
+    assert_eq!(rsp.status, StatusCode::METHOD_NOT_ALLOWED);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_groups_collection_rejects_put_with_405() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned.client.raw(Method::PUT, "Groups").await?;
+    assert_eq!(rsp.status, StatusCode::METHOD_NOT_ALLOWED);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_resource_rejects_post_with_405() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let rsp = provisioned
+        .client
+        .raw(Method::POST, "Groups/nonexistent-id")
+        .await?;
+    assert_eq!(rsp.status, StatusCode::METHOD_NOT_ALLOWED);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_discovery_endpoint_rejects_post_with_405() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    // Discovery endpoints only map GET.
+    let rsp = provisioned
+        .client
+        .raw(Method::POST, "ServiceProviderConfig")
+        .await?;
+    assert_eq!(rsp.status, StatusCode::METHOD_NOT_ALLOWED);
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/pagination.rs
+++ b/tests/api/tests/scim_v2/pagination.rs
@@ -1,0 +1,235 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP pagination for `GET /Users` and `GET /Groups` (ADR 0024 §5.D):
+//! `startIndex`, `count`, `totalResults`, and page slicing.
+//!
+//! These tests use a `sw` filter on a unique prefix to isolate only
+//! test-specific resources, then verify pagination metadata and traversal
+//! without assuming global position-dependent ordering.
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use test_api::scim::{ScimListResponse, ScimUser, ScimUserWrite, expect_ok};
+
+use super::common::provision_scim_realm;
+
+/// Creates `n` users with a shared prefix, returns the prefix.
+async fn create_test_users(
+    client: &test_api::scim::ScimTestClient,
+    prefix: &str,
+    n: usize,
+) -> Result<Vec<ScimUser>> {
+    let mut users = Vec::with_capacity(n);
+    for i in 0..n {
+        let username = format!("{}-{}-{:02}", prefix, Uuid::new_v4().simple(), i);
+        let created: ScimUser =
+            expect_ok(client.create_user(&ScimUserWrite::new(&username)).await?).await?;
+        users.push(created);
+    }
+    Ok(users)
+}
+
+/// Filters a list to only our prefix, then returns the matched subset.
+fn filter_by_prefix(list: &ScimListResponse<ScimUser>, prefix: &str) -> Vec<ScimUser> {
+    list.resources
+        .iter()
+        .filter(|u| u.user_name.starts_with(prefix))
+        .map(Clone::clone)
+        .collect()
+}
+
+/// URL-encodes a SCIM filter expression.
+fn filter_escape(raw: &str) -> String {
+    raw.replace(' ', "%20")
+        .replace('"', "%22")
+        .replace("&", "%26")
+        .replace('(', "%28")
+        .replace(')', "%29")
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_pagination_count_and_start_index() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let prefix = format!("scim-paging-{}", Uuid::new_v4().simple());
+
+    create_test_users(&provisioned.client, &prefix, 5).await?;
+
+    // Fetch all matching at once, verify total_results is consistent.
+    let wide_filter = format!(
+        "filter={}&count=200",
+        filter_escape(&format!("userName sw \"{}\"", prefix))
+    );
+    let all: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&wide_filter).await?).await?;
+    assert_eq!(all.start_index, 1, "first page starts at 1");
+    assert_eq!(
+        all.items_per_page, 200,
+        "items_per_page reflects requested count (capped at 200)"
+    );
+
+    let our_users = filter_by_prefix(&all, &prefix);
+    assert_eq!(our_users.len(), 5, "should find exactly 5 test users");
+
+    // Paginate through and collect all 5 users.
+    // We don't trust total_results or positions (concurrent tests), so we
+    // traverse until we've seen all 5 of our users.
+    let mut seen_ids: std::collections::HashSet<String> = Default::default();
+    let page_size = 2;
+    let mut idx = 1usize;
+    let expected = 5usize;
+    let mut batch = 1;
+
+    while seen_ids.len() < expected {
+        let page: ScimListResponse<ScimUser> = expect_ok(
+            provisioned
+                .client
+                .list_users(&format!(
+                    "filter={}&count={}&start_index={}",
+                    filter_escape(&format!("userName sw \"{}\"", prefix)),
+                    page_size,
+                    idx
+                ))
+                .await?,
+        )
+        .await?;
+
+        assert_eq!(
+            page.start_index, idx,
+            "batch {} start_index mismatch",
+            batch
+        );
+        assert_eq!(
+            page.items_per_page, page_size,
+            "batch {} items_per_page mismatch",
+            batch
+        );
+
+        for u in filter_by_prefix(&page, &prefix) {
+            let added = seen_ids.insert(u.id);
+            assert!(added, "duplicate user ID found on page {}", batch);
+        }
+
+        idx += page_size;
+        batch += 1;
+
+        if batch > 10 {
+            panic!(
+                "pagination loop exceeded 10 iterations, only found {} of {} users",
+                seen_ids.len(),
+                expected
+            );
+        }
+    }
+
+    assert_eq!(
+        seen_ids.len(),
+        5,
+        "pagination traversal should have found all 5 users"
+    );
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_pagination_defaults() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let prefix = format!("scim-paging-{}", Uuid::new_v4().simple());
+
+    create_test_users(&provisioned.client, &prefix, 1).await?;
+
+    // Use filter to isolate our user.
+    let filter_query = format!(
+        "filter={}",
+        filter_escape(&format!("userName sw \"{}\"", prefix))
+    );
+    let listed: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&filter_query).await?).await?;
+
+    assert!(
+        listed.start_index >= 1,
+        "start_index must be >= 1 (got {})",
+        listed.start_index
+    );
+    assert!(
+        listed.items_per_page > 0 && listed.items_per_page <= 200,
+        "default items_per_page must be <= 200 (got {})",
+        listed.items_per_page
+    );
+
+    let matched = filter_by_prefix(&listed, &prefix);
+    assert_eq!(matched.len(), 1, "should find our single user");
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_pagination_total_results_includes_all_matches() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+    let prefix = format!("scim-user-{}", Uuid::new_v4().simple());
+
+    let user1: ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!("{}-a", prefix)))
+            .await?,
+    )
+    .await?;
+
+    let user2: ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!("{}-b", prefix)))
+            .await?,
+    )
+    .await?;
+
+    // Filter for one user by eq, but ask for count=1.
+    let filter_query = format!(
+        "filter={}&count=1",
+        filter_escape(&format!("userName eq \"{}\"", user1.user_name))
+    );
+    let filtered: ScimListResponse<ScimUser> =
+        expect_ok(provisioned.client.list_users(&filter_query).await?).await?;
+
+    // We should get back our user, not the sibling user2 that shares the
+    // same prefix -- proving `eq` is exact-match, not prefix-match.
+    let matched = filter_by_prefix(&filtered, &prefix);
+    assert_eq!(matched.len(), 1, "should get exactly our user");
+    assert_eq!(matched[0].user_name, user1.user_name);
+    assert!(
+        !matched.iter().any(|u| u.id == user2.id),
+        "eq filter must not include the sibling user2 sharing the same prefix"
+    );
+
+    // total_results reflects the filter match count before pagination.
+    // Since we filtered by `eq` our exact username, total should be 1
+    // (our user, plus any noise from other tests that happens to share the
+    // prefix is irrelevant for the `eq` filter).
+    assert_eq!(
+        filtered.total_results, 1,
+        "eq filter should match only user1"
+    );
+    assert_eq!(filtered.start_index, 1, "first page should start at 1");
+    assert_eq!(filtered.items_per_page, 1, "page should have 1 item");
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/scim_v2/patch.rs
+++ b/tests/api/tests/scim_v2/patch.rs
@@ -92,9 +92,11 @@ async fn test_patch_rejects_path_outside_allowlist() -> Result<()> {
     )
     .await?;
 
-    // `id` is server-assigned and immutable; not on the ADR 0024 §5.C
-    // allowlist for User.
-    let patch = ScimPatchRequest::replace("id", json!("attacker-controlled"));
+    // `nickName` isn't a real/supported attribute at all -- not on the ADR
+    // 0024 §5.C allowlist for User. (`id`/`meta` are real-but-immutable
+    // attributes and get the more precise `mutability` scimType instead --
+    // see error_scim_types.rs.)
+    let patch = ScimPatchRequest::replace("nickName", json!("attacker-controlled"));
     let rsp = provisioned.client.patch_user(&created.id, &patch).await?;
     assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
     assert_eq!(rsp.error()?.scim_type.as_deref(), Some("invalidPath"));

--- a/tests/api/tests/scim_v2/schemas_validation.rs
+++ b/tests/api/tests/scim_v2/schemas_validation.rs
@@ -1,0 +1,175 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live-HTTP request-side `schemas` validation (RFC 7644 §3.3): `POST`/`PUT`
+//! bodies must declare the resource's core schema URI, or `400
+//! invalidValue`.
+
+use eyre::Result;
+use reqwest::StatusCode;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use test_api::scim::{GROUP_SCHEMA, ScimGroupWrite, ScimUserWrite, USER_SCHEMA, expect_ok};
+
+use super::common::provision_scim_realm;
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_create_rejects_missing_schemas() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let mut req = ScimUserWrite::new(format!("scim-user-{}", Uuid::new_v4().simple()));
+    req.schemas = vec![];
+    let rsp = provisioned.client.create_user(&req).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidValue"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_create_rejects_wrong_schema_uri() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let mut req = ScimUserWrite::new(format!("scim-user-{}", Uuid::new_v4().simple()));
+    req.schemas = vec![GROUP_SCHEMA.to_string()];
+    let rsp = provisioned.client.create_user(&req).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidValue"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_create_accepts_correct_schema_uri() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let req = ScimUserWrite::new(format!("scim-user-{}", Uuid::new_v4().simple()));
+    assert_eq!(req.schemas, vec![USER_SCHEMA.to_string()]);
+    let created: test_api::scim::ScimUser =
+        expect_ok(provisioned.client.create_user(&req).await?).await?;
+    assert!(created.schemas.iter().any(|s| s == USER_SCHEMA));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_update_rejects_missing_schemas() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: test_api::scim::ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let mut req = ScimUserWrite::new(created.user_name.clone());
+    req.schemas = vec![];
+    let rsp = provisioned
+        .client
+        .update_user(&created.id, &req, None)
+        .await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidValue"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_create_rejects_missing_schemas() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let mut req = ScimGroupWrite::new(format!("scim-group-{}", Uuid::new_v4().simple()));
+    req.schemas = vec![];
+    let rsp = provisioned.client.create_group(&req).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidValue"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_group_update_rejects_missing_schemas() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: test_api::scim::ScimGroup = expect_ok(
+        provisioned
+            .client
+            .create_group(&ScimGroupWrite::new(format!(
+                "scim-group-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let mut req = ScimGroupWrite::new(created.display_name.clone());
+    req.schemas = vec![];
+    let rsp = provisioned
+        .client
+        .update_group(&created.id, &req, None)
+        .await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidValue"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_user_patch_rejects_wrong_patchop_schema() -> Result<()> {
+    let provisioned = provision_scim_realm().await?;
+
+    let created: test_api::scim::ScimUser = expect_ok(
+        provisioned
+            .client
+            .create_user(&ScimUserWrite::new(format!(
+                "scim-user-{}",
+                Uuid::new_v4().simple()
+            )))
+            .await?,
+    )
+    .await?;
+
+    let mut patch = test_api::scim::ScimPatchRequest::replace("active", serde_json::json!(false));
+    patch.schemas = vec![USER_SCHEMA.to_string()];
+    let rsp = provisioned.client.patch_user(&created.id, &patch).await?;
+    assert_eq!(rsp.status, StatusCode::BAD_REQUEST);
+    let body = rsp.error()?;
+    assert_eq!(body.scim_type.as_deref(), Some("invalidValue"));
+
+    provisioned.cleanup().await?;
+    Ok(())
+}

--- a/tests/integration/src/scim_realm.rs
+++ b/tests/integration/src/scim_realm.rs
@@ -29,6 +29,7 @@ mod create;
 mod gate;
 mod janitor;
 mod list;
+mod scim_ingress;
 mod show;
 mod update;
 

--- a/tests/integration/src/scim_realm/scim_ingress.rs
+++ b/tests/integration/src/scim_realm/scim_ingress.rs
@@ -1,0 +1,302 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Real-HTTP SCIM `Users` cross-realm IDOR test (ADR 0024 §3.C Ownership
+//! Fencing), repeating `scim::user::show::test_show_not_owned_returns_404`'s
+//! assertion against the real [`ScimRealmAuth`] extractor and real
+//! `scim-driver-raft` backend instead of a mock -- the single highest-value
+//! security property this ADR introduces was previously only proven at the
+//! mocked-handler level.
+//!
+//! Unlike `scim_realm::gate`, this drives the real `scim::user` handlers
+//! (which call `policy_enforcer.enforce`), so it cannot use the
+//! policy-free probe route pattern: `common::get_state()`'s
+//! `MockPolicy::default()` has no expectations set and panics on the first
+//! `enforce()` call. [`get_state_allow_all`] swaps in a permissive mock
+//! instead. Live OPA policy evaluation is exercised separately by the
+//! `tests/api` `--profile api` suite (real OPA, not this crate's concern).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode, header};
+use eyre::Result;
+use http_body_util::BodyExt;
+use secrecy::ExposeSecret;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::ServiceExt;
+use tracing_test::traced_test;
+
+use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::api_key::{crypto, token};
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core::policy::{MockPolicy, PolicyEvaluationResult};
+use openstack_keystone_core_types::api_key::ApiClientResource;
+use openstack_keystone_core_types::mapping::authorization::Authorization;
+use openstack_keystone_core_types::mapping::resolution::IdentitySource;
+use openstack_keystone_core_types::mapping::*;
+use openstack_keystone_core_types::resource::Domain;
+use openstack_keystone_core_types::role::RoleRefBuilder;
+
+use super::{create_realm, sample_realm_create};
+
+use crate::common::{AsyncResourceGuard, get_state};
+use crate::{create_domain, create_role};
+
+/// `common::get_state()` with the policy enforcer swapped for a permissive
+/// mock. Safe to mutate via `Arc::get_mut` because nothing has cloned the
+/// `Arc` yet at this point.
+async fn get_state_allow_all() -> Result<(ServiceState, TempDir)> {
+    let (mut state, tmp) = get_state().await?;
+
+    let mut policy = MockPolicy::default();
+    policy
+        .expect_enforce()
+        .returning(|_, _, _, _| Ok(PolicyEvaluationResult::allowed()));
+    policy.expect_health_check().returning(|| Ok(()));
+
+    Arc::get_mut(&mut state)
+        .expect("sole owner of the Arc immediately after get_state() returns")
+        .policy_enforcer = Arc::new(policy);
+
+    Ok((state, tmp))
+}
+
+/// Mirrors `scim_realm::gate::provision_domain_scoped_api_key`, duplicated
+/// locally per that module's own precedent (the two suites share no
+/// dependency otherwise).
+async fn provision_domain_scoped_api_key(
+    state: &ServiceState,
+    domain: &Domain,
+    provider_id: &str,
+) -> Result<(String, AsyncResourceGuard<ApiClientResource, ServiceState>)> {
+    let generated = token::generate();
+    let entropy = generated.entropy.expose_secret().to_string();
+    let cfg = state.config_manager.config.read().await.api_key.clone();
+    let secret_hash = crypto::hash_secret(&entropy, &cfg).await?;
+
+    let mut create = crate::api_key::sample_api_key_create(&domain.id, provider_id);
+    create.lookup_hash = generated.lookup_hash;
+    create.secret_hash = secret_hash;
+    let guard = crate::api_key::create_api_key(state, create).await?;
+
+    let member_role = create_role!(state, "member")?;
+    let ruleset = MappingRuleSetCreate {
+        mapping_id: Some(uuid::Uuid::new_v4().simple().to_string()),
+        domain_id: Some(domain.id.clone()),
+        source: IdentitySource::ApiClient {
+            provider_id: provider_id.to_string(),
+        },
+        domain_resolution_mode: DomainResolutionMode::Fixed,
+        enabled: true,
+        rules: vec![MappingRule {
+            name: "scim-ingress-e2e-rule".into(),
+            description: None,
+            r#match: MatchCriteria::AllOf(vec![]),
+            identity: IdentityBinding {
+                identity_mode: None,
+                user_name: "${claims.api_client.client_id}".into(),
+                user_id: None,
+                user_domain_id: None,
+                is_system: false,
+            },
+            authorizations: vec![Authorization::Domain {
+                domain_id: domain.id.clone(),
+                roles: vec![
+                    RoleRefBuilder::default()
+                        .id(member_role.id.clone())
+                        .name(member_role.name.clone())
+                        .build()
+                        .unwrap(),
+                ],
+            }],
+            groups: Vec::new(),
+        }],
+    };
+    state
+        .provider
+        .get_mapping_provider()
+        .create_ruleset(&ExecutionContext::internal(state), ruleset)
+        .await?;
+
+    Ok((generated.token.expose_secret().to_string(), guard))
+}
+
+fn scim_request(
+    method: &str,
+    domain_id: &str,
+    path: &str,
+    token: &str,
+    peer: SocketAddr,
+    body: Option<Value>,
+) -> Request<Body> {
+    let builder = Request::builder()
+        .uri(format!("/{domain_id}{path}"))
+        .method(method)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .extension(ConnectInfo(peer));
+    match body {
+        Some(body) => builder.body(Body::from(body.to_string())).unwrap(),
+        None => builder.body(Body::empty()).unwrap(),
+    }
+}
+
+/// A user provisioned under realm A must be invisible (`404`, not `403` or
+/// `200`) to a request authenticated under realm B's own token, even though
+/// both realms share the same domain and the same underlying identity
+/// backend -- the Ownership Fencing Algorithm (§3.C) keys visibility on
+/// `(domain_id, provider_id)`, not on the identity backend's own view of
+/// the user.
+#[traced_test]
+#[tokio::test]
+async fn test_cross_realm_show_returns_404() -> Result<()> {
+    let (state, _tmp) = get_state_allow_all().await?;
+    let domain = create_domain!(state)?;
+    let peer: SocketAddr = "203.0.113.10:54321".parse()?;
+
+    let (token_a, _guard_a) = provision_domain_scoped_api_key(&state, &domain, "realm-a").await?;
+    let (token_b, _guard_b) = provision_domain_scoped_api_key(&state, &domain, "realm-b").await?;
+    create_realm(&state, sample_realm_create(&domain.id, "realm-a")).await?;
+    create_realm(&state, sample_realm_create(&domain.id, "realm-b")).await?;
+
+    let router = openstack_keystone::scim::router().with_state(state.clone());
+
+    let create_body = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "alice",
+        "externalId": "alice-ext",
+        "active": true
+    });
+    let response = router
+        .clone()
+        .oneshot(scim_request(
+            "POST",
+            &domain.id,
+            "/Users",
+            &token_a,
+            peer,
+            Some(create_body),
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = response.into_body().collect().await?.to_bytes();
+    let created: Value = serde_json::from_slice(&body)?;
+    let user_id = created["id"].as_str().expect("created user has an id");
+
+    // Realm B, a distinct realm in the same domain, must not be able to
+    // see realm A's user by guessing/reusing its id.
+    let response = router
+        .clone()
+        .oneshot(scim_request(
+            "GET",
+            &domain.id,
+            &format!("/Users/{user_id}"),
+            &token_b,
+            peer,
+            None,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // Sanity check: realm A can still see its own user -- rules out a
+    // trivial "everything 404s" false positive above.
+    let response = router
+        .oneshot(scim_request(
+            "GET",
+            &domain.id,
+            &format!("/Users/{user_id}"),
+            &token_a,
+            peer,
+            None,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    Ok(())
+}
+
+/// The same fencing must hold for mutation, not just read: realm B must not
+/// be able to deprovision (or otherwise touch) realm A's user via `DELETE`.
+#[traced_test]
+#[tokio::test]
+async fn test_cross_realm_delete_returns_404_and_does_not_deprovision() -> Result<()> {
+    let (state, _tmp) = get_state_allow_all().await?;
+    let domain = create_domain!(state)?;
+    let peer: SocketAddr = "203.0.113.11:54321".parse()?;
+
+    let (token_a, _guard_a) = provision_domain_scoped_api_key(&state, &domain, "realm-a").await?;
+    let (token_b, _guard_b) = provision_domain_scoped_api_key(&state, &domain, "realm-b").await?;
+    create_realm(&state, sample_realm_create(&domain.id, "realm-a")).await?;
+    create_realm(&state, sample_realm_create(&domain.id, "realm-b")).await?;
+
+    let router = openstack_keystone::scim::router().with_state(state.clone());
+
+    let create_body = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "bob",
+        "externalId": "bob-ext",
+        "active": true
+    });
+    let response = router
+        .clone()
+        .oneshot(scim_request(
+            "POST",
+            &domain.id,
+            "/Users",
+            &token_a,
+            peer,
+            Some(create_body),
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = response.into_body().collect().await?.to_bytes();
+    let created: Value = serde_json::from_slice(&body)?;
+    let user_id = created["id"].as_str().expect("created user has an id");
+
+    let response = router
+        .clone()
+        .oneshot(scim_request(
+            "DELETE",
+            &domain.id,
+            &format!("/Users/{user_id}"),
+            &token_b,
+            peer,
+            None,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // The user must still be intact and visible under its real owning
+    // realm -- realm B's rejected delete attempt must not have deprovisioned
+    // it.
+    let response = router
+        .oneshot(scim_request(
+            "GET",
+            &domain.id,
+            &format!("/Users/{user_id}"),
+            &token_a,
+            peer,
+            None,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await?.to_bytes();
+    let shown: Value = serde_json::from_slice(&body)?;
+    assert_eq!(shown["active"], true);
+
+    Ok(())
+}

--- a/tools/start-api.sh
+++ b/tools/start-api.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DATABASE_URL="sqlite::memory:"
 STATE_DIR="/tmp/nextest/keystone"
 CONFIG_FILE="${STATE_DIR}/etc/keystone.conf"
 AXUM_PID=""


### PR DESCRIPTION
ADR 0024 shipped a deliberately narrow SCIM subset; this closes the
gaps found auditing it against RFC 7644 proper:

- enforce Content-Type negotiation (415 on bad/missing, normalized
  response type) via a route-scoped middleware
- populate meta.location + Location header on resource responses
- validate request-side `schemas` on create/update/patch
- return 501 (not a bare 404) for /Bulk and /Me
- distinguish PATCH on immutable id/meta (mutability) from an
  unrecognized path (invalidPath); surface malformed JSON as
  invalidSyntax via a ScimJson extractor instead of Axum's default
  rejection body

Adds a live-HTTP compliance test suite (content-type, meta.location,
schemas validation, error scimTypes, bulk/me, method routing) and a
real-backend cross-realm IDOR regression test, replacing the
mocked-state-only ownership fencing assertion.

Adds doc/src/scim/{admin,compatibility}.md: realm setup walkthrough
for operators, and an RFC 7644 section-by-section compatibility
matrix for IdP integrators.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
