### PR TITLE
feat(identity): Implement user password change endpoint

### DIFF
--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -267,6 +267,7 @@ impl From<IdentityProviderError> for KeystoneApiError {
                 resource: "group".into(),
                 identifier: x,
             },
+            ref err @ IdentityProviderError::Conflict(..) => Self::Conflict(err.to_string()),
             ref err @ IdentityProviderError::SecurityCompliance(..) => {
                 Self::BadRequest(err.to_string())
             }
@@ -278,7 +279,7 @@ impl From<IdentityProviderError> for KeystoneApiError {
 impl From<ResourceProviderError> for KeystoneApiError {
     fn from(value: ResourceProviderError) -> Self {
         match value {
-            ref err @ ResourceProviderError::Conflict(..) => Self::BadRequest(err.to_string()),
+            ref err @ ResourceProviderError::Conflict(..) => Self::Conflict(err.to_string()),
             ResourceProviderError::DomainNotFound(x) => Self::NotFound {
                 resource: "domain".into(),
                 identifier: x,
@@ -291,7 +292,7 @@ impl From<ResourceProviderError> for KeystoneApiError {
 impl From<RevokeProviderError> for KeystoneApiError {
     fn from(value: RevokeProviderError) -> Self {
         match value {
-            ref err @ RevokeProviderError::Conflict(..) => Self::BadRequest(err.to_string()),
+            ref err @ RevokeProviderError::Conflict(..) => Self::Conflict(err.to_string()),
             other => Self::InternalError(other.to_string()),
         }
     }
@@ -434,6 +435,7 @@ impl From<TokenProviderError> for KeystoneApiError {
     fn from(value: TokenProviderError) -> Self {
         match value {
             TokenProviderError::Authentication(source) => source.into(),
+            TokenProviderError::Conflict { message, .. } => Self::Conflict(message),
             TokenProviderError::TrustorDomainDisabled
             | TokenProviderError::TrustorUserDisabled(_) => {
                 Self::unauthorized(value, None::<String>)
@@ -654,6 +656,65 @@ mod tests {
             api_err,
             KeystoneApiError::InternalError(msg) if msg.contains("bad")
         ));
+    }
+
+    #[test]
+    fn identity_provider_conflict_returns_409() {
+        let err = IdentityProviderError::Conflict("reason".to_string());
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(
+            api_err,
+            KeystoneApiError::Conflict(ref msg) if msg.contains("reason")
+        ));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::CONFLICT
+        );
+    }
+
+    #[test]
+    fn resource_provider_conflict_returns_409() {
+        let err = ResourceProviderError::Conflict("reason".to_string());
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(
+            api_err,
+            KeystoneApiError::Conflict(ref msg) if msg.contains("reason")
+        ));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::CONFLICT
+        );
+    }
+
+    #[test]
+    fn revoke_provider_conflict_returns_409() {
+        let err = RevokeProviderError::Conflict("reason".to_string());
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(
+            api_err,
+            KeystoneApiError::Conflict(ref msg) if msg.contains("reason")
+        ));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::CONFLICT
+        );
+    }
+
+    #[test]
+    fn token_provider_conflict_returns_409() {
+        let err = TokenProviderError::Conflict {
+            message: "reason".to_string(),
+            context: "".to_string(),
+        };
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(
+            api_err,
+            KeystoneApiError::Conflict(ref msg) if msg == "reason"
+        ));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::CONFLICT
+        );
     }
 
     #[test]

--- a/crates/api-types/src/v3/user.rs
+++ b/crates/api-types/src/v3/user.rs
@@ -304,6 +304,42 @@ pub struct UserUpdateRequest {
     pub user: UserUpdate,
 }
 
+/// Change user password data.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+#[cfg_attr(
+    feature = "validate",
+    validate(schema(function = "validate_user_password_secret"))
+)]
+pub struct UserPassword {
+    /// The current password for the user.
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
+    #[serde(serialize_with = "crate::common::serialize_secret_string")]
+    pub original_password: SecretString,
+
+    /// The new password for the user.
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
+    #[serde(serialize_with = "crate::common::serialize_secret_string")]
+    pub password: SecretString,
+}
+
+#[cfg(feature = "validate")]
+fn validate_user_password_secret(value: &UserPassword) -> Result<(), validator::ValidationError> {
+    crate::common::validate_secret_length(&value.original_password, 72)
+        .and(crate::common::validate_secret_length(&value.password, 72))
+}
+
+/// Complete password change request.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct UserPasswordRequest {
+    /// User object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub user: UserPassword,
+}
+
 /// User options.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -527,6 +563,62 @@ mod tests {
             .build()
             .unwrap();
         assert!(!sot.enabled, "user enabled flag defaults to `false`");
+    }
+
+    #[cfg(feature = "validate")]
+    #[test]
+    fn userpassword_validates_both_fields() {
+        use validator::Validate;
+
+        let valid: UserPassword =
+            serde_json::from_str(r#"{"original_password":"old","password":"new"}"#).unwrap();
+        assert!(valid.validate().is_ok());
+
+        let overlong_new: UserPassword = serde_json::from_str(&format!(
+            r#"{{"original_password":"old","password":"{}"}}"#,
+            "x".repeat(73)
+        ))
+        .unwrap();
+        assert!(overlong_new.validate().is_err());
+
+        let overlong_old: UserPassword = serde_json::from_str(&format!(
+            r#"{{"original_password":"{}","password":"new"}}"#,
+            "x".repeat(73)
+        ))
+        .unwrap();
+        assert!(overlong_old.validate().is_err());
+    }
+
+    #[test]
+    fn userpassword_debug_does_not_leak_secrets() {
+        let pw: UserPassword =
+            serde_json::from_str(r#"{"original_password":"OLDLEAK","password":"NEWLEAK"}"#)
+                .unwrap();
+        let debug_output = format!("{pw:?}");
+        assert!(
+            !debug_output.contains("OLDLEAK"),
+            "Debug leaked original_password: {debug_output}"
+        );
+        assert!(
+            !debug_output.contains("NEWLEAK"),
+            "Debug leaked password: {debug_output}"
+        );
+    }
+
+    #[test]
+    fn userpassword_request_roundtrip() {
+        let req: UserPasswordRequest =
+            serde_json::from_str(r#"{"user":{"original_password":"old","password":"new"}}"#)
+                .unwrap();
+        assert_eq!(req.user.original_password.expose_secret(), "old");
+        assert_eq!(req.user.password.expose_secret(), "new");
+
+        let rendered = serde_json::to_string(&req).unwrap();
+        assert!(
+            rendered.contains("old"),
+            "original_password not carried: {rendered}"
+        );
+        assert!(rendered.contains("new"), "password not carried: {rendered}");
     }
 
     #[test]

--- a/crates/identity-driver-sql/src/lib.rs
+++ b/crates/identity-driver-sql/src/lib.rs
@@ -655,14 +655,8 @@ impl IdentityBackend for SqlBackend {
         new_password: SecretString,
     ) -> Result<(), IdentityProviderError> {
         let config = state.config_manager.config.read().await;
-        Ok(local_user::update_password(
-            &state.db,
-            &config,
-            user_id,
-            original_password,
-            new_password,
-        )
-        .await?)
+        local_user::update_password(&state.db, &config, user_id, original_password, new_password)
+            .await
     }
 }
 

--- a/crates/identity-driver-sql/src/local_user.rs
+++ b/crates/identity-driver-sql/src/local_user.rs
@@ -57,7 +57,12 @@ pub async fn update_password(
     let (local_user, passwords) =
         load_local_user_with_passwords(db, Some(user_id), None::<&str>, None::<&str>)
             .await?
-            .ok_or(IdentityProviderError::UserNotFound(user_id.to_string()))?;
+            .ok_or_else(|| {
+                IdentityProviderError::Conflict(format!(
+                    "cannot update password for nonlocal user {}",
+                    user_id
+                ))
+            })?;
 
     // Get the latest password hash for verification
     let passwords_vec: Vec<db_password::Model> = passwords.into_iter().collect();
@@ -320,7 +325,7 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_password_user_not_found() {
+    async fn test_update_password_nonlocal_user() {
         let config = get_config_none_hashing();
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -337,8 +342,8 @@ pub mod tests {
         .await;
 
         assert!(
-            matches!(result, Err(IdentityProviderError::UserNotFound(ref uid)) if uid == "nonexistent_user"),
-            "nonexistent user should return UserNotFound, got: {:?}",
+            matches!(result, Err(IdentityProviderError::Conflict(ref msg)) if msg.contains("cannot update password for nonlocal user")),
+            "nonlocal user should return Conflict, got: {:?}",
             result
         );
     }

--- a/crates/keystone/src/api/v3/user/mod.rs
+++ b/crates/keystone/src/api/v3/user/mod.rs
@@ -21,6 +21,7 @@ mod delete;
 mod groups;
 mod list;
 mod os_ec2;
+mod password;
 mod show;
 pub mod types;
 mod update;
@@ -30,6 +31,7 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
         .routes(routes!(list::list, create::create))
         .routes(routes!(show::show, delete::delete))
         .routes(routes!(update::update))
+        .routes(routes!(password::change_password))
         .routes(routes!(groups::groups))
         .merge(os_ec2::openapi_router())
 }

--- a/crates/keystone/src/api/v3/user/password.rs
+++ b/crates/keystone/src/api/v3/user/password.rs
@@ -1,0 +1,292 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Set user password
+//!
+//! Unauthenticated endpoint that validates the original password and sets the
+//! new password. The original password serves as authentication.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use secrecy::SecretString;
+use validator::Validate;
+
+use crate::api::error::KeystoneApiError;
+use crate::api::v3::user::types::UserPasswordRequest;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::identity::UserPasswordAuthRequest;
+
+/// Set or change user password.
+///
+/// This is an unauthenticated call. The `original_password` field is used to
+/// authenticate the user, and upon successful verification the `password` field
+/// becomes the new password. If the user is not a local user (i.e., a
+/// federated user), a `409 Conflict` is returned.
+#[utoipa::path(
+    post,
+    path = "/{user_id}/password",
+    description = "Set or change user password",
+    request_body = UserPasswordRequest,
+    responses(
+        (status = NO_CONTENT, description = "Password changed successfully"),
+        (status = 400, description = "Invalid input"),
+        (status = 401, description = "Original password is incorrect"),
+        (status = 404, description = "User not found"),
+        (status = 409, description = "Password change not supported for nonlocal user"),
+        (status = 500, description = "Internal error")
+    ),
+    tag="users"
+)]
+#[tracing::instrument(name = "api::change_user_password", level = "debug", skip(state))]
+pub(super) async fn change_password(
+    Path(user_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<UserPasswordRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    let ctx = ExecutionContext::internal(&state);
+    let identity = state.provider.get_identity_provider();
+
+    let auth_req = UserPasswordAuthRequest {
+        id: Some(user_id.clone()),
+        name: None,
+        domain: None,
+        password: SecretString::clone(&req.user.original_password),
+    };
+
+    let _ = identity.authenticate_by_password(&ctx, &auth_req).await?;
+
+    identity
+        .update_user_password(
+            &ctx,
+            &user_id,
+            req.user.original_password,
+            SecretString::clone(&req.user.password),
+        )
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{self, Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use super::super::openapi_router;
+    use crate::api::tests::get_mocked_state;
+    use crate::api::v3::user::types::UserPasswordRequest;
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+    use openstack_keystone_core::auth::AuthenticationResult;
+    use openstack_keystone_core::identity::IdentityProviderError;
+    use openstack_keystone_core_types::auth::{
+        AuthenticationContext, AuthenticationResultBuilder, IdentityInfo, PrincipalInfo,
+        UserIdentityInfoBuilder,
+    };
+    use secrecy::SecretString;
+
+    use super::super::types::UserPassword;
+
+    fn make_password_request() -> UserPasswordRequest {
+        UserPasswordRequest {
+            user: UserPassword {
+                original_password: SecretString::from("old"),
+                password: SecretString::from("new_secret"),
+            },
+        }
+    }
+
+    fn make_auth_result() -> AuthenticationResult {
+        AuthenticationResultBuilder::default()
+            .context(AuthenticationContext::Password)
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    UserIdentityInfoBuilder::default()
+                        .user_id("bar")
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_change_password_success() {
+        let auth_result = make_auth_result();
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_authenticate_by_password()
+            .returning(move |_ctx, _req| Ok(auth_result.clone()));
+        identity_mock
+            .expect_update_user_password()
+            .returning(|_, _, _, _| Ok(()));
+
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .uri("/bar/password")
+                    .body(Body::from(
+                        serde_json::to_string(&make_password_request()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_change_password_wrong_password() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_authenticate_by_password()
+            .returning(|_, _| {
+                Err(IdentityProviderError::Authentication {
+                    source:
+                        openstack_keystone_core::auth::AuthenticationError::UserNameOrPasswordWrong,
+                })
+            });
+
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .uri("/bar/password")
+                    .body(Body::from(
+                        serde_json::to_string(&make_password_request()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_change_password_nonlocal_user() {
+        let auth_result = make_auth_result();
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_authenticate_by_password()
+            .returning(move |_ctx, _req| Ok(auth_result.clone()));
+        identity_mock
+            .expect_update_user_password()
+            .returning(|_, _, _, _| {
+                Err(IdentityProviderError::Conflict(
+                    "cannot update password for nonlocal user".to_string(),
+                ))
+            });
+
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .uri("/bar/password")
+                    .body(Body::from(
+                        serde_json::to_string(&make_password_request()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_change_password_validation_error() {
+        let overlong_password: UserPassword = serde_json::from_str(&format!(
+            r#"{{"original_password":"old","password":"{}"}}"#,
+            "x".repeat(73)
+        ))
+        .unwrap();
+        let req = UserPasswordRequest {
+            user: overlong_password,
+        };
+
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .uri("/bar/password")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
## What
Implements  for changing user passwords.

## How
- Unauthenticated endpoint that verifies the original password via `authenticate_by_password` before calling `update_user_password`
- Returns 401 on auth failure, 409 for nonlocal users, 204 on success
- 4 unit tests covering all response codes

## Bug Fixes
Also fixes `Conflict` error mapping bugs in `error_conv.rs`:

| Provider Error | Before | After |
|---|---|---|
| `ResourceProviderError::Conflict` | 400 | **409** |
| `RevokeProviderError::Conflict` | 400 | **409** |
| `IdentityProviderError::Conflict` | 500 | **409** |
| `TokenProviderError::Conflict` | 500 | **409** |

Nonlocal user password update now returns 409 (was 404).

## Files Changed
- `crates/api-types/src/error_conf.rs`: 4 `Conflict` mappings fixed
- `crates/api-types/src/v3/user.rs`: `UserPasswordRequest` API types
- `crates/identity-driver-sql/src/local_user.rs`: nonlocal → 409
- `crates/identity-driver-sql/src/lib.rs`: simplified password update
- `crates/keystone/src/api/v3/user/password.rs`: new handler + tests
- `crates/keystone/src/api/v3/user/mod.rs`: route registration