### PR TITLE
feat(adr0026): Add RFC 8628 Device Authorization Grant

### DIFF
--- a/crates/config/src/oauth2.rs
+++ b/crates/config/src/oauth2.rs
@@ -133,6 +133,19 @@ pub struct Oauth2Provider {
     #[serde(default = "default_pre_auth_session_lifetime_minutes")]
     #[validate(range(min = 1))]
     pub pre_auth_session_lifetime_minutes: u32,
+
+    /// Lifetime, in minutes, of a `device_code`/`user_code` pair minted at
+    /// `POST /device_authorization` before the grant expires unclaimed
+    /// (RFC 8628 §3.2 `expires_in`, ADR 0026 §7.C).
+    #[serde(default = "default_device_code_lifetime_minutes")]
+    #[validate(range(min = 1))]
+    pub device_code_lifetime_minutes: u32,
+
+    /// Minimum interval, in seconds, between two `/token` polls for the
+    /// same `device_code` (RFC 8628 §3.2 `interval`, §3.5 `slow_down`).
+    #[serde(default = "default_device_code_poll_interval_seconds")]
+    #[validate(range(min = 1))]
+    pub device_code_poll_interval_seconds: u32,
 }
 
 fn default_signing_key_rotation_days() -> u32 {
@@ -183,6 +196,14 @@ fn default_pre_auth_session_lifetime_minutes() -> u32 {
     10
 }
 
+fn default_device_code_lifetime_minutes() -> u32 {
+    10
+}
+
+fn default_device_code_poll_interval_seconds() -> u32 {
+    5
+}
+
 impl Default for Oauth2Provider {
     fn default() -> Self {
         Self {
@@ -199,6 +220,8 @@ impl Default for Oauth2Provider {
             refresh_token_lifetime_days: default_refresh_token_lifetime_days(),
             refresh_token_reuse_grace_minutes: default_refresh_token_reuse_grace_minutes(),
             pre_auth_session_lifetime_minutes: default_pre_auth_session_lifetime_minutes(),
+            device_code_lifetime_minutes: default_device_code_lifetime_minutes(),
+            device_code_poll_interval_seconds: default_device_code_poll_interval_seconds(),
         }
     }
 }
@@ -220,6 +243,8 @@ mod tests {
         assert_eq!(cfg.refresh_token_lifetime_days, 30);
         assert_eq!(cfg.refresh_token_reuse_grace_minutes, 10);
         assert_eq!(cfg.pre_auth_session_lifetime_minutes, 10);
+        assert_eq!(cfg.device_code_lifetime_minutes, 10);
+        assert_eq!(cfg.device_code_poll_interval_seconds, 5);
         assert!(cfg.validate().is_ok());
     }
 

--- a/crates/core-types/src/oauth2_session/resource.rs
+++ b/crates/core-types/src/oauth2_session/resource.rs
@@ -188,6 +188,84 @@ pub struct RefreshToken {
     pub expires_at: i64,
 }
 
+/// Status of an RFC 8628 Device Authorization Grant (ADR 0026 §7.C).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeviceGrantStatus {
+    /// Awaiting the user to complete the verification-page login/consent
+    /// flow.
+    Pending,
+    /// Consent granted; the device may redeem `device_code` at `/token`
+    /// exactly once.
+    Authorized,
+    /// Consent denied; polling returns `access_denied`.
+    Denied,
+}
+
+/// An RFC 8628 Device Authorization Grant, minted at
+/// `POST /device_authorization` and completed via the browser verification
+/// page (ADR 0026 §7.C). Single-use like [`AuthorizationCode`]: redeemed
+/// exactly once at `/token` while `Authorized`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceCodeGrant {
+    /// 256-bit-entropy value the polling device holds; also the storage
+    /// key. Never displayed to the user.
+    pub device_code: String,
+    /// Short, human-typeable code displayed to the user and entered at the
+    /// verification page.
+    pub user_code: String,
+    /// Owning domain.
+    pub domain_id: String,
+    /// The `OAuth2Client.client_id` this grant was issued to.
+    pub client_id: String,
+    /// Requested scope values.
+    pub scope: Vec<String>,
+    /// Current lifecycle state.
+    pub status: DeviceGrantStatus,
+    /// Set once the verification page's login step succeeds.
+    pub user_id: Option<String>,
+    /// Set once the verification page's login step succeeds: epoch seconds
+    /// of primary authentication.
+    pub auth_time: Option<i64>,
+    /// Authentication methods references, set alongside `user_id`.
+    pub amr: Vec<String>,
+    /// OIDC `nonce`, if the polling device supplied one.
+    pub nonce: Option<String>,
+    /// Server-side secret used to derive the CSRF token for the
+    /// verification page's login/consent POST forms, mirroring
+    /// `PreAuthSession.server_side_session_secret`.
+    pub server_side_session_secret: String,
+    /// Epoch seconds of the most recent `/token` poll for this
+    /// `device_code`, for RFC 8628 §3.5 `slow_down` interval enforcement.
+    /// `None` before the first poll.
+    pub last_polled_at: Option<i64>,
+    /// UTC epoch seconds.
+    pub created_at: i64,
+    /// UTC epoch seconds (`[oauth2] device_code_lifetime_minutes`).
+    pub expires_at: i64,
+}
+
+/// Input to create a new [`DeviceCodeGrant`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceCodeGrantCreate {
+    /// 256-bit-entropy value the polling device holds.
+    pub device_code: String,
+    /// Short, human-typeable code displayed to the user.
+    pub user_code: String,
+    /// Owning domain.
+    pub domain_id: String,
+    /// The `OAuth2Client.client_id` this grant is issued to.
+    pub client_id: String,
+    /// Requested scope values.
+    pub scope: Vec<String>,
+    /// Server-side CSRF-derivation secret.
+    pub server_side_session_secret: String,
+    /// UTC epoch seconds.
+    pub created_at: i64,
+    /// UTC epoch seconds.
+    pub expires_at: i64,
+}
+
 /// Input to create a new [`RefreshToken`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RefreshTokenCreate {

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -263,11 +263,12 @@ mod oauth2_session {
     use super::*;
 
     use openstack_keystone_core_types::oauth2_session::{
-        AuthorizationCode, PreAuthSession, RefreshToken,
+        AuthorizationCode, DeviceCodeGrant, PreAuthSession, RefreshToken,
     };
 
     use crate::oauth2_session::provider_api::{
-        IssueAuthorizationCodeRequest, IssueRefreshTokenRequest, RefreshTokenRedemption,
+        DeviceAuthorizationStart, DevicePollOutcome, IssueAuthorizationCodeRequest,
+        IssueRefreshTokenRequest, RefreshTokenRedemption, StartDeviceAuthorizationRequest,
         StartPreAuthSessionRequest,
     };
     use crate::oauth2_session::{Oauth2SessionApi, Oauth2SessionProviderError};
@@ -333,6 +334,47 @@ mod oauth2_session {
                 state: &ServiceState,
                 presented_bearer: &str,
             ) -> Result<RefreshTokenRedemption, Oauth2SessionProviderError>;
+
+            async fn start_device_authorization(
+                &self,
+                state: &ServiceState,
+                req: StartDeviceAuthorizationRequest,
+            ) -> Result<DeviceAuthorizationStart, Oauth2SessionProviderError>;
+
+            async fn get_device_code_grant_by_user_code(
+                &self,
+                state: &ServiceState,
+                user_code: &str,
+            ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError>;
+
+            async fn get_device_code_grant(
+                &self,
+                state: &ServiceState,
+                device_code: &str,
+            ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError>;
+
+            async fn mark_device_authenticated(
+                &self,
+                state: &ServiceState,
+                device_code: &str,
+                user_id: &str,
+                auth_time: i64,
+                amr: Vec<String>,
+            ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError>;
+
+            async fn mark_device_decision(
+                &self,
+                state: &ServiceState,
+                device_code: &str,
+                granted: bool,
+            ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError>;
+
+            async fn poll_device_code_grant(
+                &self,
+                state: &ServiceState,
+                device_code: &str,
+                client_id: &str,
+            ) -> Result<DevicePollOutcome, Oauth2SessionProviderError>;
         }
     }
 }

--- a/crates/core/src/oauth2_session.rs
+++ b/crates/core/src/oauth2_session.rs
@@ -28,7 +28,8 @@ pub mod service;
 pub use crate::mocks::MockOauth2SessionProvider;
 pub use error::Oauth2SessionProviderError;
 pub use provider_api::{
-    IssueAuthorizationCodeRequest, IssueRefreshTokenRequest, Oauth2SessionApi,
-    RefreshTokenRedemption, StartPreAuthSessionRequest,
+    DeviceAuthorizationStart, DevicePollOutcome, IssueAuthorizationCodeRequest,
+    IssueRefreshTokenRequest, Oauth2SessionApi, RefreshTokenRedemption,
+    StartDeviceAuthorizationRequest, StartPreAuthSessionRequest,
 };
 pub use service::Oauth2SessionService;

--- a/crates/core/src/oauth2_session/backend.rs
+++ b/crates/core/src/oauth2_session/backend.rs
@@ -119,4 +119,64 @@ pub trait Oauth2SessionBackend: Send + Sync {
         state: &ServiceState,
         family_id: &str,
     ) -> Result<(), Oauth2SessionProviderError>;
+
+    /// Persist a new RFC 8628 Device Authorization Grant (ADR 0026 §7.C).
+    async fn create_device_code_grant(
+        &self,
+        state: &ServiceState,
+        data: DeviceCodeGrantCreate,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError>;
+
+    /// Fetch a device code grant by the `device_code` the polling device
+    /// holds.
+    async fn get_device_code_grant(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError>;
+
+    /// Fetch a device code grant by the short `user_code` entered at the
+    /// verification page.
+    async fn get_device_code_grant_by_user_code(
+        &self,
+        state: &ServiceState,
+        user_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError>;
+
+    /// Stamp `user_id`/`auth_time`/`amr` once the verification page's login
+    /// step succeeds.
+    async fn mark_device_code_grant_authenticated(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        user_id: &str,
+        auth_time: i64,
+        amr: Vec<String>,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError>;
+
+    /// Stamp the terminal `status` once the verification page's consent
+    /// step completes.
+    async fn mark_device_code_grant_decision(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        status: DeviceGrantStatus,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError>;
+
+    /// Stamp `last_polled_at`, for RFC 8628 §3.5 poll-interval enforcement.
+    async fn mark_device_code_grant_polled(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        polled_at: i64,
+    ) -> Result<(), Oauth2SessionProviderError>;
+
+    /// Atomically fetch and delete a device code grant -- a second call for
+    /// the same `device_code` returns `Ok(None)`, never the same record
+    /// twice (single-use redemption at `/token`).
+    async fn take_device_code_grant(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError>;
 }

--- a/crates/core/src/oauth2_session/provider_api.rs
+++ b/crates/core/src/oauth2_session/provider_api.rs
@@ -16,7 +16,7 @@
 use async_trait::async_trait;
 
 use openstack_keystone_core_types::oauth2_session::{
-    AuthorizationCode, PreAuthSession, RefreshToken,
+    AuthorizationCode, DeviceCodeGrant, PreAuthSession, RefreshToken,
 };
 
 use crate::keystone::ServiceState;
@@ -112,6 +112,56 @@ pub enum RefreshTokenRedemption {
     Invalid,
 }
 
+/// Input to [`Oauth2SessionApi::start_device_authorization`].
+#[derive(Debug, Clone)]
+pub struct StartDeviceAuthorizationRequest {
+    /// Domain the `/device_authorization` request targets.
+    pub domain_id: String,
+    /// Requesting `OAuth2Client.client_id`.
+    pub client_id: String,
+    /// Requested scope values.
+    pub scope: Vec<String>,
+}
+
+/// Outcome of [`Oauth2SessionApi::start_device_authorization`]. Deliberately
+/// narrower than [`DeviceCodeGrant`]: the HTTP handler builds
+/// `verification_uri`/`verification_uri_complete` (it alone knows the
+/// request's base URL) and the wire-level `expires_in` (seconds from now),
+/// neither of which the service layer should compute.
+#[derive(Debug, Clone)]
+pub struct DeviceAuthorizationStart {
+    /// 256-bit-entropy value the polling device holds.
+    pub device_code: String,
+    /// Short, human-typeable code displayed to the user.
+    pub user_code: String,
+    /// UTC epoch seconds after which the grant expires unclaimed.
+    pub expires_at: i64,
+    /// Minimum seconds between `/token` polls (RFC 8628 §3.2 `interval`).
+    pub interval: u32,
+}
+
+/// Outcome of [`Oauth2SessionApi::poll_device_code_grant`] (RFC 8628 §3.4,
+/// §3.5): the `/token` handler maps each variant directly to the matching
+/// wire-level error code (or successful issuance for `Authorized`).
+#[derive(Debug, Clone)]
+pub enum DevicePollOutcome {
+    /// Unknown `device_code`, or it does not belong to the polling
+    /// `client_id`.
+    InvalidGrant,
+    /// Past `expires_at`.
+    Expired,
+    /// Polled again before `interval` seconds have elapsed since the last
+    /// poll.
+    SlowDown,
+    /// Awaiting the user to complete the verification page.
+    Pending,
+    /// The user denied consent.
+    Denied,
+    /// Consent granted; the grant has been redeemed (deleted) as part of
+    /// this call and must not be polled again.
+    Authorized(Box<DeviceCodeGrant>),
+}
+
 /// The trait for the OAuth2 browser session provider (ADR 0026 §10 Phase
 /// 4): pre-auth session, authorization code, and refresh token family
 /// lifecycle, including the reuse-detection state machine.
@@ -192,4 +242,61 @@ pub trait Oauth2SessionApi: Send + Sync {
         state: &ServiceState,
         presented_bearer: &str,
     ) -> Result<RefreshTokenRedemption, Oauth2SessionProviderError>;
+
+    /// Mint a new RFC 8628 Device Authorization Grant at
+    /// `POST /device_authorization` (ADR 0026 §7.C).
+    async fn start_device_authorization(
+        &self,
+        state: &ServiceState,
+        req: StartDeviceAuthorizationRequest,
+    ) -> Result<DeviceAuthorizationStart, Oauth2SessionProviderError>;
+
+    /// Fetch a device code grant by `user_code`, for the verification page.
+    /// Returns `Ok(None)` for an unknown or expired code (expiry enforced
+    /// here, lazily, on read -- mirrors [`Self::get_pre_auth_session`]).
+    async fn get_device_code_grant_by_user_code(
+        &self,
+        state: &ServiceState,
+        user_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError>;
+
+    /// Fetch a device code grant by `device_code`, for the verification
+    /// page's login/consent POST handlers (which hold `device_code` in a
+    /// cookie, not `user_code`). Same lazy-expiry semantics as
+    /// [`Self::get_device_code_grant_by_user_code`].
+    async fn get_device_code_grant(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError>;
+
+    /// Stamp `user_id`/`auth_time`/`amr` once the verification page's login
+    /// step succeeds.
+    async fn mark_device_authenticated(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        user_id: &str,
+        auth_time: i64,
+        amr: Vec<String>,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError>;
+
+    /// Stamp the terminal decision once the verification page's consent
+    /// step completes.
+    async fn mark_device_decision(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        granted: bool,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError>;
+
+    /// Poll a device code grant from the `/token` handler (RFC 8628 §3.4):
+    /// validates ownership, expiry, and the minimum poll interval, and
+    /// redeems (deletes) the grant on success. See [`DevicePollOutcome`].
+    async fn poll_device_code_grant(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        client_id: &str,
+    ) -> Result<DevicePollOutcome, Oauth2SessionProviderError>;
 }

--- a/crates/core/src/oauth2_session/service.rs
+++ b/crates/core/src/oauth2_session/service.rs
@@ -27,8 +27,9 @@ use crate::keystone::ServiceState;
 use crate::oauth2_session::Oauth2SessionProviderError;
 use crate::oauth2_session::backend::Oauth2SessionBackend;
 use crate::oauth2_session::provider_api::{
-    IssueAuthorizationCodeRequest, IssueRefreshTokenRequest, Oauth2SessionApi,
-    RefreshTokenRedemption, StartPreAuthSessionRequest,
+    DeviceAuthorizationStart, DevicePollOutcome, IssueAuthorizationCodeRequest,
+    IssueRefreshTokenRequest, Oauth2SessionApi, RefreshTokenRedemption,
+    StartDeviceAuthorizationRequest, StartPreAuthSessionRequest,
 };
 use crate::plugin_manager::PluginManagerApi;
 
@@ -48,6 +49,22 @@ const ENTROPY_LEN: usize = 43;
 
 fn generate_entropy() -> String {
     Alphanumeric.sample_string(&mut rand::rng(), ENTROPY_LEN)
+}
+
+/// Unambiguous charset for RFC 8628 `user_code` generation (ADR 0026 §7.C):
+/// excludes vowels (avoids accidentally spelling words) and visually
+/// confusable characters (`0`/`O`, `1`/`I`). 8 symbols formatted as
+/// `XXXX-XXXX`, matching the ADR's stated shape.
+const USER_CODE_ALPHABET: &[u8] = b"BCDFGHJKLMNPQRSTVWXZ23456789";
+const USER_CODE_LEN: usize = 8;
+
+fn generate_user_code() -> String {
+    use rand::RngExt;
+    let mut rng = rand::rng();
+    let code: String = (0..USER_CODE_LEN)
+        .map(|_| USER_CODE_ALPHABET[rng.random_range(0..USER_CODE_ALPHABET.len())] as char)
+        .collect();
+    format!("{}-{}", &code[0..4], &code[4..8])
 }
 
 fn hash_bearer(bearer: &str) -> String {
@@ -328,6 +345,155 @@ impl Oauth2SessionApi for Oauth2SessionService {
             }
         }
     }
+
+    async fn start_device_authorization(
+        &self,
+        state: &ServiceState,
+        req: StartDeviceAuthorizationRequest,
+    ) -> Result<DeviceAuthorizationStart, Oauth2SessionProviderError> {
+        let created_at = now();
+        let expires_at =
+            created_at + i64::from(self.oauth2_config.device_code_lifetime_minutes) * 60;
+        let record = self
+            .backend_driver
+            .create_device_code_grant(
+                state,
+                DeviceCodeGrantCreate {
+                    device_code: generate_entropy(),
+                    user_code: generate_user_code(),
+                    domain_id: req.domain_id,
+                    client_id: req.client_id,
+                    scope: req.scope,
+                    server_side_session_secret: generate_entropy(),
+                    created_at,
+                    expires_at,
+                },
+            )
+            .await?;
+        Ok(DeviceAuthorizationStart {
+            device_code: record.device_code,
+            user_code: record.user_code,
+            expires_at: record.expires_at,
+            interval: self.oauth2_config.device_code_poll_interval_seconds,
+        })
+    }
+
+    async fn get_device_code_grant_by_user_code(
+        &self,
+        state: &ServiceState,
+        user_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError> {
+        let Some(grant) = self
+            .backend_driver
+            .get_device_code_grant_by_user_code(state, user_code)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if grant.expires_at < now() {
+            return Ok(None);
+        }
+        Ok(Some(grant))
+    }
+
+    async fn get_device_code_grant(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError> {
+        let Some(grant) = self
+            .backend_driver
+            .get_device_code_grant(state, device_code)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if grant.expires_at < now() {
+            return Ok(None);
+        }
+        Ok(Some(grant))
+    }
+
+    async fn mark_device_authenticated(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        user_id: &str,
+        auth_time: i64,
+        amr: Vec<String>,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError> {
+        self.backend_driver
+            .mark_device_code_grant_authenticated(state, device_code, user_id, auth_time, amr)
+            .await
+    }
+
+    async fn mark_device_decision(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        granted: bool,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError> {
+        let status = if granted {
+            DeviceGrantStatus::Authorized
+        } else {
+            DeviceGrantStatus::Denied
+        };
+        self.backend_driver
+            .mark_device_code_grant_decision(state, device_code, status)
+            .await
+    }
+
+    async fn poll_device_code_grant(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        client_id: &str,
+    ) -> Result<DevicePollOutcome, Oauth2SessionProviderError> {
+        let Some(record) = self
+            .backend_driver
+            .get_device_code_grant(state, device_code)
+            .await?
+        else {
+            return Ok(DevicePollOutcome::InvalidGrant);
+        };
+        if record.client_id != client_id {
+            return Ok(DevicePollOutcome::InvalidGrant);
+        }
+
+        let now = now();
+        if record.expires_at < now {
+            return Ok(DevicePollOutcome::Expired);
+        }
+
+        let interval_secs = i64::from(self.oauth2_config.device_code_poll_interval_seconds);
+        if let Some(last_polled_at) = record.last_polled_at
+            && now - last_polled_at < interval_secs
+        {
+            return Ok(DevicePollOutcome::SlowDown);
+        }
+
+        match record.status {
+            DeviceGrantStatus::Pending => {
+                self.backend_driver
+                    .mark_device_code_grant_polled(state, device_code, now)
+                    .await?;
+                Ok(DevicePollOutcome::Pending)
+            }
+            DeviceGrantStatus::Denied => Ok(DevicePollOutcome::Denied),
+            DeviceGrantStatus::Authorized => {
+                match self
+                    .backend_driver
+                    .take_device_code_grant(state, device_code)
+                    .await?
+                {
+                    // Concurrent poll already redeemed it between the read
+                    // above and this call; treat the same as unknown.
+                    None => Ok(DevicePollOutcome::InvalidGrant),
+                    Some(taken) => Ok(DevicePollOutcome::Authorized(Box::new(taken))),
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -509,5 +675,200 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(result, RefreshTokenRedemption::Invalid));
+    }
+
+    fn sample_device_grant(
+        status: DeviceGrantStatus,
+        last_polled_at: Option<i64>,
+    ) -> DeviceCodeGrant {
+        DeviceCodeGrant {
+            device_code: "device-code-1".to_string(),
+            user_code: "ABCD-EFGH".to_string(),
+            domain_id: "domain-1".to_string(),
+            client_id: "client-1".to_string(),
+            scope: vec!["openid".to_string()],
+            status,
+            user_id: None,
+            auth_time: None,
+            amr: vec![],
+            nonce: None,
+            server_side_session_secret: "secret".to_string(),
+            last_polled_at,
+            created_at: now() - 100,
+            expires_at: now() + 1_000_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_device_authorization_generates_codes() {
+        let mut mock = MockOauth2SessionBackend::new();
+        mock.expect_create_device_code_grant().returning(|_, data| {
+            Ok(DeviceCodeGrant {
+                device_code: data.device_code,
+                user_code: data.user_code,
+                domain_id: data.domain_id,
+                client_id: data.client_id,
+                scope: data.scope,
+                status: DeviceGrantStatus::Pending,
+                user_id: None,
+                auth_time: None,
+                amr: vec![],
+                nonce: None,
+                server_side_session_secret: data.server_side_session_secret,
+                last_polled_at: None,
+                created_at: data.created_at,
+                expires_at: data.expires_at,
+            })
+        });
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+
+        let start = service
+            .start_device_authorization(
+                &state,
+                StartDeviceAuthorizationRequest {
+                    domain_id: "domain-1".to_string(),
+                    client_id: "client-1".to_string(),
+                    scope: vec!["openid".to_string()],
+                },
+            )
+            .await
+            .unwrap();
+        assert!(!start.device_code.is_empty());
+        // "XXXX-XXXX" shape (ADR 0026 §7.C).
+        assert_eq!(start.user_code.len(), 9);
+        assert_eq!(start.user_code.chars().nth(4), Some('-'));
+    }
+
+    #[tokio::test]
+    async fn test_get_device_code_grant_by_user_code_expired_returns_none() {
+        let mut mock = MockOauth2SessionBackend::new();
+        mock.expect_get_device_code_grant_by_user_code()
+            .returning(|_, _| {
+                Ok(Some(DeviceCodeGrant {
+                    expires_at: now() - 1,
+                    ..sample_device_grant(DeviceGrantStatus::Pending, None)
+                }))
+            });
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .get_device_code_grant_by_user_code(&state, "ABCD-EFGH")
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_poll_device_code_grant_unknown_client_id_is_invalid_grant() {
+        let mut mock = MockOauth2SessionBackend::new();
+        mock.expect_get_device_code_grant()
+            .returning(|_, _| Ok(Some(sample_device_grant(DeviceGrantStatus::Pending, None))));
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .poll_device_code_grant(&state, "device-code-1", "wrong-client")
+            .await
+            .unwrap();
+        assert!(matches!(result, DevicePollOutcome::InvalidGrant));
+    }
+
+    #[tokio::test]
+    async fn test_poll_device_code_grant_pending_stamps_last_polled_at() {
+        let mut mock = MockOauth2SessionBackend::new();
+        mock.expect_get_device_code_grant()
+            .returning(|_, _| Ok(Some(sample_device_grant(DeviceGrantStatus::Pending, None))));
+        mock.expect_mark_device_code_grant_polled()
+            .returning(|_, _, _| Ok(()));
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .poll_device_code_grant(&state, "device-code-1", "client-1")
+            .await
+            .unwrap();
+        assert!(matches!(result, DevicePollOutcome::Pending));
+    }
+
+    #[tokio::test]
+    async fn test_poll_device_code_grant_too_soon_is_slow_down() {
+        let mut mock = MockOauth2SessionBackend::new();
+        mock.expect_get_device_code_grant().returning(|_, _| {
+            Ok(Some(sample_device_grant(
+                DeviceGrantStatus::Pending,
+                Some(now()),
+            )))
+        });
+        // No `expect_mark_device_code_grant_polled`: calling it would panic
+        // the mock -- a throttled poll must not reset the interval clock.
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .poll_device_code_grant(&state, "device-code-1", "client-1")
+            .await
+            .unwrap();
+        assert!(matches!(result, DevicePollOutcome::SlowDown));
+    }
+
+    #[tokio::test]
+    async fn test_poll_device_code_grant_denied() {
+        let mut mock = MockOauth2SessionBackend::new();
+        mock.expect_get_device_code_grant()
+            .returning(|_, _| Ok(Some(sample_device_grant(DeviceGrantStatus::Denied, None))));
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .poll_device_code_grant(&state, "device-code-1", "client-1")
+            .await
+            .unwrap();
+        assert!(matches!(result, DevicePollOutcome::Denied));
+    }
+
+    #[tokio::test]
+    async fn test_poll_device_code_grant_authorized_takes_and_returns_record() {
+        let mut mock = MockOauth2SessionBackend::new();
+        mock.expect_get_device_code_grant().returning(|_, _| {
+            Ok(Some(sample_device_grant(
+                DeviceGrantStatus::Authorized,
+                None,
+            )))
+        });
+        mock.expect_take_device_code_grant().returning(|_, _| {
+            Ok(Some(sample_device_grant(
+                DeviceGrantStatus::Authorized,
+                None,
+            )))
+        });
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .poll_device_code_grant(&state, "device-code-1", "client-1")
+            .await
+            .unwrap();
+        assert!(matches!(result, DevicePollOutcome::Authorized(_)));
+    }
+
+    #[tokio::test]
+    async fn test_poll_device_code_grant_expired() {
+        let mut mock = MockOauth2SessionBackend::new();
+        mock.expect_get_device_code_grant().returning(|_, _| {
+            Ok(Some(DeviceCodeGrant {
+                expires_at: now() - 1,
+                ..sample_device_grant(DeviceGrantStatus::Pending, None)
+            }))
+        });
+        let service = service_with(mock);
+        let state = get_mocked_state(None, None).await;
+
+        let result = service
+            .poll_device_code_grant(&state, "device-code-1", "client-1")
+            .await
+            .unwrap();
+        assert!(matches!(result, DevicePollOutcome::Expired));
     }
 }

--- a/crates/keystone/src/api/v4/oauth2/authorize.rs
+++ b/crates/keystone/src/api/v4/oauth2/authorize.rs
@@ -27,16 +27,13 @@ use askama::Template;
 use axum::{
     Form,
     extract::{Path, Query, State},
-    http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header},
+    http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse, Redirect, Response},
 };
 use axum_extra::extract::CookieJar;
 use axum_extra::extract::cookie::{Cookie, SameSite};
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use hmac::{Hmac, KeyInit, Mac};
 use secrecy::SecretString;
 use serde::Deserialize;
-use sha2::Sha256;
 
 use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core::oauth2_session::{
@@ -49,6 +46,9 @@ use openstack_keystone_core_types::identity::{
 use openstack_keystone_core_types::oauth2_client::GrantType;
 use openstack_keystone_core_types::oauth2_session::PreAuthSession;
 
+use super::html::{
+    ConsentTemplate, LoginTemplate, error_page, security_headers, too_many_requests,
+};
 use crate::api::common::PeerAddr;
 use crate::audit::{CorrelationId, build_initiator_unknown, emit_oauth2_session_event};
 use crate::keystone::ServiceState;
@@ -86,68 +86,6 @@ pub(super) struct LoginForm {
 pub(super) struct ConsentForm {
     csrf_token: String,
     decision: String,
-}
-
-#[derive(Template)]
-#[template(path = "oauth2/login.html")]
-struct LoginTemplate<'a> {
-    client_id: &'a str,
-    csrf_token: &'a str,
-    error: Option<&'a str>,
-    action: String,
-}
-
-#[derive(Template)]
-#[template(path = "oauth2/consent.html")]
-struct ConsentTemplate<'a> {
-    client_id: &'a str,
-    scopes: &'a [String],
-    csrf_token: &'a str,
-    action: String,
-}
-
-#[derive(Template)]
-#[template(path = "oauth2/error.html")]
-struct ErrorTemplate<'a> {
-    message: &'a str,
-}
-
-/// ADR 0026 §8: defense-in-depth headers on every server-rendered OP
-/// response (HTML pages and the redirects between them alike).
-fn security_headers(mut response: Response) -> Response {
-    let headers = response.headers_mut();
-    headers.insert(
-        HeaderName::from_static("content-security-policy"),
-        HeaderValue::from_static("default-src 'self'"),
-    );
-    headers.insert(
-        HeaderName::from_static("x-frame-options"),
-        HeaderValue::from_static("DENY"),
-    );
-    headers.insert(
-        header::X_CONTENT_TYPE_OPTIONS,
-        HeaderValue::from_static("nosniff"),
-    );
-    headers.insert(
-        HeaderName::from_static("x-xss-protection"),
-        HeaderValue::from_static("0"),
-    );
-    response
-}
-
-fn error_page(status: StatusCode, message: &str) -> Response {
-    let body = ErrorTemplate { message }
-        .render()
-        .unwrap_or_else(|_| message.to_string());
-    security_headers((status, Html(body)).into_response())
-}
-
-fn too_many_requests(retry_after: u64) -> Response {
-    let mut response = error_page(StatusCode::TOO_MANY_REQUESTS, "rate limit exceeded");
-    response
-        .headers_mut()
-        .insert(header::RETRY_AFTER, retry_after.into());
-    response
 }
 
 /// Append query parameters to `redirect_uri` and return a
@@ -195,28 +133,15 @@ fn redirect_with_code(redirect_uri: &str, code: &str, state_param: &str) -> Resp
 /// input -- generated server-side and never sent to the client in cleartext --
 /// is what an attacker crafting a link for a victim to click cannot supply.
 fn compute_csrf_token(session: &PreAuthSession) -> Option<String> {
-    let mut mac =
-        Hmac::<Sha256>::new_from_slice(session.server_side_session_secret.as_bytes()).ok()?;
-    mac.update(session.session_id.as_bytes());
-    mac.update(session.state.as_bytes());
-    mac.update(session.code_challenge.as_bytes());
-    Some(URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes()))
-}
-
-fn constant_time_eq(a: &str, b: &str) -> bool {
-    let (a, b) = (a.as_bytes(), b.as_bytes());
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
+    super::html::compute_csrf_token(
+        &session.server_side_session_secret,
+        &[&session.session_id, &session.state, &session.code_challenge],
+    )
 }
 
 fn verify_csrf_token(session: &PreAuthSession, presented: &str) -> bool {
-    compute_csrf_token(session).is_some_and(|expected| constant_time_eq(&expected, presented))
+    compute_csrf_token(session)
+        .is_some_and(|expected| super::html::constant_time_eq(&expected, presented))
 }
 
 fn is_https(headers: &HeaderMap) -> bool {

--- a/crates/keystone/src/api/v4/oauth2/device.rs
+++ b/crates/keystone/src/api/v4/oauth2/device.rs
@@ -1,0 +1,555 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `GET/POST /v4/oauth2/{domain_id}/device`, `POST .../device/login`,
+//! `POST .../device/consent`: the RFC 8628 Device Authorization Grant's
+//! browser verification page (ADR 0026 §7.C).
+//!
+//! Structurally parallel to `authorize.rs`'s login/consent steps, but there
+//! is no `redirect_uri`/PKCE and the flow terminates in a static result
+//! page rather than a redirect back to a relying party -- the polling
+//! device, not this browser, receives the eventual token at `/token`.
+
+use askama::Template;
+use axum::{
+    Form,
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{Html, IntoResponse, Response},
+};
+use axum_extra::extract::CookieJar;
+use axum_extra::extract::cookie::{Cookie, SameSite};
+use secrecy::SecretString;
+use serde::Deserialize;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::auth::IdentityInfo;
+use openstack_keystone_core_types::identity::{
+    Domain as IdentityDomain, UserPasswordAuthRequestBuilder,
+};
+use openstack_keystone_core_types::oauth2_session::DeviceCodeGrant;
+
+use super::html::{ConsentTemplate, LoginTemplate, error_page, security_headers};
+use crate::audit::{CorrelationId, build_initiator_unknown, emit_oauth2_session_event};
+use crate::keystone::ServiceState;
+
+const DEVICE_COOKIE_NAME: &str = "keystone_oauth2_device_code";
+
+#[derive(Debug, Default, Deserialize, utoipa::IntoParams)]
+pub(super) struct DeviceQuery {
+    #[serde(default)]
+    user_code: Option<String>,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub(super) struct DeviceCodeForm {
+    user_code: String,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub(super) struct DeviceLoginForm {
+    csrf_token: String,
+    username: String,
+    password: String,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub(super) struct DeviceConsentForm {
+    csrf_token: String,
+    decision: String,
+}
+
+#[derive(Template)]
+#[template(path = "oauth2/device_entry.html")]
+struct DeviceEntryTemplate<'a> {
+    error: Option<&'a str>,
+    prefill: &'a str,
+    action: String,
+}
+
+#[derive(Template)]
+#[template(path = "oauth2/device_result.html")]
+struct DeviceResultTemplate<'a> {
+    granted: bool,
+    client_id: &'a str,
+}
+
+/// CSRF token derivation, mirroring `authorize.rs`'s but keyed on the
+/// device grant's own identifiers instead of a `PreAuthSession`'s.
+fn compute_csrf_token(grant: &DeviceCodeGrant) -> Option<String> {
+    super::html::compute_csrf_token(
+        &grant.server_side_session_secret,
+        &[&grant.device_code, &grant.user_code],
+    )
+}
+
+fn verify_csrf_token(grant: &DeviceCodeGrant, presented: &str) -> bool {
+    compute_csrf_token(grant)
+        .is_some_and(|expected| super::html::constant_time_eq(&expected, presented))
+}
+
+fn is_https(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        == Some("https")
+}
+
+fn device_cookie(device_code: String, secure: bool) -> Cookie<'static> {
+    Cookie::build((DEVICE_COOKIE_NAME, device_code))
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .secure(secure)
+        .path("/")
+        .build()
+}
+
+fn render_entry(domain_id: &str, error: Option<&str>, prefill: &str) -> Response {
+    let body = match (DeviceEntryTemplate {
+        error,
+        prefill,
+        action: format!("/v4/oauth2/{domain_id}/device"),
+    })
+    .render()
+    {
+        Ok(body) => body,
+        Err(_) => return error_page(StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
+    };
+    security_headers((StatusCode::OK, Html(body)).into_response())
+}
+
+fn render_login(
+    domain_id: &str,
+    client_id: &str,
+    grant: &DeviceCodeGrant,
+    error: Option<&str>,
+) -> Response {
+    let Some(csrf_token) = compute_csrf_token(grant) else {
+        return error_page(StatusCode::INTERNAL_SERVER_ERROR, "internal error");
+    };
+    let body = match (LoginTemplate {
+        client_id,
+        csrf_token: &csrf_token,
+        error,
+        action: format!("/v4/oauth2/{domain_id}/device/login"),
+    })
+    .render()
+    {
+        Ok(body) => body,
+        Err(_) => return error_page(StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
+    };
+    security_headers((StatusCode::OK, Html(body)).into_response())
+}
+
+fn render_consent(domain_id: &str, client_id: &str, grant: &DeviceCodeGrant) -> Response {
+    let Some(csrf_token) = compute_csrf_token(grant) else {
+        return error_page(StatusCode::INTERNAL_SERVER_ERROR, "internal error");
+    };
+    let body = match (ConsentTemplate {
+        client_id,
+        scopes: &grant.scope,
+        csrf_token: &csrf_token,
+        action: format!("/v4/oauth2/{domain_id}/device/consent"),
+    })
+    .render()
+    {
+        Ok(body) => body,
+        Err(_) => return error_page(StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
+    };
+    security_headers((StatusCode::OK, Html(body)).into_response())
+}
+
+fn render_result(granted: bool, client_id: &str) -> Response {
+    let body = match (DeviceResultTemplate { granted, client_id }).render() {
+        Ok(body) => body,
+        Err(_) => return error_page(StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
+    };
+    security_headers((StatusCode::OK, Html(body)).into_response())
+}
+
+async fn client_id_for_display(state: &ServiceState, client_id: &str) -> String {
+    // Best-effort display only (the actual grant is already bound to
+    // `client_id` in storage); a lookup failure just falls back to the raw
+    // ID rather than failing the whole page render.
+    let exec = ExecutionContext::internal(state);
+    state
+        .provider
+        .get_oauth2_client_provider()
+        .get_by_client_id(&exec, client_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|c| c.client_id)
+        .unwrap_or_else(|| client_id.to_string())
+}
+
+/// `GET /v4/oauth2/{domain_id}/device` (RFC 8628 §3.3). Renders the
+/// user_code entry form, pre-filled from `verification_uri_complete`'s
+/// `user_code` query parameter if present.
+#[utoipa::path(
+    get,
+    path = "/{domain_id}/device",
+    operation_id = "/oauth2:device",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+        DeviceQuery,
+    ),
+    responses(
+        (status = OK, description = "Code-entry form rendered", content_type = "text/html"),
+    ),
+    tag = "oauth2"
+)]
+#[tracing::instrument(name = "api::v4::oauth2::device_entry", level = "debug")]
+pub(super) async fn device(
+    Path(domain_id): Path<String>,
+    Query(query): Query<DeviceQuery>,
+) -> Result<Response, std::convert::Infallible> {
+    Ok(render_entry(
+        &domain_id,
+        None,
+        query.user_code.as_deref().unwrap_or_default(),
+    ))
+}
+
+/// `POST /v4/oauth2/{domain_id}/device`: submit the `user_code`.
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/device",
+    operation_id = "/oauth2:device_submit_code",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    responses(
+        (status = OK, description = "Login form rendered, or code-entry form re-rendered on failure", content_type = "text/html"),
+    ),
+    tag = "oauth2"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::device_submit_code",
+    level = "debug",
+    skip(state, form),
+    err(Debug)
+)]
+pub(super) async fn device_login_code(
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Form(form): Form<DeviceCodeForm>,
+) -> Result<Response, std::convert::Infallible> {
+    // The lookup itself is a single keyed storage read (not a linear scan
+    // over every live code), so it does not carry the classic
+    // string-comparison timing side channel a naive brute-force defense
+    // would need to guard against separately.
+    let grant = match state
+        .provider
+        .get_oauth2_session_provider()
+        .get_device_code_grant_by_user_code(&state, form.user_code.trim())
+        .await
+    {
+        Ok(Some(g)) => g,
+        Ok(None) => {
+            return Ok(render_entry(
+                &domain_id,
+                Some("invalid or expired code"),
+                &form.user_code,
+            ));
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "oauth2 device code grant lookup failed");
+            return Ok(error_page(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal error",
+            ));
+        }
+    };
+
+    let client_id = client_id_for_display(&state, &grant.client_id).await;
+    let jar = jar.add(device_cookie(grant.device_code.clone(), is_https(&headers)));
+    let response = render_login(&domain_id, &client_id, &grant, None);
+    Ok((jar, response).into_response())
+}
+
+/// `POST /v4/oauth2/{domain_id}/device/login`.
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/device/login",
+    operation_id = "/oauth2:device_login",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    responses(
+        (status = OK, description = "Consent form rendered, login re-rendered on failure, or the final result page for pre_authorized clients", content_type = "text/html"),
+        (status = BAD_REQUEST, description = "Missing/expired grant or invalid CSRF token"),
+    ),
+    tag = "oauth2"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::device_login",
+    level = "debug",
+    skip(state, form),
+    err(Debug)
+)]
+pub(super) async fn device_login(
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    correlation_id: CorrelationId,
+    jar: CookieJar,
+    Form(form): Form<DeviceLoginForm>,
+) -> Result<Response, std::convert::Infallible> {
+    let Some(device_code) = jar.get(DEVICE_COOKIE_NAME).map(|c| c.value().to_string()) else {
+        return Ok(error_page(
+            StatusCode::BAD_REQUEST,
+            "code expired; please restart",
+        ));
+    };
+    let grant = match state
+        .provider
+        .get_oauth2_session_provider()
+        .get_device_code_grant(&state, &device_code)
+        .await
+    {
+        Ok(Some(g)) => g,
+        Ok(None) => {
+            return Ok(error_page(
+                StatusCode::BAD_REQUEST,
+                "code expired; please restart",
+            ));
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "oauth2 device code grant lookup failed");
+            return Ok(error_page(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal error",
+            ));
+        }
+    };
+
+    if !verify_csrf_token(&grant, &form.csrf_token) {
+        return Ok(error_page(
+            StatusCode::BAD_REQUEST,
+            "invalid or expired form submission; please restart",
+        ));
+    }
+
+    let client_id = client_id_for_display(&state, &grant.client_id).await;
+
+    let auth_req = match UserPasswordAuthRequestBuilder::default()
+        .name(form.username.clone())
+        .domain(IdentityDomain {
+            id: Some(domain_id.clone()),
+            name: None,
+        })
+        .password(SecretString::from(form.password.clone()))
+        .build()
+    {
+        Ok(req) => req,
+        Err(_) => {
+            return Ok(render_login(
+                &domain_id,
+                &client_id,
+                &grant,
+                Some("invalid username or password"),
+            ));
+        }
+    };
+
+    let exec = ExecutionContext::internal(&state);
+    let auth_result = state
+        .provider
+        .get_identity_provider()
+        .authenticate_by_password(&exec, &auth_req)
+        .await;
+    let auth_result = match auth_result {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(error = %e, "oauth2 device login failed");
+            emit_oauth2_session_event(
+                &state.audit_dispatcher,
+                &correlation_id.0,
+                "authenticate",
+                build_initiator_unknown(),
+                &grant.client_id,
+                "failure",
+                Some("invalid username or password".to_string()),
+            );
+            return Ok(render_login(
+                &domain_id,
+                &client_id,
+                &grant,
+                Some("invalid username or password"),
+            ));
+        }
+    };
+
+    let IdentityInfo::Principal(pinfo) = &auth_result.principal.identity else {
+        return Ok(error_page(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal error",
+        ));
+    };
+    let user_id = pinfo.id.clone();
+    let now = chrono::Utc::now().timestamp();
+
+    let grant = match state
+        .provider
+        .get_oauth2_session_provider()
+        .mark_device_authenticated(&state, &device_code, &user_id, now, vec!["pwd".to_string()])
+        .await
+    {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!(error = %e, "oauth2 device code grant update failed");
+            return Ok(error_page(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal error",
+            ));
+        }
+    };
+
+    emit_oauth2_session_event(
+        &state.audit_dispatcher,
+        &correlation_id.0,
+        "authenticate",
+        build_initiator_unknown(),
+        &grant.client_id,
+        "success",
+        None,
+    );
+
+    // `pre_authorized` skips consent only, never login (same invariant as
+    // `authorize.rs`): a `pre_authorized` client can never carry
+    // `openstack:api` in `allowed_scopes` (enforced at CRUD time), so
+    // skipping consent here cannot silently grant OpenStack authorization.
+    let client = state
+        .provider
+        .get_oauth2_client_provider()
+        .get_by_client_id(&exec, &grant.client_id)
+        .await
+        .ok()
+        .flatten();
+    if client.as_ref().is_some_and(|c| c.pre_authorized) {
+        return Ok(finish_decision(&state, &grant, true, &correlation_id.0).await);
+    }
+
+    Ok(render_consent(&domain_id, &client_id, &grant))
+}
+
+/// `POST /v4/oauth2/{domain_id}/device/consent`.
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/device/consent",
+    operation_id = "/oauth2:device_consent",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    responses(
+        (status = OK, description = "Final result page rendered", content_type = "text/html"),
+        (status = BAD_REQUEST, description = "Missing/expired grant, not signed in, or invalid CSRF token"),
+    ),
+    tag = "oauth2"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::device_consent",
+    level = "debug",
+    skip(state, form),
+    err(Debug)
+)]
+pub(super) async fn device_consent(
+    Path(_domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    correlation_id: CorrelationId,
+    jar: CookieJar,
+    Form(form): Form<DeviceConsentForm>,
+) -> Result<Response, std::convert::Infallible> {
+    let Some(device_code) = jar.get(DEVICE_COOKIE_NAME).map(|c| c.value().to_string()) else {
+        return Ok(error_page(
+            StatusCode::BAD_REQUEST,
+            "code expired; please restart",
+        ));
+    };
+    let grant = match state
+        .provider
+        .get_oauth2_session_provider()
+        .get_device_code_grant(&state, &device_code)
+        .await
+    {
+        Ok(Some(g)) => g,
+        Ok(None) => {
+            return Ok(error_page(
+                StatusCode::BAD_REQUEST,
+                "code expired; please restart",
+            ));
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "oauth2 device code grant lookup failed");
+            return Ok(error_page(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal error",
+            ));
+        }
+    };
+
+    if !verify_csrf_token(&grant, &form.csrf_token) {
+        return Ok(error_page(
+            StatusCode::BAD_REQUEST,
+            "invalid or expired form submission; please restart",
+        ));
+    }
+    if grant.user_id.is_none() {
+        return Ok(error_page(
+            StatusCode::BAD_REQUEST,
+            "not signed in; please restart",
+        ));
+    }
+
+    let granted = form.decision == "allow";
+    Ok(finish_decision(&state, &grant, granted, &correlation_id.0).await)
+}
+
+/// Complete the flow after consent is known (explicit consent POST, or the
+/// `pre_authorized` skip from `device_login`): stamp the terminal decision
+/// and show the static result page. Unlike `authorize.rs`'s `finish_consent`,
+/// there is no redirect target -- the polling device, not this browser,
+/// receives the eventual token at `/token`.
+async fn finish_decision(
+    state: &ServiceState,
+    grant: &DeviceCodeGrant,
+    granted: bool,
+    correlation_id: &str,
+) -> Response {
+    let client_id = client_id_for_display(state, &grant.client_id).await;
+    match state
+        .provider
+        .get_oauth2_session_provider()
+        .mark_device_decision(state, &grant.device_code, granted)
+        .await
+    {
+        Ok(_) => {
+            emit_oauth2_session_event(
+                &state.audit_dispatcher,
+                correlation_id,
+                "authorize",
+                build_initiator_unknown(),
+                &grant.client_id,
+                if granted { "success" } else { "failure" },
+                (!granted).then(|| "consent denied".to_string()),
+            );
+            render_result(granted, &client_id)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "oauth2 device code grant decision update failed");
+            error_page(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+        }
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/device_authorization.rs
+++ b/crates/keystone/src/api/v4/oauth2/device_authorization.rs
@@ -1,0 +1,328 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `POST /v4/oauth2/{domain_id}/device_authorization` (RFC 8628 §3.1/§3.2,
+//! ADR 0026 §7.C).
+//!
+//! Unauthenticated at the `Auth`-extractor level like `/authorize`: device
+//! flow clients are overwhelmingly public/native applications, so -- like
+//! `/authorize` -- this endpoint validates the client is registered,
+//! enabled, and holds the `device_code` grant type, but does not require a
+//! `client_secret`.
+
+use axum::{
+    Form,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core::oauth2_session::StartDeviceAuthorizationRequest;
+use openstack_keystone_core_types::oauth2_client::GrantType;
+
+use super::token::Oauth2TokenError;
+use super::well_known::base_url;
+use crate::keystone::ServiceState;
+
+#[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
+pub(super) struct DeviceAuthorizationForm {
+    client_id: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub(super) struct DeviceAuthorizationResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    verification_uri_complete: String,
+    expires_in: i64,
+    interval: u32,
+}
+
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/device_authorization",
+    operation_id = "/oauth2:device_authorization",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    responses(
+        (status = OK, description = "Device authorization grant issued"),
+        (status = BAD_REQUEST, description = "Malformed request, unknown client, or invalid scope"),
+    ),
+    tag = "oauth2"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::device_authorization",
+    level = "debug",
+    skip(state, form),
+    err(Debug)
+)]
+pub(super) async fn device_authorization(
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    Form(form): Form<DeviceAuthorizationForm>,
+) -> Result<Response, Oauth2TokenError> {
+    let Some(client_id) = form.client_id.clone() else {
+        return Err(Oauth2TokenError::invalid_request(
+            "missing required parameter: client_id",
+        ));
+    };
+
+    let exec = ExecutionContext::internal(&state);
+    let client = state
+        .provider
+        .get_oauth2_client_provider()
+        .get_by_client_id(&exec, &client_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "oauth2 client lookup failed");
+            Oauth2TokenError::internal("client lookup failed")
+        })?;
+    let Some(client) =
+        client.filter(|c| c.domain_id == domain_id && c.enabled && c.deleted_at.is_none())
+    else {
+        return Err(Oauth2TokenError::invalid_client(
+            "unknown or disabled client",
+        ));
+    };
+    if !client.grant_types.contains(&GrantType::DeviceCode) {
+        return Err(Oauth2TokenError::unauthorized_client(
+            "client is not authorized to use the device_code grant",
+        ));
+    }
+
+    let requested_scope: Vec<String> = form
+        .scope
+        .clone()
+        .unwrap_or_default()
+        .split_whitespace()
+        .map(str::to_string)
+        .collect();
+    const DISPLAY_SCOPES: &[&str] = &["openid", "profile", "email"];
+    for s in &requested_scope {
+        // Mirrors `/authorize`'s guard: full `OpenStackAccessTokenClaims`
+        // issuance requires resolving a project/domain authorization scope,
+        // which this phase's verification page does not collect.
+        if s == "openstack:api" {
+            return Err(Oauth2TokenError::invalid_scope(
+                "openstack:api is not yet supported on the device_code grant",
+            ));
+        }
+        if !DISPLAY_SCOPES.contains(&s.as_str()) || !client.allowed_scopes.iter().any(|a| a == s) {
+            return Err(Oauth2TokenError::invalid_scope(
+                "requested scope exceeds the client's allowed_scopes",
+            ));
+        }
+    }
+
+    let start = state
+        .provider
+        .get_oauth2_session_provider()
+        .start_device_authorization(
+            &state,
+            StartDeviceAuthorizationRequest {
+                domain_id: domain_id.clone(),
+                client_id: client.client_id.clone(),
+                scope: requested_scope,
+            },
+        )
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "oauth2 device authorization grant creation failed");
+            Oauth2TokenError::internal("device authorization failed")
+        })?;
+
+    let base = base_url(&state, &headers).await;
+    let verification_uri = format!("{base}/v4/oauth2/{domain_id}/device");
+    let verification_uri_complete = {
+        let mut url = url::Url::parse(&verification_uri).map_err(|e| {
+            tracing::warn!(error = %e, "oauth2 device verification_uri build failed");
+            Oauth2TokenError::internal("device authorization failed")
+        })?;
+        url.query_pairs_mut()
+            .append_pair("user_code", &start.user_code);
+        url.to_string()
+    };
+    let now = chrono::Utc::now().timestamp();
+
+    let response = DeviceAuthorizationResponse {
+        device_code: start.device_code,
+        user_code: start.user_code,
+        verification_uri,
+        verification_uri_complete,
+        expires_in: (start.expires_at - now).max(0),
+        interval: start.interval,
+    };
+    Ok((StatusCode::OK, axum::Json(response)).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core::oauth2_session::DeviceAuthorizationStart;
+    use openstack_keystone_core_types::oauth2_client as provider_types;
+
+    use super::super::openapi_router;
+    use crate::api::tests::get_mocked_state;
+    use crate::oauth2_client::MockOauth2ClientProvider;
+    use crate::oauth2_session::MockOauth2SessionProvider;
+    use crate::provider::Provider;
+
+    fn device_client() -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            client_id: "client-1".into(),
+            provider_id: "provider-1".into(),
+            domain_id: "domain-1".into(),
+            client_secret_hash: None,
+            redirect_uris: vec![],
+            token_endpoint_auth_method: "none".into(),
+            grant_types: vec![provider_types::GrantType::DeviceCode],
+            require_pkce: false,
+            allowed_scopes: vec!["openid".into()],
+            pre_authorized: false,
+            enabled: true,
+            claims_template: Default::default(),
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    fn request(body: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/domain-1/device_authorization")
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_missing_client_id_is_invalid_request() {
+        let provider = Provider::mocked_builder();
+        let state = get_mocked_state(provider, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(request("scope=openid"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_client_without_device_code_grant_is_unauthorized() {
+        let mut client = device_client();
+        client.grant_types = vec![provider_types::GrantType::ClientCredentials];
+        let mut client_mock = MockOauth2ClientProvider::default();
+        client_mock
+            .expect_get_by_client_id()
+            .returning(move |_, _| Ok(Some(client.clone())));
+        let provider = Provider::mocked_builder().mock_oauth2_client(client_mock);
+        let state = get_mocked_state(provider, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(request("client_id=client-1"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_openstack_api_scope_is_invalid_scope() {
+        let client = device_client();
+        let mut client_mock = MockOauth2ClientProvider::default();
+        client_mock
+            .expect_get_by_client_id()
+            .returning(move |_, _| Ok(Some(client.clone())));
+        let provider = Provider::mocked_builder().mock_oauth2_client(client_mock);
+        let state = get_mocked_state(provider, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(request("client_id=client-1&scope=openstack:api"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_success_returns_device_and_user_codes() {
+        let client = device_client();
+        let mut client_mock = MockOauth2ClientProvider::default();
+        client_mock
+            .expect_get_by_client_id()
+            .returning(move |_, _| Ok(Some(client.clone())));
+
+        let mut session_mock = MockOauth2SessionProvider::default();
+        session_mock
+            .expect_start_device_authorization()
+            .returning(|_, _| {
+                Ok(DeviceAuthorizationStart {
+                    device_code: "device-code-1".to_string(),
+                    user_code: "ABCD-EFGH".to_string(),
+                    expires_at: chrono::Utc::now().timestamp() + 600,
+                    interval: 5,
+                })
+            });
+
+        let provider = Provider::mocked_builder()
+            .mock_oauth2_client(client_mock)
+            .mock_oauth2_session(session_mock);
+        let state = get_mocked_state(provider, true, None).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(request("client_id=client-1&scope=openid"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["device_code"], "device-code-1");
+        assert_eq!(json["user_code"], "ABCD-EFGH");
+        assert!(
+            json["verification_uri_complete"]
+                .as_str()
+                .unwrap()
+                .contains("ABCD-EFGH")
+        );
+        assert_eq!(json["interval"], 5);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/html.rs
+++ b/crates/keystone/src/api/v4/oauth2/html.rs
@@ -1,0 +1,113 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Server-rendered HTML helpers shared by every human-facing OAuth2 flow
+//! (`authorize`'s `authorization_code` login/consent, `device`'s RFC 8628
+//! verification page): security headers, the login/consent/error
+//! templates, and CSRF token derivation (ADR 0026 §8).
+
+use askama::Template;
+use axum::{
+    http::{HeaderName, HeaderValue, StatusCode, header},
+    response::{Html, IntoResponse, Response},
+};
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+
+#[derive(Template)]
+#[template(path = "oauth2/login.html")]
+pub(super) struct LoginTemplate<'a> {
+    pub(super) client_id: &'a str,
+    pub(super) csrf_token: &'a str,
+    pub(super) error: Option<&'a str>,
+    pub(super) action: String,
+}
+
+#[derive(Template)]
+#[template(path = "oauth2/consent.html")]
+pub(super) struct ConsentTemplate<'a> {
+    pub(super) client_id: &'a str,
+    pub(super) scopes: &'a [String],
+    pub(super) csrf_token: &'a str,
+    pub(super) action: String,
+}
+
+#[derive(Template)]
+#[template(path = "oauth2/error.html")]
+pub(super) struct ErrorTemplate<'a> {
+    pub(super) message: &'a str,
+}
+
+/// ADR 0026 §8: defense-in-depth headers on every server-rendered OP
+/// response (HTML pages and the redirects between them alike).
+pub(super) fn security_headers(mut response: Response) -> Response {
+    let headers = response.headers_mut();
+    headers.insert(
+        HeaderName::from_static("content-security-policy"),
+        HeaderValue::from_static("default-src 'self'"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-frame-options"),
+        HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-xss-protection"),
+        HeaderValue::from_static("0"),
+    );
+    response
+}
+
+pub(super) fn error_page(status: StatusCode, message: &str) -> Response {
+    let body = ErrorTemplate { message }
+        .render()
+        .unwrap_or_else(|_| message.to_string());
+    security_headers((status, Html(body)).into_response())
+}
+
+pub(super) fn too_many_requests(retry_after: u64) -> Response {
+    let mut response = error_page(StatusCode::TOO_MANY_REQUESTS, "rate limit exceeded");
+    response
+        .headers_mut()
+        .insert(header::RETRY_AFTER, retry_after.into());
+    response
+}
+
+pub(super) fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// CSRF token derivation (ADR 0026 §8): `HMAC-SHA256(secret, parts.concat())`.
+/// `parts` are typically attacker-choosable (whoever initiates the flow may
+/// not be the victim), so the secret -- generated server-side and never
+/// sent to the client in cleartext -- is what an attacker crafting a link
+/// or code for a victim to use cannot supply.
+pub(super) fn compute_csrf_token(secret: &str, parts: &[&str]) -> Option<String> {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+    for part in parts {
+        mac.update(part.as_bytes());
+    }
+    Some(URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes()))
+}

--- a/crates/keystone/src/api/v4/oauth2/mod.rs
+++ b/crates/keystone/src/api/v4/oauth2/mod.rs
@@ -27,6 +27,9 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 mod authorize;
 mod clients;
 mod confirm_rotate_signing_key;
+mod device;
+mod device_authorization;
+mod html;
 mod jwks;
 mod jwks_revocation;
 mod rotate_signing_key;
@@ -53,6 +56,10 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
         .routes(routes!(authorize::authorize))
         .routes(routes!(authorize::authorize_login))
         .routes(routes!(authorize::authorize_consent))
+        .routes(routes!(device_authorization::device_authorization))
+        .routes(routes!(device::device, device::device_login_code))
+        .routes(routes!(device::device_login))
+        .routes(routes!(device::device_consent))
         .routes(routes!(rotate_signing_key::rotate_signing_key))
         .routes(routes!(
             confirm_rotate_signing_key::confirm_rotate_signing_key

--- a/crates/keystone/src/api/v4/oauth2/token.rs
+++ b/crates/keystone/src/api/v4/oauth2/token.rs
@@ -37,7 +37,9 @@ use sha2::{Digest, Sha256};
 
 use openstack_keystone_core::oauth2_client::hydrate_client_credentials_context;
 use openstack_keystone_core::oauth2_client::{build_access_token_claims, crypto, pkce};
-use openstack_keystone_core::oauth2_session::{IssueRefreshTokenRequest, RefreshTokenRedemption};
+use openstack_keystone_core::oauth2_session::{
+    DevicePollOutcome, IssueRefreshTokenRequest, RefreshTokenRedemption,
+};
 use openstack_keystone_core_types::oauth2_client::{
     GrantType, IdTokenClaims, OidcAccessTokenClaims,
 };
@@ -93,6 +95,10 @@ pub(super) struct TokenForm {
     #[serde(default)]
     #[allow(dead_code)]
     requested_token_type: Option<String>,
+    /// RFC 8628 `device_code` grant only (§3.4): the value returned by
+    /// `/device_authorization`.
+    #[serde(default)]
+    device_code: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -131,15 +137,15 @@ impl Oauth2TokenError {
         }
     }
 
-    fn invalid_request(description: impl Into<String>) -> Self {
+    pub(super) fn invalid_request(description: impl Into<String>) -> Self {
         Self::new(StatusCode::BAD_REQUEST, "invalid_request", description)
     }
 
-    fn invalid_client(description: impl Into<String>) -> Self {
+    pub(super) fn invalid_client(description: impl Into<String>) -> Self {
         Self::new(StatusCode::UNAUTHORIZED, "invalid_client", description)
     }
 
-    fn unauthorized_client(description: impl Into<String>) -> Self {
+    pub(super) fn unauthorized_client(description: impl Into<String>) -> Self {
         Self::new(StatusCode::BAD_REQUEST, "unauthorized_client", description)
     }
 
@@ -151,12 +157,50 @@ impl Oauth2TokenError {
         )
     }
 
-    fn invalid_scope(description: impl Into<String>) -> Self {
+    pub(super) fn invalid_scope(description: impl Into<String>) -> Self {
         Self::new(StatusCode::BAD_REQUEST, "invalid_scope", description)
     }
 
     fn invalid_grant(description: impl Into<String>) -> Self {
         Self::new(StatusCode::BAD_REQUEST, "invalid_grant", description)
+    }
+
+    /// RFC 8628 §3.5: the device grant is still awaiting the user to
+    /// complete the verification page.
+    fn authorization_pending() -> Self {
+        Self::new(
+            StatusCode::BAD_REQUEST,
+            "authorization_pending",
+            "the device grant is still pending user verification",
+        )
+    }
+
+    /// RFC 8628 §3.5: the device polled more frequently than `interval`
+    /// allows; it must back off.
+    fn slow_down() -> Self {
+        Self::new(
+            StatusCode::BAD_REQUEST,
+            "slow_down",
+            "polling too frequently; increase the interval",
+        )
+    }
+
+    /// RFC 8628 §3.5: the user denied the device grant.
+    fn access_denied() -> Self {
+        Self::new(
+            StatusCode::BAD_REQUEST,
+            "access_denied",
+            "the user denied the device grant",
+        )
+    }
+
+    /// RFC 8628 §3.5: the `device_code` has expired.
+    fn expired_token() -> Self {
+        Self::new(
+            StatusCode::BAD_REQUEST,
+            "expired_token",
+            "the device_code has expired; restart the device authorization flow",
+        )
     }
 
     fn too_many_requests(retry_after: u64) -> Self {
@@ -172,7 +216,7 @@ impl Oauth2TokenError {
         }
     }
 
-    fn internal(description: impl Into<String>) -> Self {
+    pub(super) fn internal(description: impl Into<String>) -> Self {
         Self::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             "invalid_request",
@@ -284,6 +328,17 @@ pub(super) async fn token(
         }
         "urn:ietf:params:oauth:grant-type:token-exchange" => {
             return handle_token_exchange_grant(
+                &state,
+                &domain_id,
+                &headers,
+                &form,
+                &oauth2_cfg,
+                &correlation_id.0,
+            )
+            .await;
+        }
+        "urn:ietf:params:oauth:grant-type:device_code" => {
+            return handle_device_code_grant(
                 &state,
                 &domain_id,
                 &headers,
@@ -998,6 +1053,158 @@ async fn handle_token_exchange_grant(
         scope: "openstack:api".to_string(),
         id_token: None,
         refresh_token: None,
+    };
+    Ok((StatusCode::OK, Json(response)).into_response())
+}
+
+/// RFC 8628 Device Authorization Grant polling arm (§3.4, §3.5, ADR 0026
+/// §7.C). `client_id` is accepted but not authenticated against a
+/// `client_secret` -- device flow clients are overwhelmingly public/native
+/// applications, matching `/device_authorization`'s own posture. The
+/// `client_id` mismatch check happens inside `poll_device_code_grant`
+/// (same bug class as the cross-domain Token Exchange forgery this ADR's
+/// implementation previously fixed: a grant must only ever be redeemable by
+/// the client it was issued to).
+async fn handle_device_code_grant(
+    state: &ServiceState,
+    domain_id: &str,
+    headers: &HeaderMap,
+    form: &TokenForm,
+    oauth2_cfg: &openstack_keystone_config::Oauth2Provider,
+    correlation_id: &str,
+) -> Result<Response, Oauth2TokenError> {
+    let Some((client_id, _)) = client_credentials_from_request(headers, form) else {
+        return Err(Oauth2TokenError::invalid_request(
+            "missing required parameter: client_id",
+        ));
+    };
+    let Some(device_code) = form.device_code.clone() else {
+        return Err(Oauth2TokenError::invalid_request(
+            "missing required parameter: device_code",
+        ));
+    };
+
+    let outcome = state
+        .provider
+        .get_oauth2_session_provider()
+        .poll_device_code_grant(state, &device_code, &client_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "oauth2 device code grant poll failed");
+            Oauth2TokenError::internal("token issuance failed")
+        })?;
+
+    let record = match outcome {
+        DevicePollOutcome::InvalidGrant => {
+            return Err(Oauth2TokenError::invalid_grant(
+                "device_code is invalid or does not belong to this client_id",
+            ));
+        }
+        DevicePollOutcome::Expired => return Err(Oauth2TokenError::expired_token()),
+        DevicePollOutcome::SlowDown => return Err(Oauth2TokenError::slow_down()),
+        DevicePollOutcome::Pending => return Err(Oauth2TokenError::authorization_pending()),
+        DevicePollOutcome::Denied => return Err(Oauth2TokenError::access_denied()),
+        DevicePollOutcome::Authorized(record) => record,
+    };
+
+    let (Some(user_id), Some(auth_time)) = (record.user_id.clone(), record.auth_time) else {
+        tracing::warn!("oauth2 device code grant authorized without user_id/auth_time");
+        return Err(Oauth2TokenError::internal("token issuance failed"));
+    };
+
+    let exec = openstack_keystone_core::auth::ExecutionContext::internal(state);
+    let client = state
+        .provider
+        .get_oauth2_client_provider()
+        .get_by_client_id(&exec, &client_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "oauth2 client lookup failed");
+            Oauth2TokenError::internal("token issuance failed")
+        })?;
+    let Some(client) = client else {
+        return Err(Oauth2TokenError::invalid_client("unknown client"));
+    };
+
+    let base = base_url(state, headers).await;
+    let issuer = format!("{base}/v4/oauth2/{domain_id}");
+    let now = chrono::Utc::now().timestamp();
+    let access_lifetime = i64::from(oauth2_cfg.access_token_lifetime_minutes) * 60;
+    let id_lifetime = i64::from(oauth2_cfg.id_token_lifetime_minutes) * 60;
+
+    let access_claims = OidcAccessTokenClaims {
+        iss: issuer.clone(),
+        sub: user_id.clone(),
+        aud: client_id.clone(),
+        exp: now + access_lifetime,
+        iat: now,
+        nbf: now,
+        jti: uuid::Uuid::new_v4().to_string(),
+        scope: record.scope.join(" "),
+        token_use: "access".to_string(),
+    };
+    let access_token = sign_jwt(state, domain_id, &access_claims).await?;
+
+    let id_token = if record.scope.iter().any(|s| s == "openid") {
+        let id_claims = IdTokenClaims {
+            iss: issuer,
+            sub: user_id.clone(),
+            aud: client_id.clone(),
+            exp: now + id_lifetime,
+            iat: now,
+            nbf: now,
+            auth_time,
+            nonce: record.nonce.clone(),
+            amr: record.amr.clone(),
+            at_hash: Some(compute_at_hash(&access_token)),
+            token_use: "id".to_string(),
+            extra_claims: Default::default(),
+        };
+        Some(sign_jwt(state, domain_id, &id_claims).await?)
+    } else {
+        None
+    };
+
+    let refresh_token = if client.grant_types.contains(&GrantType::RefreshToken) {
+        let (_, bearer) = state
+            .provider
+            .get_oauth2_session_provider()
+            .issue_refresh_token(
+                state,
+                IssueRefreshTokenRequest {
+                    domain_id: domain_id.to_string(),
+                    client_id: client.client_id.clone(),
+                    user_id,
+                    scope: record.scope.clone(),
+                },
+            )
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, "oauth2 refresh token issuance failed");
+                Oauth2TokenError::internal("token issuance failed")
+            })?;
+        Some(bearer)
+    } else {
+        None
+    };
+
+    emit_oauth2_session_event(
+        &state.audit_dispatcher,
+        correlation_id,
+        "authenticate",
+        build_initiator_unknown(),
+        &client_id,
+        "success",
+        None,
+    );
+
+    let response = TokenResponse {
+        access_token,
+        token_type: "Bearer",
+        expires_in: access_lifetime,
+        scope: record.scope.join(" "),
+        id_token,
+        refresh_token,
     };
     Ok((StatusCode::OK, Json(response)).into_response())
 }

--- a/crates/keystone/templates/oauth2/device_entry.html
+++ b/crates/keystone/templates/oauth2/device_entry.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Enter code</title>
+</head>
+<body>
+<h1>Enter code</h1>
+<p>Enter the code displayed on your device.</p>
+{% if let Some(msg) = error %}
+<p class="error">{{ msg }}</p>
+{% endif %}
+<form method="post" action="{{ action }}">
+<label>Code <input type="text" name="user_code" value="{{ prefill }}" autocomplete="off" required></label>
+<button type="submit">Continue</button>
+</form>
+</body>
+</html>

--- a/crates/keystone/templates/oauth2/device_result.html
+++ b/crates/keystone/templates/oauth2/device_result.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{% if granted %}Device connected{% else %}Request denied{% endif %}</title>
+</head>
+<body>
+{% if granted %}
+<h1>Device connected</h1>
+<p>You have granted <strong>{{ client_id }}</strong> access. You may now close this window.</p>
+{% else %}
+<h1>Request denied</h1>
+<p>You denied <strong>{{ client_id }}</strong> access. You may now close this window.</p>
+{% endif %}
+</body>
+</html>

--- a/crates/oauth2-session-driver-raft/src/lib.rs
+++ b/crates/oauth2-session-driver-raft/src/lib.rs
@@ -58,6 +58,14 @@ fn family_idx_prefix(family_id: &str) -> String {
     format!("oauth2:refresh_family_idx:v1:{family_id}:")
 }
 
+fn device_code_key(device_code: &str) -> String {
+    format!("oauth2:device_code:v1:{device_code}")
+}
+
+fn device_user_code_key(user_code: &str) -> String {
+    format!("oauth2:device_user_code:v1:{user_code}")
+}
+
 async fn put<T: Serialize>(
     storage: &dyn StorageApi,
     key: String,
@@ -342,6 +350,139 @@ impl RaftOauth2SessionBackend {
         }
         Ok(())
     }
+
+    async fn create_device_code_grant_impl(
+        &self,
+        storage: &dyn StorageApi,
+        data: DeviceCodeGrantCreate,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError> {
+        let record = DeviceCodeGrant {
+            device_code: data.device_code.clone(),
+            user_code: data.user_code.clone(),
+            domain_id: data.domain_id,
+            client_id: data.client_id,
+            scope: data.scope,
+            status: DeviceGrantStatus::Pending,
+            user_id: None,
+            auth_time: None,
+            amr: Vec::new(),
+            nonce: None,
+            server_side_session_secret: data.server_side_session_secret,
+            last_polled_at: None,
+            created_at: data.created_at,
+            expires_at: data.expires_at,
+        };
+        put(storage, device_code_key(&data.device_code), &record)
+            .await
+            .map_err(store_err)?;
+        put(
+            storage,
+            device_user_code_key(&data.user_code),
+            &data.device_code,
+        )
+        .await
+        .map_err(store_err)?;
+        Ok(record)
+    }
+
+    async fn get_device_code_grant_impl(
+        &self,
+        storage: &dyn StorageApi,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError> {
+        get(storage, &device_code_key(device_code))
+            .await
+            .map_err(store_err)
+    }
+
+    async fn get_device_code_grant_by_user_code_impl(
+        &self,
+        storage: &dyn StorageApi,
+        user_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError> {
+        let Some(device_code) = get::<String>(storage, &device_user_code_key(user_code))
+            .await
+            .map_err(store_err)?
+        else {
+            return Ok(None);
+        };
+        self.get_device_code_grant_impl(storage, &device_code).await
+    }
+
+    async fn mark_device_code_grant_authenticated_impl(
+        &self,
+        storage: &dyn StorageApi,
+        device_code: &str,
+        user_id: &str,
+        auth_time: i64,
+        amr: Vec<String>,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError> {
+        let mut record: DeviceCodeGrant = get(storage, &device_code_key(device_code))
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| Oauth2SessionProviderError::NotFound(device_code.to_string()))?;
+        record.user_id = Some(user_id.to_string());
+        record.auth_time = Some(auth_time);
+        record.amr = amr;
+        put(storage, device_code_key(device_code), &record)
+            .await
+            .map_err(store_err)?;
+        Ok(record)
+    }
+
+    async fn mark_device_code_grant_decision_impl(
+        &self,
+        storage: &dyn StorageApi,
+        device_code: &str,
+        status: DeviceGrantStatus,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError> {
+        let mut record: DeviceCodeGrant = get(storage, &device_code_key(device_code))
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| Oauth2SessionProviderError::NotFound(device_code.to_string()))?;
+        record.status = status;
+        put(storage, device_code_key(device_code), &record)
+            .await
+            .map_err(store_err)?;
+        Ok(record)
+    }
+
+    async fn mark_device_code_grant_polled_impl(
+        &self,
+        storage: &dyn StorageApi,
+        device_code: &str,
+        polled_at: i64,
+    ) -> Result<(), Oauth2SessionProviderError> {
+        let mut record: DeviceCodeGrant = get(storage, &device_code_key(device_code))
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| Oauth2SessionProviderError::NotFound(device_code.to_string()))?;
+        record.last_polled_at = Some(polled_at);
+        put(storage, device_code_key(device_code), &record)
+            .await
+            .map_err(store_err)
+    }
+
+    async fn take_device_code_grant_impl(
+        &self,
+        storage: &dyn StorageApi,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError> {
+        let existing: Option<DeviceCodeGrant> = get(storage, &device_code_key(device_code))
+            .await
+            .map_err(store_err)?;
+        if let Some(record) = &existing {
+            storage
+                .remove(device_code_key(device_code), None)
+                .await
+                .map_err(store_err)?;
+            storage
+                .remove(device_user_code_key(&record.user_code), None)
+                .await
+                .map_err(store_err)?;
+        }
+        Ok(existing)
+    }
 }
 
 #[async_trait]
@@ -460,6 +601,80 @@ impl Oauth2SessionBackend for RaftOauth2SessionBackend {
         family_id: &str,
     ) -> Result<(), Oauth2SessionProviderError> {
         self.revoke_refresh_token_family_impl(self.storage(state)?, family_id)
+            .await
+    }
+
+    async fn create_device_code_grant(
+        &self,
+        state: &ServiceState,
+        data: DeviceCodeGrantCreate,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError> {
+        self.create_device_code_grant_impl(self.storage(state)?, data)
+            .await
+    }
+
+    async fn get_device_code_grant(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError> {
+        self.get_device_code_grant_impl(self.storage(state)?, device_code)
+            .await
+    }
+
+    async fn get_device_code_grant_by_user_code(
+        &self,
+        state: &ServiceState,
+        user_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError> {
+        self.get_device_code_grant_by_user_code_impl(self.storage(state)?, user_code)
+            .await
+    }
+
+    async fn mark_device_code_grant_authenticated(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        user_id: &str,
+        auth_time: i64,
+        amr: Vec<String>,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError> {
+        self.mark_device_code_grant_authenticated_impl(
+            self.storage(state)?,
+            device_code,
+            user_id,
+            auth_time,
+            amr,
+        )
+        .await
+    }
+
+    async fn mark_device_code_grant_decision(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        status: DeviceGrantStatus,
+    ) -> Result<DeviceCodeGrant, Oauth2SessionProviderError> {
+        self.mark_device_code_grant_decision_impl(self.storage(state)?, device_code, status)
+            .await
+    }
+
+    async fn mark_device_code_grant_polled(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+        polled_at: i64,
+    ) -> Result<(), Oauth2SessionProviderError> {
+        self.mark_device_code_grant_polled_impl(self.storage(state)?, device_code, polled_at)
+            .await
+    }
+
+    async fn take_device_code_grant(
+        &self,
+        state: &ServiceState,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeGrant>, Oauth2SessionProviderError> {
+        self.take_device_code_grant_impl(self.storage(state)?, device_code)
             .await
     }
 }
@@ -686,6 +901,121 @@ mod tests {
                 .await
                 .unwrap()
                 .is_some()
+        );
+    }
+
+    fn sample_device_grant_create() -> DeviceCodeGrantCreate {
+        DeviceCodeGrantCreate {
+            device_code: "device-code-1".to_string(),
+            user_code: "ABCD-EFGH".to_string(),
+            domain_id: "domain-1".to_string(),
+            client_id: "client-1".to_string(),
+            scope: vec!["openid".to_string()],
+            server_side_session_secret: "secret".to_string(),
+            created_at: 1000,
+            expires_at: 1600,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_device_code_grant_create_and_lookup_by_both_codes() {
+        let backend = RaftOauth2SessionBackend::default();
+        let storage = MockStorage::default();
+
+        let created = backend
+            .create_device_code_grant_impl(&storage, sample_device_grant_create())
+            .await
+            .unwrap();
+        assert_eq!(created.status, DeviceGrantStatus::Pending);
+
+        let by_device_code = backend
+            .get_device_code_grant_impl(&storage, "device-code-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(by_device_code, created);
+
+        let by_user_code = backend
+            .get_device_code_grant_by_user_code_impl(&storage, "ABCD-EFGH")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(by_user_code, created);
+    }
+
+    #[tokio::test]
+    async fn test_device_code_grant_authenticate_and_decide() {
+        let backend = RaftOauth2SessionBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .create_device_code_grant_impl(&storage, sample_device_grant_create())
+            .await
+            .unwrap();
+
+        let authenticated = backend
+            .mark_device_code_grant_authenticated_impl(
+                &storage,
+                "device-code-1",
+                "user-1",
+                1500,
+                vec!["pwd".to_string()],
+            )
+            .await
+            .unwrap();
+        assert_eq!(authenticated.user_id.as_deref(), Some("user-1"));
+
+        let decided = backend
+            .mark_device_code_grant_decision_impl(
+                &storage,
+                "device-code-1",
+                DeviceGrantStatus::Authorized,
+            )
+            .await
+            .unwrap();
+        assert_eq!(decided.status, DeviceGrantStatus::Authorized);
+    }
+
+    #[tokio::test]
+    async fn test_device_code_grant_poll_stamp_and_single_use_take() {
+        let backend = RaftOauth2SessionBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .create_device_code_grant_impl(&storage, sample_device_grant_create())
+            .await
+            .unwrap();
+
+        backend
+            .mark_device_code_grant_polled_impl(&storage, "device-code-1", 1100)
+            .await
+            .unwrap();
+        let polled = backend
+            .get_device_code_grant_impl(&storage, "device-code-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(polled.last_polled_at, Some(1100));
+
+        let taken = backend
+            .take_device_code_grant_impl(&storage, "device-code-1")
+            .await
+            .unwrap();
+        assert!(taken.is_some());
+
+        // Single-use: the primary record and the user_code index are both
+        // gone after the first take.
+        assert!(
+            backend
+                .get_device_code_grant_impl(&storage, "device-code-1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            backend
+                .get_device_code_grant_by_user_code_impl(&storage, "ABCD-EFGH")
+                .await
+                .unwrap()
+                .is_none()
         );
     }
 }


### PR DESCRIPTION
Adds the third post-Phase-6 follow-up gap: the device_code grant
(GrantType::DeviceCode already existed in both API-types enums, declared
ahead of implementation -- this fills that gap).

- New oauth2:device_code:v1:* / oauth2:device_user_code:v1:* Raft
  keyspace (the latter a secondary index, mirroring the existing
  refresh_family_idx pattern) and a DeviceCodeGrant record type sibling
  to AuthorizationCode/RefreshToken.
- POST /device_authorization mints a 256-bit device_code and an
  8-char unambiguous-alphabet user_code (excludes vowels and
  0/O/1/I to avoid confusable characters and accidental words).
- GET/POST /device, /device/login, /device/consent: a verification page
  structurally parallel to authorize.rs's login/consent steps, but with
  no redirect_uri/PKCE and no redirect back to a relying party -- it
  terminates in a static result page, since the polling device (not this
  browser) receives the eventual token. The shared HTML/CSRF/template
  helpers (security headers, login/consent/error templates, HMAC-based
  CSRF derivation) are extracted into a new html.rs module and reused by
  both authorize.rs and device.rs rather than duplicated.
- New /token grant arm polls the grant, enforces that the polling
  client_id matches the one device_authorization issued to (same bug
  class as the cross-domain Token Exchange forgery fixed earlier this
  branch), and maps Pending/Denied/Expired/too-frequent-poll to the RFC
  8628 §3.5 authorization_pending/access_denied/expired_token/slow_down
  error codes. The minimum poll interval is enforced via the grant's own
  last_polled_at timestamp rather than a separate rate-limiter bucket --
  the existing global per-IP limiter already covers baseline abuse
  protection on the new endpoints.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
