### PR TITLE
feat(adr0026): Add previous-key and JTI-revocation janitor

### DIFF
--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -237,6 +237,23 @@ mod oauth2_key {
                 state: &ServiceState,
                 domain_id: &str,
             ) -> Result<HashSet<String>, Oauth2KeyProviderError>;
+
+            async fn list_all_active_keys(
+                &self,
+                state: &ServiceState,
+            ) -> Result<Vec<(String, openstack_keystone_key_repository::asymmetric::ActiveKeys)>, Oauth2KeyProviderError>;
+
+            async fn retire_previous_key(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+            ) -> Result<bool, Oauth2KeyProviderError>;
+
+            async fn prune_expired_jtis(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+            ) -> Result<(), Oauth2KeyProviderError>;
         }
     }
 }

--- a/crates/core/src/oauth2_key.rs
+++ b/crates/core/src/oauth2_key.rs
@@ -27,6 +27,7 @@
 pub mod backend;
 pub mod error;
 pub mod hook;
+pub mod janitor;
 pub mod jwks;
 mod provider_api;
 pub mod service;

--- a/crates/core/src/oauth2_key/backend.rs
+++ b/crates/core/src/oauth2_key/backend.rs
@@ -95,4 +95,28 @@ pub trait Oauth2KeyBackend: Send + Sync {
         state: &ServiceState,
         domain_id: &str,
     ) -> Result<HashSet<String>, Oauth2KeyProviderError>;
+
+    /// Cross-domain scan of every domain currently holding a `Primary`
+    /// signing key, for the previous-key/JTI janitor.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::list_all_active_keys`].
+    async fn list_all_active_keys(
+        &self,
+        state: &ServiceState,
+    ) -> Result<Vec<(String, ActiveKeys)>, Oauth2KeyProviderError>;
+
+    /// Remove `domain_id`'s `Previous` signing key, if present.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::retire_previous_key`].
+    async fn retire_previous_key(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<bool, Oauth2KeyProviderError>;
+
+    /// Proactively sweep `domain_id`'s JTI revocation list for expired
+    /// entries. See [`crate::oauth2_key::Oauth2KeyApi::prune_expired_jtis`].
+    async fn prune_expired_jtis(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<(), Oauth2KeyProviderError>;
 }

--- a/crates/core/src/oauth2_key/janitor.rs
+++ b/crates/core/src/oauth2_key/janitor.rs
@@ -1,0 +1,376 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! OAuth2 signing key janitor: demoted-key retirement and proactive JTI
+//! revocation-list pruning (ADR 0026 §3).
+//!
+//! Mirrors the leader-gated background sweep pattern used by
+//! [`crate::api_key::janitor`]: [`spawn`] runs on every cluster node on a
+//! fixed interval, but [`run_once`]'s work only actually executes when that
+//! node is the current Raft leader, so exactly one retirement -- and one
+//! audit record -- is produced per key past its retention window.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use openstack_keystone_audit::{AuditDispatcher, CadfEventPayload, Initiator, Observer, Target};
+
+use crate::keystone::ServiceState;
+use crate::oauth2_key::Oauth2KeyProviderError;
+
+/// Interval between sweep passes. Retention is measured in whole access-token
+/// lifetimes (minutes to hours), so this is deliberately coarse.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// Outcome of a single sweep pass.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct JanitorReport {
+    /// Demoted `Previous` keys retired (removed from JWKS) this pass.
+    pub retired: usize,
+    /// Domains whose JTI revocation list was proactively pruned this pass.
+    pub jtis_pruned: usize,
+    /// Operations that failed this pass (e.g. a Raft CAS conflict with a
+    /// concurrent rotation). Failures are isolated per domain -- one
+    /// failing domain does not prevent the rest of the sweep from running
+    /// -- and are retried on the next pass.
+    pub errors: usize,
+}
+
+/// Run a single janitor sweep pass over every domain's OAuth2 signing keys.
+/// Idempotent and safe to call repeatedly: a `Previous` key already retired
+/// is simply absent from the next pass's [`Oauth2KeyApi::list_all_active_keys`]
+/// result.
+///
+/// Only `list_all_active_keys` failing aborts the whole pass (there is
+/// nothing to sweep without it); a failure retiring one domain's key or
+/// pruning its JTI list is logged and counted in [`JanitorReport::errors`],
+/// and the pass continues with the remaining domains.
+///
+/// [`Oauth2KeyApi::list_all_active_keys`]: crate::oauth2_key::Oauth2KeyApi::list_all_active_keys
+pub async fn run_once(state: &ServiceState) -> Result<JanitorReport, Oauth2KeyProviderError> {
+    let access_token_lifetime_secs = i64::from(
+        state
+            .config_manager
+            .config
+            .read()
+            .await
+            .oauth2
+            .access_token_lifetime_minutes,
+    ) * 60;
+    let now = Utc::now();
+
+    let mut report = JanitorReport::default();
+    let all = state
+        .provider
+        .get_oauth2_key_provider()
+        .list_all_active_keys(state)
+        .await?;
+
+    for (domain_id, active) in all {
+        match state
+            .provider
+            .get_oauth2_key_provider()
+            .prune_expired_jtis(state, &domain_id)
+            .await
+        {
+            Ok(()) => report.jtis_pruned += 1,
+            Err(e) => {
+                warn!(
+                    domain_id = %domain_id,
+                    error = %e,
+                    "oauth2_key janitor: failed to prune JTI revocation list, continuing sweep"
+                );
+                report.errors += 1;
+            }
+        }
+
+        let Some(previous) = active.previous else {
+            continue;
+        };
+        // A `Previous` key with no `demoted_at` predates this field's
+        // introduction; leave it alone rather than force-retiring it --
+        // there's no way to tell how long ago it was actually demoted.
+        let Some(demoted_at) = previous.demoted_at else {
+            continue;
+        };
+        if (now - demoted_at).num_seconds() <= access_token_lifetime_secs {
+            continue;
+        }
+
+        match state
+            .provider
+            .get_oauth2_key_provider()
+            .retire_previous_key(state, &domain_id)
+            .await
+        {
+            Ok(true) => {
+                emit_maintenance_event(&state.audit_dispatcher, "retire_previous_key", &domain_id);
+                report.retired += 1;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                warn!(
+                    domain_id = %domain_id,
+                    error = %e,
+                    "oauth2_key janitor: failed to retire previous signing key, continuing sweep"
+                );
+                report.errors += 1;
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Emit a `maintenance` CADF event for a janitor-driven lifecycle action.
+/// Best-effort, mirroring `api_key::janitor`'s dispatch discipline: this is
+/// background housekeeping, not a user-facing request, so there is no real
+/// correlation ID to thread through.
+fn emit_maintenance_event(dispatcher: &Arc<AuditDispatcher>, action: &str, domain_id: &str) {
+    let node_id = dispatcher.node_id().to_string();
+    let event_id = format!("{node_id}:{}", Uuid::new_v4());
+    let correlation_id = format!("janitor:{}", Uuid::new_v4());
+    let initiator = Initiator::new("oauth2_key_janitor".to_string(), None, None, None);
+    let payload = CadfEventPayload::new(
+        event_id,
+        "1.0".to_string(),
+        "default".to_string(),
+        correlation_id,
+        Utc::now().to_rfc3339(),
+        action.to_string(),
+        "success".to_string(),
+        None,
+        initiator,
+        Target {
+            id: domain_id.to_string(),
+            type_uri: "data/security/keystone/oauth2_signing_key".to_string(),
+        },
+        Observer {
+            node_id: node_id.clone(),
+            id: format!("service/security/keystone/{node_id}"),
+        },
+    );
+    let event = payload.sign(dispatcher);
+    dispatcher.dispatch(event);
+}
+
+/// Spawn the leader-gated background sweep loop. Intended to be called once
+/// at server startup with the long-lived `ServiceState`.
+pub fn spawn(state: ServiceState) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SWEEP_INTERVAL);
+        loop {
+            interval.tick().await;
+
+            let Some(storage) = state.storage.as_deref() else {
+                continue;
+            };
+            if storage.current_leader().await != Some(storage.node_id().await) {
+                continue;
+            }
+
+            match run_once(&state).await {
+                Ok(report) if report.retired > 0 || report.errors > 0 => {
+                    info!(
+                        retired = report.retired,
+                        jtis_pruned = report.jtis_pruned,
+                        errors = report.errors,
+                        "oauth2_key janitor: sweep complete"
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => warn!(
+                    error = %e,
+                    "oauth2_key janitor: list_all_active_keys failed, sweep aborted"
+                ),
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chrono::Duration as ChronoDuration;
+    use openstack_keystone_key_repository::asymmetric::{
+        ActiveKeys, KeyMaterial, SigningAlgorithm, generate_keypair,
+    };
+
+    use crate::oauth2_key::MockOauth2KeyProvider;
+    use crate::provider::Provider;
+    use crate::tests::get_mocked_state;
+
+    fn key() -> KeyMaterial {
+        generate_keypair(SigningAlgorithm::Es256).unwrap()
+    }
+
+    fn key_with_demotion(demoted_at: Option<chrono::DateTime<Utc>>) -> KeyMaterial {
+        KeyMaterial {
+            demoted_at,
+            ..key()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_once_retires_previous_key_past_retention() {
+        let stale_demotion = Utc::now() - ChronoDuration::hours(2);
+        let previous = key_with_demotion(Some(stale_demotion));
+
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_list_all_active_keys().returning(move |_| {
+            Ok(vec![(
+                "domain-1".to_string(),
+                ActiveKeys {
+                    primary: key(),
+                    previous: Some(previous.clone()),
+                },
+            )])
+        });
+        mock.expect_prune_expired_jtis().returning(|_, _| Ok(()));
+        mock.expect_retire_previous_key()
+            .withf(|_, domain_id| domain_id == "domain-1")
+            .returning(|_, _| Ok(true));
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_oauth2_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.retired, 1);
+        assert_eq!(report.jtis_pruned, 1);
+        assert_eq!(report.errors, 0);
+    }
+
+    #[tokio::test]
+    async fn test_run_once_leaves_recently_demoted_key_alone() {
+        let recent_demotion = Utc::now() - ChronoDuration::seconds(60);
+        let previous = key_with_demotion(Some(recent_demotion));
+
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_list_all_active_keys().returning(move |_| {
+            Ok(vec![(
+                "domain-1".to_string(),
+                ActiveKeys {
+                    primary: key(),
+                    previous: Some(previous.clone()),
+                },
+            )])
+        });
+        mock.expect_prune_expired_jtis().returning(|_, _| Ok(()));
+        // No `expect_retire_previous_key`: calling it would panic the mock.
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_oauth2_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.retired, 0);
+    }
+
+    #[tokio::test]
+    async fn test_run_once_leaves_key_with_no_demoted_at_alone() {
+        // Pre-migration data: a `Previous` key with no `demoted_at` must
+        // never be force-retired, since there's no way to tell how long
+        // ago it was actually demoted.
+        let previous = key_with_demotion(None);
+
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_list_all_active_keys().returning(move |_| {
+            Ok(vec![(
+                "domain-1".to_string(),
+                ActiveKeys {
+                    primary: key(),
+                    previous: Some(previous.clone()),
+                },
+            )])
+        });
+        mock.expect_prune_expired_jtis().returning(|_, _| Ok(()));
+        // No `expect_retire_previous_key`: calling it would panic the mock.
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_oauth2_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.retired, 0);
+    }
+
+    #[tokio::test]
+    async fn test_run_once_isolates_per_domain_failure() {
+        let stale_demotion = Utc::now() - ChronoDuration::hours(2);
+        let previous_a = key_with_demotion(Some(stale_demotion));
+        let previous_b = key_with_demotion(Some(stale_demotion));
+
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_list_all_active_keys().returning(move |_| {
+            Ok(vec![
+                (
+                    "domain-fails".to_string(),
+                    ActiveKeys {
+                        primary: key(),
+                        previous: Some(previous_a.clone()),
+                    },
+                ),
+                (
+                    "domain-ok".to_string(),
+                    ActiveKeys {
+                        primary: key(),
+                        previous: Some(previous_b.clone()),
+                    },
+                ),
+            ])
+        });
+        mock.expect_prune_expired_jtis().returning(|_, _| Ok(()));
+        mock.expect_retire_previous_key()
+            .withf(|_, domain_id| domain_id == "domain-fails")
+            .returning(|_, _| Err(Oauth2KeyProviderError::NotFound("domain-fails".into())));
+        mock.expect_retire_previous_key()
+            .withf(|_, domain_id| domain_id == "domain-ok")
+            .returning(|_, _| Ok(true));
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_oauth2_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.retired, 1, "the second domain must still be retired");
+        assert_eq!(
+            report.errors, 1,
+            "the first domain's failure must be counted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_once_no_previous_key_is_a_noop_for_retirement() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_list_all_active_keys().returning(move |_| {
+            Ok(vec![(
+                "domain-1".to_string(),
+                ActiveKeys {
+                    primary: key(),
+                    previous: None,
+                },
+            )])
+        });
+        mock.expect_prune_expired_jtis().returning(|_, _| Ok(()));
+        // No `expect_retire_previous_key`: calling it would panic the mock.
+
+        let state =
+            get_mocked_state(None, Some(Provider::mocked_builder().mock_oauth2_key(mock))).await;
+
+        let report = run_once(&state).await.unwrap();
+        assert_eq!(report.retired, 0);
+        assert_eq!(report.jtis_pruned, 1);
+    }
+}

--- a/crates/core/src/oauth2_key/provider_api.rs
+++ b/crates/core/src/oauth2_key/provider_api.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use async_trait::async_trait;
 
-use openstack_keystone_key_repository::asymmetric::KeyMaterial;
+use openstack_keystone_key_repository::asymmetric::{ActiveKeys, KeyMaterial};
 
 use crate::keystone::ServiceState;
 use crate::oauth2_key::Oauth2KeyProviderError;
@@ -142,4 +142,33 @@ pub trait Oauth2KeyApi: Send + Sync {
         state: &ServiceState,
         domain_id: &str,
     ) -> Result<HashSet<String>, Oauth2KeyProviderError>;
+
+    /// Cross-domain scan of every domain currently holding a `Primary`
+    /// signing key with its `Previous` (if any), for the previous-key/JTI
+    /// janitor (`crate::oauth2_key::janitor`). There is no cluster-wide
+    /// domain listing elsewhere in this provider (every other method is
+    /// scoped to a single `domain_id`), so this is the janitor's only entry
+    /// point for discovering which domains to sweep.
+    async fn list_all_active_keys(
+        &self,
+        state: &ServiceState,
+    ) -> Result<Vec<(String, ActiveKeys)>, Oauth2KeyProviderError>;
+
+    /// Remove `domain_id`'s `Previous` signing key, if present (ADR 0026
+    /// §3: one full access-token lifetime after demotion). Idempotent:
+    /// returns `Ok(false)`, not an error, if there was nothing to remove.
+    async fn retire_previous_key(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<bool, Oauth2KeyProviderError>;
+
+    /// Proactively sweep `domain_id`'s JTI revocation list for entries past
+    /// their TTL, for domains with no emergency rotation to otherwise
+    /// trigger the lazy sweep in [`Self::confirm_emergency_rotation`].
+    async fn prune_expired_jtis(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<(), Oauth2KeyProviderError>;
 }

--- a/crates/core/src/oauth2_key/service.rs
+++ b/crates/core/src/oauth2_key/service.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use openstack_keystone_config::Config;
 use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
 use openstack_keystone_key_repository::asymmetric::{
-    KeyMaterial, SigningAlgorithm as KeySigningAlgorithm,
+    ActiveKeys, KeyMaterial, SigningAlgorithm as KeySigningAlgorithm,
 };
 
 use crate::keystone::ServiceState;
@@ -129,6 +129,33 @@ impl Oauth2KeyApi for Oauth2KeyService {
         domain_id: &str,
     ) -> Result<HashSet<String>, Oauth2KeyProviderError> {
         self.backend_driver.revoked_jtis(state, domain_id).await
+    }
+
+    async fn list_all_active_keys(
+        &self,
+        state: &ServiceState,
+    ) -> Result<Vec<(String, ActiveKeys)>, Oauth2KeyProviderError> {
+        self.backend_driver.list_all_active_keys(state).await
+    }
+
+    async fn retire_previous_key(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<bool, Oauth2KeyProviderError> {
+        self.backend_driver
+            .retire_previous_key(state, domain_id)
+            .await
+    }
+
+    async fn prune_expired_jtis(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<(), Oauth2KeyProviderError> {
+        self.backend_driver
+            .prune_expired_jtis(state, domain_id)
+            .await
     }
 }
 

--- a/crates/key-repository/src/asymmetric/filesystem.rs
+++ b/crates/key-repository/src/asymmetric/filesystem.rs
@@ -135,6 +135,10 @@ impl FilesystemAsymmetricKeySource {
             public_key_der,
             kid,
             created_at,
+            // Not persisted to disk: this source has no rotation janitor
+            // (ADR 0026 §10 Phase 0, JWS-only single-node use), so there is
+            // nothing that needs to measure time-since-demotion here.
+            demoted_at: None,
         }))
     }
 

--- a/crates/key-repository/src/asymmetric/keygen.rs
+++ b/crates/key-repository/src/asymmetric/keygen.rs
@@ -68,6 +68,7 @@ pub fn generate_keypair(algorithm: SigningAlgorithm) -> Result<KeyMaterial, KeyR
         public_key_der,
         kid,
         created_at: Utc::now(),
+        demoted_at: None,
     })
 }
 

--- a/crates/key-repository/src/asymmetric/source.rs
+++ b/crates/key-repository/src/asymmetric/source.rs
@@ -69,6 +69,13 @@ pub struct KeyMaterial {
     pub kid: String,
     /// When this keypair was generated.
     pub created_at: DateTime<Utc>,
+    /// When this keypair was demoted out of [`KeyRole::Primary`], if ever
+    /// (ADR 0026 §3). `None` for a key that has never been `Previous`.
+    /// Distinct from `created_at`: a key can serve as `Primary` for an
+    /// arbitrarily long time before its first rotation, so retention
+    /// windows for a demoted key must be measured from demotion, not
+    /// generation.
+    pub demoted_at: Option<DateTime<Utc>>,
 }
 
 impl Clone for KeyMaterial {
@@ -80,6 +87,7 @@ impl Clone for KeyMaterial {
             public_key_der: self.public_key_der.clone(),
             kid: self.kid.clone(),
             created_at: self.created_at,
+            demoted_at: self.demoted_at,
         }
     }
 }
@@ -90,6 +98,7 @@ impl std::fmt::Debug for KeyMaterial {
             .field("algorithm", &self.algorithm)
             .field("kid", &self.kid)
             .field("created_at", &self.created_at)
+            .field("demoted_at", &self.demoted_at)
             .field("private_key_der", &"<redacted>")
             .finish()
     }
@@ -125,7 +134,11 @@ pub trait AsymmetricKeySource: Send + Sync {
             .remove(&KeyRole::Pending)
             .ok_or(KeyRepositoryError::RoleMissing(KeyRole::Pending))?;
         if let Some(old_primary) = current.remove(&KeyRole::Primary) {
-            self.write(KeyRole::Previous, &old_primary).await?;
+            let demoted = KeyMaterial {
+                demoted_at: Some(Utc::now()),
+                ..old_primary
+            };
+            self.write(KeyRole::Previous, &demoted).await?;
         }
         self.write(KeyRole::Primary, &pending).await?;
         self.remove(KeyRole::Pending).await?;

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -92,6 +92,7 @@ use openstack_keystone_core::auth_plugin_startup::load_auth_plugins;
 use openstack_keystone_core::cadf_hook::CadfAuditHook;
 use openstack_keystone_core::db::sync_schema;
 use openstack_keystone_core::error::KeystoneError;
+use openstack_keystone_core::oauth2_key::janitor as oauth2_key_janitor;
 use openstack_keystone_core::scim_resource::janitor as scim_resource_janitor;
 use openstack_keystone_credential_driver_sql::fernet::FernetKeyRepository;
 use openstack_keystone_distributed_storage::{StorageApi, app::Storage};
@@ -276,6 +277,11 @@ async fn main() -> Result<(), Report> {
     // the configured retention window (ADR 0024 §6.C). Same leader-gated
     // pattern as the API Key janitor above.
     scim_resource_janitor::spawn(shared_state.clone());
+
+    // OAuth2 signing key janitor: demoted `Previous` key retirement and
+    // proactive JTI revocation-list pruning (ADR 0026 §3). Same leader-gated
+    // pattern as the API Key janitor above.
+    oauth2_key_janitor::spawn(shared_state.clone());
 
     // Reset the dummy-password-hash cache whenever the configuration is
     // hot-reloaded. The cache is keyed by (algorithm, rounds); if the operator

--- a/crates/oauth2-key-driver-raft/src/lib.rs
+++ b/crates/oauth2-key-driver-raft/src/lib.rs
@@ -45,6 +45,8 @@ struct StoredKeyMaterial {
     public_key_der: Vec<u8>,
     kid: String,
     created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default)]
+    demoted_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
@@ -79,6 +81,7 @@ impl From<&KeyMaterial> for StoredKeyMaterial {
             public_key_der: value.public_key_der.clone(),
             kid: value.kid.clone(),
             created_at: value.created_at,
+            demoted_at: value.demoted_at,
         }
     }
 }
@@ -91,9 +94,16 @@ impl From<StoredKeyMaterial> for KeyMaterial {
             public_key_der: value.public_key_der,
             kid: value.kid,
             created_at: value.created_at,
+            demoted_at: value.demoted_at,
         }
     }
 }
+
+/// Prefix shared by every domain's signing-key entries, for the cross-domain
+/// janitor scan (`list_all_active_keys_impl`). Assumes domain IDs never
+/// contain `:` (true for identity domain IDs, which are opaque UUIDs/slugs),
+/// so the tail of a full key unambiguously splits into `<domain_id>:<role>`.
+const ALL_SIGNING_KEYS_PREFIX: &str = "oauth2:signing_key:v1:";
 
 fn role_str(role: KeyRole) -> &'static str {
     match role {
@@ -104,11 +114,11 @@ fn role_str(role: KeyRole) -> &'static str {
 }
 
 fn key_name(domain_id: &str, role: KeyRole) -> String {
-    format!("oauth2:signing_key:v1:{domain_id}:{}", role_str(role))
+    format!("{ALL_SIGNING_KEYS_PREFIX}{domain_id}:{}", role_str(role))
 }
 
 fn key_prefix(domain_id: &str) -> String {
-    format!("oauth2:signing_key:v1:{domain_id}:")
+    format!("{ALL_SIGNING_KEYS_PREFIX}{domain_id}:")
 }
 
 fn role_from_key(key: &str, prefix: &str) -> Option<KeyRole> {
@@ -118,6 +128,18 @@ fn role_from_key(key: &str, prefix: &str) -> Option<KeyRole> {
         "pending" => Some(KeyRole::Pending),
         _ => None,
     }
+}
+
+fn parse_domain_and_role(key: &str) -> Option<(String, KeyRole)> {
+    let rest = key.strip_prefix(ALL_SIGNING_KEYS_PREFIX)?;
+    let (domain_id, role_str) = rest.rsplit_once(':')?;
+    let role = match role_str {
+        "primary" => KeyRole::Primary,
+        "previous" => KeyRole::Previous,
+        "pending" => KeyRole::Pending,
+        _ => return None,
+    };
+    Some((domain_id.to_string(), role))
 }
 
 /// A per-domain, Raft-backed [`AsymmetricKeySource`].
@@ -338,12 +360,16 @@ impl RaftOauth2KeyBackend {
         let fresh = repo
             .generate_keypair(algorithm)
             .map_err(Oauth2KeyProviderError::crypto)?;
+        let demoted_primary = KeyMaterial {
+            demoted_at: Some(chrono::Utc::now()),
+            ..active.primary
+        };
 
         let mutations = vec![
             key_set_mutation(domain_id, KeyRole::Primary, &fresh)
                 .map_err(store_err_to_key_repo_err)
                 .map_err(Oauth2KeyProviderError::crypto)?,
-            key_set_mutation(domain_id, KeyRole::Previous, &active.primary)
+            key_set_mutation(domain_id, KeyRole::Previous, &demoted_primary)
                 .map_err(store_err_to_key_repo_err)
                 .map_err(Oauth2KeyProviderError::crypto)?,
         ];
@@ -470,12 +496,16 @@ impl RaftOauth2KeyBackend {
 
         let new_primary = KeyMaterial::from(record.key);
         let active = self.active_keys_impl(storage, domain_id).await?;
+        let demoted_primary = KeyMaterial {
+            demoted_at: Some(chrono::Utc::now()),
+            ..active.primary
+        };
 
         let mutations = vec![
             key_set_mutation(domain_id, KeyRole::Primary, &new_primary)
                 .map_err(store_err_to_key_repo_err)
                 .map_err(Oauth2KeyProviderError::crypto)?,
-            key_set_mutation(domain_id, KeyRole::Previous, &active.primary)
+            key_set_mutation(domain_id, KeyRole::Previous, &demoted_primary)
                 .map_err(store_err_to_key_repo_err)
                 .map_err(Oauth2KeyProviderError::crypto)?,
             Mutation::remove(pending_emergency_key_name(domain_id), None::<&str>, None),
@@ -554,6 +584,82 @@ impl RaftOauth2KeyBackend {
             .filter(|(_, expires_at)| *expires_at > now)
             .map(|(jti, _)| jti)
             .collect())
+    }
+
+    /// Cross-domain scan for the previous-key/JTI janitor: every domain
+    /// that currently has a `Primary` signing key, with its `Previous` (if
+    /// any). Mirrors `api-key-driver-raft`'s `list_all_impl` cross-domain
+    /// prefix scan.
+    async fn list_all_active_keys_impl(
+        &self,
+        storage: &dyn StorageApi,
+    ) -> Result<Vec<(String, ActiveKeys)>, Oauth2KeyProviderError> {
+        let entries = storage
+            .prefix(ALL_SIGNING_KEYS_PREFIX.as_bytes(), None)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+
+        let mut by_domain: BTreeMap<String, BTreeMap<KeyRole, KeyMaterial>> = BTreeMap::new();
+        for (key, envelope) in entries {
+            let Some((domain_id, role)) = parse_domain_and_role(&key) else {
+                continue;
+            };
+            let stored: StoreDataEnvelope<StoredKeyMaterial> = envelope
+                .try_deserialize()
+                .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+            by_domain
+                .entry(domain_id)
+                .or_default()
+                .insert(role, KeyMaterial::from(stored.data));
+        }
+
+        Ok(by_domain
+            .into_iter()
+            .filter_map(|(domain_id, mut roles)| {
+                let primary = roles.remove(&KeyRole::Primary)?;
+                let previous = roles.remove(&KeyRole::Previous);
+                Some((domain_id, ActiveKeys { primary, previous }))
+            })
+            .collect())
+    }
+
+    /// Remove `domain_id`'s `Previous` signing key, if present. Idempotent:
+    /// returns `false` (not an error) when there was nothing to remove, so
+    /// the janitor can safely call this every sweep without tracking state
+    /// across passes.
+    async fn retire_previous_key_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+    ) -> Result<bool, Oauth2KeyProviderError> {
+        let key = key_name(domain_id, KeyRole::Previous);
+        let existed = storage
+            .get_by_key(key.as_bytes(), None)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?
+            .is_some();
+        if existed {
+            storage
+                .remove(key, None)
+                .await
+                .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+        }
+        Ok(existed)
+    }
+
+    /// Proactively sweep `domain_id`'s JTI revocation list for expired
+    /// entries. `add_revoked_jtis_impl` already lazy-sweeps on every write
+    /// (ADR 0020 §4.A posture); this just triggers that same rewrite with no
+    /// new entries, for domains that see no emergency rotations to trigger
+    /// it otherwise.
+    async fn prune_expired_jtis_impl(
+        &self,
+        storage: &dyn StorageApi,
+        domain_id: &str,
+        jti_ttl_secs: i64,
+    ) -> Result<(), Oauth2KeyProviderError> {
+        self.add_revoked_jtis_impl(storage, domain_id, vec![], jti_ttl_secs)
+            .await
     }
 }
 
@@ -656,6 +762,51 @@ impl Oauth2KeyBackend for RaftOauth2KeyBackend {
             .as_deref()
             .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
         self.revoked_jtis_impl(storage, domain_id).await
+    }
+
+    async fn list_all_active_keys(
+        &self,
+        state: &ServiceState,
+    ) -> Result<Vec<(String, ActiveKeys)>, Oauth2KeyProviderError> {
+        let storage = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
+        self.list_all_active_keys_impl(storage).await
+    }
+
+    async fn retire_previous_key(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<bool, Oauth2KeyProviderError> {
+        let storage = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
+        self.retire_previous_key_impl(storage, domain_id).await
+    }
+
+    async fn prune_expired_jtis(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<(), Oauth2KeyProviderError> {
+        let storage = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
+        let jti_ttl_secs = i64::from(
+            state
+                .config_manager
+                .config
+                .read()
+                .await
+                .oauth2
+                .access_token_lifetime_minutes,
+        ) * 60;
+        self.prune_expired_jtis_impl(storage, domain_id, jti_ttl_secs)
+            .await
     }
 }
 


### PR DESCRIPTION
Adds the second of three post-Phase-6 follow-up gaps: a background
janitor retiring demoted OAuth2 signing keys and pruning JTI revocation
lists (ADR 0026 §3), mirroring api_key::janitor's leader-gated sweep
pattern.

- KeyMaterial/StoredKeyMaterial gain demoted_at, set on the clone written
  into the Previous slot by both rotate_signing_key_impl and
  confirm_emergency_rotation_impl -- never on the key while still
  Primary. Without this, "one full access-token lifetime after
  demotion" (ADR §3) had no timestamp to measure from: created_at only
  tracks original generation, and a key can serve as Primary for months
  before its first rotation.
- New Oauth2KeyApi/Backend methods: list_all_active_keys (a coarse
  cross-domain prefix scan over oauth2:signing_key:v1:, the same
  technique RaftAsymmetricKeySource::load already uses per-domain --
  there is no existing cross-domain listing for oauth2 keys, unlike
  ApiKeyApi::list_all), retire_previous_key, and prune_expired_jtis
  (a thin trigger for the lazy-sweep rewrite add_revoked_jtis_impl
  already does).
- A Previous key with demoted_at: None (pre-migration data) is left
  alone rather than force-retired, since there's no way to tell how
  long ago it was actually demoted.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
