### PR TITLE
feat(adr0026): Extend keystone-manage oauth2 CLI

### DIFF
--- a/crates/api-types/src/v4.rs
+++ b/crates/api-types/src/v4.rs
@@ -17,6 +17,7 @@ pub mod auth;
 pub mod auth_plugin;
 pub mod mapping;
 pub mod oauth2_client;
+pub mod oauth2_key;
 pub mod scim_realm;
 pub mod token_restriction;
 pub mod user;

--- a/crates/api-types/src/v4/oauth2_key.rs
+++ b/crates/api-types/src/v4/oauth2_key.rs
@@ -1,0 +1,64 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 signing key rotation API types (ADR 0026 §3).
+
+use serde::{Deserialize, Serialize};
+
+/// Request body for `POST /v4/oauth2/{domain_id}/rotate-signing-key`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct RotateSigningKeyRequest {
+    /// Stage an emergency (dual-control) rotation instead of committing
+    /// immediately.
+    #[serde(default)]
+    pub emergency: bool,
+}
+
+/// Response body for `POST /v4/oauth2/{domain_id}/rotate-signing-key`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct RotateSigningKeyResponse {
+    /// Set when `emergency` was `false`: the newly active `Primary` key's
+    /// `kid`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
+    /// Set when `emergency` was `true`: pass this to
+    /// `confirm-rotate-signing-key`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_rotation_id: Option<String>,
+    /// Set when `emergency` was `true`: Unix epoch seconds after which the
+    /// pending rotation auto-aborts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
+}
+
+/// Request body for `POST /v4/oauth2/{domain_id}/confirm-rotate-signing-key`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ConfirmRotateSigningKeyRequest {
+    /// The `pending_rotation_id` returned by `rotate-signing-key`.
+    pub rotation_id: String,
+    /// JTIs known to have been issued by the compromised key during the
+    /// incident window, to add to the JTI revocation list (ADR 0026 §3).
+    #[serde(default)]
+    pub revoke_jtis: Vec<String>,
+}
+
+/// Response body for `POST /v4/oauth2/{domain_id}/confirm-rotate-signing-key`.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ConfirmRotateSigningKeyResponse {
+    /// The newly active `Primary` key's `kid`.
+    pub kid: String,
+}

--- a/crates/cli-manage/src/main.rs
+++ b/crates/cli-manage/src/main.rs
@@ -26,12 +26,14 @@ mod bootstrap;
 mod common;
 mod credential;
 mod db;
+mod oauth2;
 mod storage;
 mod token;
 
 use crate::bootstrap::*;
 use crate::credential::*;
 use crate::db::*;
+use crate::oauth2::*;
 use crate::storage::*;
 use crate::token::*;
 
@@ -66,6 +68,9 @@ enum Command {
     /// Database management commands.
     Db(DbCommand),
 
+    /// OAuth2/OIDC provider administration (ADR 0026).
+    Oauth2(Oauth2Command),
+
     /// Distributed storage management.
     Storage(StorageCommand),
 
@@ -87,6 +92,7 @@ async fn main() -> Result<(), Report> {
         Command::Bootstrap(x) => x.take_action(&cfg).await?,
         Command::Credential(x) => x.take_action(&cfg).await?,
         Command::Db(x) => x.take_action(&cfg).await?,
+        Command::Oauth2(x) => x.take_action(&cfg).await?,
         Command::Storage(x) => x.take_action(&cfg).await?,
         Command::Token(x) => x.take_action(&cfg).await?,
     }

--- a/crates/cli-manage/src/oauth2.rs
+++ b/crates/cli-manage/src/oauth2.rs
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OAuth2 subcommand of the keystone-manage cli.
+
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+use color_eyre::{Report, eyre::WrapErr, eyre::eyre};
+use reqwest::Client;
+use spiffe_rustls::{authorizer, mtls_client};
+
+use openstack_keystone_config::Config;
+
+mod confirm_rotate_signing_key;
+mod rotate_signing_key;
+
+use crate::PerformAction;
+use crate::oauth2::confirm_rotate_signing_key::ConfirmRotateSigningKeyCommand;
+use crate::oauth2::rotate_signing_key::RotateSigningKeyCommand;
+
+/// OAuth2/OIDC provider administration (ADR 0026).
+#[derive(Parser)]
+pub struct Oauth2Command {
+    #[command(subcommand)]
+    command: Oauth2Commands,
+}
+
+#[async_trait]
+impl PerformAction for Oauth2Command {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        match self.command {
+            Oauth2Commands::RotateSigningKey(e) => e.take_action(config).await,
+            Oauth2Commands::ConfirmRotateSigningKey(e) => e.take_action(config).await,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+enum Oauth2Commands {
+    RotateSigningKey(RotateSigningKeyCommand),
+    ConfirmRotateSigningKey(ConfirmRotateSigningKeyCommand),
+}
+
+/// Build a `reqwest::Client` bound to the admin interface's Unix domain
+/// socket, authenticating via SPIFFE mTLS. Mirrors `bootstrap.rs`: a request
+/// over the admin UDS with a valid SVID auto-authenticates as `SystemAdmin`
+/// (`crates/core/src/api/auth.rs`), so no bearer/Fernet token is needed.
+async fn get_admin_client(config: &Config) -> Result<Client, Report> {
+    let admin_if = config.interface_admin.as_ref().ok_or_else(|| {
+        eyre!("admin interface not configured; oauth2 commands require [interface_admin]")
+    })?;
+
+    let source = spiffe::X509Source::new().await?;
+    let client_config = mtls_client(source.clone())
+        .authorize(authorizer::any())
+        .build()
+        .wrap_err("Building SPIFFE mTLS client config failed")?;
+
+    Client::builder()
+        .unix_socket(admin_if.listener.socket_path.clone())
+        .tls_backend_preconfigured(client_config)
+        .build()
+        .wrap_err("Building reqwest client failed")
+}

--- a/crates/cli-manage/src/oauth2/confirm_rotate_signing_key.rs
+++ b/crates/cli-manage/src/oauth2/confirm_rotate_signing_key.rs
@@ -1,0 +1,86 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::WrapErr, eyre::eyre};
+
+use openstack_keystone_api_types::v4::oauth2_key::{
+    ConfirmRotateSigningKeyRequest, ConfirmRotateSigningKeyResponse,
+};
+use openstack_keystone_config::Config;
+
+use super::get_admin_client;
+use crate::PerformAction;
+
+/// Confirm a pending emergency signing-key rotation (dual-control second
+/// factor).
+///
+/// Must be invoked by a different operator than the one who ran
+/// `rotate-signing-key --emergency`, within 15 minutes of that command --
+/// enforced by the provider layer. If the window has already expired, the
+/// pending rotation has been automatically aborted and this command will
+/// return an error.
+#[derive(Parser)]
+pub(super) struct ConfirmRotateSigningKeyCommand {
+    /// Domain whose signing-key rotation is being confirmed.
+    #[arg(long)]
+    pub domain: String,
+
+    /// The rotation_id printed by `rotate-signing-key --emergency`.
+    #[arg(long)]
+    pub rotation_id: String,
+
+    /// JTIs known to have been issued by the compromised key during the
+    /// incident window, to add to the JTI revocation list. Repeat the flag
+    /// for multiple JTIs.
+    #[arg(long = "revoke-jti")]
+    pub revoke_jtis: Vec<String>,
+}
+
+#[async_trait]
+impl PerformAction for ConfirmRotateSigningKeyCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = get_admin_client(config).await?;
+
+        let res = client
+            .post(format!(
+                "https://localhost/v4/oauth2/{}/confirm-rotate-signing-key",
+                self.domain
+            ))
+            .json(&ConfirmRotateSigningKeyRequest {
+                rotation_id: self.rotation_id.clone(),
+                revoke_jtis: self.revoke_jtis,
+            })
+            .send()
+            .await
+            .wrap_err("confirm-rotate-signing-key request failed")?;
+
+        if !res.status().is_success() {
+            return Err(eyre!(
+                "confirm-rotate-signing-key failed: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        let body: ConfirmRotateSigningKeyResponse = res.json().await?;
+        println!(
+            "Emergency signing-key rotation {} confirmed for domain {}. New kid: {}",
+            self.rotation_id, self.domain, body.kid
+        );
+
+        Ok(())
+    }
+}

--- a/crates/cli-manage/src/oauth2/rotate_signing_key.rs
+++ b/crates/cli-manage/src/oauth2/rotate_signing_key.rs
@@ -1,0 +1,102 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::WrapErr, eyre::eyre};
+
+use openstack_keystone_api_types::v4::oauth2_key::{
+    RotateSigningKeyRequest, RotateSigningKeyResponse,
+};
+use openstack_keystone_config::Config;
+
+use super::get_admin_client;
+use crate::PerformAction;
+
+/// Rotate an OAuth2/OIDC domain's signing key (ADR 0026 §3).
+///
+/// Normal rotation (default) generates a new key, promotes it to `Primary`
+/// and demotes the current `Primary` to `Previous` immediately -- both keys
+/// remain published in JWKS so in-flight tokens still verify.
+///
+/// Use `--emergency` when the current signing key is suspected or confirmed
+/// compromised. Emergency rotation only stages the new key: a second
+/// operator must run `confirm-rotate-signing-key` with the returned
+/// rotation-id within 15 minutes, or the rotation is automatically aborted.
+#[derive(Parser)]
+pub(super) struct RotateSigningKeyCommand {
+    /// Domain whose signing key should be rotated.
+    #[arg(long)]
+    pub domain: String,
+
+    /// Initiate an emergency rotation (dual-control required).
+    #[arg(long, default_value_t = false)]
+    pub emergency: bool,
+}
+
+#[async_trait]
+impl PerformAction for RotateSigningKeyCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = get_admin_client(config).await?;
+
+        let res = client
+            .post(format!(
+                "https://localhost/v4/oauth2/{}/rotate-signing-key",
+                self.domain
+            ))
+            .json(&RotateSigningKeyRequest {
+                emergency: self.emergency,
+            })
+            .send()
+            .await
+            .wrap_err("rotate-signing-key request failed")?;
+
+        if !res.status().is_success() {
+            return Err(eyre!(
+                "rotate-signing-key failed: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        let body: RotateSigningKeyResponse = res.json().await?;
+
+        if self.emergency {
+            match (body.pending_rotation_id, body.expires_at) {
+                (Some(rotation_id), Some(expires_at)) => {
+                    println!(
+                        "Emergency signing-key rotation staged for domain {}.\n\
+                         rotation_id={rotation_id}\n\
+                         expires_at={expires_at}\n\n\
+                         A second operator must confirm within 15 minutes:\n\
+                         \n  keystone-manage oauth2 confirm-rotate-signing-key \\\n\
+                           \t--domain {} --rotation-id {rotation_id}",
+                        self.domain, self.domain,
+                    );
+                }
+                _ => {
+                    println!("Emergency signing-key rotation staged but no rotation_id returned.");
+                }
+            }
+        } else {
+            println!(
+                "Signing-key rotation committed for domain {}. New kid: {}",
+                self.domain,
+                body.kid.unwrap_or_default()
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/confirm_rotate_signing_key.rs
+++ b/crates/keystone/src/api/v4/oauth2/confirm_rotate_signing_key.rs
@@ -26,8 +26,10 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+
+use openstack_keystone_api_types::v4::oauth2_key::{
+    ConfirmRotateSigningKeyRequest, ConfirmRotateSigningKeyResponse,
+};
 
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
@@ -35,26 +37,6 @@ use crate::audit::{
     CorrelationId, build_initiator_from_vsc, emit_oauth2_emergency_key_rotation_critical_event,
 };
 use crate::keystone::ServiceState;
-
-/// Request body for `confirm-rotate-signing-key`.
-#[derive(Debug, Deserialize, ToSchema)]
-pub(super) struct ConfirmRotateSigningKeyRequest {
-    /// The `pending_rotation_id` returned by `rotate-signing-key`.
-    rotation_id: String,
-    /// JTIs known to have been issued by the compromised key during the
-    /// incident window, to add to the JTI revocation list (ADR 0026 §3).
-    /// Empty by default: this repository has no audit-log query capability
-    /// to derive this list automatically (see ADR 0026 §3 amendment).
-    #[serde(default)]
-    revoke_jtis: Vec<String>,
-}
-
-/// Response body for `confirm-rotate-signing-key`.
-#[derive(Debug, Serialize, ToSchema)]
-pub(super) struct ConfirmRotateSigningKeyResponse {
-    /// The newly active `Primary` key's `kid`.
-    kid: String,
-}
 
 #[utoipa::path(
     post,

--- a/crates/keystone/src/api/v4/oauth2/rotate_signing_key.rs
+++ b/crates/keystone/src/api/v4/oauth2/rotate_signing_key.rs
@@ -30,39 +30,15 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+
+use openstack_keystone_api_types::v4::oauth2_key::{
+    RotateSigningKeyRequest, RotateSigningKeyResponse,
+};
 
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::audit::{CorrelationId, build_initiator_from_vsc, emit_oauth2_key_rotation_event};
 use crate::keystone::ServiceState;
-
-/// Request body for `rotate-signing-key`.
-#[derive(Debug, Deserialize, ToSchema)]
-pub(super) struct RotateSigningKeyRequest {
-    /// Stage an emergency (dual-control) rotation instead of committing
-    /// immediately.
-    #[serde(default)]
-    emergency: bool,
-}
-
-/// Response body for `rotate-signing-key`.
-#[derive(Debug, Serialize, ToSchema)]
-pub(super) struct RotateSigningKeyResponse {
-    /// Set when `emergency` was `false`: the newly active `Primary` key's
-    /// `kid`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    kid: Option<String>,
-    /// Set when `emergency` was `true`: pass this to
-    /// `confirm-rotate-signing-key`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pending_rotation_id: Option<String>,
-    /// Set when `emergency` was `true`: Unix epoch seconds after which the
-    /// pending rotation auto-aborts.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    expires_at: Option<i64>,
-}
 
 #[utoipa::path(
     post,


### PR DESCRIPTION
Adds keystone-manage oauth2 rotate-signing-key/confirm-rotate-signing-key,
following the post-Phase-6 review's implementation plan for the three
gaps left after the ADR 0026 phased rollout.

- Promotes RotateSigningKeyRequest/Response and
  ConfirmRotateSigningKeyRequest/Response out of pub(super) into
  crates/api-types, matching the convention every other CLI/handler
  pairing already follows (bootstrap.rs, clients/create.rs) rather than
  duplicating hand-rolled wire structs in cli-manage.
- CLI subcommands POST to the admin Unix domain socket over SPIFFE mTLS,
  mirroring bootstrap.rs's client construction -- the admin-UDS SVID
  auto-authenticates as SystemAdmin, so no bearer/Fernet token is needed.
- --revoke-jti is a repeatable flag, not comma-joined, and emergency
  rotation echoes pending_rotation_id/expires_at so the 15-minute
  confirmation window is visible in the CLI output.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
