### PR TITLE
fix(raft): Gracefully handle start_raft_app errors

### DIFF
--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -777,13 +777,22 @@ async fn start_raft(
 
         // Signal channel: start_raft_app sends `true` once the gRPC listener
         // is bound. `ensure_raft_initialized` waits for this before calling
-        // join_cluster, ensuring the new node's listener can accept replication
-        // traffic from the leader immediately.
+        // join_cluster, ensuring the new node's listener is ready to accept
+        // replication traffic from the leader.
         let (raft_bound_tx, raft_bound_rx) = tokio::sync::watch::channel(false);
+        let raft_task_token = token.clone();
         handles.spawn(async move {
-            raft_grpc::start_raft_app(raft_storage, raft_config, raft_cancel_token, raft_bound_tx)
-                .await
-                .unwrap()
+            if let Err(e) = raft_grpc::start_raft_app(
+                raft_storage,
+                raft_config,
+                raft_cancel_token,
+                raft_bound_tx,
+            )
+            .await
+            {
+                error!("Raft gRPC listener error: {:#}", e);
+                raft_task_token.cancel();
+            }
         });
         raft_grpc::ensure_raft_initialized(raft_storage_init, cfg.clone(), raft_bound_rx).await?;
     }

--- a/crates/keystone/src/server/listener/spiffe_common.rs
+++ b/crates/keystone/src/server/listener/spiffe_common.rs
@@ -52,7 +52,7 @@ pub async fn build_spiffe_config(
     let source = tokio::select! {
         res = spiffe::X509Source::new() => { res? }
         _ = token.cancelled() => {
-            tracing::info!("Ctrl+C signal received while waiting for the SPIFFE communication");
+            tracing::info!("Cancelled while waiting for SPIFFE X509 source");
             return Ok(None);
         }
     };


### PR DESCRIPTION
The Raft task used .unwrap() on start_raft_app(), causing it to panic
on any error and silently take down the entire server. The panic was
caught by JoinSet::join_all() which returned early, cancelling all
other tasks without logging the actual error. All other listener tasks
handled errors gracefully with if let Err(e).

Now the Raft task logs the error and cancels the token, consistent
with the other listener tasks.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
