### PR TITLE
feat(adr0026): Phase 2 client registration & OIDC discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4471,6 +4471,7 @@ dependencies = [
  "openstack-keystone-k8s-auth-driver-sql",
  "openstack-keystone-key-repository",
  "openstack-keystone-mapping-driver-raft",
+ "openstack-keystone-oauth2-client-driver-raft",
  "openstack-keystone-oauth2-key-driver-raft",
  "openstack-keystone-resource-driver-sql",
  "openstack-keystone-revoke-driver-sql",
@@ -4993,6 +4994,20 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "openstack-keystone-oauth2-client-driver-raft"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "openstack-keystone-core",
+ "openstack-keystone-core-types",
+ "openstack-keystone-distributed-storage",
+ "rmp-serde",
+ "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/key-repository",
   "crates/keystone",
   "crates/mapping-driver-raft",
+  "crates/oauth2-client-driver-raft",
   "crates/oauth2-key-driver-raft",
   "crates/resource-driver-sql",
   "crates/role-driver-sql",
@@ -127,6 +128,7 @@ openstack-keystone-k8s-auth-driver-sql = { version = "0.1", path = "crates/k8s-a
 openstack-keystone-k8s-auth-driver-raft = { version = "0.1", path = "crates/k8s-auth-driver-raft/" }
 openstack-keystone-key-repository = { version = "0.1.0", path = "crates/key-repository" }
 openstack-keystone-mapping-driver-raft = { version = "0.1", path = "crates/mapping-driver-raft/" }
+openstack-keystone-oauth2-client-driver-raft = { version = "0.1", path = "crates/oauth2-client-driver-raft/" }
 openstack-keystone-oauth2-key-driver-raft = { version = "0.1", path = "crates/oauth2-key-driver-raft/" }
 openstack-keystone-identity-driver-sql = { version = "0.1", path = "crates/identity-driver-sql" }
 openstack-keystone-idmapping-driver-sql = { version = "0.1", path = "crates/idmapping-driver-sql/" }

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -33,6 +33,7 @@ use openstack_keystone_core_types::error::BuilderError;
 use openstack_keystone_core_types::error::KeystoneError;
 use openstack_keystone_core_types::identity::IdentityProviderError;
 use openstack_keystone_core_types::mapping::MappingProviderError;
+use openstack_keystone_core_types::oauth2_client::Oauth2ClientProviderError;
 use openstack_keystone_core_types::oauth2_key::Oauth2KeyProviderError;
 use openstack_keystone_core_types::resource::ResourceProviderError;
 use openstack_keystone_core_types::revoke::RevokeProviderError;
@@ -318,6 +319,20 @@ impl From<ApiKeyProviderError> for KeystoneApiError {
             // never leak detail to the client (ADR 0021 §6.D OPSEC leakage);
             // callers on that path should prefer mapping these to a generic
             // `AuthenticationError::Unauthorized` before this conversion runs.
+            other => Self::InternalError(other.to_string()),
+        }
+    }
+}
+
+impl From<Oauth2ClientProviderError> for KeystoneApiError {
+    fn from(value: Oauth2ClientProviderError) -> Self {
+        match value {
+            Oauth2ClientProviderError::NotFound(x) => Self::NotFound {
+                resource: "oauth2_client".into(),
+                identifier: x,
+            },
+            Oauth2ClientProviderError::Conflict(x) => Self::Conflict(x),
+            Oauth2ClientProviderError::Validation(x) => Self::UnprocessableEntity(x),
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/api-types/src/v4/oauth2_client.rs
+++ b/crates/api-types/src/v4/oauth2_client.rs
@@ -1,0 +1,247 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client (relying party registration) API types (ADR 0026 §5).
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "validate")]
+use validator::Validate;
+
+use crate::Link;
+
+/// OAuth2/OIDC grant type a client is authorized to use.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum GrantType {
+    /// RFC 6749 `authorization_code`, optionally with PKCE (RFC 7636).
+    AuthorizationCode,
+    /// RFC 6749 `client_credentials` (machine-to-machine).
+    ClientCredentials,
+    /// OAuth 2.0 Device Authorization Grant (RFC 8628).
+    DeviceCode,
+    /// RFC 6749 `refresh_token`.
+    RefreshToken,
+}
+
+/// A registered OAuth2/OIDC relying party. Never carries `client_secret` or
+/// its hash -- the plaintext secret is only ever returned once, by `create`
+/// or `rotate-secret`.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct OAuth2Client {
+    /// Scopes this client may request.
+    pub allowed_scopes: Vec<String>,
+
+    /// Per-client output claim templates (ADR 0026 §4, "Claim Safety").
+    pub claims_template: HashMap<String, String>,
+
+    /// Whether this is a confidential client (has a `client_secret`).
+    pub confidential: bool,
+
+    /// Globally unique public client identifier (server-generated).
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub client_id: String,
+
+    /// UTC epoch seconds.
+    pub created_at: i64,
+
+    /// UTC epoch seconds of soft-delete, if revoked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<i64>,
+
+    /// Domain owning this client registration.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub domain_id: String,
+
+    /// Whether the client is currently usable.
+    pub enabled: bool,
+
+    /// Grant types this client is authorized to use.
+    pub grant_types: Vec<GrantType>,
+
+    /// Whether consent is pre-authorized. SystemAdmin-only to set.
+    pub pre_authorized: bool,
+
+    /// The Unified Mapping Engine (ADR 0020) `provider_id` coordinate.
+    /// Unique within `domain_id`.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub provider_id: String,
+
+    /// Allowed redirect URIs for the `authorization_code` grant.
+    pub redirect_uris: Vec<String>,
+
+    /// Whether PKCE (RFC 7636) is mandatory for this client.
+    pub require_pkce: bool,
+
+    /// Token endpoint authentication method. Immutable after creation.
+    pub token_endpoint_auth_method: String,
+
+    /// UTC epoch seconds.
+    pub updated_at: i64,
+}
+
+/// OAuth2 client creation payload.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct OAuth2ClientCreate {
+    /// Scopes this client may request.
+    #[serde(default)]
+    pub allowed_scopes: Vec<String>,
+
+    /// Per-client output claim templates.
+    #[serde(default)]
+    pub claims_template: HashMap<String, String>,
+
+    /// Whether to register a confidential client (server generates and
+    /// returns a `client_secret` exactly once) or a public client (no
+    /// secret, PKCE mandatory).
+    pub confidential: bool,
+
+    /// Grant types this client is authorized to use.
+    #[serde(default)]
+    pub grant_types: Vec<GrantType>,
+
+    /// Whether consent is pre-authorized. SystemAdmin-only to set.
+    #[serde(default)]
+    pub pre_authorized: bool,
+
+    /// The `provider_id` coordinate this client registers under. `domain_id`
+    /// comes from the URL path, not the body.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub provider_id: String,
+
+    /// Allowed redirect URIs for the `authorization_code` grant.
+    #[serde(default)]
+    pub redirect_uris: Vec<String>,
+
+    /// Whether PKCE is mandatory. Always `true` for public clients.
+    #[serde(default)]
+    pub require_pkce: bool,
+
+    /// Token endpoint authentication method (e.g. `client_secret_basic`,
+    /// `none`).
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub token_endpoint_auth_method: String,
+}
+
+/// OAuth2 client creation request wrapper.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct OAuth2ClientCreateRequest {
+    /// OAuth2 client creation payload.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub oauth2_client: OAuth2ClientCreate,
+}
+
+/// OAuth2 client creation response. `client_secret` is populated exactly
+/// once for a confidential client, and never again on any subsequent read.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OAuth2ClientCreateResponse {
+    /// One-time plaintext client secret. `None` for a public client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+
+    /// The created OAuth2 client.
+    pub oauth2_client: OAuth2Client,
+}
+
+/// OAuth2 client update payload. `None` fields are left unchanged.
+/// `client_id`, `provider_id`, `domain_id`, and `token_endpoint_auth_method`
+/// are immutable after creation.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct OAuth2ClientUpdate {
+    /// New allowed scopes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_scopes: Option<Vec<String>>,
+
+    /// New claim templates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claims_template: Option<HashMap<String, String>>,
+
+    /// Enable/disable toggle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    /// New grant types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grant_types: Option<Vec<GrantType>>,
+
+    /// New pre-authorized flag. SystemAdmin-only to set to `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_authorized: Option<bool>,
+
+    /// New redirect URIs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_uris: Option<Vec<String>>,
+
+    /// New PKCE requirement.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub require_pkce: Option<bool>,
+}
+
+/// OAuth2 client update request wrapper.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct OAuth2ClientUpdateRequest {
+    /// OAuth2 client update payload.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub oauth2_client: OAuth2ClientUpdate,
+}
+
+/// OAuth2 client response.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OAuth2ClientResponse {
+    /// OAuth2 client object.
+    pub oauth2_client: OAuth2Client,
+}
+
+/// OAuth2 client list response.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OAuth2ClientList {
+    /// Pagination links.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+    /// Collection of OAuth2 clients.
+    pub oauth2_clients: Vec<OAuth2Client>,
+}
+
+/// OAuth2 client list query parameters.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct OAuth2ClientListParameters {
+    /// Filter by enabled/disabled state. `domain_id` comes from the URL
+    /// path, not the query string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+/// Response to `POST .../{provider_id}/rotate-secret`.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OAuth2ClientRotateSecretResponse {
+    /// One-time plaintext client secret.
+    pub client_secret: String,
+}

--- a/crates/api-types/src/v4/oauth2_client_conv.rs
+++ b/crates/api-types/src/v4/oauth2_client_conv.rs
@@ -1,0 +1,108 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client conversion implementations.
+
+use openstack_keystone_core_types::oauth2_client as core;
+
+use crate::v4::oauth2_client as api;
+
+impl From<api::GrantType> for core::GrantType {
+    fn from(value: api::GrantType) -> Self {
+        match value {
+            api::GrantType::AuthorizationCode => Self::AuthorizationCode,
+            api::GrantType::ClientCredentials => Self::ClientCredentials,
+            api::GrantType::RefreshToken => Self::RefreshToken,
+            api::GrantType::DeviceCode => Self::DeviceCode,
+        }
+    }
+}
+
+impl From<core::GrantType> for api::GrantType {
+    fn from(value: core::GrantType) -> Self {
+        match value {
+            core::GrantType::AuthorizationCode => Self::AuthorizationCode,
+            core::GrantType::ClientCredentials => Self::ClientCredentials,
+            core::GrantType::RefreshToken => Self::RefreshToken,
+            core::GrantType::DeviceCode => Self::DeviceCode,
+        }
+    }
+}
+
+impl From<api::OAuth2ClientCreateRequest> for core::OAuth2ClientResourceCreate {
+    /// `domain_id` comes from the URL path (`.domain_id = ...` is set by the
+    /// handler after this conversion), not the request body.
+    fn from(value: api::OAuth2ClientCreateRequest) -> Self {
+        let c = value.oauth2_client;
+        Self {
+            // Filled in by the service layer (server-generated UUIDv4).
+            client_id: String::new(),
+            provider_id: c.provider_id,
+            // Filled in by the handler from the URL path.
+            domain_id: String::new(),
+            // Filled in by the service layer after hashing.
+            client_secret_hash: None,
+            redirect_uris: c.redirect_uris,
+            token_endpoint_auth_method: c.token_endpoint_auth_method,
+            grant_types: c.grant_types.into_iter().map(Into::into).collect(),
+            require_pkce: c.require_pkce,
+            allowed_scopes: c.allowed_scopes,
+            pre_authorized: c.pre_authorized,
+            claims_template: c.claims_template,
+        }
+    }
+}
+
+impl From<api::OAuth2ClientUpdateRequest> for core::OAuth2ClientResourceUpdate {
+    fn from(value: api::OAuth2ClientUpdateRequest) -> Self {
+        value.oauth2_client.into()
+    }
+}
+
+impl From<api::OAuth2ClientUpdate> for core::OAuth2ClientResourceUpdate {
+    fn from(value: api::OAuth2ClientUpdate) -> Self {
+        Self {
+            redirect_uris: value.redirect_uris,
+            grant_types: value
+                .grant_types
+                .map(|g| g.into_iter().map(Into::into).collect()),
+            require_pkce: value.require_pkce,
+            allowed_scopes: value.allowed_scopes,
+            pre_authorized: value.pre_authorized,
+            enabled: value.enabled,
+            claims_template: value.claims_template,
+        }
+    }
+}
+
+impl From<core::OAuth2ClientResource> for api::OAuth2Client {
+    fn from(value: core::OAuth2ClientResource) -> Self {
+        Self {
+            client_id: value.client_id,
+            provider_id: value.provider_id,
+            domain_id: value.domain_id,
+            confidential: value.client_secret_hash.is_some(),
+            redirect_uris: value.redirect_uris,
+            token_endpoint_auth_method: value.token_endpoint_auth_method,
+            grant_types: value.grant_types.into_iter().map(Into::into).collect(),
+            require_pkce: value.require_pkce,
+            allowed_scopes: value.allowed_scopes,
+            pre_authorized: value.pre_authorized,
+            enabled: value.enabled,
+            claims_template: value.claims_template,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+            deleted_at: value.deleted_at,
+        }
+    }
+}

--- a/crates/config/src/oauth2.rs
+++ b/crates/config/src/oauth2.rs
@@ -57,10 +57,39 @@ pub struct Oauth2Provider {
     #[serde(default = "default_signing_key_rotation_days")]
     #[validate(range(min = 1))]
     pub signing_key_rotation_days: u32,
+
+    /// Argon2id memory cost, in KiB, for `OAuth2Client` confidential-client
+    /// secret hashing (ADR 0026 §5). A separate knob set from `[api_key]`
+    /// so the two credential classes can be tuned independently.
+    #[serde(default = "default_argon2_memory_kib")]
+    #[validate(range(min = 1))]
+    pub argon2_memory_kib: u32,
+
+    /// Argon2id time cost (iterations) for client secret hashing.
+    #[serde(default = "default_argon2_time_cost")]
+    #[validate(range(min = 1))]
+    pub argon2_time_cost: u32,
+
+    /// Argon2id parallelism (lanes) for client secret hashing.
+    #[serde(default = "default_argon2_parallelism")]
+    #[validate(range(min = 1))]
+    pub argon2_parallelism: u32,
 }
 
 fn default_signing_key_rotation_days() -> u32 {
     90
+}
+
+fn default_argon2_memory_kib() -> u32 {
+    65536
+}
+
+fn default_argon2_time_cost() -> u32 {
+    3
+}
+
+fn default_argon2_parallelism() -> u32 {
+    4
 }
 
 impl Default for Oauth2Provider {
@@ -68,6 +97,9 @@ impl Default for Oauth2Provider {
         Self {
             signing_algorithm: SigningAlgorithm::default(),
             signing_key_rotation_days: default_signing_key_rotation_days(),
+            argon2_memory_kib: default_argon2_memory_kib(),
+            argon2_time_cost: default_argon2_time_cost(),
+            argon2_parallelism: default_argon2_parallelism(),
         }
     }
 }

--- a/crates/core-types/src/error.rs
+++ b/crates/core-types/src/error.rs
@@ -28,6 +28,7 @@ use crate::identity::IdentityProviderError;
 use crate::idmapping::IdMappingProviderError;
 use crate::k8s_auth::K8sAuthProviderError;
 use crate::mapping::MappingProviderError;
+use crate::oauth2_client::Oauth2ClientProviderError;
 use crate::oauth2_key::Oauth2KeyProviderError;
 use crate::resource::ResourceProviderError;
 use crate::revoke::RevokeProviderError;
@@ -152,6 +153,14 @@ pub enum KeystoneError {
         /// The source of the error.
         #[from]
         source: MappingProviderError,
+    },
+
+    /// OAuth2 client provider.
+    #[error(transparent)]
+    Oauth2ClientProvider {
+        /// The source of the error.
+        #[from]
+        source: Oauth2ClientProviderError,
     },
 
     /// OAuth2 signing key provider.

--- a/crates/core-types/src/lib.rs
+++ b/crates/core-types/src/lib.rs
@@ -31,6 +31,7 @@ pub mod identity;
 pub mod idmapping;
 pub mod k8s_auth;
 pub mod mapping;
+pub mod oauth2_client;
 pub mod oauth2_key;
 pub mod resource;
 pub mod revoke;

--- a/crates/core-types/src/oauth2_client.rs
+++ b/crates/core-types/src/oauth2_client.rs
@@ -11,21 +11,10 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # V4 API types
-pub mod api_key;
-pub mod auth;
-pub mod auth_plugin;
-pub mod mapping;
-pub mod oauth2_client;
-pub mod scim_realm;
-pub mod token_restriction;
-pub mod user;
+//! # OAuth2 client (relying party registration) resource (ADR 0026 §5)
 
-#[cfg(feature = "conv")]
-mod api_key_conv;
-#[cfg(feature = "conv")]
-mod oauth2_client_conv;
-#[cfg(feature = "conv")]
-mod scim_realm_conv;
-#[cfg(feature = "conv")]
-mod token_restriction_conv;
+mod error;
+mod resource;
+
+pub use error::*;
+pub use resource::*;

--- a/crates/core-types/src/oauth2_client/error.rs
+++ b/crates/core-types/src/oauth2_client/error.rs
@@ -1,0 +1,95 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OAuth2 client provider error
+
+use thiserror::Error;
+
+use crate::error::BuilderError;
+
+/// OAuth2 client (`OAuth2ClientResource`) provider error (ADR 0026 §5).
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum Oauth2ClientProviderError {
+    /// Conflict (`provider_id` already registered in the domain, or
+    /// `client_id` collision).
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Argon2id hashing error (client secret generation/hashing). Stored as
+    /// a message rather than a boxed source because
+    /// `argon2::password_hash::Error` does not implement
+    /// `std::error::Error` (the crate targets `no_std`).
+    #[error("crypto error in the oauth2 client provider: {0}")]
+    Crypto(String),
+
+    /// OAuth2 client not found.
+    #[error("OAuth2 client {0} not found")]
+    NotFound(String),
+
+    /// Raft storage is not available for the OAuth2 client provider.
+    #[error("raft storage is not available in the oauth2 client provider")]
+    RaftNotAvailable,
+
+    /// Raft storage error.
+    #[error("raft storage error in the oauth2 client provider: {source}")]
+    RaftStoreError {
+        /// The source of the error.
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Structures builder error.
+    #[error(transparent)]
+    StructBuilder {
+        /// The source of the error.
+        #[from]
+        source: Box<BuilderError>,
+    },
+
+    /// Unsupported driver.
+    #[error("unsupported driver `{0}` for the oauth2 client provider")]
+    UnsupportedDriver(String),
+
+    /// Request validation error (redirect URI scheme, PKCE requirement,
+    /// reserved claim template key).
+    #[error("validation error in the oauth2 client provider: {0}")]
+    Validation(String),
+}
+
+impl Oauth2ClientProviderError {
+    /// Wrap a crypto (Argon2id) error.
+    pub fn crypto<E>(source: E) -> Self
+    where
+        E: std::fmt::Display,
+    {
+        Self::Crypto(source.to_string())
+    }
+
+    /// Wrap a raft storage error.
+    pub fn raft<E>(source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::RaftStoreError {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<BuilderError> for Oauth2ClientProviderError {
+    fn from(value: BuilderError) -> Self {
+        Self::StructBuilder {
+            source: Box::new(value),
+        }
+    }
+}

--- a/crates/core-types/src/oauth2_client/resource.rs
+++ b/crates/core-types/src/oauth2_client/resource.rs
@@ -1,0 +1,298 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OAuth2 client (relying party registration) resource (ADR 0026 §5)
+
+use std::collections::HashMap;
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use crate::error::BuilderError;
+
+/// OAuth2/OIDC grant type an [`OAuth2ClientResource`] is authorized to use.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GrantType {
+    /// RFC 6749 `authorization_code`, optionally with PKCE (RFC 7636).
+    AuthorizationCode,
+    /// RFC 6749 `client_credentials` (machine-to-machine).
+    ClientCredentials,
+    /// RFC 6749 `refresh_token`.
+    RefreshToken,
+    /// OAuth 2.0 Device Authorization Grant (RFC 8628).
+    DeviceCode,
+}
+
+/// A registered OAuth2/OIDC relying party (ADR 0026 §5, "Amendment to ADR
+/// 0020: OAuth2 Client as a Fourth Provider Resource").
+///
+/// Indexed in storage by `(domain_id, provider_id)` under
+/// `oauth2:client:v1:<domain_id>:<provider_id>`, with `client_id` resolved
+/// globally (not domain-scoped) via
+/// `oauth2:client:client_id_idx:v1:<client_id>`.
+#[derive(Builder, Clone, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct OAuth2ClientResource {
+    /// Globally unique public client identifier (server-generated UUIDv4).
+    pub client_id: String,
+
+    /// The Unified Mapping Engine (ADR 0020) `provider_id` coordinate this
+    /// client is registered under. Unique within `domain_id`.
+    pub provider_id: String,
+
+    /// Domain owning this client registration.
+    pub domain_id: String,
+
+    /// Argon2id PHC hash of the client secret. `None` for a public client
+    /// (e.g. SPA or native app using PKCE, no client authentication).
+    #[builder(default)]
+    pub client_secret_hash: Option<String>,
+
+    /// Allowed redirect URIs for the `authorization_code` grant. Confidential
+    /// clients (`client_secret_hash.is_some()`) must use `https://` only;
+    /// public clients may additionally use `http://localhost:*`.
+    #[builder(default)]
+    pub redirect_uris: Vec<String>,
+
+    /// Token endpoint authentication method (e.g. `client_secret_basic`,
+    /// `none`). Immutable after creation.
+    pub token_endpoint_auth_method: String,
+
+    /// Grant types this client is authorized to use.
+    #[builder(default)]
+    pub grant_types: Vec<GrantType>,
+
+    /// Whether PKCE (RFC 7636) is mandatory for this client. Always `true`
+    /// for public clients.
+    #[builder(default)]
+    pub require_pkce: bool,
+
+    /// Scopes this client may request.
+    #[builder(default)]
+    pub allowed_scopes: Vec<String>,
+
+    /// Whether consent is pre-authorized (skips the interactive consent
+    /// screen). SystemAdmin-only to set (ADR 0026 §5).
+    #[builder(default)]
+    pub pre_authorized: bool,
+
+    /// Whether the client is currently usable. Cleared by soft-delete.
+    pub enabled: bool,
+
+    /// Per-client output claim templates, interpolated at `/token` issuance
+    /// (ADR 0026 §4, "Claim Safety"). Keys colliding with the reserved claim
+    /// set are rejected at save time.
+    #[builder(default)]
+    pub claims_template: HashMap<String, String>,
+
+    /// UTC epoch seconds.
+    pub created_at: i64,
+
+    /// UTC epoch seconds.
+    pub updated_at: i64,
+
+    /// UTC epoch seconds of soft-delete (`DELETE`). Record retained (not
+    /// hard-deleted) for Phase 4's refresh-token family-tree invalidation.
+    #[builder(default)]
+    pub deleted_at: Option<i64>,
+}
+
+impl std::fmt::Debug for OAuth2ClientResource {
+    /// Redacts `client_secret_hash` to prevent leaking the Argon2id PHC
+    /// string into application error logs.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuth2ClientResource")
+            .field("client_id", &self.client_id)
+            .field("provider_id", &self.provider_id)
+            .field("domain_id", &self.domain_id)
+            .field(
+                "client_secret_hash",
+                &self.client_secret_hash.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("redirect_uris", &self.redirect_uris)
+            .field(
+                "token_endpoint_auth_method",
+                &self.token_endpoint_auth_method,
+            )
+            .field("grant_types", &self.grant_types)
+            .field("require_pkce", &self.require_pkce)
+            .field("allowed_scopes", &self.allowed_scopes)
+            .field("pre_authorized", &self.pre_authorized)
+            .field("enabled", &self.enabled)
+            .field("claims_template", &self.claims_template)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("deleted_at", &self.deleted_at)
+            .finish()
+    }
+}
+
+impl OAuth2ClientResource {
+    /// Apply a partial [`OAuth2ClientResourceUpdate`], returning the new
+    /// version to persist.
+    ///
+    /// Defense in depth: the service layer (`Oauth2ClientService::update`)
+    /// already refuses to update a soft-deleted client at all, so this path
+    /// should never see `self.deleted_at.is_some()`. If it ever does anyway
+    /// (a future caller bypassing the service layer), `deleted_at` is
+    /// cleared here rather than left stale alongside a newly `enabled` flag
+    /// -- `enabled: true` and a set `deleted_at` must never coexist.
+    pub fn with_update(self, update: OAuth2ClientResourceUpdate, now: i64) -> Self {
+        let enabled = update.enabled.unwrap_or(self.enabled);
+        let deleted_at = if enabled { None } else { self.deleted_at };
+        Self {
+            redirect_uris: update.redirect_uris.unwrap_or(self.redirect_uris),
+            grant_types: update.grant_types.unwrap_or(self.grant_types),
+            require_pkce: update.require_pkce.unwrap_or(self.require_pkce),
+            allowed_scopes: update.allowed_scopes.unwrap_or(self.allowed_scopes),
+            pre_authorized: update.pre_authorized.unwrap_or(self.pre_authorized),
+            enabled,
+            claims_template: update.claims_template.unwrap_or(self.claims_template),
+            updated_at: now,
+            deleted_at,
+            ..self
+        }
+    }
+
+    /// Apply the soft-delete path: disables the client and stamps the
+    /// tombstone, without deleting the record (Phase 2 design decision --
+    /// keeps the record available for Phase 4's refresh-token family-tree
+    /// invalidation walk).
+    pub fn soft_delete(self, now: i64) -> Self {
+        Self {
+            enabled: false,
+            deleted_at: Some(now),
+            updated_at: now,
+            ..self
+        }
+    }
+}
+
+/// Input to create a new [`OAuth2ClientResource`]. `client_id` is
+/// server-generated; `client_secret_hash` is pre-hashed by the service layer
+/// before reaching the backend.
+#[derive(Builder, Clone, Deserialize, Serialize, PartialEq)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct OAuth2ClientResourceCreate {
+    /// Globally unique public client identifier (server-generated UUIDv4).
+    pub client_id: String,
+
+    /// The Unified Mapping Engine (ADR 0020) `provider_id` coordinate.
+    pub provider_id: String,
+
+    /// Domain owning this client registration.
+    pub domain_id: String,
+
+    /// Argon2id PHC hash of the client secret. `None` for a public client.
+    #[builder(default)]
+    pub client_secret_hash: Option<String>,
+
+    /// Allowed redirect URIs for the `authorization_code` grant.
+    #[builder(default)]
+    pub redirect_uris: Vec<String>,
+
+    /// Token endpoint authentication method.
+    pub token_endpoint_auth_method: String,
+
+    /// Grant types this client is authorized to use.
+    #[builder(default)]
+    pub grant_types: Vec<GrantType>,
+
+    /// Whether PKCE is mandatory for this client.
+    #[builder(default)]
+    pub require_pkce: bool,
+
+    /// Scopes this client may request.
+    #[builder(default)]
+    pub allowed_scopes: Vec<String>,
+
+    /// Whether consent is pre-authorized. SystemAdmin-only to set.
+    #[builder(default)]
+    pub pre_authorized: bool,
+
+    /// Per-client output claim templates.
+    #[builder(default)]
+    pub claims_template: HashMap<String, String>,
+}
+
+impl std::fmt::Debug for OAuth2ClientResourceCreate {
+    /// Redacts `client_secret_hash`; see [`OAuth2ClientResource::fmt`].
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuth2ClientResourceCreate")
+            .field("client_id", &self.client_id)
+            .field("provider_id", &self.provider_id)
+            .field("domain_id", &self.domain_id)
+            .field(
+                "client_secret_hash",
+                &self.client_secret_hash.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("redirect_uris", &self.redirect_uris)
+            .field(
+                "token_endpoint_auth_method",
+                &self.token_endpoint_auth_method,
+            )
+            .field("grant_types", &self.grant_types)
+            .field("require_pkce", &self.require_pkce)
+            .field("allowed_scopes", &self.allowed_scopes)
+            .field("pre_authorized", &self.pre_authorized)
+            .field("claims_template", &self.claims_template)
+            .finish()
+    }
+}
+
+/// Partial update for an [`OAuth2ClientResource`]
+/// (`PUT /v4/oauth2/{domain_id}/clients/{provider_id}`).
+///
+/// `client_id`, `provider_id`, `domain_id`, and `token_endpoint_auth_method`
+/// are immutable after creation and therefore absent from this type.
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
+pub struct OAuth2ClientResourceUpdate {
+    /// `None` = unchanged.
+    pub redirect_uris: Option<Vec<String>>,
+
+    /// `None` = unchanged.
+    pub grant_types: Option<Vec<GrantType>>,
+
+    /// `None` = unchanged.
+    pub require_pkce: Option<bool>,
+
+    /// `None` = unchanged.
+    pub allowed_scopes: Option<Vec<String>>,
+
+    /// `None` = unchanged. Setting `Some(true)` requires SystemAdmin
+    /// (enforced by Rego policy, not this type).
+    pub pre_authorized: Option<bool>,
+
+    /// `None` = unchanged.
+    pub enabled: Option<bool>,
+
+    /// `None` = unchanged.
+    pub claims_template: Option<HashMap<String, String>>,
+}
+
+/// Filter parameters for `GET /v4/oauth2/{domain_id}/clients`.
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct OAuth2ClientResourceListParameters {
+    /// Domain to list clients for.
+    pub domain_id: String,
+
+    /// Restrict to enabled/disabled clients.
+    #[builder(default)]
+    pub enabled: Option<bool>,
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -101,6 +101,7 @@ pub mod k8s_auth;
 pub mod keystone;
 pub mod mapping;
 pub mod net;
+pub mod oauth2_client;
 pub mod oauth2_key;
 pub mod plugin_manager;
 pub mod policy;

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -112,6 +112,71 @@ mod api_key {
 }
 pub use api_key::MockApiKeyProvider;
 
+mod oauth2_client {
+    use super::*;
+
+    use openstack_keystone_core_types::oauth2_client::*;
+
+    use crate::auth::ExecutionContext;
+    use crate::oauth2_client::{Oauth2ClientApi, Oauth2ClientProviderError};
+
+    mock! {
+        pub Oauth2ClientProvider {}
+
+        #[async_trait]
+        impl Oauth2ClientApi for Oauth2ClientProvider {
+            async fn create<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                data: OAuth2ClientResourceCreate,
+                confidential: bool,
+            ) -> Result<(OAuth2ClientResource, Option<String>), Oauth2ClientProviderError>;
+
+            async fn get<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                domain_id: &'a str,
+                provider_id: &'a str,
+            ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+            async fn get_by_client_id<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                client_id: &'a str,
+            ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+            async fn list<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                params: &OAuth2ClientResourceListParameters,
+            ) -> Result<Vec<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+            async fn update<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                domain_id: &'a str,
+                provider_id: &'a str,
+                data: OAuth2ClientResourceUpdate,
+            ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError>;
+
+            async fn rotate_secret<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                domain_id: &'a str,
+                provider_id: &'a str,
+            ) -> Result<(OAuth2ClientResource, String), Oauth2ClientProviderError>;
+
+            async fn delete<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                domain_id: &'a str,
+                provider_id: &'a str,
+            ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError>;
+        }
+    }
+}
+pub use oauth2_client::MockOauth2ClientProvider;
+
 mod oauth2_key {
     use super::*;
 

--- a/crates/core/src/oauth2_client.rs
+++ b/crates/core/src/oauth2_client.rs
@@ -11,21 +11,20 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # V4 API types
-pub mod api_key;
-pub mod auth;
-pub mod auth_plugin;
-pub mod mapping;
-pub mod oauth2_client;
-pub mod scim_realm;
-pub mod token_restriction;
-pub mod user;
+//! # OAuth2 client (relying party registration) provider (ADR 0026 §5, Phase 2)
+//!
+//! Admin CRUD for `OAuth2Client` registrations: storage schema and
+//! validation only in Phase 2 -- wiring into the mapping engine's
+//! `IdentitySource` for actual `/token` issuance is Phase 3/4.
 
-#[cfg(feature = "conv")]
-mod api_key_conv;
-#[cfg(feature = "conv")]
-mod oauth2_client_conv;
-#[cfg(feature = "conv")]
-mod scim_realm_conv;
-#[cfg(feature = "conv")]
-mod token_restriction_conv;
+pub mod backend;
+pub mod crypto;
+pub mod error;
+mod provider_api;
+pub mod service;
+
+#[cfg(any(test, feature = "mock"))]
+pub use crate::mocks::MockOauth2ClientProvider;
+pub use error::Oauth2ClientProviderError;
+pub use provider_api::Oauth2ClientApi;
+pub use service::Oauth2ClientService;

--- a/crates/core/src/oauth2_client/backend.rs
+++ b/crates/core/src/oauth2_client/backend.rs
@@ -1,0 +1,84 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OAuth2 client provider: Backends.
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::oauth2_client::*;
+
+use crate::keystone::ServiceState;
+use crate::oauth2_client::Oauth2ClientProviderError;
+
+/// OAuth2 client Backend trait.
+///
+/// Backend driver interface expected by the OAuth2 client provider (ADR 0026
+/// §5).
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait Oauth2ClientBackend: Send + Sync {
+    /// Register a new OAuth2 client.
+    async fn create(
+        &self,
+        state: &ServiceState,
+        data: OAuth2ClientResourceCreate,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError>;
+
+    /// Soft-delete: disables the client and stamps the tombstone without
+    /// deleting the record.
+    async fn delete<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError>;
+
+    /// Fetch a client by its `(domain_id, provider_id)` coordinate.
+    async fn get<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+    /// Fetch a client by its globally unique `client_id`.
+    async fn get_by_client_id<'a>(
+        &self,
+        state: &ServiceState,
+        client_id: &'a str,
+    ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+    /// List OAuth2 clients for a domain.
+    async fn list(
+        &self,
+        state: &ServiceState,
+        params: &OAuth2ClientResourceListParameters,
+    ) -> Result<Vec<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+    /// Replace the stored `client_secret_hash` for a client.
+    async fn rotate_secret<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        provider_id: &'a str,
+        client_secret_hash: String,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError>;
+
+    /// Update an OAuth2 client's configuration.
+    async fn update<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        provider_id: &'a str,
+        data: OAuth2ClientResourceUpdate,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError>;
+}

--- a/crates/core/src/oauth2_client/crypto.rs
+++ b/crates/core/src/oauth2_client/crypto.rs
@@ -1,0 +1,115 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OAuth2 client secret generation & Argon2id hashing (ADR 0026 §5)
+use argon2::password_hash::{PasswordHasher, SaltString};
+use argon2::{Algorithm, Argon2, Params, Version};
+use base64::{Engine as _, engine::general_purpose::STANDARD_NO_PAD};
+use rand::RngExt;
+use rand::distr::{Alphanumeric, SampleString};
+use secrecy::SecretString;
+
+use openstack_keystone_config::Oauth2Provider;
+
+use crate::oauth2_client::Oauth2ClientProviderError;
+
+const SECRET_PREFIX: &str = "kosc";
+/// ~256 bits of entropy over the 62-character alphanumeric alphabet.
+const ENTROPY_LEN: usize = 43;
+
+fn generate_salt() -> String {
+    let mut bytes = [0u8; 16];
+    rand::rng().fill(&mut bytes);
+    STANDARD_NO_PAD.encode(bytes)
+}
+
+fn build_params(config: &Oauth2Provider) -> Result<Params, Oauth2ClientProviderError> {
+    Params::new(
+        config.argon2_memory_kib,
+        config.argon2_time_cost,
+        config.argon2_parallelism,
+        None,
+    )
+    .map_err(Oauth2ClientProviderError::crypto)
+}
+
+/// Generate a fresh plaintext client secret (`kosc_<entropy>`), shown to the
+/// caller exactly once on `create`/`rotate_secret`.
+pub fn generate_secret() -> SecretString {
+    let entropy = Alphanumeric.sample_string(&mut rand::rng(), ENTROPY_LEN);
+    SecretString::from(format!("{SECRET_PREFIX}_{entropy}"))
+}
+
+/// Hash a plaintext client secret into a PHC-formatted Argon2id string using
+/// the configured parameters.
+pub async fn hash_secret(
+    secret: &SecretString,
+    config: &Oauth2Provider,
+) -> Result<String, Oauth2ClientProviderError> {
+    use secrecy::ExposeSecret;
+    let secret_plain = secret.expose_secret().to_string();
+    let config = config.clone();
+    tokio::task::spawn_blocking(move || {
+        let params = build_params(&config)?;
+        let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+        let salt = SaltString::from_b64(generate_salt().as_str())
+            .map_err(Oauth2ClientProviderError::crypto)?;
+        argon2
+            .hash_password(secret_plain.as_bytes(), &salt)
+            .map(|h| h.to_string())
+            .map_err(Oauth2ClientProviderError::crypto)
+    })
+    .await
+    .map_err(Oauth2ClientProviderError::crypto)?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use argon2::password_hash::{PasswordHash, PasswordVerifier};
+    use secrecy::ExposeSecret;
+
+    fn test_config() -> Oauth2Provider {
+        Oauth2Provider {
+            argon2_memory_kib: 8,
+            argon2_time_cost: 1,
+            argon2_parallelism: 1,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_generate_secret_has_expected_prefix() {
+        let secret = generate_secret();
+        assert!(secret.expose_secret().starts_with("kosc_"));
+    }
+
+    #[tokio::test]
+    async fn test_hash_secret_roundtrips() {
+        let config = test_config();
+        let secret = generate_secret();
+        let phc = hash_secret(&secret, &config).await.unwrap();
+        let parsed = PasswordHash::new(&phc).unwrap();
+        assert!(
+            Argon2::default()
+                .verify_password(secret.expose_secret().as_bytes(), &parsed)
+                .is_ok()
+        );
+        let wrong = generate_secret();
+        assert!(
+            Argon2::default()
+                .verify_password(wrong.expose_secret().as_bytes(), &parsed)
+                .is_err()
+        );
+    }
+}

--- a/crates/core/src/oauth2_client/error.rs
+++ b/crates/core/src/oauth2_client/error.rs
@@ -11,21 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # V4 API types
-pub mod api_key;
-pub mod auth;
-pub mod auth_plugin;
-pub mod mapping;
-pub mod oauth2_client;
-pub mod scim_realm;
-pub mod token_restriction;
-pub mod user;
-
-#[cfg(feature = "conv")]
-mod api_key_conv;
-#[cfg(feature = "conv")]
-mod oauth2_client_conv;
-#[cfg(feature = "conv")]
-mod scim_realm_conv;
-#[cfg(feature = "conv")]
-mod token_restriction_conv;
+//! # OAuth2 client provider error
+pub use openstack_keystone_core_types::oauth2_client::Oauth2ClientProviderError;

--- a/crates/core/src/oauth2_client/provider_api.rs
+++ b/crates/core/src/oauth2_client/provider_api.rs
@@ -1,0 +1,89 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OAuth2 client (relying party registration) provider API.
+
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::oauth2_client::*;
+
+use crate::auth::ExecutionContext;
+use crate::oauth2_client::Oauth2ClientProviderError;
+
+/// The trait for managing OAuth2 client (relying party) registrations (ADR
+/// 0026 §5).
+#[async_trait]
+pub trait Oauth2ClientApi: Send + Sync {
+    /// Register a new OAuth2 client. Generates `client_id`, and -- for
+    /// confidential clients -- a fresh plaintext secret, returning it
+    /// alongside the created resource (shown to the caller exactly once).
+    ///
+    /// # Returns
+    /// * Success with the created [`OAuth2ClientResource`] and, for
+    ///   confidential clients, the one-time plaintext secret.
+    /// * Error if validation fails or the client could not be created.
+    async fn create<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        data: OAuth2ClientResourceCreate,
+        confidential: bool,
+    ) -> Result<(OAuth2ClientResource, Option<String>), Oauth2ClientProviderError>;
+
+    /// Soft-delete a client (disables and stamps the tombstone).
+    async fn delete<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError>;
+
+    /// Fetch a client by its `(domain_id, provider_id)` coordinate.
+    async fn get<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+    /// Fetch a client by its globally unique `client_id`.
+    async fn get_by_client_id<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        client_id: &'a str,
+    ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+    /// List OAuth2 clients for a domain.
+    async fn list<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        params: &OAuth2ClientResourceListParameters,
+    ) -> Result<Vec<OAuth2ClientResource>, Oauth2ClientProviderError>;
+
+    /// Generate and persist a fresh client secret, returning the updated
+    /// resource alongside the one-time plaintext secret.
+    async fn rotate_secret<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<(OAuth2ClientResource, String), Oauth2ClientProviderError>;
+
+    /// Update an OAuth2 client's configuration.
+    async fn update<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        provider_id: &'a str,
+        data: OAuth2ClientResourceUpdate,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError>;
+}

--- a/crates/core/src/oauth2_client/service.rs
+++ b/crates/core/src/oauth2_client/service.rs
@@ -1,0 +1,497 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OAuth2 client (relying party registration) provider (ADR 0026 §5)
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use secrecy::ExposeSecret;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core_types::oauth2_client::*;
+
+use crate::auth::ExecutionContext;
+use crate::oauth2_client::backend::Oauth2ClientBackend;
+use crate::oauth2_client::crypto;
+use crate::oauth2_client::{Oauth2ClientApi, Oauth2ClientProviderError};
+use crate::plugin_manager::PluginManagerApi;
+
+/// The only backend name registered for the OAuth2 client provider: like
+/// `[oauth2]`'s signing key provider, there is no alternative driver to
+/// select between.
+const BACKEND_NAME: &str = "raft";
+
+/// Output claim names reserved by `IdTokenClaims`, `OpenStackContext`, and
+/// `OpenStackScope` (ADR 0026 §4, "Claim Safety"). A `claims_template` key
+/// colliding with one of these is rejected at save time so a client cannot
+/// override a baseline claim via `#[serde(flatten)]`.
+const RESERVED_CLAIM_NAMES: &[&str] = &[
+    "sub",
+    "iss",
+    "aud",
+    "exp",
+    "iat",
+    "nbf",
+    "auth_time",
+    "nonce",
+    "acr",
+    "amr",
+    "at_hash",
+    "c_hash",
+    "azp",
+    "jti",
+    "client_id",
+    "keystone_ruleset_version",
+    "delegation_context",
+    "auth_method",
+    "delegated_project_id",
+    "token_use",
+    "openstack_context",
+    "user_id",
+    "user_name",
+    "user_domain_id",
+    "scope_type",
+    "project_id",
+    "project_domain_id",
+    "domain_id",
+    "system_id",
+    "roles",
+];
+
+fn validate_claims_template(
+    claims_template: &std::collections::HashMap<String, String>,
+) -> Result<(), Oauth2ClientProviderError> {
+    for key in claims_template.keys() {
+        if RESERVED_CLAIM_NAMES.contains(&key.as_str()) {
+            return Err(Oauth2ClientProviderError::Validation(format!(
+                "claims_template key `{key}` collides with a reserved claim name"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate redirect URI scheme rules (ADR 0026 §5): confidential clients
+/// must use `https://` only; public clients may additionally use
+/// `http://localhost:*` (logged once, not rejected).
+fn validate_redirect_uris(
+    redirect_uris: &[String],
+    confidential: bool,
+) -> Result<(), Oauth2ClientProviderError> {
+    for uri in redirect_uris {
+        if uri.starts_with("https://") {
+            continue;
+        }
+        if !confidential && uri.starts_with("http://localhost") {
+            tracing::warn!(
+                redirect_uri = %uri,
+                "public OAuth2 client registered with an http://localhost redirect URI"
+            );
+            continue;
+        }
+        return Err(Oauth2ClientProviderError::Validation(format!(
+            "redirect_uri `{uri}` must use https:// ({}; public clients may additionally use http://localhost:*)",
+            if confidential {
+                "confidential client"
+            } else {
+                "public client"
+            }
+        )));
+    }
+    Ok(())
+}
+
+/// Validate the PKCE requirement (ADR 0026 §5): mandatory for public
+/// clients.
+fn validate_require_pkce(
+    require_pkce: bool,
+    confidential: bool,
+) -> Result<(), Oauth2ClientProviderError> {
+    if !confidential && !require_pkce {
+        return Err(Oauth2ClientProviderError::Validation(
+            "require_pkce must be true for a public client (no client_secret)".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// OAuth2 client Provider.
+pub struct Oauth2ClientService {
+    /// Backend driver.
+    backend_driver: Arc<dyn Oauth2ClientBackend>,
+    /// `[oauth2]` config, for client secret Argon2id parameters.
+    oauth2_config: openstack_keystone_config::Oauth2Provider,
+}
+
+impl Oauth2ClientService {
+    /// Create a new `Oauth2ClientService`.
+    pub fn new<P: PluginManagerApi>(
+        config: &Config,
+        plugin_manager: &P,
+    ) -> Result<Self, Oauth2ClientProviderError> {
+        let backend_driver = plugin_manager
+            .get_oauth2_client_backend(BACKEND_NAME)?
+            .clone();
+        Ok(Self {
+            backend_driver,
+            oauth2_config: config.oauth2.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl Oauth2ClientApi for Oauth2ClientService {
+    async fn create<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        data: OAuth2ClientResourceCreate,
+        confidential: bool,
+    ) -> Result<(OAuth2ClientResource, Option<String>), Oauth2ClientProviderError> {
+        validate_redirect_uris(&data.redirect_uris, confidential)?;
+        validate_require_pkce(data.require_pkce, confidential)?;
+        validate_claims_template(&data.claims_template)?;
+
+        let mut data = data;
+        data.client_id = uuid::Uuid::new_v4().to_string();
+
+        let plaintext_secret = if confidential {
+            let secret = crypto::generate_secret();
+            data.client_secret_hash =
+                Some(crypto::hash_secret(&secret, &self.oauth2_config).await?);
+            Some(secret.expose_secret().to_string())
+        } else {
+            data.client_secret_hash = None;
+            None
+        };
+
+        let created = self.backend_driver.create(ctx.state(), data).await?;
+        Ok((created, plaintext_secret))
+    }
+
+    async fn delete<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError> {
+        self.backend_driver
+            .delete(ctx.state(), domain_id, provider_id)
+            .await
+    }
+
+    async fn get<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError> {
+        self.backend_driver
+            .get(ctx.state(), domain_id, provider_id)
+            .await
+    }
+
+    async fn get_by_client_id<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        client_id: &'a str,
+    ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError> {
+        self.backend_driver
+            .get_by_client_id(ctx.state(), client_id)
+            .await
+    }
+
+    async fn list<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        params: &OAuth2ClientResourceListParameters,
+    ) -> Result<Vec<OAuth2ClientResource>, Oauth2ClientProviderError> {
+        self.backend_driver.list(ctx.state(), params).await
+    }
+
+    async fn rotate_secret<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<(OAuth2ClientResource, String), Oauth2ClientProviderError> {
+        let current = self
+            .backend_driver
+            .get(ctx.state(), domain_id, provider_id)
+            .await?
+            .ok_or_else(|| Oauth2ClientProviderError::NotFound(provider_id.to_string()))?;
+        if current.deleted_at.is_some() {
+            return Err(Oauth2ClientProviderError::Conflict(
+                "cannot rotate a secret for a revoked (soft-deleted) OAuth2 client".to_string(),
+            ));
+        }
+        if current.client_secret_hash.is_none() {
+            return Err(Oauth2ClientProviderError::Validation(
+                "cannot rotate a secret for a public client (no client_secret)".to_string(),
+            ));
+        }
+
+        let secret = crypto::generate_secret();
+        let hash = crypto::hash_secret(&secret, &self.oauth2_config).await?;
+        let updated = self
+            .backend_driver
+            .rotate_secret(ctx.state(), domain_id, provider_id, hash)
+            .await?;
+        Ok((updated, secret.expose_secret().to_string()))
+    }
+
+    async fn update<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        provider_id: &'a str,
+        data: OAuth2ClientResourceUpdate,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError> {
+        let current = self
+            .backend_driver
+            .get(ctx.state(), domain_id, provider_id)
+            .await?
+            .ok_or_else(|| Oauth2ClientProviderError::NotFound(provider_id.to_string()))?;
+        // Soft-delete is the revocation path (mirrors ADR 0021 §5.C for
+        // api_key) and MUST NOT be reversible or bypassable through the
+        // ordinary update surface -- a revoked client must stay revoked.
+        if current.deleted_at.is_some() {
+            return Err(Oauth2ClientProviderError::Conflict(
+                "cannot update a revoked (soft-deleted) OAuth2 client".to_string(),
+            ));
+        }
+        let confidential = current.client_secret_hash.is_some();
+
+        if let Some(redirect_uris) = &data.redirect_uris {
+            validate_redirect_uris(redirect_uris, confidential)?;
+        }
+        let effective_pkce = data.require_pkce.unwrap_or(current.require_pkce);
+        validate_require_pkce(effective_pkce, confidential)?;
+        if let Some(claims_template) = &data.claims_template {
+            validate_claims_template(claims_template)?;
+        }
+
+        self.backend_driver
+            .update(ctx.state(), domain_id, provider_id, data)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oauth2_client::backend::MockOauth2ClientBackend;
+    use crate::tests::get_mocked_state;
+    use std::collections::HashMap;
+
+    fn sample_create() -> OAuth2ClientResourceCreate {
+        OAuth2ClientResourceCreate {
+            client_id: String::new(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain-1".into(),
+            client_secret_hash: None,
+            redirect_uris: vec!["https://rp.example.com/callback".into()],
+            token_endpoint_auth_method: "client_secret_basic".into(),
+            grant_types: vec![GrantType::AuthorizationCode],
+            require_pkce: true,
+            allowed_scopes: vec!["openid".into()],
+            pre_authorized: false,
+            claims_template: HashMap::new(),
+        }
+    }
+
+    fn service_with(mock: MockOauth2ClientBackend) -> Oauth2ClientService {
+        Oauth2ClientService {
+            backend_driver: Arc::new(mock),
+            oauth2_config: openstack_keystone_config::Oauth2Provider {
+                argon2_memory_kib: 8,
+                argon2_time_cost: 1,
+                argon2_parallelism: 1,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_confidential_client_returns_plaintext_secret_once() {
+        let mut mock = MockOauth2ClientBackend::new();
+        mock.expect_create()
+            .returning(|_, data| Ok(sample_resource_from(data)));
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+        let ctx = ExecutionContext::internal(&state);
+
+        let (created, secret) = service.create(&ctx, sample_create(), true).await.unwrap();
+        assert!(created.client_secret_hash.is_some());
+        assert!(secret.unwrap().starts_with("kosc_"));
+    }
+
+    #[tokio::test]
+    async fn test_create_public_client_has_no_secret() {
+        let mut mock = MockOauth2ClientBackend::new();
+        mock.expect_create()
+            .returning(|_, data| Ok(sample_resource_from(data)));
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+        let ctx = ExecutionContext::internal(&state);
+
+        let (created, secret) = service.create(&ctx, sample_create(), false).await.unwrap();
+        assert!(created.client_secret_hash.is_none());
+        assert!(secret.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_non_https_redirect_uri_for_confidential_client() {
+        let service = service_with(MockOauth2ClientBackend::new());
+        let state = get_mocked_state(None, None).await;
+        let ctx = ExecutionContext::internal(&state);
+
+        let mut req = sample_create();
+        req.redirect_uris = vec!["http://insecure.example.com/callback".into()];
+        let result = service.create(&ctx, req, true).await;
+        assert!(matches!(
+            result,
+            Err(Oauth2ClientProviderError::Validation(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_public_client_without_pkce() {
+        let service = service_with(MockOauth2ClientBackend::new());
+        let state = get_mocked_state(None, None).await;
+        let ctx = ExecutionContext::internal(&state);
+
+        let mut req = sample_create();
+        req.require_pkce = false;
+        let result = service.create(&ctx, req, false).await;
+        assert!(matches!(
+            result,
+            Err(Oauth2ClientProviderError::Validation(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_reserved_claims_template_key() {
+        let service = service_with(MockOauth2ClientBackend::new());
+        let state = get_mocked_state(None, None).await;
+        let ctx = ExecutionContext::internal(&state);
+
+        let mut req = sample_create();
+        req.claims_template
+            .insert("sub".to_string(), "${user.id}".to_string());
+        let result = service.create(&ctx, req, true).await;
+        assert!(matches!(
+            result,
+            Err(Oauth2ClientProviderError::Validation(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_rotate_secret_rejects_public_client() {
+        let mut mock = MockOauth2ClientBackend::new();
+        mock.expect_get().returning(|_, _, _| {
+            Ok(Some(sample_resource_from(OAuth2ClientResourceCreate {
+                client_secret_hash: None,
+                ..sample_create()
+            })))
+        });
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+        let ctx = ExecutionContext::internal(&state);
+
+        let result = service.rotate_secret(&ctx, "domain-1", "provider-1").await;
+        assert!(matches!(
+            result,
+            Err(Oauth2ClientProviderError::Validation(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_rotate_secret_rejects_revoked_client() {
+        let mut mock = MockOauth2ClientBackend::new();
+        mock.expect_get().returning(|_, _, _| {
+            Ok(Some(OAuth2ClientResource {
+                deleted_at: Some(1),
+                enabled: false,
+                ..sample_resource_from(sample_create())
+            }))
+        });
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+        let ctx = ExecutionContext::internal(&state);
+
+        let result = service.rotate_secret(&ctx, "domain-1", "provider-1").await;
+        assert!(matches!(
+            result,
+            Err(Oauth2ClientProviderError::Conflict(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_revoked_client() {
+        let mut mock = MockOauth2ClientBackend::new();
+        mock.expect_get().returning(|_, _, _| {
+            Ok(Some(OAuth2ClientResource {
+                deleted_at: Some(1),
+                enabled: false,
+                ..sample_resource_from(sample_create())
+            }))
+        });
+        // `expect_update` deliberately not configured: mockall panics if
+        // it's called, proving the guard short-circuits before reaching
+        // the backend.
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+        let ctx = ExecutionContext::internal(&state);
+
+        let result = service
+            .update(
+                &ctx,
+                "domain-1",
+                "provider-1",
+                OAuth2ClientResourceUpdate {
+                    enabled: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(Oauth2ClientProviderError::Conflict(_))
+        ));
+    }
+
+    fn sample_resource_from(data: OAuth2ClientResourceCreate) -> OAuth2ClientResource {
+        OAuth2ClientResource {
+            client_id: if data.client_id.is_empty() {
+                "client-1".into()
+            } else {
+                data.client_id
+            },
+            provider_id: data.provider_id,
+            domain_id: data.domain_id,
+            client_secret_hash: data.client_secret_hash,
+            redirect_uris: data.redirect_uris,
+            token_endpoint_auth_method: data.token_endpoint_auth_method,
+            grant_types: data.grant_types,
+            require_pkce: data.require_pkce,
+            allowed_scopes: data.allowed_scopes,
+            pre_authorized: data.pre_authorized,
+            enabled: true,
+            claims_template: data.claims_template,
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+}

--- a/crates/core/src/plugin_manager.rs
+++ b/crates/core/src/plugin_manager.rs
@@ -45,6 +45,8 @@ use crate::k8s_auth::K8sAuthProviderError;
 use crate::k8s_auth::backend::K8sAuthBackend;
 use crate::mapping::MappingBackend;
 use crate::mapping::error::MappingProviderError;
+use crate::oauth2_client::Oauth2ClientProviderError;
+use crate::oauth2_client::backend::Oauth2ClientBackend;
 use crate::oauth2_key::Oauth2KeyProviderError;
 use crate::oauth2_key::backend::Oauth2KeyBackend;
 use crate::resource::backend::ResourceBackend;
@@ -194,6 +196,19 @@ pub trait PluginManagerApi {
         &self,
         name: S,
     ) -> Result<&Arc<dyn MappingBackend>, MappingProviderError>;
+
+    /// Get registered OAuth2 client backend.
+    ///
+    /// # Parameters
+    /// - `name`: The name of the backend to retrieve.
+    ///
+    /// # Returns
+    /// - `Ok(&Arc<dyn Oauth2ClientBackend>)` if found, otherwise
+    ///   `Err(Oauth2ClientProviderError)`.
+    fn get_oauth2_client_backend<S: AsRef<str>>(
+        &self,
+        name: S,
+    ) -> Result<&Arc<dyn Oauth2ClientBackend>, Oauth2ClientProviderError>;
 
     /// Get registered OAuth2 signing key backend.
     ///
@@ -422,6 +437,17 @@ pub trait PluginManagerApi {
     /// - `name`: The name to register the backend under.
     /// - `plugin`: The backend implementation.
     fn register_mapping_backend<S: AsRef<str>>(&mut self, name: S, plugin: Arc<dyn MappingBackend>);
+
+    /// Register OAuth2 client backend.
+    ///
+    /// # Parameters
+    /// - `name`: The name to register the backend under.
+    /// - `plugin`: The backend implementation.
+    fn register_oauth2_client_backend<S: AsRef<str>>(
+        &mut self,
+        name: S,
+        plugin: Arc<dyn Oauth2ClientBackend>,
+    );
 
     /// Register OAuth2 signing key backend.
     ///

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -58,6 +58,9 @@ use crate::mapping::MappingApi;
 #[cfg(any(test, feature = "mock"))]
 use crate::mapping::MockMappingProvider;
 #[cfg(any(test, feature = "mock"))]
+use crate::oauth2_client::MockOauth2ClientProvider;
+use crate::oauth2_client::Oauth2ClientApi;
+#[cfg(any(test, feature = "mock"))]
 use crate::oauth2_key::MockOauth2KeyProvider;
 use crate::oauth2_key::Oauth2KeyApi;
 use crate::plugin_manager::PluginManagerApi;
@@ -107,6 +110,8 @@ pub struct Provider {
     idmapping: Box<dyn IdMappingApi>,
     /// Mapping provider.
     mapping: Box<dyn MappingApi>,
+    /// OAuth2 client provider.
+    oauth2_client: Box<dyn Oauth2ClientApi>,
     /// OAuth2 signing key provider.
     oauth2_key: Box<dyn Oauth2KeyApi>,
     /// K8s auth provider.
@@ -183,6 +188,12 @@ impl ProviderBuilder {
     pub fn mock_mapping(self, value: impl MappingApi + 'static) -> Self {
         let mut new = self;
         new.mapping = Some(Box::new(value));
+        new
+    }
+
+    pub fn mock_oauth2_client(self, value: impl Oauth2ClientApi + 'static) -> Self {
+        let mut new = self;
+        new.oauth2_client = Some(Box::new(value));
         new
     }
 
@@ -284,6 +295,10 @@ impl Provider {
             cfg,
             plugin_manager,
         )?);
+        let oauth2_client = Box::new(crate::oauth2_client::Oauth2ClientService::new(
+            cfg,
+            plugin_manager,
+        )?);
         let k8s_auth = Box::new(
             crate::k8s_auth::K8sAuthService::new(cfg, plugin_manager, k8s_http_client)
                 .map_err(|e| KeystoneError::K8sAuthProvider { source: e })?,
@@ -313,6 +328,7 @@ impl Provider {
             identity,
             idmapping,
             mapping,
+            oauth2_client,
             oauth2_key,
             k8s_auth,
             resource,
@@ -338,6 +354,7 @@ impl Provider {
             .mock_identity(MockIdentityProvider::default())
             .mock_idmapping(MockIdMappingProvider::default())
             .mock_mapping(MockMappingProvider::default())
+            .mock_oauth2_client(MockOauth2ClientProvider::default())
             .mock_oauth2_key(MockOauth2KeyProvider::default())
             .mock_federation(MockFederationProvider::default())
             .mock_k8s_auth(MockK8sAuthProvider::default())
@@ -393,6 +410,11 @@ impl Provider {
     /// Get the mapping provider.
     pub fn get_mapping_provider(&self) -> &dyn MappingApi {
         &*self.mapping
+    }
+
+    /// Get the OAuth2 client provider.
+    pub fn get_oauth2_client_provider(&self) -> &dyn Oauth2ClientApi {
+        &*self.oauth2_client
     }
 
     /// Get the OAuth2 signing key provider.

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -50,6 +50,7 @@ openstack-keystone-federation-driver-sql.workspace = true
 openstack-keystone-k8s-auth-driver-sql.workspace = true
 openstack-keystone-k8s-auth-driver-raft.workspace = true
 openstack-keystone-mapping-driver-raft.workspace = true
+openstack-keystone-oauth2-client-driver-raft.workspace = true
 openstack-keystone-oauth2-key-driver-raft.workspace = true
 openstack-keystone-identity-driver-sql.workspace = true
 openstack-keystone-idmapping-driver-sql.workspace = true

--- a/crates/keystone/src/api/v4/oauth2/clients/create.rs
+++ b/crates/keystone/src/api/v4/oauth2/clients/create.rs
@@ -1,0 +1,241 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client: create.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use openstack_keystone_api_types::v4::oauth2_client::{
+    OAuth2Client, OAuth2ClientCreateRequest, OAuth2ClientCreateResponse,
+};
+use validator::Validate;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Register a new OAuth2 client (relying party).
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/clients",
+    operation_id = "/oauth2/client:create",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    request_body = OAuth2ClientCreateRequest,
+    responses(
+        (status = CREATED, description = "OAuth2 client object", body = OAuth2ClientCreateResponse),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_client"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::clients::create",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn create(
+    Auth(user_auth): Auth,
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<OAuth2ClientCreateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/client/create",
+            &user_auth,
+            serde_json::json!({"oauth2_client": req.oauth2_client, "domain_id": domain_id}),
+            None,
+        )
+        .await?;
+
+    let confidential = req.oauth2_client.confidential;
+    let mut data: openstack_keystone_core_types::oauth2_client::OAuth2ClientResourceCreate =
+        req.into();
+    data.domain_id = domain_id;
+    let exec = ExecutionContext::from_auth(&state, &user_auth);
+    let (created, client_secret) = state
+        .provider
+        .get_oauth2_client_provider()
+        .create(&exec, data, confidential)
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(OAuth2ClientCreateResponse {
+            oauth2_client: OAuth2Client::from(created),
+            client_secret,
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::oauth2_client::{
+        OAuth2ClientCreate, OAuth2ClientCreateRequest, OAuth2ClientCreateResponse,
+    };
+    use openstack_keystone_core_types::oauth2_client as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_client::MockOauth2ClientProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource(confidential: bool) -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            client_id: "client-1".into(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain_id".into(),
+            client_secret_hash: confidential
+                .then(|| "$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".to_string()),
+            redirect_uris: vec!["https://rp.example.com/callback".into()],
+            token_endpoint_auth_method: "client_secret_basic".into(),
+            grant_types: vec![provider_types::GrantType::AuthorizationCode],
+            require_pkce: !confidential,
+            allowed_scopes: vec!["openid".into()],
+            pre_authorized: false,
+            enabled: true,
+            claims_template: Default::default(),
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    fn sample_create(confidential: bool) -> OAuth2ClientCreateRequest {
+        OAuth2ClientCreateRequest {
+            oauth2_client: OAuth2ClientCreate {
+                provider_id: "provider-1".into(),
+                confidential,
+                redirect_uris: vec!["https://rp.example.com/callback".into()],
+                token_endpoint_auth_method: "client_secret_basic".into(),
+                grant_types: vec![],
+                require_pkce: !confidential,
+                allowed_scopes: vec!["openid".into()],
+                pre_authorized: false,
+                claims_template: Default::default(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_create().returning(|_, _, confidential| {
+            Ok((sample_resource(confidential), Some("kosc_secret".into())))
+        });
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_create(true);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain_id/clients")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: OAuth2ClientCreateResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.oauth2_client.provider_id, "provider-1");
+        assert_eq!(res.client_secret.as_deref(), Some("kosc_secret"));
+    }
+
+    #[tokio::test]
+    async fn test_create_forbidden() {
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(Provider::mocked_builder(), false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_create(true);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain_id/clients")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_create_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_create(true);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain_id/clients")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/clients/delete.rs
+++ b/crates/keystone/src/api/v4/oauth2/clients/delete.rs
@@ -1,0 +1,211 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client: delete (soft-delete -- disables and stamps the tombstone,
+//! record retained for Phase 4's refresh-token family-tree invalidation).
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_api_types::v4::oauth2_client::OAuth2Client;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Revoke (soft-delete) an OAuth2 client.
+#[utoipa::path(
+    delete,
+    path = "/{domain_id}/clients/{provider_id}",
+    operation_id = "/oauth2/client:delete",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+        ("provider_id" = String, Path, description = "Client provider_id"),
+    ),
+    responses(
+        (status = NO_CONTENT, description = "OAuth2 client revoked"),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_client"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::clients::delete",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn delete(
+    Auth(user_auth): Auth,
+    Path((domain_id, provider_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let exec = ExecutionContext::from_auth(&state, &user_auth);
+
+    let current = state
+        .provider
+        .get_oauth2_client_provider()
+        .get(&exec, &domain_id, &provider_id)
+        .await?
+        .ok_or_else(|| KeystoneApiError::NotFound {
+            resource: "oauth2_client".into(),
+            identifier: provider_id.clone(),
+        })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/client/delete",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(serde_json::json!({"oauth2_client": OAuth2Client::from(current)})),
+        )
+        .await?;
+
+    state
+        .provider
+        .get_oauth2_client_provider()
+        .delete(&exec, &domain_id, &provider_id)
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::oauth2_client as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_client::MockOauth2ClientProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource() -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            client_id: "client-1".into(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain_id".into(),
+            client_secret_hash: None,
+            redirect_uris: vec![],
+            token_endpoint_auth_method: "none".into(),
+            grant_types: vec![],
+            require_pkce: true,
+            allowed_scopes: vec![],
+            pre_authorized: false,
+            enabled: true,
+            claims_template: Default::default(),
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_soft_deletes() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_get()
+            .returning(|_, _, _| Ok(Some(sample_resource())));
+        mock.expect_delete().returning(|_, _, _| {
+            Ok(provider_types::OAuth2ClientResource {
+                enabled: false,
+                deleted_at: Some(1),
+                ..sample_resource()
+            })
+        });
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/domain_id/clients/provider-1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_get()
+            .returning(|_, _, _| Ok(Some(sample_resource())));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/domain_id/clients/provider-1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_delete_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/domain_id/clients/provider-1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/clients/list.rs
+++ b/crates/keystone/src/api/v4/oauth2/clients/list.rs
@@ -1,0 +1,209 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client: list.
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use openstack_keystone_api_types::v4::oauth2_client::{
+    OAuth2Client, OAuth2ClientList, OAuth2ClientListParameters,
+};
+use openstack_keystone_core_types::oauth2_client::OAuth2ClientResourceListParameters;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// List OAuth2 clients for a domain.
+#[utoipa::path(
+    get,
+    path = "/{domain_id}/clients",
+    operation_id = "/oauth2/client:list",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+        OAuth2ClientListParameters,
+    ),
+    responses(
+        (status = OK, description = "List of OAuth2 clients", body = OAuth2ClientList),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_client"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::clients::list",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn list(
+    Auth(user_auth): Auth,
+    Path(domain_id): Path<String>,
+    Query(query): Query<OAuth2ClientListParameters>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/client/list",
+            &user_auth,
+            serde_json::json!({"domain_id": domain_id, "oauth2_client": query}),
+            None,
+        )
+        .await?;
+
+    let params = OAuth2ClientResourceListParameters {
+        domain_id: domain_id.clone(),
+        enabled: query.enabled,
+    };
+    let clients: Vec<OAuth2Client> = state
+        .provider
+        .get_oauth2_client_provider()
+        .list(&ExecutionContext::from_auth(&state, &user_auth), &params)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+
+    Ok((
+        StatusCode::OK,
+        Json(OAuth2ClientList {
+            oauth2_clients: clients,
+            links: None,
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::oauth2_client::OAuth2ClientList;
+    use openstack_keystone_core_types::oauth2_client as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_client::MockOauth2ClientProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource() -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            client_id: "client-1".into(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain_id".into(),
+            client_secret_hash: None,
+            redirect_uris: vec!["https://rp.example.com/callback".into()],
+            token_endpoint_auth_method: "none".into(),
+            grant_types: vec![],
+            require_pkce: true,
+            allowed_scopes: vec![],
+            pre_authorized: false,
+            enabled: true,
+            claims_template: Default::default(),
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_list()
+            .returning(|_, _| Ok(vec![sample_resource()]));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain_id/clients")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: OAuth2ClientList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.oauth2_clients.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(Provider::mocked_builder(), false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain_id/clients")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain_id/clients")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/clients/mod.rs
+++ b/crates/keystone/src/api/v4/oauth2/clients/mod.rs
@@ -1,0 +1,34 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client (relying party registration) admin CRUD API (ADR 0026 §5).
+//! Unlike `jwks`/`well_known`, every route here carries an `Auth` extractor
+//! and a Rego policy check.
+
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+mod create;
+mod delete;
+mod list;
+mod rotate_secret;
+mod show;
+mod update;
+
+use crate::keystone::ServiceState;
+
+pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new()
+        .routes(routes!(create::create, list::list))
+        .routes(routes!(show::show, update::update, delete::delete))
+        .routes(routes!(rotate_secret::rotate_secret))
+}

--- a/crates/keystone/src/api/v4/oauth2/clients/rotate_secret.rs
+++ b/crates/keystone/src/api/v4/oauth2/clients/rotate_secret.rs
@@ -1,0 +1,216 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client: rotate-secret.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use openstack_keystone_api_types::v4::oauth2_client::{
+    OAuth2Client, OAuth2ClientRotateSecretResponse,
+};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Generate and persist a fresh client secret, returned exactly once.
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/clients/{provider_id}/rotate-secret",
+    operation_id = "/oauth2/client:rotate_secret",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+        ("provider_id" = String, Path, description = "Client provider_id"),
+    ),
+    responses(
+        (status = OK, description = "One-time plaintext client secret", body = OAuth2ClientRotateSecretResponse),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_client"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::clients::rotate_secret",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn rotate_secret(
+    Auth(user_auth): Auth,
+    Path((domain_id, provider_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let exec = ExecutionContext::from_auth(&state, &user_auth);
+
+    let current = state
+        .provider
+        .get_oauth2_client_provider()
+        .get(&exec, &domain_id, &provider_id)
+        .await?
+        .ok_or_else(|| KeystoneApiError::NotFound {
+            resource: "oauth2_client".into(),
+            identifier: provider_id.clone(),
+        })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/client/rotate_secret",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(serde_json::json!({"oauth2_client": OAuth2Client::from(current)})),
+        )
+        .await?;
+
+    let (_, client_secret) = state
+        .provider
+        .get_oauth2_client_provider()
+        .rotate_secret(&exec, &domain_id, &provider_id)
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(OAuth2ClientRotateSecretResponse { client_secret }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::oauth2_client::OAuth2ClientRotateSecretResponse;
+    use openstack_keystone_core_types::oauth2_client as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_client::MockOauth2ClientProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource() -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            client_id: "client-1".into(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain_id".into(),
+            client_secret_hash: Some("$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into()),
+            redirect_uris: vec!["https://rp.example.com/callback".into()],
+            token_endpoint_auth_method: "client_secret_basic".into(),
+            grant_types: vec![],
+            require_pkce: false,
+            allowed_scopes: vec![],
+            pre_authorized: false,
+            enabled: true,
+            claims_template: Default::default(),
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rotate_secret_returns_plaintext_once() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_get()
+            .returning(|_, _, _| Ok(Some(sample_resource())));
+        mock.expect_rotate_secret()
+            .returning(|_, _, _| Ok((sample_resource(), "kosc_new_secret".to_string())));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain_id/clients/provider-1/rotate-secret")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: OAuth2ClientRotateSecretResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.client_secret, "kosc_new_secret");
+    }
+
+    #[tokio::test]
+    async fn test_rotate_secret_not_found() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_get().returning(|_, _, _| Ok(None));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain_id/clients/nonexistent/rotate-secret")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_rotate_secret_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain_id/clients/provider-1/rotate-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/clients/show.rs
+++ b/crates/keystone/src/api/v4/oauth2/clients/show.rs
@@ -1,0 +1,214 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client: show.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use openstack_keystone_api_types::v4::oauth2_client::{OAuth2Client, OAuth2ClientResponse};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Show an OAuth2 client by its `(domain_id, provider_id)` coordinate.
+/// Never includes `client_secret_hash`.
+#[utoipa::path(
+    get,
+    path = "/{domain_id}/clients/{provider_id}",
+    operation_id = "/oauth2/client:show",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+        ("provider_id" = String, Path, description = "Client provider_id"),
+    ),
+    responses(
+        (status = OK, description = "OAuth2 client object", body = OAuth2ClientResponse),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_client"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::clients::show",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn show(
+    Auth(user_auth): Auth,
+    Path((domain_id, provider_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_oauth2_client_provider()
+        .get(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &domain_id,
+            &provider_id,
+        )
+        .await?
+        .ok_or_else(|| KeystoneApiError::NotFound {
+            resource: "oauth2_client".into(),
+            identifier: provider_id.clone(),
+        })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/client/show",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(serde_json::json!({"oauth2_client": OAuth2Client::from(current.clone())})),
+        )
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(OAuth2ClientResponse {
+            oauth2_client: OAuth2Client::from(current),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::oauth2_client::OAuth2ClientResponse;
+    use openstack_keystone_core_types::oauth2_client as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_client::MockOauth2ClientProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource() -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            client_id: "client-1".into(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain_id".into(),
+            client_secret_hash: Some("$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into()),
+            redirect_uris: vec!["https://rp.example.com/callback".into()],
+            token_endpoint_auth_method: "client_secret_basic".into(),
+            grant_types: vec![],
+            require_pkce: false,
+            allowed_scopes: vec![],
+            pre_authorized: false,
+            enabled: true,
+            claims_template: Default::default(),
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_show() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_get()
+            .returning(|_, _, _| Ok(Some(sample_resource())));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain_id/clients/provider-1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: OAuth2ClientResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.oauth2_client.provider_id, "provider-1");
+        assert!(!body_contains_secret_hash(&body));
+    }
+
+    fn body_contains_secret_hash(body: &[u8]) -> bool {
+        String::from_utf8_lossy(body).contains("client_secret_hash")
+    }
+
+    #[tokio::test]
+    async fn test_show_not_found() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_get().returning(|_, _, _| Ok(None));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain_id/clients/nonexistent")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_show_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain_id/clients/provider-1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/clients/update.rs
+++ b/crates/keystone/src/api/v4/oauth2/clients/update.rs
@@ -1,0 +1,253 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 client: update. `pre_authorized: true` requires SystemAdmin (ADR
+//! 0026 §5), enforced by Rego (`policy/oauth2/client/update.rego`).
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use openstack_keystone_api_types::v4::oauth2_client::{
+    OAuth2Client, OAuth2ClientResponse, OAuth2ClientUpdateRequest,
+};
+use validator::Validate;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Update an OAuth2 client's mutable configuration.
+#[utoipa::path(
+    put,
+    path = "/{domain_id}/clients/{provider_id}",
+    operation_id = "/oauth2/client:update",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+        ("provider_id" = String, Path, description = "Client provider_id"),
+    ),
+    request_body = OAuth2ClientUpdateRequest,
+    responses(
+        (status = OK, description = "OAuth2 client object", body = OAuth2ClientResponse),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_client"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::clients::update",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path((domain_id, provider_id)): Path<(String, String)>,
+    State(state): State<ServiceState>,
+    Json(req): Json<OAuth2ClientUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    let exec = ExecutionContext::from_auth(&state, &user_auth);
+
+    let current = state
+        .provider
+        .get_oauth2_client_provider()
+        .get(&exec, &domain_id, &provider_id)
+        .await?
+        .ok_or_else(|| KeystoneApiError::NotFound {
+            resource: "oauth2_client".into(),
+            identifier: provider_id.clone(),
+        })?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/client/update",
+            &user_auth,
+            serde_json::json!({"oauth2_client": req.oauth2_client}),
+            Some(serde_json::json!({"oauth2_client": OAuth2Client::from(current.clone())})),
+        )
+        .await?;
+
+    let res = state
+        .provider
+        .get_oauth2_client_provider()
+        .update(&exec, &domain_id, &provider_id, req.oauth2_client.into())
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(OAuth2ClientResponse {
+            oauth2_client: OAuth2Client::from(res),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_api_types::v4::oauth2_client::{
+        OAuth2ClientResponse, OAuth2ClientUpdate, OAuth2ClientUpdateRequest,
+    };
+    use openstack_keystone_core_types::oauth2_client as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_client::MockOauth2ClientProvider;
+    use crate::provider::Provider;
+
+    fn sample_resource() -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            client_id: "client-1".into(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain_id".into(),
+            client_secret_hash: Some("$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".into()),
+            redirect_uris: vec!["https://rp.example.com/callback".into()],
+            token_endpoint_auth_method: "client_secret_basic".into(),
+            grant_types: vec![],
+            require_pkce: false,
+            allowed_scopes: vec![],
+            pre_authorized: false,
+            enabled: true,
+            claims_template: Default::default(),
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    fn sample_disabled_resource() -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            enabled: false,
+            ..sample_resource()
+        }
+    }
+
+    fn sample_update() -> OAuth2ClientUpdateRequest {
+        OAuth2ClientUpdateRequest {
+            oauth2_client: OAuth2ClientUpdate {
+                enabled: Some(false),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_disables_client() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_get()
+            .returning(|_, _, _| Ok(Some(sample_resource())));
+        mock.expect_update()
+            .returning(|_, _, _, _| Ok(sample_disabled_resource()));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_update();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/domain_id/clients/provider-1")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: OAuth2ClientResponse = serde_json::from_slice(&body).unwrap();
+        assert!(!res.oauth2_client.enabled);
+    }
+
+    #[tokio::test]
+    async fn test_update_policy_denied() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_get()
+            .returning(|_, _, _| Ok(Some(sample_resource())));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_update();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/domain_id/clients/provider-1")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = sample_update();
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/domain_id/clients/provider-1")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/mod.rs
+++ b/crates/keystone/src/api/v4/oauth2/mod.rs
@@ -13,15 +13,20 @@
 // SPDX-License-Identifier: Apache-2.0
 //! OAuth2/OIDC provider public API (ADR 0026).
 //!
-//! Phase 1 scope only: per-domain signing key publication. Unlike every
-//! other v4 resource, these routes carry no `Auth` extractor and no policy
-//! check — the JWKS endpoint must be reachable by relying parties and edge
-//! proxies without a Keystone token (ADR 0026 §3).
+//! Phase 1 added `jwks`; Phase 2 (ADR 0026 §10) adds the unauthenticated
+//! `well_known` OIDC discovery document and the `clients` admin CRUD API for
+//! `OAuth2Client` (relying party) registration. Unlike `jwks`/`well_known`,
+//! every route under `clients` carries an `Auth` extractor and a Rego policy
+//! check (ADR 0026 §5) -- `jwks` and `well_known` remain unauthenticated by
+//! design so relying parties and edge proxies can fetch them without a
+//! Keystone token (ADR 0026 §3).
 
 use utoipa::OpenApi;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+mod clients;
 mod jwks;
+mod well_known;
 
 use crate::keystone::ServiceState;
 
@@ -35,5 +40,8 @@ use crate::keystone::ServiceState;
 pub struct ApiDoc;
 
 pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
-    OpenApiRouter::new().routes(routes!(jwks::jwks))
+    OpenApiRouter::new()
+        .routes(routes!(jwks::jwks))
+        .routes(routes!(well_known::well_known))
+        .merge(clients::openapi_router())
 }

--- a/crates/keystone/src/api/v4/oauth2/well_known.rs
+++ b/crates/keystone/src/api/v4/oauth2/well_known.rs
@@ -1,0 +1,330 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `GET /v4/oauth2/{domain_id}/.well-known/openid-configuration`: RFC 8414 /
+//! OIDC Discovery 1.0 document (ADR 0026 §10, Phase 2).
+//!
+//! Suffix form (not RFC 8414 §3's literal insertion-before-path rule): a
+//! bare cluster-root `/.well-known/openid-configuration` would collide
+//! across domains with no way to disambiguate which domain's document is
+//! being requested, and this keeps the discovery doc as a sibling of the
+//! already-adopted `jwks_uri` pattern (`/v4/oauth2/{domain_id}/jwks`).
+//! `/authorize` and `/token` are not functional until Phase 3/4; the URLs
+//! below are contractual, same as any phased OIDC rollout.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::HeaderMap,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use crate::api::common::PeerAddr;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+
+async fn base_url(state: &ServiceState, headers: &HeaderMap) -> String {
+    // Mirrors the fallback chain used by `api::v4::version`:
+    // `public_endpoint` -> `Host` header -> `http://localhost`.
+    state
+        .config_manager
+        .config
+        .read()
+        .await
+        .default
+        .public_endpoint
+        .clone()
+        .map(|x| x.to_string().trim_end_matches('/').to_owned())
+        .or_else(|| {
+            headers
+                .get(axum::http::header::HOST)
+                .and_then(|header| header.to_str().map(|val| format!("http://{val}")).ok())
+        })
+        .unwrap_or_else(|| "http://localhost".to_string())
+}
+
+/// Publish the OIDC discovery document for a domain.
+///
+/// Unauthenticated by design, same as `jwks` (ADR 0026 §3): relying parties
+/// must be able to fetch it without a Keystone token. 404s if the domain has
+/// no signing keys provisioned yet (reuses `jwks()`'s own existence check).
+#[utoipa::path(
+    get,
+    path = "/{domain_id}/.well-known/openid-configuration",
+    operation_id = "/oauth2:well_known",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    responses(
+        (status = OK, description = "OIDC discovery document"),
+        (status = NOT_FOUND, description = "No signing keys provisioned for this domain"),
+        (status = TOO_MANY_REQUESTS, description = "Rate limit exceeded"),
+    ),
+    tag = "oauth2"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::well_known",
+    level = "debug",
+    skip(state),
+    err(Debug)
+)]
+pub(super) async fn well_known(
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    PeerAddr(peer_addr): PeerAddr,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    if let Err(retry_after) = state
+        .rate_limiters
+        .check_ip(&headers, peer_addr.map(|addr| addr.ip()))
+    {
+        return Err(KeystoneApiError::TooManyRequests {
+            retry_after: retry_after.as_secs(),
+        });
+    }
+
+    // Existence check: 404 for a domain with no provisioned signing keys,
+    // same signal `jwks.rs` uses.
+    state
+        .provider
+        .get_oauth2_key_provider()
+        .jwks(&state, &domain_id)
+        .await?;
+
+    let base = base_url(&state, &headers).await;
+    let issuer = format!("{base}/v4/oauth2/{domain_id}");
+    let signing_algorithm = state
+        .config_manager
+        .config
+        .read()
+        .await
+        .oauth2
+        .signing_algorithm
+        .to_string();
+
+    let doc = json!({
+        "issuer": issuer,
+        "authorization_endpoint": format!("{issuer}/authorize"),
+        "token_endpoint": format!("{issuer}/token"),
+        "jwks_uri": format!("{issuer}/jwks"),
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": [signing_algorithm],
+        "grant_types_supported": [
+            "authorization_code",
+            "client_credentials",
+            "refresh_token",
+            "device_code",
+        ],
+        "scopes_supported": ["openid", "profile", "email", "openstack:api"],
+        "token_endpoint_auth_methods_supported": ["client_secret_basic"],
+        "claims_supported": ["sub", "iss", "aud", "exp", "iat", "auth_time", "amr"],
+    });
+
+    Ok(Json(doc))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        extract::ConnectInfo,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use sea_orm::DatabaseConnection;
+    use serde_json::Value;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_audit::AuditDispatcher;
+    use openstack_keystone_config::{Config, ConfigManager, RateLimitSection};
+    use openstack_keystone_core::keystone::Service;
+    use openstack_keystone_core::policy::MockPolicy;
+    use openstack_keystone_key_repository::asymmetric::{
+        ActiveKeys, SigningAlgorithm, generate_keypair,
+    };
+
+    use super::super::openapi_router;
+    use crate::api::tests::get_mocked_state as default_get_mocked_state;
+    use crate::oauth2_key::MockOauth2KeyProvider;
+    use crate::provider::Provider;
+
+    fn ok_mock() -> MockOauth2KeyProvider {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_jwks().returning(|_, _| {
+            let active = ActiveKeys {
+                primary: generate_keypair(SigningAlgorithm::Es256).unwrap(),
+                previous: None,
+            };
+            Ok(openstack_keystone_core::oauth2_key::jwks::active_keys_to_jwk_set(&active).unwrap())
+        });
+        mock
+    }
+
+    #[tokio::test]
+    async fn test_well_known_has_required_fields() {
+        let provider = Provider::mocked_builder().mock_oauth2_key(ok_mock());
+        let state = default_get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain-1/.well-known/openid-configuration")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let doc: Value = serde_json::from_slice(&body).unwrap();
+        for field in [
+            "issuer",
+            "authorization_endpoint",
+            "token_endpoint",
+            "jwks_uri",
+            "response_types_supported",
+            "subject_types_supported",
+            "id_token_signing_alg_values_supported",
+        ] {
+            assert!(
+                !doc.get(field).unwrap().is_null(),
+                "missing required field {field}"
+            );
+        }
+        assert_eq!(doc["issuer"], "http://localhost/v4/oauth2/domain-1");
+    }
+
+    #[tokio::test]
+    async fn test_well_known_not_found_for_unprovisioned_domain() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_jwks().returning(|_, _| {
+            Err(
+                openstack_keystone_core_types::oauth2_key::Oauth2KeyProviderError::NotFound(
+                    "domain-unknown".into(),
+                ),
+            )
+        });
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = default_get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain-unknown/.well-known/openid-configuration")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_well_known_unauthenticated_reachability() {
+        // No `Auth` extractor and no `.extension(vsc)`: must stay reachable
+        // without any authentication context.
+        let provider = Provider::mocked_builder().mock_oauth2_key(ok_mock());
+        let state = default_get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain-1/.well-known/openid-configuration")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_well_known_rate_limit_returns_429_after_burst_exhausted() {
+        let config = Config {
+            rate_limit_global_ip: RateLimitSection {
+                enabled: true,
+                burst_size: 1,
+                replenish_rate_per_second: 1,
+            },
+            ..Config::default()
+        };
+
+        let provider = Provider::mocked_builder()
+            .mock_oauth2_key(ok_mock())
+            .build()
+            .unwrap();
+
+        let state = Arc::new(
+            Service::new(
+                ConfigManager::not_watched(config),
+                DatabaseConnection::Disconnected,
+                provider,
+                Arc::new(MockPolicy::default()),
+                AuditDispatcher::noop(),
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+
+        let client_addr: SocketAddr = "203.0.113.5:1234".parse().unwrap();
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let mut req1 = Request::builder()
+            .uri("/domain-1/.well-known/openid-configuration")
+            .body(Body::empty())
+            .unwrap();
+        req1.extensions_mut().insert(ConnectInfo(client_addr));
+        assert_eq!(
+            api.as_service().oneshot(req1).await.unwrap().status(),
+            StatusCode::OK
+        );
+
+        let mut req2 = Request::builder()
+            .uri("/domain-1/.well-known/openid-configuration")
+            .body(Body::empty())
+            .unwrap();
+        req2.extensions_mut().insert(ConnectInfo(client_addr));
+        assert_eq!(
+            api.as_service().oneshot(req2).await.unwrap().status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+}

--- a/crates/keystone/src/lib.rs
+++ b/crates/keystone/src/lib.rs
@@ -92,6 +92,7 @@ pub mod k8s_auth;
 pub mod k8s_auth_client;
 pub mod keystone;
 pub mod mapping;
+pub mod oauth2_client;
 pub mod oauth2_key;
 
 // Force inventory::submit! sections from each plugin crate to remain

--- a/crates/keystone/src/oauth2_client.rs
+++ b/crates/keystone/src/oauth2_client.rs
@@ -11,21 +11,6 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # V4 API types
-pub mod api_key;
-pub mod auth;
-pub mod auth_plugin;
-pub mod mapping;
-pub mod oauth2_client;
-pub mod scim_realm;
-pub mod token_restriction;
-pub mod user;
+//! # OAuth2 client provider re-export.
 
-#[cfg(feature = "conv")]
-mod api_key_conv;
-#[cfg(feature = "conv")]
-mod oauth2_client_conv;
-#[cfg(feature = "conv")]
-mod scim_realm_conv;
-#[cfg(feature = "conv")]
-mod token_restriction_conv;
+pub use openstack_keystone_core::oauth2_client::*;

--- a/crates/keystone/src/plugin_manager.rs
+++ b/crates/keystone/src/plugin_manager.rs
@@ -47,6 +47,8 @@ use openstack_keystone_core::k8s_auth::K8sAuthProviderError;
 use openstack_keystone_core::k8s_auth::backend::K8sAuthBackend;
 use openstack_keystone_core::mapping::MappingBackend;
 use openstack_keystone_core::mapping::MappingProviderError;
+use openstack_keystone_core::oauth2_client::Oauth2ClientProviderError;
+use openstack_keystone_core::oauth2_client::backend::Oauth2ClientBackend;
 use openstack_keystone_core::oauth2_key::Oauth2KeyProviderError;
 use openstack_keystone_core::oauth2_key::backend::Oauth2KeyBackend;
 use openstack_keystone_core::resource::backend::ResourceBackend;
@@ -90,6 +92,8 @@ pub struct PluginManager {
     idmapping_backends: HashMap<String, Arc<dyn IdMappingBackend>>,
     /// Mapping backend plugins.
     mapping_backends: HashMap<String, Arc<dyn MappingBackend>>,
+    /// OAuth2 client backend plugins.
+    oauth2_client_backends: HashMap<String, Arc<dyn Oauth2ClientBackend>>,
     /// OAuth2 signing key backend plugins.
     oauth2_key_backends: HashMap<String, Arc<dyn Oauth2KeyBackend>>,
     /// K8s auth backend plugins.
@@ -304,6 +308,24 @@ impl PluginManagerApi for PluginManager {
             .ok_or(MappingProviderError::UnsupportedDriver(
                 name.as_ref().to_string(),
             ))
+    }
+
+    /// Get registered OAuth2 client backend.
+    ///
+    /// # Parameters
+    /// * `name` - The name of the backend to retrieve.
+    ///
+    /// # Returns
+    /// A `Result` containing a reference to the `Oauth2ClientBackend` if
+    /// found, or a `Oauth2ClientProviderError`.
+    #[allow(clippy::borrowed_box)]
+    fn get_oauth2_client_backend<S: AsRef<str>>(
+        &self,
+        name: S,
+    ) -> Result<&Arc<dyn Oauth2ClientBackend>, Oauth2ClientProviderError> {
+        self.oauth2_client_backends.get(name.as_ref()).ok_or(
+            Oauth2ClientProviderError::UnsupportedDriver(name.as_ref().to_string()),
+        )
     }
 
     /// Get registered OAuth2 signing key backend.
@@ -634,6 +656,20 @@ impl PluginManagerApi for PluginManager {
             .insert(name.as_ref().to_string(), plugin);
     }
 
+    /// Register OAuth2 client backend.
+    ///
+    /// # Parameters
+    /// * `name` - The name of the backend to register.
+    /// * `plugin` - The backend implementation to register.
+    fn register_oauth2_client_backend<S: AsRef<str>>(
+        &mut self,
+        name: S,
+        plugin: Arc<dyn Oauth2ClientBackend>,
+    ) {
+        self.oauth2_client_backends
+            .insert(name.as_ref().to_string(), plugin);
+    }
+
     /// Register OAuth2 signing key backend.
     ///
     /// # Parameters
@@ -834,6 +870,7 @@ impl PluginManager {
             identity_backends: HashMap::new(),
             idmapping_backends: HashMap::new(),
             mapping_backends: HashMap::new(),
+            oauth2_client_backends: HashMap::new(),
             oauth2_key_backends: HashMap::new(),
             k8s_auth_backends: HashMap::new(),
             resource_backends: HashMap::new(),
@@ -878,6 +915,12 @@ impl PluginManager {
         slf.register_oauth2_key_backend(
             "raft",
             Arc::new(openstack_keystone_oauth2_key_driver_raft::RaftOauth2KeyBackend::default()),
+        );
+        slf.register_oauth2_client_backend(
+            "raft",
+            Arc::new(
+                openstack_keystone_oauth2_client_driver_raft::RaftOauth2ClientBackend::default(),
+            ),
         );
         slf.register_api_key_backend(
             "raft",

--- a/crates/oauth2-client-driver-raft/Cargo.toml
+++ b/crates/oauth2-client-driver-raft/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "openstack-keystone-oauth2-client-driver-raft"
+description = "OpenStack Keystone Raft driver for OAuth2 client (relying party) registration"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+exclude.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+chrono = { workspace = true, default-features = false, features = ["clock", "serde"] }
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
+openstack-keystone-distributed-storage.workspace = true
+rmp-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+openstack-keystone-distributed-storage = { workspace = true, features = ["mock"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/oauth2-client-driver-raft/src/lib.rs
+++ b/crates/oauth2-client-driver-raft/src/lib.rs
@@ -1,0 +1,647 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OpenStack Keystone Raft driver for OAuth2 client (relying party)
+//! registration (ADR 0026 §5).
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::oauth2_client::Oauth2ClientProviderError;
+use openstack_keystone_core::oauth2_client::backend::Oauth2ClientBackend;
+use openstack_keystone_core_types::oauth2_client::*;
+use openstack_keystone_distributed_storage::{
+    ApiStoreError, Metadata, StorageApi, StoreDataEnvelope, StoreError, StoreResponse,
+    store_command::Mutation,
+};
+
+/// Bridges two different backend behaviors for the same semantic event: the
+/// real Raft-backed [`StorageApi`] converts the first `Violation` on a
+/// `transaction` call into an immediate `Err(ApiStoreError::Conflict)`;
+/// `MockStorage`, used by this crate's own unit tests, instead returns every
+/// violation as data on an `Ok` response's `violations` field. Both call
+/// sites need conflict detection to behave identically against either
+/// backend (mirrors `scim-driver-raft`'s helper of the same name).
+fn require_no_conflict(
+    result: Result<StoreResponse, ApiStoreError>,
+    conflict: impl FnOnce() -> StoreError,
+) -> Result<StoreResponse, StoreError> {
+    match result {
+        Ok(response) if response.violations.is_empty() => Ok(response),
+        Ok(_) => Err(conflict()),
+        Err(ApiStoreError::Conflict { .. }) => Err(conflict()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Global `client_id` index value payload: resolves to the owning
+/// `(domain_id, provider_id)` coordinate. Stored as a
+/// `Mutation::create_if_absent` data key (not `set_index`, which carries no
+/// payload) since `client_id` is unique cluster-wide, not domain-scoped --
+/// looking it up needs to recover which domain owns it.
+#[derive(Clone, Deserialize, Serialize)]
+struct ClientIdIndexEntry {
+    domain_id: String,
+    provider_id: String,
+}
+
+/// Raft Database OAuth2 client backend.
+///
+/// Primary records are indexed by `(domain_id, provider_id)` (`provider_id`
+/// unique within `domain_id`). The public `client_id` UUID is resolved
+/// cluster-wide (not domain-scoped, ADR 0026 §5) through a secondary index.
+#[derive(Default)]
+pub struct RaftOauth2ClientBackend {}
+
+impl RaftOauth2ClientBackend {
+    /// Primary storage key: `oauth2:client:v1:<domain_id>:<provider_id>`.
+    fn get_resource_key_name<D: AsRef<str>, P: AsRef<str>>(
+        &self,
+        domain_id: D,
+        provider_id: P,
+    ) -> String {
+        format!(
+            "oauth2:client:v1:{}:{}",
+            domain_id.as_ref(),
+            provider_id.as_ref()
+        )
+    }
+
+    /// Prefix covering all keys for a domain (used for listing).
+    fn get_resource_by_domain_prefix<D: AsRef<str>>(&self, domain_id: D) -> String {
+        format!("oauth2:client:v1:{}:", domain_id.as_ref())
+    }
+
+    /// Global `client_id` index key:
+    /// `oauth2:client:client_id_idx:v1:<client_id>`.
+    fn get_client_id_idx_key_name<C: AsRef<str>>(&self, client_id: C) -> String {
+        format!("oauth2:client:client_id_idx:v1:{}", client_id.as_ref())
+    }
+
+    async fn create_impl(
+        &self,
+        storage: &dyn StorageApi,
+        data: OAuth2ClientResourceCreate,
+    ) -> Result<OAuth2ClientResource, StoreError> {
+        let now = Utc::now().timestamp();
+        let obj = OAuth2ClientResource {
+            client_id: data.client_id,
+            provider_id: data.provider_id,
+            domain_id: data.domain_id,
+            client_secret_hash: data.client_secret_hash,
+            redirect_uris: data.redirect_uris,
+            token_endpoint_auth_method: data.token_endpoint_auth_method,
+            grant_types: data.grant_types,
+            require_pkce: data.require_pkce,
+            allowed_scopes: data.allowed_scopes,
+            pre_authorized: data.pre_authorized,
+            enabled: true,
+            claims_template: data.claims_template,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        };
+        let primary_key = self.get_resource_key_name(&obj.domain_id, &obj.provider_id);
+        let index_key = self.get_client_id_idx_key_name(&obj.client_id);
+
+        // The atomic `create_if_absent` transaction below only reports "some
+        // violation happened", not which of the two keys it was. Check both
+        // up front to name the actual offender in the conflict message --
+        // this is a best-effort read (TOCTOU-racy against a concurrent
+        // create) that only affects the error *text*, never correctness:
+        // the transaction itself is still the sole source of truth for
+        // whether the create succeeds.
+        let primary_exists = storage
+            .get_by_key(primary_key.as_bytes(), None)
+            .await?
+            .is_some();
+        let index_exists = storage
+            .get_by_key(index_key.as_bytes(), None)
+            .await?
+            .is_some();
+        let conflict_description = match (primary_exists, index_exists) {
+            (true, _) => format!(
+                "provider_id `{}` already registered in domain `{}`",
+                obj.provider_id, obj.domain_id
+            ),
+            (false, true) => format!("client_id `{}` already in use", obj.client_id),
+            (false, false) => format!(
+                "provider_id `{}` or client_id `{}` already in use",
+                obj.provider_id, obj.client_id
+            ),
+        };
+
+        let mutations = vec![
+            Mutation::create_if_absent(
+                primary_key.clone(),
+                obj.clone(),
+                Metadata::new(),
+                None::<&str>,
+            )?,
+            Mutation::create_if_absent(
+                index_key,
+                ClientIdIndexEntry {
+                    domain_id: obj.domain_id.clone(),
+                    provider_id: obj.provider_id.clone(),
+                },
+                Metadata::new(),
+                None::<&str>,
+            )?,
+        ];
+        require_no_conflict(storage.transaction(mutations).await, move || {
+            StoreError::Conflict {
+                subject: primary_key.clone(),
+                description: conflict_description,
+            }
+        })?;
+        Ok(obj)
+    }
+
+    /// Soft-delete: disables the client and stamps the tombstone. The
+    /// `client_id_idx` entry is deliberately left in place (unlike
+    /// `api-key-driver-raft`'s hard-delete `purge_impl`, which removes both)
+    /// -- `get_by_client_id` must keep resolving a soft-deleted client so
+    /// the disabled record stays reachable, which is the entire point of
+    /// choosing soft- over hard-delete here (Phase 4's refresh-token
+    /// family-tree invalidation walk needs it, and callers can still tell
+    /// it's revoked via `enabled`/`deleted_at`). There is currently no
+    /// physical-reclamation sweep for either the primary record or this
+    /// index entry; add one (mirroring `api_key`'s janitor,
+    /// ADR 0021 §6.F) if unbounded growth becomes a concern.
+    async fn delete_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        provider_id: &str,
+    ) -> Result<OAuth2ClientResource, StoreError> {
+        let key = self.get_resource_key_name(domain_id, provider_id);
+        let curr: StoreDataEnvelope<OAuth2ClientResource> = storage
+            .get_by_key(key.as_bytes(), None)
+            .await?
+            .ok_or_else(|| StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })?
+            .try_deserialize()?;
+        let new = curr.data.soft_delete(Utc::now().timestamp());
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                key,
+                StoreDataEnvelope {
+                    data: rmp_serde::to_vec(&new)?,
+                    metadata: new_meta,
+                },
+                None,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(new)
+    }
+
+    async fn get_by_client_id_impl(
+        &self,
+        storage: &dyn StorageApi,
+        client_id: &str,
+    ) -> Result<Option<OAuth2ClientResource>, StoreError> {
+        let Some(entry) = storage
+            .get_by_key(self.get_client_id_idx_key_name(client_id).as_bytes(), None)
+            .await?
+            .map(|env| env.try_deserialize::<ClientIdIndexEntry>())
+            .transpose()?
+            .map(|x| x.data)
+        else {
+            return Ok(None);
+        };
+        self.get_impl(storage, &entry.domain_id, &entry.provider_id)
+            .await
+    }
+
+    async fn get_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        provider_id: &str,
+    ) -> Result<Option<OAuth2ClientResource>, StoreError> {
+        Ok(storage
+            .get_by_key(
+                self.get_resource_key_name(domain_id, provider_id)
+                    .as_bytes(),
+                None,
+            )
+            .await?
+            .map(|env| env.try_deserialize::<OAuth2ClientResource>())
+            .transpose()?
+            .map(|x| x.data))
+    }
+
+    async fn list_impl(
+        &self,
+        storage: &dyn StorageApi,
+        params: &OAuth2ClientResourceListParameters,
+    ) -> Result<Vec<OAuth2ClientResource>, StoreError> {
+        let prefix = self.get_resource_by_domain_prefix(&params.domain_id);
+        let mut res: Vec<OAuth2ClientResource> = Vec::new();
+        for (_, envelope) in storage.prefix(prefix.as_bytes(), None).await? {
+            let candidate = envelope.try_deserialize::<OAuth2ClientResource>()?.data;
+            if let Some(enabled) = params.enabled
+                && candidate.enabled != enabled
+            {
+                continue;
+            }
+            res.push(candidate);
+        }
+        Ok(res)
+    }
+
+    async fn rotate_secret_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        provider_id: &str,
+        client_secret_hash: String,
+    ) -> Result<OAuth2ClientResource, StoreError> {
+        let key = self.get_resource_key_name(domain_id, provider_id);
+        let curr: StoreDataEnvelope<OAuth2ClientResource> = storage
+            .get_by_key(key.as_bytes(), None)
+            .await?
+            .ok_or_else(|| StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })?
+            .try_deserialize()?;
+        let mut new = curr.data;
+        new.client_secret_hash = Some(client_secret_hash);
+        new.updated_at = Utc::now().timestamp();
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                key,
+                StoreDataEnvelope {
+                    data: rmp_serde::to_vec(&new)?,
+                    metadata: new_meta,
+                },
+                None,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(new)
+    }
+
+    async fn update_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        provider_id: &str,
+        data: OAuth2ClientResourceUpdate,
+    ) -> Result<OAuth2ClientResource, StoreError> {
+        let key = self.get_resource_key_name(domain_id, provider_id);
+        let curr: StoreDataEnvelope<OAuth2ClientResource> = storage
+            .get_by_key(key.as_bytes(), None)
+            .await?
+            .ok_or_else(|| StoreError::IO {
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+            })?
+            .try_deserialize()?;
+        let new = curr.data.with_update(data, Utc::now().timestamp());
+        let new_meta = curr.metadata.new_revision();
+        storage
+            .set_value(
+                key,
+                StoreDataEnvelope {
+                    data: rmp_serde::to_vec(&new)?,
+                    metadata: new_meta,
+                },
+                None,
+                Some(curr.metadata.revision),
+            )
+            .await?;
+        Ok(new)
+    }
+}
+
+/// Maps the `StoreError::IO { source }` sentinel used by `update_impl`/
+/// `rotate_secret_impl`/`delete_impl` for "no such record" (constructed via
+/// `std::io::Error::new(std::io::ErrorKind::NotFound, ...)`) to
+/// `Oauth2ClientProviderError::NotFound`. Matches on the `io::ErrorKind`
+/// directly rather than the error's `Display` string, so it can't silently
+/// break if `StoreError`'s `Display` impl changes.
+fn map_not_found(e: StoreError, provider_id: &str) -> Oauth2ClientProviderError {
+    match e {
+        StoreError::IO { source } if source.kind() == std::io::ErrorKind::NotFound => {
+            Oauth2ClientProviderError::NotFound(provider_id.to_string())
+        }
+        e => Oauth2ClientProviderError::raft(e),
+    }
+}
+
+#[async_trait]
+impl Oauth2ClientBackend for RaftOauth2ClientBackend {
+    async fn create(
+        &self,
+        state: &ServiceState,
+        data: OAuth2ClientResourceCreate,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2ClientProviderError::RaftNotAvailable)?;
+        match self.create_impl(raft, data).await {
+            Ok(obj) => Ok(obj),
+            Err(StoreError::Conflict { description, .. }) => {
+                Err(Oauth2ClientProviderError::Conflict(description))
+            }
+            Err(e) => Err(Oauth2ClientProviderError::raft(e)),
+        }
+    }
+
+    async fn delete<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2ClientProviderError::RaftNotAvailable)?;
+        self.delete_impl(raft, domain_id, provider_id)
+            .await
+            .map_err(|e| map_not_found(e, provider_id))
+    }
+
+    async fn get<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        provider_id: &'a str,
+    ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2ClientProviderError::RaftNotAvailable)?;
+        self.get_impl(raft, domain_id, provider_id)
+            .await
+            .map_err(Oauth2ClientProviderError::raft)
+    }
+
+    async fn get_by_client_id<'a>(
+        &self,
+        state: &ServiceState,
+        client_id: &'a str,
+    ) -> Result<Option<OAuth2ClientResource>, Oauth2ClientProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2ClientProviderError::RaftNotAvailable)?;
+        self.get_by_client_id_impl(raft, client_id)
+            .await
+            .map_err(Oauth2ClientProviderError::raft)
+    }
+
+    async fn list(
+        &self,
+        state: &ServiceState,
+        params: &OAuth2ClientResourceListParameters,
+    ) -> Result<Vec<OAuth2ClientResource>, Oauth2ClientProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2ClientProviderError::RaftNotAvailable)?;
+        self.list_impl(raft, params)
+            .await
+            .map_err(Oauth2ClientProviderError::raft)
+    }
+
+    async fn rotate_secret<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        provider_id: &'a str,
+        client_secret_hash: String,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2ClientProviderError::RaftNotAvailable)?;
+        self.rotate_secret_impl(raft, domain_id, provider_id, client_secret_hash)
+            .await
+            .map_err(|e| map_not_found(e, provider_id))
+    }
+
+    async fn update<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        provider_id: &'a str,
+        data: OAuth2ClientResourceUpdate,
+    ) -> Result<OAuth2ClientResource, Oauth2ClientProviderError> {
+        let raft = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2ClientProviderError::RaftNotAvailable)?;
+        self.update_impl(raft, domain_id, provider_id, data)
+            .await
+            .map_err(|e| map_not_found(e, provider_id))
+    }
+}
+
+/// Linkage anchor -- see ADR-0018.
+#[allow(dead_code)]
+pub fn anchor() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openstack_keystone_distributed_storage::mock::MockStorage;
+    use std::collections::HashMap;
+
+    fn make_create(
+        provider_id: &str,
+        domain_id: &str,
+        client_id: &str,
+    ) -> OAuth2ClientResourceCreate {
+        OAuth2ClientResourceCreate {
+            client_id: client_id.to_string(),
+            provider_id: provider_id.to_string(),
+            domain_id: domain_id.to_string(),
+            client_secret_hash: Some("$argon2id$v=19$m=8,t=1,p=1$c2FsdA$aGFzaA".to_string()),
+            redirect_uris: vec!["https://rp.example.com/callback".to_string()],
+            token_endpoint_auth_method: "client_secret_basic".to_string(),
+            grant_types: vec![GrantType::AuthorizationCode],
+            require_pkce: false,
+            allowed_scopes: vec!["openid".to_string()],
+            pre_authorized: false,
+            claims_template: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get() {
+        let backend = RaftOauth2ClientBackend::default();
+        let storage = MockStorage::default();
+
+        let created = backend
+            .create_impl(&storage, make_create("provider-1", "domain-1", "client-1"))
+            .await
+            .unwrap();
+        assert!(created.enabled);
+
+        let fetched = backend
+            .get_impl(&storage, "domain-1", "provider-1")
+            .await
+            .unwrap();
+        assert_eq!(fetched.unwrap().client_id, "client-1");
+    }
+
+    #[tokio::test]
+    async fn test_create_duplicate_provider_id_conflicts() {
+        let backend = RaftOauth2ClientBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("provider-1", "domain-1", "client-1"))
+            .await
+            .unwrap();
+        let result = backend
+            .create_impl(&storage, make_create("provider-1", "domain-1", "client-2"))
+            .await;
+        assert!(matches!(result, Err(StoreError::Conflict { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_create_duplicate_client_id_conflicts() {
+        let backend = RaftOauth2ClientBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("provider-1", "domain-1", "client-1"))
+            .await
+            .unwrap();
+        let result = backend
+            .create_impl(&storage, make_create("provider-2", "domain-1", "client-1"))
+            .await;
+        assert!(matches!(result, Err(StoreError::Conflict { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_get_by_client_id_cross_domain() {
+        let backend = RaftOauth2ClientBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("provider-1", "domain-2", "client-1"))
+            .await
+            .unwrap();
+
+        let fetched = backend
+            .get_by_client_id_impl(&storage, "client-1")
+            .await
+            .unwrap();
+        assert_eq!(fetched.unwrap().domain_id, "domain-2");
+
+        let missing = backend
+            .get_by_client_id_impl(&storage, "nonexistent")
+            .await
+            .unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_by_domain_and_enabled_filter() {
+        let backend = RaftOauth2ClientBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("provider-1", "domain-1", "client-1"))
+            .await
+            .unwrap();
+        backend
+            .create_impl(&storage, make_create("provider-2", "domain-1", "client-2"))
+            .await
+            .unwrap();
+        backend
+            .create_impl(&storage, make_create("provider-3", "domain-2", "client-3"))
+            .await
+            .unwrap();
+
+        let params = OAuth2ClientResourceListParameters {
+            domain_id: "domain-1".to_string(),
+            enabled: None,
+        };
+        let listed = backend.list_impl(&storage, &params).await.unwrap();
+        assert_eq!(listed.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let backend = RaftOauth2ClientBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("provider-1", "domain-1", "client-1"))
+            .await
+            .unwrap();
+
+        let update = OAuth2ClientResourceUpdate {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        let updated = backend
+            .update_impl(&storage, "domain-1", "provider-1", update)
+            .await
+            .unwrap();
+        assert!(!updated.enabled);
+    }
+
+    #[tokio::test]
+    async fn test_rotate_secret() {
+        let backend = RaftOauth2ClientBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("provider-1", "domain-1", "client-1"))
+            .await
+            .unwrap();
+
+        let updated = backend
+            .rotate_secret_impl(&storage, "domain-1", "provider-1", "new-hash".to_string())
+            .await
+            .unwrap();
+        assert_eq!(updated.client_secret_hash, Some("new-hash".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_soft_delete_leaves_record_gettable_disabled() {
+        let backend = RaftOauth2ClientBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .create_impl(&storage, make_create("provider-1", "domain-1", "client-1"))
+            .await
+            .unwrap();
+
+        let deleted = backend
+            .delete_impl(&storage, "domain-1", "provider-1")
+            .await
+            .unwrap();
+        assert!(!deleted.enabled);
+        assert!(deleted.deleted_at.is_some());
+
+        let fetched = backend
+            .get_impl(&storage, "domain-1", "provider-1")
+            .await
+            .unwrap();
+        assert!(fetched.is_some());
+        assert!(!fetched.unwrap().enabled);
+    }
+}

--- a/doc/src/adr/0020-mapping-engine.md
+++ b/doc/src/adr/0020-mapping-engine.md
@@ -1082,6 +1082,7 @@ single consolidated partition layer in FjallDB.
 | **OIDC Crypto Resource**        | `data:federation:oidc:<domain_id>:<provider_id>` | `OidcProviderResource` (Struct)               |
 | **K8s Crypto Resource**         | `data:k8s_auth:<domain_id>:<provider_id>`        | `K8sClusterResource` (Struct object)          |
 | **SPIFFE Crypto Resource**      | `data:spiffe:<domain_id>:<provider_id>`          | `SpiffeTrustResource` (Struct object)         |
+| **OAuth2 Client Resource**      | `data:oauth2:client:<domain_id>:<provider_id>`   | `OAuth2ClientResource` (Struct object)        |
 | **Unified ABAC Ruleset**        | `data:mapping:<domain_id>:<provider_id>`         | `MappingRuleSet` (Contains named rule vector) |
 
 ---

--- a/policy/oauth2/client/common.rego
+++ b/policy/oauth2/client/common.rego
@@ -1,0 +1,28 @@
+# METADATA
+# description: Shared predicates for OAuth2 client (relying party) policies (ADR 0026 §5)
+package identity.oauth2.client
+
+import data.identity
+
+# Resolve domain_id from target or existing depending on operation.
+# Create/List: domain_id is a top-level input.target field (from the URL
+# path, ADR 0026 §5), not nested under input.target.oauth2_client.
+# Show/Update/RotateSecret/Delete: domain_id is in
+# input.existing.oauth2_client.
+client_domain_id := input.target.domain_id if {
+	input.target.domain_id
+}
+
+client_domain_id := input.existing.oauth2_client.domain_id if {
+	input.existing.oauth2_client.domain_id
+}
+
+own_client if {
+	client_domain_id != null
+	client_domain_id == input.credentials.domain_id
+}
+
+foreign_client if {
+	client_domain_id != null
+	client_domain_id != input.credentials.domain_id
+}

--- a/policy/oauth2/client/create.rego
+++ b/policy/oauth2/client/create.rego
@@ -1,0 +1,54 @@
+# METADATA
+# description: Policy for registering OAuth2 clients (relying parties, ADR 0026 §5)
+package identity.oauth2.client.create
+
+import data.identity.oauth2.client as client_common
+
+# Create OAuth2Client (OAuth2ClientResourceCreate).
+#
+# input.target.domain_id:   string  Domain owning the registration (URL path).
+# input.target.oauth2_client: object  OAuth2ClientCreate payload.
+#
+# input.existing is null.
+#
+# Rules (ADR 0026 §5, same tier structure as identity.api_key.create):
+# client registration requires the `manager` role (DomainManager) scoped to
+# the client's own domain, or `admin` (SystemAdmin). Registering a
+# pre-authorized client always requires `admin`, regardless of domain.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	client_common.own_client
+	"manager" in input.credentials.roles
+	not input.target.oauth2_client.pre_authorized
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	client_common.foreign_client
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "registering an OAuth2 client for another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	client_common.own_client
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "registering an OAuth2 client requires `manager` role."
+}
+
+violation contains {"field": "pre_authorized", "msg": msg} if {
+	input.target.oauth2_client.pre_authorized
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "registering a pre_authorized OAuth2 client requires `admin` role."
+}

--- a/policy/oauth2/client/create_test.rego
+++ b/policy/oauth2/client/create_test.rego
@@ -1,0 +1,24 @@
+package test_oauth2_client_create
+
+import data.identity.oauth2.client.create
+
+test_allowed if {
+	create.allow with input as {"credentials": {"roles": ["admin"]}}
+	create.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	create.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"domain_id": "foo", "oauth2_client": {"pre_authorized": false}}}
+}
+
+test_forbidden if {
+	not create.allow with input as {"credentials": {"roles": []}}
+	not create.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"domain_id": "foo1", "oauth2_client": {"pre_authorized": false}}}
+	not create.allow with input as {"credentials": {"roles": []}, "target": {"domain_id": "foo"}}
+	not create.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "target": {"domain_id": "foo", "oauth2_client": {"pre_authorized": false}}}
+}
+
+test_pre_authorized_by_manager_denied if {
+	not create.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"domain_id": "foo", "oauth2_client": {"pre_authorized": true}}}
+}
+
+test_pre_authorized_by_admin_allowed if {
+	create.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"domain_id": "foo", "oauth2_client": {"pre_authorized": true}}}
+}

--- a/policy/oauth2/client/delete.rego
+++ b/policy/oauth2/client/delete.rego
@@ -1,0 +1,39 @@
+# METADATA
+# description: Policy for revoking (soft-deleting) OAuth2 clients (ADR 0026 §5)
+package identity.oauth2.client.delete
+
+import data.identity.oauth2.client as client_common
+
+# Soft-delete an OAuth2ClientResource (DELETE .../clients/{provider_id}).
+#
+# input.target is null.
+# input.existing.oauth2_client is the stored resource to be revoked.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	client_common.own_client
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	client_common.foreign_client
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "revoking an OAuth2 client in another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	client_common.own_client
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "revoking an OAuth2 client requires `manager` role."
+}

--- a/policy/oauth2/client/delete_test.rego
+++ b/policy/oauth2/client/delete_test.rego
@@ -1,0 +1,15 @@
+package test_oauth2_client_delete
+
+import data.identity.oauth2.client.delete
+
+test_allowed if {
+	delete.allow with input as {"credentials": {"roles": ["admin"]}}
+	delete.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	delete.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not delete.allow with input as {"credentials": {"roles": []}}
+	not delete.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo1"}}}
+	not delete.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo"}}}
+}

--- a/policy/oauth2/client/list.rego
+++ b/policy/oauth2/client/list.rego
@@ -1,0 +1,39 @@
+# METADATA
+# description: Policy for listing OAuth2 clients (relying parties, ADR 0026 §5)
+package identity.oauth2.client.list
+
+import data.identity.oauth2.client as client_common
+
+# List OAuth2ClientResources.
+#
+# input.target.domain_id: string  Domain to list clients for (URL path).
+# input.existing is null.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	client_common.own_client
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	client_common.foreign_client
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "listing OAuth2 clients for another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	client_common.own_client
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "listing OAuth2 clients requires `manager` role."
+}

--- a/policy/oauth2/client/list_test.rego
+++ b/policy/oauth2/client/list_test.rego
@@ -1,0 +1,15 @@
+package test_oauth2_client_list
+
+import data.identity.oauth2.client.list
+
+test_allowed if {
+	list.allow with input as {"credentials": {"roles": ["admin"]}}
+	list.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	list.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"domain_id": "foo"}}
+}
+
+test_forbidden if {
+	not list.allow with input as {"credentials": {"roles": []}}
+	not list.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"domain_id": "foo1"}}
+	not list.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "target": {"domain_id": "foo"}}
+}

--- a/policy/oauth2/client/rotate_secret.rego
+++ b/policy/oauth2/client/rotate_secret.rego
@@ -1,0 +1,54 @@
+# METADATA
+# description: Policy for rotating an OAuth2 client's secret (ADR 0026 §5)
+package identity.oauth2.client.rotate_secret
+
+import data.identity.oauth2.client as client_common
+
+# Rotate an OAuth2Client's secret (POST .../clients/{provider_id}/rotate-secret).
+#
+# input.target is null.
+# input.existing.oauth2_client is the stored resource to rotate. A public
+# client (`confidential == false`) has no `client_secret` to rotate -- the
+# service layer (`Oauth2ClientService::rotate_secret`) already rejects this
+# with a 422 `Validation` error, but the policy denies it too, up front and
+# regardless of role, so the rejection shows up as a clear policy violation
+# rather than only a provider-error message.
+
+default allow := false
+
+allow if {
+	input.existing.oauth2_client.confidential
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.existing.oauth2_client.confidential
+	input.credentials.is_admin
+}
+
+allow if {
+	input.existing.oauth2_client.confidential
+	client_common.own_client
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "confidential", "msg": msg} if {
+	not input.existing.oauth2_client.confidential
+	msg := "cannot rotate a secret for a public OAuth2 client (no client_secret)."
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	input.existing.oauth2_client.confidential
+	client_common.foreign_client
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "rotating an OAuth2 client secret in another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	input.existing.oauth2_client.confidential
+	client_common.own_client
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "rotating an OAuth2 client secret requires `manager` role."
+}

--- a/policy/oauth2/client/rotate_secret_test.rego
+++ b/policy/oauth2/client/rotate_secret_test.rego
@@ -1,0 +1,20 @@
+package test_oauth2_client_rotate_secret
+
+import data.identity.oauth2.client.rotate_secret
+
+test_allowed if {
+	rotate_secret.allow with input as {"credentials": {"roles": ["admin"]}, "existing": {"oauth2_client": {"confidential": true}}}
+	rotate_secret.allow with input as {"credentials": {"roles": [], "is_admin": true}, "existing": {"oauth2_client": {"confidential": true}}}
+	rotate_secret.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo", "confidential": true}}}
+}
+
+test_forbidden if {
+	not rotate_secret.allow with input as {"credentials": {"roles": []}, "existing": {"oauth2_client": {"confidential": true}}}
+	not rotate_secret.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo1", "confidential": true}}}
+	not rotate_secret.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo", "confidential": true}}}
+}
+
+test_public_client_denied_even_for_admin if {
+	not rotate_secret.allow with input as {"credentials": {"roles": ["admin"]}, "existing": {"oauth2_client": {"confidential": false}}}
+	not rotate_secret.allow with input as {"credentials": {"roles": [], "is_admin": true}, "existing": {"oauth2_client": {"confidential": false}}}
+}

--- a/policy/oauth2/client/show.rego
+++ b/policy/oauth2/client/show.rego
@@ -1,0 +1,40 @@
+# METADATA
+# description: Policy for viewing a single OAuth2 client's metadata (ADR 0026 §5)
+package identity.oauth2.client.show
+
+import data.identity.oauth2.client as client_common
+
+# Show a single OAuth2ClientResource (GET .../clients/{provider_id}).
+#
+# input.target is null.
+# input.existing.oauth2_client is the stored resource (never carries
+# client_secret_hash).
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	client_common.own_client
+	"manager" in input.credentials.roles
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	client_common.foreign_client
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "showing an OAuth2 client in another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	client_common.own_client
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "showing an OAuth2 client requires `manager` role."
+}

--- a/policy/oauth2/client/show_test.rego
+++ b/policy/oauth2/client/show_test.rego
@@ -1,0 +1,15 @@
+package test_oauth2_client_show
+
+import data.identity.oauth2.client.show
+
+test_allowed if {
+	show.allow with input as {"credentials": {"roles": ["admin"]}}
+	show.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	show.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not show.allow with input as {"credentials": {"roles": []}}
+	not show.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo1"}}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "existing": {"oauth2_client": {"domain_id": "foo"}}}
+}

--- a/policy/oauth2/client/update.rego
+++ b/policy/oauth2/client/update.rego
@@ -1,0 +1,66 @@
+# METADATA
+# description: Policy for updating OAuth2 clients (relying parties, ADR 0026 §5)
+package identity.oauth2.client.update
+
+import data.identity.oauth2.client as client_common
+
+# Update OAuth2ClientResource (PUT .../clients/{provider_id}, OAuth2ClientUpdate).
+#
+# input.target.oauth2_client is the update patch (redirect_uris, grant_types,
+# require_pkce, allowed_scopes, pre_authorized, enabled, claims_template).
+# input.existing.oauth2_client is the stored resource, which carries
+# domain_id -- the patch itself does not.
+#
+# ADR 0026 §5 deviation: even a domain-manager with otherwise-Tier-2 access
+# must be denied when the patch sets pre_authorized == true, unless
+# `admin`/`is_admin`. Also denied any edit to a client that is *already*
+# pre_authorized == true, even one that doesn't touch that field itself --
+# a manager could otherwise use e.g. `redirect_uris` on a pre-authorized
+# (no interactive consent) client to widen where its tokens land, without
+# ever needing to touch the `pre_authorized` field the admin-only gate
+# actually watches.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	client_common.own_client
+	"manager" in input.credentials.roles
+	not input.target.oauth2_client.pre_authorized
+	not input.existing.oauth2_client.pre_authorized
+}
+
+violation contains {"field": "domain_id", "msg": msg} if {
+	client_common.foreign_client
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "updating an OAuth2 client in another domain requires `admin` role."
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	client_common.own_client
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	msg := "updating an OAuth2 client requires `manager` role."
+}
+
+violation contains {"field": "pre_authorized", "msg": msg} if {
+	input.target.oauth2_client.pre_authorized
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "setting pre_authorized on an OAuth2 client requires `admin` role."
+}
+
+violation contains {"field": "pre_authorized", "msg": msg} if {
+	input.existing.oauth2_client.pre_authorized
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "editing an already pre_authorized OAuth2 client requires `admin` role."
+}

--- a/policy/oauth2/client/update_test.rego
+++ b/policy/oauth2/client/update_test.rego
@@ -1,0 +1,31 @@
+package test_oauth2_client_update
+
+import data.identity.oauth2.client.update
+
+test_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}}
+	update.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"oauth2_client": {"enabled": false}}, "existing": {"oauth2_client": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"oauth2_client": {}}, "existing": {"oauth2_client": {"domain_id": "foo1"}}}
+	not update.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "target": {"oauth2_client": {}}, "existing": {"oauth2_client": {"domain_id": "foo"}}}
+}
+
+test_pre_authorized_by_manager_denied if {
+	not update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"oauth2_client": {"pre_authorized": true}}, "existing": {"oauth2_client": {"domain_id": "foo"}}}
+}
+
+test_pre_authorized_by_admin_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"oauth2_client": {"pre_authorized": true}}, "existing": {"oauth2_client": {"domain_id": "foo"}}}
+}
+
+test_existing_pre_authorized_edit_by_manager_denied if {
+	not update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "target": {"oauth2_client": {"enabled": false}}, "existing": {"oauth2_client": {"domain_id": "foo", "pre_authorized": true}}}
+}
+
+test_existing_pre_authorized_edit_by_admin_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"oauth2_client": {"enabled": false}}, "existing": {"oauth2_client": {"domain_id": "foo", "pre_authorized": true}}}
+}


### PR DESCRIPTION
Implements Ingress API Routing & OIDC Discovery: admin CRUD for
OAuth2Client (relying party) registration and the unauthenticated
RFC 8414/OIDC discovery document, both scoped per domain.

- crates/oauth2-client-driver-raft: Raft storage, provider_id
  unique per domain + globally unique client_id via secondary
  index, soft-delete (record retained for Phase 4 refresh-token
  family-tree invalidation)
- crates/core/oauth2_client: service layer validation (redirect
  URI scheme, PKCE requirement for public clients, reserved claim
  names), Argon2id client-secret hashing, guards against
  mutating a revoked (soft-deleted) client
- GET /v4/oauth2/{domain_id}/.well-known/openid-configuration:
  unauthenticated, rate-limited, mirrors jwks.rs's pattern
- POST/GET/PUT/DELETE /v4/oauth2/{domain_id}/clients: Tier 1/2
  Rego policy, pre_authorized gated to admin (including edits to
  an already pre_authorized client)
- new [oauth2] argon2_* config knobs, independent of [api_key]'s

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
