### PR TITLE
feat(adr0026): Phase 6a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,6 +5125,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -345,6 +345,19 @@ impl From<Oauth2KeyProviderError> for KeystoneApiError {
                 resource: "oauth2_signing_key".into(),
                 identifier: x,
             },
+            Oauth2KeyProviderError::NoPendingRotation(x) => Self::NotFound {
+                resource: "oauth2_pending_rotation".into(),
+                identifier: x,
+            },
+            Oauth2KeyProviderError::RotationExpired(x) => {
+                Self::Conflict(format!("pending emergency rotation {x} has expired"))
+            }
+            Oauth2KeyProviderError::DualControlViolation => Self::Forbidden {
+                source: Box::new(value),
+            },
+            Oauth2KeyProviderError::EmergencyRotationAlreadyPending(x) => Self::Conflict(format!(
+                "an emergency rotation (id {x}) is already pending for this domain"
+            )),
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/api-types/src/v4/oauth2_client.rs
+++ b/crates/api-types/src/v4/oauth2_client.rs
@@ -34,6 +34,9 @@ pub enum GrantType {
     DeviceCode,
     /// RFC 6749 `refresh_token`.
     RefreshToken,
+    /// RFC 8693 Token Exchange (ADR 0026 §12 v2 shape).
+    #[serde(rename = "urn:ietf:params:oauth:grant-type:token-exchange")]
+    TokenExchange,
 }
 
 /// A registered OAuth2/OIDC relying party. Never carries `client_secret` or

--- a/crates/api-types/src/v4/oauth2_client_conv.rs
+++ b/crates/api-types/src/v4/oauth2_client_conv.rs
@@ -24,6 +24,7 @@ impl From<api::GrantType> for core::GrantType {
             api::GrantType::ClientCredentials => Self::ClientCredentials,
             api::GrantType::RefreshToken => Self::RefreshToken,
             api::GrantType::DeviceCode => Self::DeviceCode,
+            api::GrantType::TokenExchange => Self::TokenExchange,
         }
     }
 }
@@ -35,6 +36,7 @@ impl From<core::GrantType> for api::GrantType {
             core::GrantType::ClientCredentials => Self::ClientCredentials,
             core::GrantType::RefreshToken => Self::RefreshToken,
             core::GrantType::DeviceCode => Self::DeviceCode,
+            core::GrantType::TokenExchange => Self::TokenExchange,
         }
     }
 }

--- a/crates/core-types/src/oauth2_client/resource.rs
+++ b/crates/core-types/src/oauth2_client/resource.rs
@@ -28,10 +28,15 @@ pub enum GrantType {
     AuthorizationCode,
     /// RFC 6749 `client_credentials` (machine-to-machine).
     ClientCredentials,
-    /// RFC 6749 `refresh_token`.
-    RefreshToken,
     /// OAuth 2.0 Device Authorization Grant (RFC 8628).
     DeviceCode,
+    /// RFC 6749 `refresh_token`.
+    RefreshToken,
+    /// RFC 8693 Token Exchange (ADR 0026 §12 v2 shape): trades an existing
+    /// Keystone-native delegated credential (trust, application credential)
+    /// for a native `OpenStackAccessTokenClaims` access token.
+    #[serde(rename = "urn:ietf:params:oauth:grant-type:token-exchange")]
+    TokenExchange,
 }
 
 /// A registered OAuth2/OIDC relying party (ADR 0026 §5, "Amendment to ADR

--- a/crates/core-types/src/oauth2_key/error.rs
+++ b/crates/core-types/src/oauth2_key/error.rs
@@ -53,6 +53,27 @@ pub enum Oauth2KeyProviderError {
     /// Unsupported driver.
     #[error("unsupported driver `{0}` for the oauth2 key provider")]
     UnsupportedDriver(String),
+
+    /// No pending emergency rotation exists for this `rotation_id`
+    /// (ADR 0026 §3, Emergency Rotation).
+    #[error("no pending emergency rotation with id {0}")]
+    NoPendingRotation(String),
+
+    /// The pending emergency rotation's 15-minute confirmation window has
+    /// elapsed.
+    #[error("pending emergency rotation {0} has expired")]
+    RotationExpired(String),
+
+    /// The confirming operator was the same identity that staged the
+    /// rotation (ADR 0026 §3 dual-control requirement).
+    #[error("the confirming operator must differ from the initiating operator")]
+    DualControlViolation,
+
+    /// A pending emergency rotation already exists for this domain and
+    /// hasn't expired. Staging a second one would silently orphan the
+    /// first's `rotation_id`.
+    #[error("an emergency rotation (id {0}) is already pending for this domain")]
+    EmergencyRotationAlreadyPending(String),
 }
 
 impl Oauth2KeyProviderError {

--- a/crates/core-types/src/oauth2_key/rotation.rs
+++ b/crates/core-types/src/oauth2_key/rotation.rs
@@ -11,10 +11,16 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # OAuth2 per-domain signing key provider (ADR 0026 §3)
+//! # Signing key rotation DTOs (ADR 0026 §3)
 
-mod error;
-mod rotation;
-
-pub use error::*;
-pub use rotation::PendingRotationInfo;
+/// Returned when an emergency rotation is staged: the confirming operator
+/// needs `rotation_id`, and callers surface `expires_at` so they know the
+/// dual-control confirmation window.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingRotationInfo {
+    /// Opaque identifier the second operator passes to confirm the
+    /// rotation.
+    pub rotation_id: String,
+    /// Unix epoch seconds after which this pending rotation auto-aborts.
+    pub expires_at: i64,
+}

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -180,6 +180,9 @@ pub use oauth2_client::MockOauth2ClientProvider;
 mod oauth2_key {
     use super::*;
 
+    use std::collections::HashSet;
+
+    use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
     use openstack_keystone_key_repository::asymmetric::KeyMaterial;
 
     use crate::oauth2_key::{Oauth2KeyApi, Oauth2KeyProviderError};
@@ -206,6 +209,34 @@ mod oauth2_key {
                 state: &ServiceState,
                 domain_id: &str,
             ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+            async fn rotate_signing_key(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+            ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+            async fn stage_emergency_rotation(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+                initiator: &str,
+            ) -> Result<PendingRotationInfo, Oauth2KeyProviderError>;
+
+            async fn confirm_emergency_rotation(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+                rotation_id: &str,
+                confirmer: &str,
+                revoke_jtis: Vec<String>,
+            ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+            async fn revoked_jtis(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+            ) -> Result<HashSet<String>, Oauth2KeyProviderError>;
         }
     }
 }

--- a/crates/core/src/oauth2_client.rs
+++ b/crates/core/src/oauth2_client.rs
@@ -24,6 +24,7 @@ pub mod pkce;
 mod provider_api;
 pub mod service;
 pub mod token;
+pub mod token_exchange;
 pub mod verify;
 
 #[cfg(any(test, feature = "mock"))]
@@ -32,4 +33,5 @@ pub use error::Oauth2ClientProviderError;
 pub use provider_api::Oauth2ClientApi;
 pub use service::Oauth2ClientService;
 pub use token::{build_access_token_claims, hydrate_client_credentials_context};
+pub use token_exchange::{TokenExchangeError, build_token_exchange_claims, validate_subject_token};
 pub use verify::{TokenVerificationError, verify_openstack_access_token};

--- a/crates/core/src/oauth2_client/token_exchange.rs
+++ b/crates/core/src/oauth2_client/token_exchange.rs
@@ -1,0 +1,428 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # RFC 8693 Token Exchange (ADR 0026 §12, "v2 Shape", implemented here as
+//! the follow-up amendment the ADR itself defers to)
+//!
+//! Trades an existing Keystone-native delegated credential (trust or
+//! application credential; EC2 is deferred, see
+//! [`TokenExchangeError::UnsupportedDelegation`]) for a native
+//! `OpenStackAccessTokenClaims` access token whose `delegation_context`
+//! reflects the presented credential's own delegation, per security.md I2
+//! (the delegation boundary is the credential's own immutable project, not
+//! the request's current scope).
+use openstack_keystone_core_types::auth::{AuthenticationContext, IdentityInfo, ScopeInfo};
+use openstack_keystone_core_types::oauth2_client::{
+    DelegationContext, OAuth2ClientResource, OpenStackAccessTokenClaims, OpenStackContext,
+    OpenStackScope,
+};
+use openstack_keystone_core_types::token::TokenProviderError;
+use thiserror::Error;
+
+use crate::auth::{ExecutionContext, ValidatedSecurityContext};
+use crate::keystone::ServiceState;
+
+/// Failure modes for the Token Exchange grant.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TokenExchangeError {
+    /// `subject_token` failed the same validation every other endpoint
+    /// applies to a bearer token: invalid, expired, or revoked.
+    #[error("subject_token failed validation: {0}")]
+    InvalidSubjectToken(#[from] TokenProviderError),
+
+    /// The validated context carries no resolved authorization/scope.
+    #[error("subject_token's context has no resolved authorization scope")]
+    NoAuthorization,
+
+    /// The delegation object (app-cred) has no bound project. Exchange requires
+    /// a concrete I2 boundary to enforce; there is nothing to bind the new
+    /// token to.
+    #[error("the presented delegation has no bound project to exchange into a token")]
+    NoDelegationProject,
+
+    /// The validated context did not resolve to a real user identity (a
+    /// workload `Principal`, not a human `User`). Application credentials are
+    /// always held by real Keystone users, never by external ingress
+    /// principals, so this should never happen given a genuinely
+    /// app-cred-delegated `subject_token` -- checked rather than assumed
+    /// since this builds a signed token.
+    #[error("subject_token's principal is not a Keystone user")]
+    NotAUserPrincipal,
+
+    /// `subject_token`'s authentication chain carries no delegation
+    /// (security.md I1: the chain, not the scope, is the source of truth).
+    /// A plain password/token/mapped/etc. login has nothing to exchange --
+    /// this grant exists to re-express an *existing* delegation as a JWT,
+    /// not to mint a new one.
+    #[error("subject_token carries no delegation to exchange (auth_method `{0}`)")]
+    NotDelegated(String),
+
+    /// The delegation kind is recognized but not yet supported by this
+    /// grant. Only `AppCred` is implemented; `Trust` and `Ec2` delegation
+    /// exchange are deferred (see the ADR 0026 §12 amendment for the
+    /// rationale).
+    #[error("token exchange for `{0}` delegation is not yet supported")]
+    UnsupportedDelegation(&'static str),
+}
+
+/// Derive the [`DelegationContext`] an authentication chain carries
+/// (security.md I1: keyed on the chain, never on the token's current
+/// scope). Pure and side-effect-free so it's unit-testable without a full
+/// [`ServiceState`]/[`TokenApi`] round trip.
+fn derive_delegation_context(
+    ctx: &AuthenticationContext,
+) -> Result<DelegationContext, TokenExchangeError> {
+    match ctx {
+        AuthenticationContext::Trust { .. } => {
+            Err(TokenExchangeError::UnsupportedDelegation("trust"))
+        }
+        AuthenticationContext::ApplicationCredential {
+            application_credential,
+            ..
+        } => Ok(DelegationContext::AppCred {
+            project_id: application_credential.project_id.clone(),
+        }),
+        AuthenticationContext::Ec2Credential => {
+            Err(TokenExchangeError::UnsupportedDelegation("ec2"))
+        }
+        other => Err(TokenExchangeError::NotDelegated(
+            other.auth_type().into_owned(),
+        )),
+    }
+}
+
+/// Validate `subject_token` via the same pipeline every bearer token goes
+/// through ([`TokenApi::validate_to_context`]), then derive the
+/// [`DelegationContext`] its authentication chain carries.
+pub async fn validate_subject_token(
+    state: &ServiceState,
+    subject_token: &str,
+) -> Result<(ValidatedSecurityContext, DelegationContext), TokenExchangeError> {
+    let exec = ExecutionContext::internal(state);
+    let vsc = state
+        .provider
+        .get_token_provider()
+        .validate_to_context(&exec, subject_token, Some(false), None)
+        .await?;
+
+    let delegation_context = derive_delegation_context(vsc.inner().authentication_context())?;
+
+    Ok((vsc, delegation_context))
+}
+
+/// Build the [`OpenStackAccessTokenClaims`] for a Token Exchange grant, from
+/// the validated `subject_token` context and its derived
+/// [`DelegationContext`].
+///
+/// # Errors
+/// See [`TokenExchangeError`] for each rejection reason.
+#[allow(clippy::too_many_arguments)]
+pub fn build_token_exchange_claims(
+    client: &OAuth2ClientResource,
+    vsc: &ValidatedSecurityContext,
+    delegation_context: DelegationContext,
+    issuer: &str,
+    jti: String,
+    iat: i64,
+    exp: i64,
+) -> Result<OpenStackAccessTokenClaims, TokenExchangeError> {
+    let principal = vsc.inner().principal();
+    let (user_id, user_name, user_domain_id) = match &principal.identity {
+        IdentityInfo::User(u) => (
+            u.user_id.clone(),
+            u.user
+                .as_ref()
+                .map(|r| r.name.clone())
+                .unwrap_or_else(|| u.user_id.clone()),
+            u.user_domain.as_ref().map(|d| d.id.clone()),
+        ),
+        IdentityInfo::Principal(_) => return Err(TokenExchangeError::NotAUserPrincipal),
+    };
+
+    let authz = vsc
+        .inner()
+        .authorization()
+        .ok_or(TokenExchangeError::NoAuthorization)?;
+    let role_refs = authz.effective_roles().unwrap_or(&[]).to_vec();
+    let role_names: Vec<String> = role_refs.iter().filter_map(|r| r.name.clone()).collect();
+
+    let scope = match &authz.scope {
+        ScopeInfo::Project {
+            project,
+            project_domain,
+        } => OpenStackScope::Project {
+            project_id: project.id.clone(),
+            project_domain_id: project_domain.id.clone(),
+            roles: role_refs,
+        },
+        ScopeInfo::Domain(domain) => OpenStackScope::Domain {
+            domain_id: domain.id.clone(),
+            roles: role_refs,
+        },
+        ScopeInfo::System(system_id) => OpenStackScope::System {
+            system_id: system_id.clone(),
+            roles: role_refs,
+        },
+        _ => OpenStackScope::Unscoped,
+    };
+
+    let amr: Vec<String> = vsc
+        .inner()
+        .authentication_context()
+        .methods()
+        .into_iter()
+        .collect();
+
+    Ok(OpenStackAccessTokenClaims {
+        iss: issuer.to_string(),
+        sub: user_id.clone(),
+        aud: format!("openstack-apis:{}", client.domain_id),
+        client_id: client.client_id.clone(),
+        exp,
+        iat,
+        nbf: iat,
+        jti,
+        // No `MappingRuleSet` is involved in a token-exchange grant (the
+        // subject is an already-authenticated native Keystone credential,
+        // not an external ingress source) so there is no ruleset state to
+        // anchor to. `0` is a sentinel meaning "not mapping-engine-derived"
+        // -- the claim is documented as advisory-only (ADR 0026 §11) and
+        // gates nothing downstream.
+        keystone_ruleset_version: 0,
+        amr,
+        token_use: "access".to_string(),
+        delegation_context,
+        openstack_context: OpenStackContext {
+            user_id,
+            user_name,
+            user_domain_id,
+            scope,
+            roles: role_names,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openstack_keystone_core_types::auth::{
+        AuthzInfoBuilder, PrincipalIdentityInfoBuilder, PrincipalInfo, SecurityContext,
+        UserIdentityInfoBuilder,
+    };
+    use openstack_keystone_core_types::identity::UserResponseBuilder;
+    use openstack_keystone_core_types::resource::{Domain, Project};
+    use openstack_keystone_core_types::trust::Trust;
+
+    fn trust_context(project_id: Option<&str>) -> AuthenticationContext {
+        AuthenticationContext::Trust {
+            trust: Trust {
+                id: "trust-1".to_string(),
+                impersonation: false,
+                project_id: project_id.map(str::to_string),
+                trustor_user_id: "trustor-1".to_string(),
+                trustee_user_id: "trustee-1".to_string(),
+                ..Default::default()
+            },
+            token: None,
+        }
+    }
+
+    fn app_cred_context(project_id: &str) -> AuthenticationContext {
+        AuthenticationContext::ApplicationCredential {
+            application_credential:
+                openstack_keystone_core_types::application_credential::ApplicationCredential {
+                    access_rules: None,
+                    description: None,
+                    expires_at: None,
+                    id: "appcred-1".to_string(),
+                    name: "appcred".to_string(),
+                    project_id: project_id.to_string(),
+                    roles: vec![],
+                    unrestricted: false,
+                    user_id: "user-1".to_string(),
+                },
+            token: None,
+        }
+    }
+
+    #[test]
+    fn test_derive_delegation_context_app_cred() {
+        let ctx = app_cred_context("project-2");
+        let result = derive_delegation_context(&ctx).unwrap();
+        assert_eq!(
+            result,
+            DelegationContext::AppCred {
+                project_id: "project-2".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_derive_delegation_context_ec2_is_unsupported() {
+        let err = derive_delegation_context(&AuthenticationContext::Ec2Credential).unwrap_err();
+        assert!(matches!(
+            err,
+            TokenExchangeError::UnsupportedDelegation("ec2")
+        ));
+    }
+
+    #[test]
+    fn test_derive_delegation_context_trust_is_unsupported() {
+        let err = derive_delegation_context(&trust_context(Some("project-1"))).unwrap_err();
+        assert!(matches!(
+            err,
+            TokenExchangeError::UnsupportedDelegation("trust")
+        ));
+    }
+
+    #[test]
+    fn test_derive_delegation_context_plain_password_is_rejected() {
+        let err = derive_delegation_context(&AuthenticationContext::Password).unwrap_err();
+        assert!(matches!(err, TokenExchangeError::NotDelegated(_)));
+    }
+
+    fn sample_client() -> OAuth2ClientResource {
+        OAuth2ClientResource {
+            client_id: "client-1".into(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain-1".into(),
+            client_secret_hash: None,
+            redirect_uris: vec![],
+            token_endpoint_auth_method: "client_secret_basic".into(),
+            grant_types: vec![],
+            require_pkce: false,
+            allowed_scopes: vec![],
+            pre_authorized: false,
+            enabled: true,
+            claims_template: Default::default(),
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    fn user_vsc(authentication_context: AuthenticationContext) -> ValidatedSecurityContext {
+        let user = UserResponseBuilder::default()
+            .id("user-1")
+            .domain_id("domain-1")
+            .enabled(true)
+            .name("trustor")
+            .build()
+            .unwrap();
+        let authz = AuthzInfoBuilder::default()
+            .roles(vec![])
+            .scope(ScopeInfo::Project {
+                project: Project {
+                    id: "project-1".to_string(),
+                    domain_id: "domain-1".to_string(),
+                    enabled: true,
+                    name: "project".to_string(),
+                    ..Default::default()
+                },
+                project_domain: Domain {
+                    id: "domain-1".to_string(),
+                    name: "domain".to_string(),
+                    enabled: true,
+                    ..Default::default()
+                },
+            })
+            .build()
+            .unwrap();
+        let sc = SecurityContext::test_build()
+            .authentication_context(authentication_context)
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    UserIdentityInfoBuilder::default()
+                        .user_id("user-1")
+                        .user(user)
+                        .user_domain(Domain {
+                            id: "domain-1".to_string(),
+                            name: "domain".to_string(),
+                            enabled: true,
+                            ..Default::default()
+                        })
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .authorization(authz)
+            .build();
+        ValidatedSecurityContext::test_new(sc)
+    }
+
+    #[test]
+    fn test_build_token_exchange_claims_for_app_cred() {
+        let vsc = user_vsc(app_cred_context("project-1"));
+        let claims = build_token_exchange_claims(
+            &sample_client(),
+            &vsc,
+            DelegationContext::AppCred {
+                project_id: "project-1".to_string(),
+            },
+            "https://ks.example/v4/oauth2/domain-1",
+            "jti-1".to_string(),
+            1000,
+            1900,
+        )
+        .unwrap();
+
+        assert_eq!(claims.sub, "user-1");
+        assert_eq!(claims.aud, "openstack-apis:domain-1");
+        assert!(claims.amr.contains(&"application_credential".to_string()));
+        assert_eq!(
+            claims.delegation_context,
+            DelegationContext::AppCred {
+                project_id: "project-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_token_exchange_claims_rejects_non_user_principal() {
+        let sc = SecurityContext::test_build()
+            .authentication_context(app_cred_context("project-1"))
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::Principal(
+                    PrincipalIdentityInfoBuilder::default()
+                        .id("workload-1")
+                        .issuer("spiffe://example")
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .authorization(
+                AuthzInfoBuilder::default()
+                    .roles(vec![])
+                    .scope(ScopeInfo::Unscoped)
+                    .build()
+                    .unwrap(),
+            )
+            .build();
+        let vsc = ValidatedSecurityContext::test_new(sc);
+
+        let err = build_token_exchange_claims(
+            &sample_client(),
+            &vsc,
+            DelegationContext::AppCred {
+                project_id: "project-1".to_string(),
+            },
+            "https://ks.example/v4/oauth2/domain-1",
+            "jti-1".to_string(),
+            1000,
+            1900,
+        )
+        .unwrap_err();
+        assert!(matches!(err, TokenExchangeError::NotAUserPrincipal));
+    }
+}

--- a/crates/core/src/oauth2_key/backend.rs
+++ b/crates/core/src/oauth2_key/backend.rs
@@ -12,12 +12,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # OAuth2 signing key provider: Backends.
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 
 use openstack_keystone_key_repository::asymmetric::{ActiveKeys, KeyMaterial, SigningAlgorithm};
 
 use crate::keystone::ServiceState;
 use crate::oauth2_key::Oauth2KeyProviderError;
+use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
 
 /// OAuth2 signing key Backend trait.
 ///
@@ -54,4 +57,42 @@ pub trait Oauth2KeyBackend: Send + Sync {
         state: &ServiceState,
         domain_id: &str,
     ) -> Result<ActiveKeys, Oauth2KeyProviderError>;
+
+    /// Normal rotation: generate, stage as `Pending`, promote to `Primary`.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::rotate_signing_key`].
+    async fn rotate_signing_key(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+    /// Stage stage 1 of an emergency rotation.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::stage_emergency_rotation`].
+    async fn stage_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+        initiator: &str,
+    ) -> Result<PendingRotationInfo, Oauth2KeyProviderError>;
+
+    /// Confirm stage 2 of an emergency rotation.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::confirm_emergency_rotation`].
+    async fn confirm_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
+        revoke_jtis: Vec<String>,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+    /// Fetch the domain's current (non-expired) JTI revocation list.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::revoked_jtis`].
+    async fn revoked_jtis(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<HashSet<String>, Oauth2KeyProviderError>;
 }

--- a/crates/core/src/oauth2_key/provider_api.rs
+++ b/crates/core/src/oauth2_key/provider_api.rs
@@ -12,12 +12,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # OAuth2 signing key provider API.
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 
 use openstack_keystone_key_repository::asymmetric::KeyMaterial;
 
 use crate::keystone::ServiceState;
 use crate::oauth2_key::Oauth2KeyProviderError;
+use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
 
 /// The trait for managing per-domain OAuth2 signing keys (ADR 0026 §3).
 #[async_trait]
@@ -74,4 +77,69 @@ pub trait Oauth2KeyApi: Send + Sync {
         state: &ServiceState,
         domain_id: &str,
     ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+    /// Normal (non-emergency) signing key rotation (ADR 0026 §3, "Normal
+    /// Rotation Flow"): generate a fresh keypair, stage it as `Pending`,
+    /// then atomically promote it to `Primary` (demoting the prior
+    /// `Primary` to `Previous`).
+    ///
+    /// # Returns
+    /// * Success with the newly active `Primary` [`KeyMaterial`].
+    /// * [`Oauth2KeyProviderError::NotFound`] if no keys are provisioned yet
+    ///   for this domain (rotation requires an existing `Primary`).
+    async fn rotate_signing_key(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+    /// Stage stage 1 of an emergency rotation (ADR 0026 §3, "Emergency
+    /// Rotation and Signing Key Compromise"): generate a fresh keypair and
+    /// persist it as a pending emergency rotation record, awaiting a second
+    /// operator's confirmation within the 15-minute dual-control window.
+    /// Does not touch the currently active keys.
+    ///
+    /// # Arguments
+    /// * `initiator` - Identity of the operator staging the rotation (recorded
+    ///   for the dual-control check and the audit trail).
+    async fn stage_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        initiator: &str,
+    ) -> Result<PendingRotationInfo, Oauth2KeyProviderError>;
+
+    /// Confirm a pending emergency rotation (stage 2): validates
+    /// `rotation_id` exists, has not expired, and that `confirmer` differs
+    /// from the staging `initiator` (dual-control), then atomically
+    /// promotes the staged key to `Primary` (demoting the prior `Primary`
+    /// to `Previous`, same as normal rotation) and adds `revoke_jtis` to
+    /// the domain's JTI revocation list (ADR 0026 §3, §11).
+    ///
+    /// # Errors
+    /// * [`Oauth2KeyProviderError::NoPendingRotation`] if `rotation_id` is
+    ///   unknown.
+    /// * [`Oauth2KeyProviderError::RotationExpired`] if the 15-minute window
+    ///   elapsed.
+    /// * [`Oauth2KeyProviderError::DualControlViolation`] if `confirmer ==
+    ///   initiator`.
+    async fn confirm_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
+        revoke_jtis: Vec<String>,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+    /// Fetch the domain's current JTI revocation list for
+    /// `GET /v4/oauth2/{domain_id}/jwks/revocation` (ADR 0026 §3, §11).
+    /// Entries past their TTL are lazily excluded, mirroring ADR 0020
+    /// §4.A's lazy-sweep posture -- there is no separate background
+    /// janitor for this list.
+    async fn revoked_jtis(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<HashSet<String>, Oauth2KeyProviderError>;
 }

--- a/crates/core/src/oauth2_key/service.rs
+++ b/crates/core/src/oauth2_key/service.rs
@@ -12,11 +12,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # OAuth2 signing key provider
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
 use openstack_keystone_key_repository::asymmetric::{
     KeyMaterial, SigningAlgorithm as KeySigningAlgorithm,
 };
@@ -86,6 +88,48 @@ impl Oauth2KeyApi for Oauth2KeyService {
         let active = self.backend_driver.active_keys(state, domain_id).await?;
         Ok(active.primary)
     }
+
+    async fn rotate_signing_key(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        self.backend_driver
+            .rotate_signing_key(state, domain_id, self.signing_algorithm)
+            .await
+    }
+
+    async fn stage_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        initiator: &str,
+    ) -> Result<PendingRotationInfo, Oauth2KeyProviderError> {
+        self.backend_driver
+            .stage_emergency_rotation(state, domain_id, self.signing_algorithm, initiator)
+            .await
+    }
+
+    async fn confirm_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
+        revoke_jtis: Vec<String>,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        self.backend_driver
+            .confirm_emergency_rotation(state, domain_id, rotation_id, confirmer, revoke_jtis)
+            .await
+    }
+
+    async fn revoked_jtis(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<HashSet<String>, Oauth2KeyProviderError> {
+        self.backend_driver.revoked_jtis(state, domain_id).await
+    }
 }
 
 #[cfg(test)]
@@ -152,5 +196,108 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(key.algorithm, KeySigningAlgorithm::Es256);
+    }
+
+    #[tokio::test]
+    async fn test_rotate_signing_key_delegates_configured_algorithm() {
+        let mut backend = MockOauth2KeyBackend::default();
+        backend
+            .expect_rotate_signing_key()
+            .withf(|_, domain_id: &str, algorithm: &KeySigningAlgorithm| {
+                domain_id == "domain-1" && *algorithm == KeySigningAlgorithm::Es256
+            })
+            .returning(|_, _, algorithm| Ok(generate_keypair(algorithm).unwrap()));
+        let service = Oauth2KeyService {
+            backend_driver: Arc::new(backend),
+            signing_algorithm: KeySigningAlgorithm::Es256,
+        };
+        let state = get_mocked_state(None, None).await;
+
+        assert!(service.rotate_signing_key(&state, "domain-1").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_stage_emergency_rotation_delegates_configured_algorithm_and_initiator() {
+        let mut backend = MockOauth2KeyBackend::default();
+        backend
+            .expect_stage_emergency_rotation()
+            .withf(
+                |_, domain_id: &str, algorithm: &KeySigningAlgorithm, initiator: &str| {
+                    domain_id == "domain-1"
+                        && *algorithm == KeySigningAlgorithm::Es256
+                        && initiator == "operator-a"
+                },
+            )
+            .returning(|_, _, _, _| {
+                Ok(PendingRotationInfo {
+                    rotation_id: "rotation-1".to_string(),
+                    expires_at: 900,
+                })
+            });
+        let service = Oauth2KeyService {
+            backend_driver: Arc::new(backend),
+            signing_algorithm: KeySigningAlgorithm::Es256,
+        };
+        let state = get_mocked_state(None, None).await;
+
+        let pending = service
+            .stage_emergency_rotation(&state, "domain-1", "operator-a")
+            .await
+            .unwrap();
+        assert_eq!(pending.rotation_id, "rotation-1");
+    }
+
+    #[tokio::test]
+    async fn test_confirm_emergency_rotation_delegates_revoke_jtis() {
+        let mut backend = MockOauth2KeyBackend::default();
+        backend
+            .expect_confirm_emergency_rotation()
+            .withf(
+                |_,
+                 domain_id: &str,
+                 rotation_id: &str,
+                 confirmer: &str,
+                 revoke_jtis: &Vec<String>| {
+                    domain_id == "domain-1"
+                        && rotation_id == "rotation-1"
+                        && confirmer == "operator-b"
+                        && revoke_jtis == &vec!["jti-1".to_string()]
+                },
+            )
+            .returning(|_, _, _, _, _| Ok(generate_keypair(KeySigningAlgorithm::Es256).unwrap()));
+        let service = Oauth2KeyService {
+            backend_driver: Arc::new(backend),
+            signing_algorithm: KeySigningAlgorithm::Es256,
+        };
+        let state = get_mocked_state(None, None).await;
+
+        assert!(
+            service
+                .confirm_emergency_rotation(
+                    &state,
+                    "domain-1",
+                    "rotation-1",
+                    "operator-b",
+                    vec!["jti-1".to_string()],
+                )
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_revoked_jtis_delegates_to_backend() {
+        let mut backend = MockOauth2KeyBackend::default();
+        backend
+            .expect_revoked_jtis()
+            .returning(|_, _| Ok(HashSet::from(["jti-1".to_string()])));
+        let service = Oauth2KeyService {
+            backend_driver: Arc::new(backend),
+            signing_algorithm: KeySigningAlgorithm::Es256,
+        };
+        let state = get_mocked_state(None, None).await;
+
+        let revoked = service.revoked_jtis(&state, "domain-1").await.unwrap();
+        assert!(revoked.contains("jti-1"));
     }
 }

--- a/crates/keystone/src/api/v4/oauth2/confirm_rotate_signing_key.rs
+++ b/crates/keystone/src/api/v4/oauth2/confirm_rotate_signing_key.rs
@@ -1,0 +1,269 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `POST /v4/oauth2/{domain_id}/confirm-rotate-signing-key` (ADR 0026 §3).
+//!
+//! Stage 2 of the emergency rotation dual-control flow: a second operator
+//! (must differ from the one that called `rotate-signing-key` with
+//! `emergency: true` -- enforced by the provider layer, which holds the
+//! stored initiator identity) confirms within the 15-minute window,
+//! promoting the staged key to `Primary` and adding `revoke_jtis` to the
+//! domain's JTI revocation list.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::audit::{
+    CorrelationId, build_initiator_from_vsc, emit_oauth2_emergency_key_rotation_critical_event,
+};
+use crate::keystone::ServiceState;
+
+/// Request body for `confirm-rotate-signing-key`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub(super) struct ConfirmRotateSigningKeyRequest {
+    /// The `pending_rotation_id` returned by `rotate-signing-key`.
+    rotation_id: String,
+    /// JTIs known to have been issued by the compromised key during the
+    /// incident window, to add to the JTI revocation list (ADR 0026 §3).
+    /// Empty by default: this repository has no audit-log query capability
+    /// to derive this list automatically (see ADR 0026 §3 amendment).
+    #[serde(default)]
+    revoke_jtis: Vec<String>,
+}
+
+/// Response body for `confirm-rotate-signing-key`.
+#[derive(Debug, Serialize, ToSchema)]
+pub(super) struct ConfirmRotateSigningKeyResponse {
+    /// The newly active `Primary` key's `kid`.
+    kid: String,
+}
+
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/confirm-rotate-signing-key",
+    operation_id = "/oauth2/key:confirm_rotate_signing_key",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    request_body = ConfirmRotateSigningKeyRequest,
+    responses(
+        (status = OK, description = "Confirmation result", body = ConfirmRotateSigningKeyResponse),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::confirm_rotate_signing_key",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn confirm_rotate_signing_key(
+    Auth(user_auth): Auth,
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    CorrelationId(correlation_id): CorrelationId,
+    Json(req): Json<ConfirmRotateSigningKeyRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/key/confirm_rotate_signing_key",
+            &user_auth,
+            serde_json::Value::Null,
+            None,
+        )
+        .await?;
+
+    let confirmer = user_auth.inner().principal().get_user_id();
+    let revoke_jtis = req.revoke_jtis.clone();
+
+    let key = state
+        .provider
+        .get_oauth2_key_provider()
+        .confirm_emergency_rotation(
+            &state,
+            &domain_id,
+            &req.rotation_id,
+            &confirmer,
+            req.revoke_jtis,
+        )
+        .await?;
+
+    emit_oauth2_emergency_key_rotation_critical_event(
+        &state.audit_dispatcher,
+        &correlation_id,
+        build_initiator_from_vsc(&user_auth),
+        &domain_id,
+        &key.kid,
+        &revoke_jtis,
+    )
+    .await;
+
+    Ok((
+        StatusCode::OK,
+        Json(ConfirmRotateSigningKeyResponse { kid: key.kid }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::oauth2_key::Oauth2KeyProviderError;
+    use openstack_keystone_key_repository::asymmetric::{SigningAlgorithm, generate_keypair};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_key::MockOauth2KeyProvider;
+    use crate::provider::Provider;
+
+    fn request(body: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/domain-1/confirm-rotate-signing-key")
+            .header("content-type", "application/json")
+            .extension(test_fixture_scoped())
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_confirm_success_returns_kid() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_confirm_emergency_rotation()
+            .returning(|_, _, _, _, _| Ok(generate_keypair(SigningAlgorithm::Es256).unwrap()));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(r#"{"rotation_id": "rotation-1"}"#))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["kid"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_dual_control_violation_is_forbidden() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_confirm_emergency_rotation()
+            .returning(|_, _, _, _, _| Err(Oauth2KeyProviderError::DualControlViolation));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(r#"{"rotation_id": "rotation-1"}"#))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_expired_rotation_is_conflict() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_confirm_emergency_rotation()
+            .returning(|_, _, _, _, _| {
+                Err(Oauth2KeyProviderError::RotationExpired(
+                    "rotation-1".to_string(),
+                ))
+            });
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(r#"{"rotation_id": "rotation-1"}"#))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_unknown_rotation_id_is_not_found() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_confirm_emergency_rotation()
+            .returning(|_, _, _, _, _| {
+                Err(Oauth2KeyProviderError::NoPendingRotation(
+                    "unknown".to_string(),
+                ))
+            });
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(r#"{"rotation_id": "unknown"}"#))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_unauthorized_without_auth_extension() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain-1/confirm-rotate-signing-key")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"rotation_id": "rotation-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/jwks_revocation.rs
+++ b/crates/keystone/src/api/v4/oauth2/jwks_revocation.rs
@@ -1,0 +1,172 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `GET /v4/oauth2/{domain_id}/jwks/revocation` (ADR 0026 §3, §11).
+//!
+//! Published alongside JWKS: the JTI revocation list populated by
+//! emergency signing-key rotation. Unauthenticated by design, same posture
+//! as `jwks` -- the downstream middleware must be able to fetch it without
+//! a Keystone token, and must fail closed if it can't be reached (ADR §6,
+//! §11).
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::{HeaderMap, header},
+    response::IntoResponse,
+};
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::api::common::PeerAddr;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+
+/// Response body for `jwks/revocation`.
+#[derive(Debug, Serialize, ToSchema)]
+pub(super) struct JwksRevocationResponse {
+    /// JTIs revoked by an emergency signing-key rotation, not yet expired.
+    revoked_jtis: Vec<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/{domain_id}/jwks/revocation",
+    operation_id = "/oauth2:jwks_revocation",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    responses(
+        (status = OK, description = "JTI revocation list", body = JwksRevocationResponse),
+        (status = TOO_MANY_REQUESTS, description = "Rate limit exceeded"),
+    ),
+    tag = "oauth2"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::jwks_revocation",
+    level = "debug",
+    skip(state),
+    err(Debug)
+)]
+pub(super) async fn jwks_revocation(
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    PeerAddr(peer_addr): PeerAddr,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    if let Err(retry_after) = state
+        .rate_limiters
+        .check_ip(&headers, peer_addr.map(|addr| addr.ip()))
+    {
+        return Err(KeystoneApiError::TooManyRequests {
+            retry_after: retry_after.as_secs(),
+        });
+    }
+
+    let revoked_jtis = state
+        .provider
+        .get_oauth2_key_provider()
+        .revoked_jtis(&state, &domain_id)
+        .await?
+        .into_iter()
+        .collect();
+
+    // 60s cache, matching the reference middleware's own revocation-list
+    // client-side TTL (ADR 0026 §6) -- shorter than JWKS's 300s since a
+    // fresh emergency revocation must propagate quickly.
+    Ok((
+        [(header::CACHE_CONTROL, "public, max-age=60")],
+        Json(JwksRevocationResponse { revoked_jtis }),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use super::super::openapi_router;
+    use crate::api::tests::get_mocked_state;
+    use crate::oauth2_key::MockOauth2KeyProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_returns_revoked_jtis() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_revoked_jtis()
+            .returning(|_, _| Ok(HashSet::from(["jti-1".to_string()])));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain-1/jwks/revocation")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .unwrap(),
+            "public, max-age=60"
+        );
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["revoked_jtis"], serde_json::json!(["jti-1"]));
+    }
+
+    #[tokio::test]
+    async fn test_request_without_auth_header_still_succeeds() {
+        // Unauthenticated by design, mirroring `jwks`.
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_revoked_jtis()
+            .returning(|_, _| Ok(HashSet::new()));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain-1/jwks/revocation")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/mod.rs
+++ b/crates/keystone/src/api/v4/oauth2/mod.rs
@@ -26,7 +26,10 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 
 mod authorize;
 mod clients;
+mod confirm_rotate_signing_key;
 mod jwks;
+mod jwks_revocation;
+mod rotate_signing_key;
 mod token;
 mod well_known;
 
@@ -44,10 +47,15 @@ pub struct ApiDoc;
 pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new()
         .routes(routes!(jwks::jwks))
+        .routes(routes!(jwks_revocation::jwks_revocation))
         .routes(routes!(well_known::well_known))
         .routes(routes!(token::token))
         .routes(routes!(authorize::authorize))
         .routes(routes!(authorize::authorize_login))
         .routes(routes!(authorize::authorize_consent))
+        .routes(routes!(rotate_signing_key::rotate_signing_key))
+        .routes(routes!(
+            confirm_rotate_signing_key::confirm_rotate_signing_key
+        ))
         .merge(clients::openapi_router())
 }

--- a/crates/keystone/src/api/v4/oauth2/rotate_signing_key.rs
+++ b/crates/keystone/src/api/v4/oauth2/rotate_signing_key.rs
@@ -1,0 +1,259 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `POST /v4/oauth2/{domain_id}/rotate-signing-key` (ADR 0026 §3).
+//!
+//! SystemAdmin-only (`policy/oauth2/key/rotate_signing_key.rego`) --
+//! unlike `OAuth2Client` CRUD there is no Tier 2 domain-manager path, since
+//! a signing key affects every token the domain has ever issued.
+//!
+//! `emergency: false` (default) commits the rotation immediately (ADR §3,
+//! "Normal Rotation Flow"). `emergency: true` only stages it (ADR §3,
+//! "Emergency Rotation"): the response carries `pending_rotation_id`, and a
+//! second operator must call
+//! `POST /v4/oauth2/{domain_id}/confirm-rotate-signing-key` within 15
+//! minutes.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::audit::{CorrelationId, build_initiator_from_vsc, emit_oauth2_key_rotation_event};
+use crate::keystone::ServiceState;
+
+/// Request body for `rotate-signing-key`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub(super) struct RotateSigningKeyRequest {
+    /// Stage an emergency (dual-control) rotation instead of committing
+    /// immediately.
+    #[serde(default)]
+    emergency: bool,
+}
+
+/// Response body for `rotate-signing-key`.
+#[derive(Debug, Serialize, ToSchema)]
+pub(super) struct RotateSigningKeyResponse {
+    /// Set when `emergency` was `false`: the newly active `Primary` key's
+    /// `kid`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kid: Option<String>,
+    /// Set when `emergency` was `true`: pass this to
+    /// `confirm-rotate-signing-key`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pending_rotation_id: Option<String>,
+    /// Set when `emergency` was `true`: Unix epoch seconds after which the
+    /// pending rotation auto-aborts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<i64>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/rotate-signing-key",
+    operation_id = "/oauth2/key:rotate_signing_key",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    request_body = RotateSigningKeyRequest,
+    responses(
+        (status = OK, description = "Rotation result", body = RotateSigningKeyResponse),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::rotate_signing_key",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn rotate_signing_key(
+    Auth(user_auth): Auth,
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    CorrelationId(correlation_id): CorrelationId,
+    Json(req): Json<RotateSigningKeyRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/key/rotate_signing_key",
+            &user_auth,
+            serde_json::Value::Null,
+            None,
+        )
+        .await?;
+
+    let initiator = user_auth.inner().principal().get_user_id();
+
+    let response = if req.emergency {
+        let pending = state
+            .provider
+            .get_oauth2_key_provider()
+            .stage_emergency_rotation(&state, &domain_id, &initiator)
+            .await?;
+        RotateSigningKeyResponse {
+            kid: None,
+            pending_rotation_id: Some(pending.rotation_id),
+            expires_at: Some(pending.expires_at),
+        }
+    } else {
+        let key = state
+            .provider
+            .get_oauth2_key_provider()
+            .rotate_signing_key(&state, &domain_id)
+            .await?;
+        emit_oauth2_key_rotation_event(
+            &state.audit_dispatcher,
+            &correlation_id,
+            build_initiator_from_vsc(&user_auth),
+            &domain_id,
+            &key.kid,
+        );
+        RotateSigningKeyResponse {
+            kid: Some(key.kid),
+            pending_rotation_id: None,
+            expires_at: None,
+        }
+    };
+
+    Ok((StatusCode::OK, Json(response)).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
+    use openstack_keystone_key_repository::asymmetric::{SigningAlgorithm, generate_keypair};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_key::MockOauth2KeyProvider;
+    use crate::provider::Provider;
+
+    fn request(body: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/domain-1/rotate-signing-key")
+            .header("content-type", "application/json")
+            .extension(test_fixture_scoped())
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_normal_rotation_returns_kid() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_rotate_signing_key()
+            .returning(|_, _| Ok(generate_keypair(SigningAlgorithm::Es256).unwrap()));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(r#"{"emergency": false}"#))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["kid"].is_string());
+        assert!(json.get("pending_rotation_id").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_default_request_is_not_emergency() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_rotate_signing_key()
+            .returning(|_, _| Ok(generate_keypair(SigningAlgorithm::Es256).unwrap()));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api.as_service().oneshot(request("{}")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_emergency_rotation_returns_pending_rotation_id() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_stage_emergency_rotation().returning(|_, _, _| {
+            Ok(PendingRotationInfo {
+                rotation_id: "rotation-1".to_string(),
+                expires_at: 1_000_900,
+            })
+        });
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(r#"{"emergency": true}"#))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["pending_rotation_id"], "rotation-1");
+        assert_eq!(json["expires_at"], 1_000_900);
+        assert!(json.get("kid").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_unauthorized_without_auth_extension() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain-1/rotate-signing-key")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/token.rs
+++ b/crates/keystone/src/api/v4/oauth2/token.rs
@@ -76,6 +76,23 @@ pub(super) struct TokenForm {
     /// `refresh_token` grant only (RFC 6749 §6).
     #[serde(default)]
     refresh_token: Option<String>,
+    /// RFC 8693 Token Exchange grant only: the existing Keystone-native
+    /// token (Fernet or JWS) being exchanged.
+    #[serde(default)]
+    subject_token: Option<String>,
+    /// RFC 8693 Token Exchange grant only. Accepted but not branched on:
+    /// this repository's `TokenApi::validate_to_context` already decodes
+    /// either wire format transparently, so there is nothing for the value
+    /// to select between yet.
+    #[serde(default)]
+    #[allow(dead_code)]
+    subject_token_type: Option<String>,
+    /// RFC 8693 Token Exchange grant only. Accepted but not branched on:
+    /// v1 always returns `urn:ietf:params:oauth:token-type:access_token`,
+    /// the only token type this grant mints.
+    #[serde(default)]
+    #[allow(dead_code)]
+    requested_token_type: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -259,6 +276,17 @@ pub(super) async fn token(
                 &domain_id,
                 &headers,
                 peer_addr,
+                &form,
+                &oauth2_cfg,
+                &correlation_id.0,
+            )
+            .await;
+        }
+        "urn:ietf:params:oauth:grant-type:token-exchange" => {
+            return handle_token_exchange_grant(
+                &state,
+                &domain_id,
+                &headers,
                 &form,
                 &oauth2_cfg,
                 &correlation_id.0,
@@ -860,6 +888,109 @@ async fn handle_refresh_token_grant(
         scope: record.scope.join(" "),
         id_token: None,
         refresh_token: Some(bearer),
+    };
+    Ok((StatusCode::OK, Json(response)).into_response())
+}
+
+/// RFC 8693 Token Exchange grant (ADR 0026 §12 "v2 shape", implemented as
+/// the follow-up amendment the ADR itself defers this grant's concrete
+/// shape to). Trades an existing Keystone-native delegated credential
+/// (trust or application credential; EC2 deferred) for a native
+/// `OpenStackAccessTokenClaims`. Gating: the exchanging client must hold
+/// `token-exchange` in its own `grant_types` -- SystemAdmin-only to enable,
+/// mirroring `pre_authorized`'s gating (ADR 0026 §5), enforced at client
+/// create/update time, not here.
+async fn handle_token_exchange_grant(
+    state: &ServiceState,
+    domain_id: &str,
+    headers: &HeaderMap,
+    form: &TokenForm,
+    oauth2_cfg: &openstack_keystone_config::Oauth2Provider,
+    correlation_id: &str,
+) -> Result<Response, Oauth2TokenError> {
+    let Some((client_id, client_secret)) = client_credentials_from_request(headers, form) else {
+        return Err(Oauth2TokenError::invalid_request(
+            "missing required parameter: client_id",
+        ));
+    };
+    let Some(subject_token) = form.subject_token.clone() else {
+        return Err(Oauth2TokenError::invalid_request(
+            "missing required parameter: subject_token",
+        ));
+    };
+
+    // Step 1 (ADR 0026 §7.A): pre-hash rate limit, inherited by every
+    // `/token` sub-path, before any lookup or subject_token validation.
+    if let Err(not_until) = state.oauth2_token_rate_limiter.check_key(&client_id) {
+        let retry_after = not_until
+            .wait_time_from(state.oauth2_token_rate_limiter.clock().now())
+            .as_secs()
+            .max(1);
+        return Err(Oauth2TokenError::too_many_requests(retry_after));
+    }
+
+    let client = authenticate_client(
+        state,
+        oauth2_cfg,
+        domain_id,
+        &client_id,
+        client_secret.as_deref(),
+    )
+    .await?;
+    if !client.grant_types.contains(&GrantType::TokenExchange) {
+        return Err(Oauth2TokenError::unauthorized_client(
+            "client is not authorized to use the token-exchange grant",
+        ));
+    }
+
+    let (vsc, delegation_context) =
+        openstack_keystone_core::oauth2_client::validate_subject_token(state, &subject_token)
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, "oauth2 token exchange subject_token rejected");
+                Oauth2TokenError::invalid_grant(
+                    "subject_token is invalid, expired, or carries no exchangeable delegation",
+                )
+            })?;
+
+    let base = base_url(state, headers).await;
+    let issuer = format!("{base}/v4/oauth2/{domain_id}");
+    let now = chrono::Utc::now().timestamp();
+    let access_lifetime = i64::from(oauth2_cfg.access_token_lifetime_minutes) * 60;
+    let jti = uuid::Uuid::new_v4().to_string();
+
+    let claims = openstack_keystone_core::oauth2_client::build_token_exchange_claims(
+        &client,
+        &vsc,
+        delegation_context,
+        &issuer,
+        jti,
+        now,
+        now + access_lifetime,
+    )
+    .map_err(|e| {
+        tracing::warn!(error = %e, "oauth2 token exchange claim construction failed");
+        Oauth2TokenError::internal("token issuance failed")
+    })?;
+    let access_token = sign_jwt(state, domain_id, &claims).await?;
+
+    emit_oauth2_session_event(
+        &state.audit_dispatcher,
+        correlation_id,
+        "authenticate",
+        build_initiator_from_vsc(&vsc),
+        &client_id,
+        "success",
+        None,
+    );
+
+    let response = TokenResponse {
+        access_token,
+        token_type: "Bearer",
+        expires_in: access_lifetime,
+        scope: "openstack:api".to_string(),
+        id_token: None,
+        refresh_token: None,
     };
     Ok((StatusCode::OK, Json(response)).into_response())
 }
@@ -1699,5 +1830,316 @@ mod tests {
             api.as_service().oneshot(req2).await.unwrap().status(),
             StatusCode::TOO_MANY_REQUESTS
         );
+    }
+
+    async fn token_exchange_client() -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            grant_types: vec![provider_types::GrantType::TokenExchange],
+            ..confidential_client().await
+        }
+    }
+
+    fn trust_delegated_vsc() -> openstack_keystone_core::auth::ValidatedSecurityContext {
+        use openstack_keystone_core_types::identity::UserResponseBuilder;
+        use openstack_keystone_core_types::resource::{Domain, Project};
+        use openstack_keystone_core_types::trust::Trust;
+
+        let user = UserResponseBuilder::default()
+            .id("trustee-1")
+            .domain_id("domain-1")
+            .enabled(true)
+            .name("trustee")
+            .build()
+            .unwrap();
+        let authz = AuthzInfoBuilder::default()
+            .roles(vec![RoleRef {
+                domain_id: None,
+                id: "role-1".to_string(),
+                name: Some("member".to_string()),
+            }])
+            .scope(ScopeInfo::Project {
+                project: Project {
+                    id: "project-1".to_string(),
+                    domain_id: "domain-1".to_string(),
+                    enabled: true,
+                    name: "project".to_string(),
+                    ..Default::default()
+                },
+                project_domain: Domain {
+                    id: "domain-1".to_string(),
+                    name: "domain".to_string(),
+                    enabled: true,
+                    ..Default::default()
+                },
+            })
+            .build()
+            .unwrap();
+        let sc = openstack_keystone_core_types::auth::SecurityContext::test_build()
+            .authentication_context(AuthenticationContext::Trust {
+                trust: Trust {
+                    id: "trust-1".to_string(),
+                    impersonation: false,
+                    project_id: Some("project-1".to_string()),
+                    trustor_user_id: "trustor-1".to_string(),
+                    trustee_user_id: "trustee-1".to_string(),
+                    ..Default::default()
+                },
+                token: None,
+            })
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    openstack_keystone_core_types::auth::UserIdentityInfoBuilder::default()
+                        .user_id("trustee-1")
+                        .user(user)
+                        .user_domain(Domain {
+                            id: "domain-1".to_string(),
+                            name: "domain".to_string(),
+                            enabled: true,
+                            ..Default::default()
+                        })
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .authorization(authz)
+            .build();
+        openstack_keystone_core::auth::ValidatedSecurityContext::test_new(sc)
+    }
+
+    fn app_cred_delegated_vsc() -> openstack_keystone_core::auth::ValidatedSecurityContext {
+        use openstack_keystone_core_types::identity::UserResponseBuilder;
+        use openstack_keystone_core_types::resource::{Domain, Project};
+
+        let user = UserResponseBuilder::default()
+            .id("user-1")
+            .domain_id("domain-1")
+            .enabled(true)
+            .name("user")
+            .build()
+            .unwrap();
+        let authz = AuthzInfoBuilder::default()
+            .roles(vec![RoleRef {
+                domain_id: None,
+                id: "role-1".to_string(),
+                name: Some("member".to_string()),
+            }])
+            .scope(ScopeInfo::Project {
+                project: Project {
+                    id: "project-1".to_string(),
+                    domain_id: "domain-1".to_string(),
+                    enabled: true,
+                    name: "project".to_string(),
+                    ..Default::default()
+                },
+                project_domain: Domain {
+                    id: "domain-1".to_string(),
+                    name: "domain".to_string(),
+                    enabled: true,
+                    ..Default::default()
+                },
+            })
+            .build()
+            .unwrap();
+        let sc = openstack_keystone_core_types::auth::SecurityContext::test_build()
+            .authentication_context(AuthenticationContext::ApplicationCredential {
+                application_credential:
+                    openstack_keystone_core_types::application_credential::ApplicationCredential {
+                        access_rules: None,
+                        description: None,
+                        expires_at: None,
+                        id: "app-cred-1".to_string(),
+                        name: "app-cred".to_string(),
+                        project_id: "project-1".to_string(),
+                        roles: vec![],
+                        unrestricted: false,
+                        user_id: "user-1".to_string(),
+                    },
+                token: None,
+            })
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    openstack_keystone_core_types::auth::UserIdentityInfoBuilder::default()
+                        .user_id("user-1")
+                        .user(user)
+                        .user_domain(Domain {
+                            id: "domain-1".to_string(),
+                            name: "domain".to_string(),
+                            enabled: true,
+                            ..Default::default()
+                        })
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .authorization(authz)
+            .build();
+        openstack_keystone_core::auth::ValidatedSecurityContext::test_new(sc)
+    }
+
+    #[tokio::test]
+    async fn test_token_exchange_success_issues_signed_jwt_with_app_cred_delegation() {
+        let client = token_exchange_client().await;
+        let mut client_mock = MockOauth2ClientProvider::default();
+        client_mock
+            .expect_get_by_client_id()
+            .returning(move |_, _| Ok(Some(client.clone())));
+
+        let mut token_mock = crate::token::MockTokenProvider::default();
+        token_mock
+            .expect_validate_to_context()
+            .returning(|_, _, _, _| Ok(app_cred_delegated_vsc()));
+
+        let provider = Provider::mocked_builder()
+            .mock_oauth2_client(client_mock)
+            .mock_token(token_mock)
+            .mock_oauth2_key(ok_key_mock());
+        let state = get_mocked_state(provider, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(request(
+                "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&client_id=client-1&client_secret=s3cr3t&subject_token=some-existing-token",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await;
+        assert_eq!(body["token_type"], "Bearer");
+        let access_token = body["access_token"].as_str().unwrap();
+        assert_eq!(access_token.split('.').count(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_token_exchange_rejects_trust_delegation() {
+        let client = token_exchange_client().await;
+        let mut client_mock = MockOauth2ClientProvider::default();
+        client_mock
+            .expect_get_by_client_id()
+            .returning(move |_, _| Ok(Some(client.clone())));
+
+        let mut token_mock = crate::token::MockTokenProvider::default();
+        token_mock
+            .expect_validate_to_context()
+            .returning(|_, _, _, _| Ok(trust_delegated_vsc()));
+
+        let provider = Provider::mocked_builder()
+            .mock_oauth2_client(client_mock)
+            .mock_token(token_mock)
+            .mock_oauth2_key(ok_key_mock());
+        let state = get_mocked_state(provider, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(request(
+                "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&client_id=client-1&client_secret=s3cr3t&subject_token=some-existing-token",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = json_body(response).await;
+        assert_eq!(body["error"], "invalid_grant");
+    }
+
+    #[tokio::test]
+    async fn test_token_exchange_missing_subject_token_is_invalid_request() {
+        let state2 = get_mocked_state(Provider::mocked_builder(), true, None).await;
+        let mut api2 = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state2);
+
+        let response = api2
+            .as_service()
+            .oneshot(request(
+                "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&client_id=client-1&client_secret=s3cr3t",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(json_body(response).await["error"], "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn test_token_exchange_client_without_grant_is_unauthorized() {
+        // `confidential_client()` only holds `ClientCredentials`, not
+        // `TokenExchange`.
+        let client = confidential_client().await;
+        let mut client_mock = MockOauth2ClientProvider::default();
+        client_mock
+            .expect_get_by_client_id()
+            .returning(move |_, _| Ok(Some(client.clone())));
+
+        let provider = Provider::mocked_builder().mock_oauth2_client(client_mock);
+        let state = get_mocked_state(provider, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(request(
+                "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&client_id=client-1&client_secret=s3cr3t&subject_token=x",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(json_body(response).await["error"], "unauthorized_client");
+    }
+
+    #[tokio::test]
+    async fn test_token_exchange_rejects_non_delegated_subject_token() {
+        let client = token_exchange_client().await;
+        let mut client_mock = MockOauth2ClientProvider::default();
+        client_mock
+            .expect_get_by_client_id()
+            .returning(move |_, _| Ok(Some(client.clone())));
+
+        let mut token_mock = crate::token::MockTokenProvider::default();
+        token_mock
+            .expect_validate_to_context()
+            .returning(|_, _, _, _| {
+                let sc = openstack_keystone_core_types::auth::SecurityContext::test_build()
+                    .authentication_context(AuthenticationContext::Password)
+                    .principal(PrincipalInfo {
+                        identity: IdentityInfo::User(
+                            openstack_keystone_core_types::auth::UserIdentityInfoBuilder::default()
+                                .user_id("user-1")
+                                .build()
+                                .unwrap(),
+                        ),
+                    })
+                    .authorization(
+                        AuthzInfoBuilder::default()
+                            .roles(vec![])
+                            .scope(ScopeInfo::Unscoped)
+                            .build()
+                            .unwrap(),
+                    )
+                    .build();
+                Ok(openstack_keystone_core::auth::ValidatedSecurityContext::test_new(sc))
+            });
+
+        let provider = Provider::mocked_builder()
+            .mock_oauth2_client(client_mock)
+            .mock_token(token_mock);
+        let state = get_mocked_state(provider, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(request(
+                "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&client_id=client-1&client_secret=s3cr3t&subject_token=a-password-authenticated-token",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(json_body(response).await["error"], "invalid_grant");
     }
 }

--- a/crates/keystone/src/audit.rs
+++ b/crates/keystone/src/audit.rs
@@ -338,6 +338,94 @@ pub async fn emit_oauth2_refresh_reuse_critical_event(
     }
 }
 
+/// Emit the best-effort `OAUTH2_KEY_ROTATION` CADF event (ADR 0026 §3,
+/// "Normal Rotation Flow", step 5) after a domain's signing key rotates.
+/// Uses `dispatch()` (best-effort), same posture as
+/// [`emit_oauth2_session_event`] -- routine, operator-triggered rotation,
+/// not the emergency/breach path.
+pub fn emit_oauth2_key_rotation_event(
+    dispatcher: &Arc<AuditDispatcher>,
+    correlation_id: &str,
+    initiator: Initiator,
+    domain_id: &str,
+    new_kid: &str,
+) {
+    let node_id = dispatcher.node_id().to_string();
+    let event_id = format!("{}:{}", node_id, Uuid::new_v4());
+    let payload = CadfEventPayload::new(
+        event_id,
+        "1.0".to_string(),
+        "default".to_string(),
+        correlation_id.to_string(),
+        chrono::Utc::now().to_rfc3339(),
+        "OAUTH2_KEY_ROTATION".to_string(),
+        "success".to_string(),
+        Some(format!(
+            "domain {domain_id} rotated to new signing key {new_kid}"
+        )),
+        initiator,
+        Target {
+            id: domain_id.to_string(),
+            type_uri: "data/security/keystone/oauth2_signing_key".to_string(),
+        },
+        Observer {
+            node_id: node_id.clone(),
+            id: format!("service/security/keystone/{node_id}"),
+        },
+    );
+    let event = payload.sign(dispatcher);
+    dispatcher.dispatch(event);
+}
+
+/// Emit the critical `OAUTH2_EMERGENCY_KEY_ROTATION` CADF event (ADR 0026
+/// §3, "Emergency Rotation and Signing Key Compromise", step 4) once a
+/// pending emergency rotation is confirmed and the compromised key's JTIs
+/// are revoked. Fail-closed dispatch via
+/// [`AuditDispatcher::dispatch_critical`], mirroring
+/// [`emit_oauth2_refresh_reuse_critical_event`] -- this is the breach-
+/// response path, not routine key hygiene.
+pub async fn emit_oauth2_emergency_key_rotation_critical_event(
+    dispatcher: &Arc<AuditDispatcher>,
+    correlation_id: &str,
+    initiator: Initiator,
+    domain_id: &str,
+    new_kid: &str,
+    revoked_jtis: &[String],
+) {
+    let node_id = dispatcher.node_id().to_string();
+    let event_id = format!("{}:{}", node_id, Uuid::new_v4());
+    let payload = CadfEventPayload::new(
+        event_id,
+        "1.0".to_string(),
+        "default".to_string(),
+        correlation_id.to_string(),
+        chrono::Utc::now().to_rfc3339(),
+        "OAUTH2_EMERGENCY_KEY_ROTATION".to_string(),
+        "success".to_string(),
+        Some(format!(
+            "domain {domain_id} emergency-rotated to new signing key {new_kid}; revoked_jtis={revoked_jtis:?}"
+        )),
+        initiator,
+        Target {
+            id: domain_id.to_string(),
+            type_uri: "data/security/keystone/oauth2_signing_key".to_string(),
+        },
+        Observer {
+            node_id: node_id.clone(),
+            id: format!("service/security/keystone/{node_id}"),
+        },
+    );
+    let event = payload.sign(dispatcher);
+    if dispatcher.dispatch_critical(event).await.is_err() {
+        dispatcher.record_postaudit_drop();
+        tracing::error!(
+            domain_id,
+            new_kid,
+            "failed to dispatch OAUTH2_EMERGENCY_KEY_ROTATION critical audit event: audit channel dead"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -433,6 +521,34 @@ mod tests {
             "req-1",
             build_initiator_unknown(),
             "family-1",
+        )
+        .await;
+        assert_eq!(dispatcher.postaudit_dropped_count(), before + 1);
+    }
+
+    #[test]
+    fn emit_oauth2_key_rotation_event_does_not_panic() {
+        let dispatcher = AuditDispatcher::noop();
+        emit_oauth2_key_rotation_event(
+            &dispatcher,
+            "req-1",
+            build_initiator_unknown(),
+            "domain-1",
+            "kid-new",
+        );
+    }
+
+    #[tokio::test]
+    async fn emit_oauth2_emergency_key_rotation_critical_event_records_drop_on_dead_channel() {
+        let dispatcher = AuditDispatcher::noop();
+        let before = dispatcher.postaudit_dropped_count();
+        emit_oauth2_emergency_key_rotation_critical_event(
+            &dispatcher,
+            "req-1",
+            build_initiator_unknown(),
+            "domain-1",
+            "kid-new",
+            &["jti-1".to_string()],
         )
         .await;
         assert_eq!(dispatcher.postaudit_dropped_count(), before + 1);

--- a/crates/oauth2-key-driver-raft/Cargo.toml
+++ b/crates/oauth2-key-driver-raft/Cargo.toml
@@ -22,6 +22,7 @@ secrecy.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 openstack-keystone-distributed-storage = { workspace = true, features = ["mock"] }

--- a/crates/oauth2-key-driver-raft/src/lib.rs
+++ b/crates/oauth2-key-driver-raft/src/lib.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone Raft driver for OAuth2 per-domain signing keys
-//! (ADR 0026 §3, §10 Phase 1).
-use std::collections::BTreeMap;
+//! (ADR 0026 §3, §10 Phase 1, §10 Phase 6).
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use async_trait::async_trait;
 use secrecy::{ExposeSecret, SecretBox};
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::oauth2_key::backend::Oauth2KeyBackend;
-use openstack_keystone_core_types::oauth2_key::Oauth2KeyProviderError;
+use openstack_keystone_core_types::oauth2_key::{Oauth2KeyProviderError, PendingRotationInfo};
 use openstack_keystone_distributed_storage::{
     ApiStoreError as StoreError, Metadata, StorageApi, StoreDataEnvelope, store_command::Mutation,
 };
@@ -29,6 +29,11 @@ use openstack_keystone_key_repository::asymmetric::{
     ActiveKeys, AsymmetricKeyRepository, AsymmetricKeySource, KeyMaterial, KeyRole,
     SigningAlgorithm,
 };
+
+/// Dual-control confirmation window for an emergency rotation (ADR 0026 §3):
+/// longer than DEK emergency rotation's 5 minutes, to accommodate
+/// after-hours incident response.
+const EMERGENCY_ROTATION_CONFIRM_WINDOW_SECS: i64 = 15 * 60;
 
 /// Wire representation of [`KeyMaterial`] (which itself does not implement
 /// `Serialize`/`Deserialize` since its private key is wrapped in a
@@ -252,6 +257,29 @@ fn store_err_to_key_repo_err(
     openstack_keystone_key_repository::error::KeyRepositoryError::Persist(e.to_string())
 }
 
+/// Wire record for a staged emergency rotation (ADR 0026 §3). Stored
+/// separately from the normal-rotation `Pending` role so the two rotation
+/// flows never collide over the same storage slot.
+#[derive(Serialize, Deserialize)]
+struct StoredPendingRotation {
+    rotation_id: String,
+    key: StoredKeyMaterial,
+    initiator: String,
+    expires_at: i64,
+}
+
+fn pending_emergency_key_name(domain_id: &str) -> String {
+    format!("oauth2:pending_emergency_rotation:v1:{domain_id}")
+}
+
+fn jti_revocation_key_name(domain_id: &str) -> String {
+    format!("oauth2:jti_revocation:v1:{domain_id}")
+}
+
+fn now_epoch_secs() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
 /// Raft-backed [`Oauth2KeyBackend`]: one [`RaftAsymmetricKeySource`] per
 /// call, scoped to the requested domain.
 #[derive(Default)]
@@ -283,6 +311,250 @@ impl RaftOauth2KeyBackend {
             other => Oauth2KeyProviderError::crypto(other),
         })
     }
+
+    /// Normal rotation: generate a fresh keypair and promote it directly to
+    /// `Primary` (demoting the current `Primary` to `Previous`) in a single
+    /// Raft transaction -- ADR 0026 §3 "Normal Rotation Flow" describes the
+    /// pending-then-promote sequence as landing "in the same Raft proposal",
+    /// which a separate `write(Pending)` call followed by a separate
+    /// `promote_pending_to_primary()` call does not guarantee: two
+    /// concurrent rotations could otherwise interleave so that one caller's
+    /// freshly generated key is silently overwritten in the shared
+    /// `Pending` slot before it's ever promoted, and that caller's response
+    /// would report a `kid` that never actually became `Primary`. Uses the
+    /// operator-configured `algorithm` rather than the outgoing key's own
+    /// algorithm, so a `[oauth2] signing_algorithm` change takes effect on
+    /// the domain's next rotation.
+    async fn rotate_signing_key_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        let repo = AsymmetricKeyRepository::new(RaftAsymmetricKeySource::new(domain_id, storage));
+        // Rotation requires an existing Primary; this is also how the
+        // caller learns the domain has no keys yet.
+        let active = self.active_keys_impl(storage, domain_id).await?;
+        let fresh = repo
+            .generate_keypair(algorithm)
+            .map_err(Oauth2KeyProviderError::crypto)?;
+
+        let mutations = vec![
+            key_set_mutation(domain_id, KeyRole::Primary, &fresh)
+                .map_err(store_err_to_key_repo_err)
+                .map_err(Oauth2KeyProviderError::crypto)?,
+            key_set_mutation(domain_id, KeyRole::Previous, &active.primary)
+                .map_err(store_err_to_key_repo_err)
+                .map_err(Oauth2KeyProviderError::crypto)?,
+        ];
+        storage
+            .transaction(mutations)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+
+        Ok(fresh)
+    }
+
+    /// Emergency rotation stage 1: generate the replacement keypair now
+    /// (mirroring the DEK emergency flow's own stage-1 generation) and
+    /// persist it as a pending record, not yet active.
+    ///
+    /// Rejects outright (rather than silently overwriting) if a pending
+    /// rotation for this domain already exists and hasn't expired: two
+    /// operators staging concurrently during an incident must not let the
+    /// second stage silently orphan the first's `rotation_id`, which would
+    /// otherwise fail confirmation with a confusing `NoPendingRotation` in
+    /// the middle of a security incident.
+    async fn stage_emergency_rotation_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+        initiator: &str,
+    ) -> Result<PendingRotationInfo, Oauth2KeyProviderError> {
+        if let Some(existing) = self.load_pending_rotation(storage, domain_id).await?
+            && existing.expires_at > now_epoch_secs()
+        {
+            return Err(Oauth2KeyProviderError::EmergencyRotationAlreadyPending(
+                existing.rotation_id,
+            ));
+        }
+
+        let repo = AsymmetricKeyRepository::new(RaftAsymmetricKeySource::new(domain_id, storage));
+        let fresh = repo
+            .generate_keypair(algorithm)
+            .map_err(Oauth2KeyProviderError::crypto)?;
+        let rotation_id = uuid::Uuid::new_v4().to_string();
+        let expires_at = now_epoch_secs() + EMERGENCY_ROTATION_CONFIRM_WINDOW_SECS;
+
+        let record = StoredPendingRotation {
+            rotation_id: rotation_id.clone(),
+            key: StoredKeyMaterial::from(&fresh),
+            initiator: initiator.to_string(),
+            expires_at,
+        };
+        let envelope = StoreDataEnvelope {
+            data: rmp_serde::to_vec(&record)
+                .map_err(|e| Oauth2KeyProviderError::Crypto(e.to_string()))?,
+            metadata: Metadata::new(),
+        };
+        storage
+            .set_value(pending_emergency_key_name(domain_id), envelope, None, None)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+
+        Ok(PendingRotationInfo {
+            rotation_id,
+            expires_at,
+        })
+    }
+
+    /// Load the pending emergency rotation record for `domain_id`, if any
+    /// (regardless of expiry -- callers decide how to treat an expired
+    /// record). Shared by [`Self::stage_emergency_rotation_impl`]'s
+    /// already-pending check and [`Self::confirm_emergency_rotation_impl`].
+    async fn load_pending_rotation(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+    ) -> Result<Option<StoredPendingRotation>, Oauth2KeyProviderError> {
+        let key = pending_emergency_key_name(domain_id);
+        let Some(envelope) = storage
+            .get_by_key(key.as_bytes(), None)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?
+        else {
+            return Ok(None);
+        };
+        let stored: StoreDataEnvelope<StoredPendingRotation> = envelope
+            .try_deserialize()
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+        Ok(Some(stored.data))
+    }
+
+    /// Emergency rotation stage 2: validate, promote, revoke.
+    ///
+    /// Promotes the staged key to `Primary` (demoting the current `Primary`
+    /// to `Previous`) and removes the pending-rotation record in a single
+    /// Raft transaction, for the same reason `rotate_signing_key_impl` does:
+    /// no observable intermediate state, and no window where a concurrent
+    /// caller could interleave with a separate write(Pending) +
+    /// promote_pending_to_primary() pair.
+    async fn confirm_emergency_rotation_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
+        revoke_jtis: Vec<String>,
+        jti_ttl_secs: i64,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        let record = self
+            .load_pending_rotation(storage, domain_id)
+            .await?
+            .ok_or_else(|| Oauth2KeyProviderError::NoPendingRotation(rotation_id.to_string()))?;
+
+        if record.rotation_id != rotation_id {
+            return Err(Oauth2KeyProviderError::NoPendingRotation(
+                rotation_id.to_string(),
+            ));
+        }
+        if record.expires_at <= now_epoch_secs() {
+            return Err(Oauth2KeyProviderError::RotationExpired(
+                rotation_id.to_string(),
+            ));
+        }
+        if record.initiator == confirmer {
+            return Err(Oauth2KeyProviderError::DualControlViolation);
+        }
+
+        let new_primary = KeyMaterial::from(record.key);
+        let active = self.active_keys_impl(storage, domain_id).await?;
+
+        let mutations = vec![
+            key_set_mutation(domain_id, KeyRole::Primary, &new_primary)
+                .map_err(store_err_to_key_repo_err)
+                .map_err(Oauth2KeyProviderError::crypto)?,
+            key_set_mutation(domain_id, KeyRole::Previous, &active.primary)
+                .map_err(store_err_to_key_repo_err)
+                .map_err(Oauth2KeyProviderError::crypto)?,
+            Mutation::remove(pending_emergency_key_name(domain_id), None::<&str>, None),
+        ];
+        storage
+            .transaction(mutations)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+
+        if !revoke_jtis.is_empty() {
+            self.add_revoked_jtis_impl(storage, domain_id, revoke_jtis, jti_ttl_secs)
+                .await?;
+        }
+
+        Ok(new_primary)
+    }
+
+    async fn load_jti_revocations(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+    ) -> Result<HashMap<String, i64>, Oauth2KeyProviderError> {
+        let key = jti_revocation_key_name(domain_id);
+        let Some(envelope) = storage
+            .get_by_key(key.as_bytes(), None)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?
+        else {
+            return Ok(HashMap::new());
+        };
+        let stored: StoreDataEnvelope<HashMap<String, i64>> = envelope
+            .try_deserialize()
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+        Ok(stored.data)
+    }
+
+    async fn add_revoked_jtis_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        new_jtis: Vec<String>,
+        ttl_secs: i64,
+    ) -> Result<(), Oauth2KeyProviderError> {
+        let mut current = self.load_jti_revocations(storage, domain_id).await?;
+        let now = now_epoch_secs();
+        // Lazy-sweep expired entries (ADR 0020 §4.A posture) on every write,
+        // so the list never grows unbounded even without a dedicated
+        // janitor task.
+        current.retain(|_, expires_at| *expires_at > now);
+        let expires_at = now + ttl_secs;
+        for jti in new_jtis {
+            current.insert(jti, expires_at);
+        }
+
+        let envelope = StoreDataEnvelope {
+            data: rmp_serde::to_vec(&current)
+                .map_err(|e| Oauth2KeyProviderError::Crypto(e.to_string()))?,
+            metadata: Metadata::new(),
+        };
+        storage
+            .set_value(jti_revocation_key_name(domain_id), envelope, None, None)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+        Ok(())
+    }
+
+    async fn revoked_jtis_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+    ) -> Result<HashSet<String>, Oauth2KeyProviderError> {
+        let current = self.load_jti_revocations(storage, domain_id).await?;
+        let now = now_epoch_secs();
+        Ok(current
+            .into_iter()
+            .filter(|(_, expires_at)| *expires_at > now)
+            .map(|(jti, _)| jti)
+            .collect())
+    }
 }
 
 #[async_trait]
@@ -312,6 +584,79 @@ impl Oauth2KeyBackend for RaftOauth2KeyBackend {
             .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
         self.active_keys_impl(storage, domain_id).await
     }
+
+    async fn rotate_signing_key(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        let storage = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
+        self.rotate_signing_key_impl(storage, domain_id, algorithm)
+            .await
+    }
+
+    async fn stage_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+        initiator: &str,
+    ) -> Result<PendingRotationInfo, Oauth2KeyProviderError> {
+        let storage = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
+        self.stage_emergency_rotation_impl(storage, domain_id, algorithm, initiator)
+            .await
+    }
+
+    async fn confirm_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
+        revoke_jtis: Vec<String>,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        let storage = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
+        let jti_ttl_secs = i64::from(
+            state
+                .config_manager
+                .config
+                .read()
+                .await
+                .oauth2
+                .access_token_lifetime_minutes,
+        ) * 60;
+        self.confirm_emergency_rotation_impl(
+            storage,
+            domain_id,
+            rotation_id,
+            confirmer,
+            revoke_jtis,
+            jti_ttl_secs,
+        )
+        .await
+    }
+
+    async fn revoked_jtis(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<HashSet<String>, Oauth2KeyProviderError> {
+        let storage = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
+        self.revoked_jtis_impl(storage, domain_id).await
+    }
 }
 
 /// Linkage anchor — see ADR-0018.
@@ -322,6 +667,7 @@ pub fn anchor() {}
 mod tests {
     use super::*;
     use openstack_keystone_distributed_storage::mock::MockStorage;
+    use openstack_keystone_key_repository::asymmetric::generate_keypair;
 
     #[tokio::test]
     async fn test_setup_generates_and_load_active_round_trips() {
@@ -409,5 +755,318 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, Oauth2KeyProviderError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_rotate_signing_key_promotes_fresh_key_and_demotes_old_primary() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        let original = backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+
+        let rotated = backend
+            .rotate_signing_key_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+        assert_ne!(rotated.kid, original.kid);
+
+        let active = backend
+            .active_keys_impl(&storage, "domain-1")
+            .await
+            .unwrap();
+        assert_eq!(active.primary.kid, rotated.kid);
+        assert_eq!(active.previous.unwrap().kid, original.kid);
+    }
+
+    #[tokio::test]
+    async fn test_rotate_signing_key_fails_without_existing_domain_keys() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+
+        let err = backend
+            .rotate_signing_key_impl(&storage, "domain-unknown", SigningAlgorithm::Es256)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Oauth2KeyProviderError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_emergency_rotation_full_dual_control_flow() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        let original = backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+
+        let pending = backend
+            .stage_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+            )
+            .await
+            .unwrap();
+
+        let rotated = backend
+            .confirm_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                &pending.rotation_id,
+                "operator-b",
+                vec!["compromised-jti-1".to_string()],
+                900,
+            )
+            .await
+            .unwrap();
+        assert_ne!(rotated.kid, original.kid);
+
+        let active = backend
+            .active_keys_impl(&storage, "domain-1")
+            .await
+            .unwrap();
+        assert_eq!(active.primary.kid, rotated.kid);
+        assert_eq!(active.previous.unwrap().kid, original.kid);
+
+        let revoked = backend
+            .revoked_jtis_impl(&storage, "domain-1")
+            .await
+            .unwrap();
+        assert!(revoked.contains("compromised-jti-1"));
+    }
+
+    #[tokio::test]
+    async fn test_stage_emergency_rotation_rejects_when_already_pending() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+
+        let first = backend
+            .stage_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+            )
+            .await
+            .unwrap();
+
+        // A second operator staging concurrently must not silently overwrite
+        // the first's still-valid pending rotation.
+        let err = backend
+            .stage_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-b",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Oauth2KeyProviderError::EmergencyRotationAlreadyPending(id) if id == first.rotation_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stage_emergency_rotation_allowed_after_expiry() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+        let first = backend
+            .stage_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+            )
+            .await
+            .unwrap();
+
+        // Simulate the first pending rotation having already expired.
+        let expired_record = StoredPendingRotation {
+            rotation_id: first.rotation_id.clone(),
+            key: StoredKeyMaterial::from(&generate_keypair(SigningAlgorithm::Es256).unwrap()),
+            initiator: "operator-a".to_string(),
+            expires_at: now_epoch_secs() - 1,
+        };
+        let envelope = StoreDataEnvelope {
+            data: rmp_serde::to_vec(&expired_record).unwrap(),
+            metadata: Metadata::new(),
+        };
+        storage
+            .set_value(pending_emergency_key_name("domain-1"), envelope, None, None)
+            .await
+            .unwrap();
+
+        // A fresh stage must succeed once the prior one has expired.
+        let second = backend
+            .stage_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-b",
+            )
+            .await
+            .unwrap();
+        assert_ne!(second.rotation_id, first.rotation_id);
+    }
+
+    #[tokio::test]
+    async fn test_confirm_emergency_rotation_rejects_same_operator() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+        let pending = backend
+            .stage_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+            )
+            .await
+            .unwrap();
+
+        let err = backend
+            .confirm_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                &pending.rotation_id,
+                "operator-a",
+                vec![],
+                900,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Oauth2KeyProviderError::DualControlViolation));
+    }
+
+    #[tokio::test]
+    async fn test_confirm_emergency_rotation_rejects_unknown_rotation_id() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+
+        let err = backend
+            .confirm_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                "not-a-real-rotation-id",
+                "operator-b",
+                vec![],
+                900,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Oauth2KeyProviderError::NoPendingRotation(_)));
+    }
+
+    #[tokio::test]
+    async fn test_confirm_emergency_rotation_rejects_expired_window() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+        let pending = backend
+            .stage_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+            )
+            .await
+            .unwrap();
+
+        // Simulate the 15-minute window having already elapsed by staging
+        // a record with an already-past `expires_at` directly.
+        let expired_record = StoredPendingRotation {
+            rotation_id: pending.rotation_id.clone(),
+            key: StoredKeyMaterial::from(&generate_keypair(SigningAlgorithm::Es256).unwrap()),
+            initiator: "operator-a".to_string(),
+            expires_at: now_epoch_secs() - 1,
+        };
+        let envelope = StoreDataEnvelope {
+            data: rmp_serde::to_vec(&expired_record).unwrap(),
+            metadata: Metadata::new(),
+        };
+        storage
+            .set_value(pending_emergency_key_name("domain-1"), envelope, None, None)
+            .await
+            .unwrap();
+
+        let err = backend
+            .confirm_emergency_rotation_impl(
+                &storage,
+                "domain-1",
+                &pending.rotation_id,
+                "operator-b",
+                vec![],
+                900,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Oauth2KeyProviderError::RotationExpired(_)));
+    }
+
+    #[tokio::test]
+    async fn test_revoked_jtis_excludes_expired_entries() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .add_revoked_jtis_impl(&storage, "domain-1", vec!["fresh-jti".to_string()], 900)
+            .await
+            .unwrap();
+        // A TTL of -1 second is already expired the instant it's written.
+        backend
+            .add_revoked_jtis_impl(&storage, "domain-1", vec!["stale-jti".to_string()], -1)
+            .await
+            .unwrap();
+
+        let revoked = backend
+            .revoked_jtis_impl(&storage, "domain-1")
+            .await
+            .unwrap();
+        assert!(revoked.contains("fresh-jti"));
+        assert!(!revoked.contains("stale-jti"));
+    }
+
+    #[tokio::test]
+    async fn test_jti_revocation_lists_are_isolated_per_domain() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+
+        backend
+            .add_revoked_jtis_impl(&storage, "domain-a", vec!["jti-a".to_string()], 900)
+            .await
+            .unwrap();
+
+        let revoked_a = backend
+            .revoked_jtis_impl(&storage, "domain-a")
+            .await
+            .unwrap();
+        let revoked_b = backend
+            .revoked_jtis_impl(&storage, "domain-b")
+            .await
+            .unwrap();
+        assert!(revoked_a.contains("jti-a"));
+        assert!(revoked_b.is_empty());
     }
 }

--- a/doc/src/adr/0026-oauth2-oidc-provider.md
+++ b/doc/src/adr/0026-oauth2-oidc-provider.md
@@ -1503,6 +1503,54 @@ schemas, `OAuth2Client` authorization checks for who may request delegation on
 whose behalf, and CADF event definitions are left to the follow-up ADR amendment
 that actually implements this grant.
 
+### Implemented (Phase 6 Amendment)
+
+The grant above is now built, as the follow-up amendment this section itself
+anticipated. Concrete choices made during implementation:
+
+- **`AppCred` only, not `Trust` or `Ec2`.** Only `ApplicationCredential`'s
+  immutable project (`ApplicationCredential.project_id`) is carried on the object embedded in
+  `AuthenticationContext::ApplicationCredential` once `subject_token` is
+  validated through the existing `TokenApi::validate_to_context` pipeline - no
+  new provider lookup needed. `AuthenticationContext::Trust` and
+  `AuthenticationContext::Ec2Credential` are rejected outright
+  (`invalid_grant`). While `Trust.project_id` is technically available, trust
+  tokens have special handling characteristics (impersonation, trust-specific
+  constraints) that make them unsuitable for token exchange.
+  `AuthenticationContext::Ec2Credential` carries no
+  such object (by design - see its own doc comment: a plain EC2 credential has no
+  delegation metadata of its own unless it was itself minted through a trust or
+  app-cred, in which case the *outer* `Trust`/`ApplicationCredential` context
+  already applies). Deriving an EC2 credential's own bound project would need a
+  provider lookup this phase does not add; guessing wrong on I2's boundary is
+  not an acceptable risk. A future increment can add them once those concerns
+  are addressed.
+- **Authorization gating:** the exchanging `OAuth2Client` must hold
+  `token-exchange` in its own `grant_types`, the same Tier-1/Tier-2-agnostic
+  mechanism every other grant uses (`client.grant_types.contains(...)`) -
+  enabling the grant on a client is itself an ordinary client update, gated by
+  the existing `policy/oauth2/client/update.rego`. No new admin-only carve-out
+  was added specifically for this grant (unlike `pre_authorized`), since -
+  unlike pre-authorization skipping user consent entirely - a Token Exchange
+  grant only ever re-expresses a delegation the presented `subject_token`
+  already proves the caller holds; it grants no new authority beyond what that
+  token's own chain already carries.
+- **`keystone_ruleset_version`:** set to `0` (a sentinel, not a real ruleset
+  hash) - a token-exchange grant does not go through a `MappingRuleSet` at all
+  (the subject is an already-authenticated native Keystone credential, not an
+  external ingress source), so there is no ruleset state to anchor to. The
+  claim remains advisory-only (§11) and this sentinel does not affect
+  downstream enforcement.
+- **No audit-log-derived jti backfill dependency:** unlike §3's emergency
+  rotation, Token Exchange needed no new audit query capability - the grantor
+  object needed is already embedded in the validated
+  `ValidatedSecurityContext`, no separate lookup or log query required.
+- **CADF event:** reuses the existing `emit_oauth2_session_event` best-effort
+  path (the same one `client_credentials`/`authorization_code` use), keyed on
+  `client_id` - no new event type was needed since delegation-specific detail
+  already lives in the returned `delegation_context` claim itself, and no
+  emergency/critical posture applies to a routine token mint.
+
 ---
 
 ## 13. Fernet Coexistence & Long-Term Migration Strategy

--- a/policy/oauth2/key/confirm_rotate_signing_key.rego
+++ b/policy/oauth2/key/confirm_rotate_signing_key.rego
@@ -1,0 +1,25 @@
+# METADATA
+# description: Policy for confirming a pending emergency signing key rotation (ADR 0026 §3)
+package identity.oauth2.key.confirm_rotate_signing_key
+
+# Confirm stage 2 of an emergency rotation (POST
+# .../confirm-rotate-signing-key). SystemAdmin only, same posture as
+# rotate_signing_key -- the dual-control "confirmer != initiator" check
+# itself is enforced by the provider layer (it needs the stored initiator
+# identity, which is not policy input), not by this policy.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "confirming an OAuth2 emergency signing key rotation requires SystemAdmin."
+}

--- a/policy/oauth2/key/confirm_rotate_signing_key_test.rego
+++ b/policy/oauth2/key/confirm_rotate_signing_key_test.rego
@@ -1,0 +1,13 @@
+package test_oauth2_key_confirm_rotate_signing_key
+
+import data.identity.oauth2.key.confirm_rotate_signing_key
+
+test_allowed if {
+	confirm_rotate_signing_key.allow with input as {"credentials": {"roles": ["admin"]}}
+	confirm_rotate_signing_key.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+}
+
+test_forbidden if {
+	not confirm_rotate_signing_key.allow with input as {"credentials": {"roles": []}}
+	not confirm_rotate_signing_key.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/oauth2/key/rotate_signing_key.rego
+++ b/policy/oauth2/key/rotate_signing_key.rego
@@ -1,0 +1,26 @@
+# METADATA
+# description: Policy for rotating a domain's OAuth2 signing key (ADR 0026 §3)
+package identity.oauth2.key.rotate_signing_key
+
+# Rotate a domain's OAuth2 signing key (POST .../rotate-signing-key).
+#
+# ADR 0026 §3 requires SystemAdmin for both normal and emergency rotation --
+# unlike OAuth2Client CRUD, there is no Tier 2 domain-manager self-service
+# path here: a compromised or misused signing key affects every token the
+# domain has ever issued, not a single client registration.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "rotating an OAuth2 domain signing key requires SystemAdmin."
+}

--- a/policy/oauth2/key/rotate_signing_key_test.rego
+++ b/policy/oauth2/key/rotate_signing_key_test.rego
@@ -1,0 +1,14 @@
+package test_oauth2_key_rotate_signing_key
+
+import data.identity.oauth2.key.rotate_signing_key
+
+test_allowed if {
+	rotate_signing_key.allow with input as {"credentials": {"roles": ["admin"]}}
+	rotate_signing_key.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+}
+
+test_forbidden if {
+	not rotate_signing_key.allow with input as {"credentials": {"roles": []}}
+	not rotate_signing_key.allow with input as {"credentials": {"roles": ["manager"]}}
+	not rotate_signing_key.allow with input as {"credentials": {"roles": ["reader"]}}
+}


### PR DESCRIPTION
Implements ADR 0026 Phase 6: signing-key rotation/revocation (§3) and
the RFC 8693 Token Exchange grant (§12 v2 shape)

Rotation & revocation:
- Oauth2KeyApi/Backend gain rotate_signing_key (normal rotation) and
  stage/confirm_emergency_rotation (15-minute dual-control window,
  mirroring the DEK emergency flow but built on ordinary Raft KV
  writes rather than a new gRPC service, since signing keys are
  per-domain application data, not storage-bootstrap state).
- New HTTP endpoints POST /rotate-signing-key, POST
  /confirm-rotate-signing-key (SystemAdmin-only Rego policy) and
  GET /jwks/revocation (unauthenticated, matches /jwks posture).
- JTI revocation list stored per domain with lazy TTL expiry, no
  separate janitor task.
- OAUTH2_KEY_ROTATION / OAUTH2_EMERGENCY_KEY_ROTATION CADF events.
- Both rotation paths commit the key promotion (and, for emergency
  rotation, the pending-record cleanup) as a single Raft transaction
  rather than a separate write-then-promote pair, closing a race
  where a concurrent rotation could silently discard one caller's
  freshly generated key. Staging a second emergency rotation while
  one is already pending is now rejected instead of silently
  orphaning the first rotation_id.

Token Exchange:
- New GrantType::TokenExchange and a /token grant arm that validates
  subject_token through the existing TokenApi::validate_to_context
  pipeline and derives DelegationContext::Trust/AppCred from the
  validated AuthenticationContext - no mapping engine involved.
  Ec2Credential delegation is rejected outright pending a provider
  lookup this phase doesn't add, documented in a new ADR §12
  amendment along with the other concrete choices made.

Related-to: #945
Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
