### PR TITLE
fix(oauth2): Rate-limit device flow, fix grant-type check order

### DIFF
--- a/crates/keystone/src/api/v4/oauth2/device.rs
+++ b/crates/keystone/src/api/v4/oauth2/device.rs
@@ -39,7 +39,10 @@ use openstack_keystone_core_types::identity::{
 };
 use openstack_keystone_core_types::oauth2_session::DeviceCodeGrant;
 
-use super::html::{ConsentTemplate, LoginTemplate, error_page, security_headers};
+use super::html::{
+    ConsentTemplate, LoginTemplate, error_page, security_headers, too_many_requests,
+};
+use crate::api::common::PeerAddr;
 use crate::audit::{CorrelationId, build_initiator_unknown, emit_oauth2_session_event};
 use crate::keystone::ServiceState;
 
@@ -244,9 +247,20 @@ pub(super) async fn device_login_code(
     Path(domain_id): Path<String>,
     State(state): State<ServiceState>,
     headers: HeaderMap,
+    PeerAddr(peer_addr): PeerAddr,
     jar: CookieJar,
     Form(form): Form<DeviceCodeForm>,
 ) -> Result<Response, std::convert::Infallible> {
+    // §7.B-equivalent pre-lookup throttle (mirrors `authorize.rs`'s
+    // `/authorize` and `/authorize/login`): the `user_code` keyspace alone
+    // is not a substitute for rate limiting a guess-and-submit endpoint.
+    if let Err(retry_after) = state
+        .rate_limiters
+        .check_ip(&headers, peer_addr.map(|a| a.ip()))
+    {
+        return Ok(too_many_requests(retry_after.as_secs()));
+    }
+
     // The lookup itself is a single keyed storage read (not a linear scan
     // over every live code), so it does not carry the classic
     // string-comparison timing side channel a naive brute-force defense
@@ -303,10 +317,24 @@ pub(super) async fn device_login_code(
 pub(super) async fn device_login(
     Path(domain_id): Path<String>,
     State(state): State<ServiceState>,
+    headers: HeaderMap,
+    PeerAddr(peer_addr): PeerAddr,
     correlation_id: CorrelationId,
     jar: CookieJar,
     Form(form): Form<DeviceLoginForm>,
 ) -> Result<Response, std::convert::Infallible> {
+    // §7.B "pre-hash enforcement" (mirrors `authorize_login`): global per-IP
+    // limiter before any password hashing work. The per-user throttle inside
+    // `authenticate_by_password` (ADR 0010) only engages after an account is
+    // known to exist, so it alone does not stop a single IP from spraying
+    // many different usernames here.
+    if let Err(retry_after) = state
+        .rate_limiters
+        .check_ip(&headers, peer_addr.map(|a| a.ip()))
+    {
+        return Ok(too_many_requests(retry_after.as_secs()));
+    }
+
     let Some(device_code) = jar.get(DEVICE_COOKIE_NAME).map(|c| c.value().to_string()) else {
         return Ok(error_page(
             StatusCode::BAD_REQUEST,
@@ -551,5 +579,125 @@ async fn finish_decision(
             tracing::warn!(error = %e, "oauth2 device code grant decision update failed");
             error_page(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        extract::ConnectInfo,
+        http::{Request, StatusCode},
+    };
+    use sea_orm::DatabaseConnection;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_audit::AuditDispatcher;
+    use openstack_keystone_config::{Config, ConfigManager};
+    use openstack_keystone_core::keystone::Service;
+    use openstack_keystone_core::policy::MockPolicy;
+
+    use super::super::openapi_router;
+    use crate::oauth2_session::MockOauth2SessionProvider;
+    use crate::provider::Provider;
+
+    fn post_form(uri: &str, body: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .method("POST")
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    async fn rate_limited_state(provider: crate::provider::ProviderBuilder) -> Arc<Service> {
+        let config = Config {
+            rate_limit_global_ip: openstack_keystone_config::RateLimitSection {
+                enabled: true,
+                burst_size: 1,
+                replenish_rate_per_second: 1,
+            },
+            ..Config::default()
+        };
+        Arc::new(
+            Service::new(
+                ConfigManager::not_watched(config),
+                DatabaseConnection::Disconnected,
+                provider.build().unwrap(),
+                Arc::new(MockPolicy::default()),
+                AuditDispatcher::noop(),
+                None,
+            )
+            .await
+            .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_device_submit_code_rate_limited_by_ip_before_lookup() {
+        let mut session_mock = MockOauth2SessionProvider::default();
+        session_mock
+            .expect_get_device_code_grant_by_user_code()
+            .returning(|_, _| Ok(None));
+        let provider = Provider::mocked_builder().mock_oauth2_session(session_mock);
+        let state = rate_limited_state(provider).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let client_addr: SocketAddr = "203.0.113.9:1234".parse().unwrap();
+
+        let mut req1 = post_form("/domain-1/device", "user_code=AAAA-AAAA");
+        req1.extensions_mut().insert(ConnectInfo(client_addr));
+        // First request consumes the single burst token and reaches the
+        // (mocked) lookup, which reports "not found" -- rendered as 200 OK
+        // with an inline error, not a distinct status.
+        assert_eq!(
+            api.as_service().oneshot(req1).await.unwrap().status(),
+            StatusCode::OK
+        );
+
+        let mut req2 = post_form("/domain-1/device", "user_code=BBBB-BBBB");
+        req2.extensions_mut().insert(ConnectInfo(client_addr));
+        // Burst exhausted: rejected by the IP limiter before the lookup runs
+        // for a second guess, regardless of which code is guessed next.
+        assert_eq!(
+            api.as_service().oneshot(req2).await.unwrap().status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+
+    #[tokio::test]
+    async fn test_device_login_rate_limited_by_ip_before_password_check() {
+        let provider = Provider::mocked_builder();
+        let state = rate_limited_state(provider).await;
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let client_addr: SocketAddr = "203.0.113.9:1234".parse().unwrap();
+        let form = "csrf_token=x&username=alice&password=guess";
+
+        let mut req1 = post_form("/domain-1/device/login", form);
+        req1.extensions_mut().insert(ConnectInfo(client_addr));
+        // First request consumes the single burst token and reaches the
+        // no-device-cookie check (no password hashing was ever attempted).
+        assert_eq!(
+            api.as_service().oneshot(req1).await.unwrap().status(),
+            StatusCode::BAD_REQUEST
+        );
+
+        let mut req2 = post_form("/domain-1/device/login", form);
+        req2.extensions_mut().insert(ConnectInfo(client_addr));
+        // Burst exhausted: rejected by the IP limiter before any password
+        // check, regardless of which username is guessed next.
+        assert_eq!(
+            api.as_service().oneshot(req2).await.unwrap().status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
     }
 }

--- a/crates/keystone/src/api/v4/oauth2/device_authorization.rs
+++ b/crates/keystone/src/api/v4/oauth2/device_authorization.rs
@@ -34,6 +34,7 @@ use openstack_keystone_core_types::oauth2_client::GrantType;
 
 use super::token::Oauth2TokenError;
 use super::well_known::base_url;
+use crate::api::common::PeerAddr;
 use crate::keystone::ServiceState;
 
 #[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
@@ -76,8 +77,21 @@ pub(super) async fn device_authorization(
     Path(domain_id): Path<String>,
     State(state): State<ServiceState>,
     headers: HeaderMap,
+    PeerAddr(peer_addr): PeerAddr,
     Form(form): Form<DeviceAuthorizationForm>,
 ) -> Result<Response, Oauth2TokenError> {
+    // Mirrors `/token`'s and `/authorize`'s pre-lookup per-IP throttle: this
+    // endpoint does a client lookup and mints session state on every call,
+    // and -- like `/authorize` -- is reachable with no client_secret.
+    if let Err(retry_after) = state
+        .rate_limiters
+        .check_ip(&headers, peer_addr.map(|a| a.ip()))
+    {
+        return Err(Oauth2TokenError::too_many_requests(
+            retry_after.as_secs().max(1),
+        ));
+    }
+
     let Some(client_id) = form.client_id.clone() else {
         return Err(Oauth2TokenError::invalid_request(
             "missing required parameter: client_id",
@@ -174,15 +188,24 @@ pub(super) async fn device_authorization(
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
     use axum::{
         body::Body,
+        extract::ConnectInfo,
         http::{Request, StatusCode},
     };
     use http_body_util::BodyExt;
+    use sea_orm::DatabaseConnection;
     use tower::ServiceExt;
     use tower_http::trace::TraceLayer;
 
+    use openstack_keystone_audit::AuditDispatcher;
+    use openstack_keystone_config::{Config, ConfigManager};
+    use openstack_keystone_core::keystone::Service;
     use openstack_keystone_core::oauth2_session::DeviceAuthorizationStart;
+    use openstack_keystone_core::policy::MockPolicy;
     use openstack_keystone_core_types::oauth2_client as provider_types;
 
     use super::super::openapi_router;
@@ -324,5 +347,60 @@ mod tests {
                 .contains("ABCD-EFGH")
         );
         assert_eq!(json["interval"], 5);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_returns_429_before_client_lookup() {
+        let config = Config {
+            rate_limit_global_ip: openstack_keystone_config::RateLimitSection {
+                enabled: true,
+                burst_size: 1,
+                replenish_rate_per_second: 1,
+            },
+            ..Config::default()
+        };
+
+        let mut client_mock = MockOauth2ClientProvider::default();
+        client_mock
+            .expect_get_by_client_id()
+            .returning(|_, _| Ok(None));
+        let provider = Provider::mocked_builder()
+            .mock_oauth2_client(client_mock)
+            .build()
+            .unwrap();
+
+        let state = Arc::new(
+            Service::new(
+                ConfigManager::not_watched(config),
+                DatabaseConnection::Disconnected,
+                provider,
+                Arc::new(MockPolicy::default()),
+                AuditDispatcher::noop(),
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+
+        let client_addr: SocketAddr = "203.0.113.9:1234".parse().unwrap();
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let mut req1 = request("client_id=client-1");
+        req1.extensions_mut().insert(ConnectInfo(client_addr));
+        // First request consumes the single burst token and reaches the
+        // (mocked) client lookup, which reports "not found".
+        assert_eq!(
+            api.as_service().oneshot(req1).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+
+        let mut req2 = request("client_id=client-1");
+        req2.extensions_mut().insert(ConnectInfo(client_addr));
+        assert_eq!(
+            api.as_service().oneshot(req2).await.unwrap().status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
     }
 }

--- a/crates/keystone/src/api/v4/oauth2/token.rs
+++ b/crates/keystone/src/api/v4/oauth2/token.rs
@@ -203,7 +203,7 @@ impl Oauth2TokenError {
         )
     }
 
-    fn too_many_requests(retry_after: u64) -> Self {
+    pub(super) fn too_many_requests(retry_after: u64) -> Self {
         Self {
             status: StatusCode::TOO_MANY_REQUESTS,
             retry_after: Some(retry_after),
@@ -406,13 +406,6 @@ pub(super) async fn token(
         ));
     }
 
-    if !client.grant_types.contains(&GrantType::ClientCredentials) {
-        let _ = crypto::generate_dummy_hash(&oauth2_cfg).await;
-        return Err(Oauth2TokenError::unauthorized_client(
-            "client is not authorized to use the client_credentials grant",
-        ));
-    }
-
     // RFC 6749 §4.4 requires a confidential client for client_credentials --
     // a public client has no secret to verify at all.
     let Some(secret_hash) = client.client_secret_hash.as_deref() else {
@@ -444,6 +437,16 @@ pub(super) async fn token(
         );
         return Err(Oauth2TokenError::invalid_client(
             "client authentication failed",
+        ));
+    }
+
+    // Enumeration defense (V8a): checked only after a verified secret, so an
+    // existing-but-unauthorized client can't be distinguished from an
+    // unknown/wrong-secret one by response shape alone -- both require
+    // proving possession of a valid secret first.
+    if !client.grant_types.contains(&GrantType::ClientCredentials) {
+        return Err(Oauth2TokenError::unauthorized_client(
+            "client is not authorized to use the client_credentials grant",
         ));
     }
 

--- a/doc/src/oauth2/admin.md
+++ b/doc/src/oauth2/admin.md
@@ -217,9 +217,10 @@ amendments for the design work required to close them:
 
 ## Troubleshooting
 
-| Symptom                                                              | Likely cause                                                                                                     |
-| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `/jwks` or `/.well-known/openid-configuration` returns 404           | Domain has no signing key — run `keystone-manage oauth2 ensure-signing-key --domain <id>`                        |
-| `429` on `/token`                                                    | Rate limit hit — see `token_rate_limit_*` config                                                                 |
-| `confirm-rotate-signing-key` fails with "rotation not found/expired" | The 15-minute confirmation window elapsed and the rotation auto-aborted; re-run `rotate-signing-key --emergency` |
-| Downstream service rejects all OP tokens after Keystone/network blip | Expected fail-closed behavior — check JWKS/revocation endpoint reachability from the service                     |
+| Symptom                                                                       | Likely cause                                                                                                     |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `/jwks` or `/.well-known/openid-configuration` returns 404                    | Domain has no signing key — run `keystone-manage oauth2 ensure-signing-key --domain <id>`                        |
+| `429` on `/token`                                                             | Rate limit hit — see `token_rate_limit_*` config                                                                 |
+| `429` on `/authorize`, `/device`, `/device/login`, or `/device_authorization` | Global per-IP limiter hit — see `[rate_limit_global_ip]`                                                         |
+| `confirm-rotate-signing-key` fails with "rotation not found/expired"          | The 15-minute confirmation window elapsed and the rotation auto-aborted; re-run `rotate-signing-key --emergency` |
+| Downstream service rejects all OP tokens after Keystone/network blip          | Expected fail-closed behavior — check JWKS/revocation endpoint reachability from the service                     |

--- a/doc/src/security-architecture-review.md
+++ b/doc/src/security-architecture-review.md
@@ -384,6 +384,56 @@ rotation. The controls are specified; the risk is drift during implementation.
 - _Pentest:_ standard OAuth2 provider test suite (redirect handling, PKCE
   downgrade, mix-up, token substitution).
 
+### V8a — OAuth2 client enumeration, timing side-channels, and credential-probing (fixed 2026-07-16; P1 device-flow rate-limit gap closed)
+
+**Attack.** Prompted by public research on "OAuth client ID spoofing"
+(Proofpoint, July 2026: attackers validate stolen Entra ID credentials at scale
+by presenting spoofed/arbitrary `client_id`s to a token endpoint that
+distinguishes valid from invalid client IDs, checking passwords without a
+successful sign-in ever being logged against a real, registered application —
+and without needing that application to actually exist). The generalizable
+attack classes are: (a) distinguish "unknown client_id" from "wrong secret" by
+response content, status, or timing; (b) probe usernames/passwords through an
+endpoint that doesn't require a real, pre-registered relying party; (c)
+brute-force short human-facing codes (device `user_code`) with no throttle.
+
+**Current state — verified by direct code read, 2026-07-16.**
+
+| Sub-vector                                                                                                                                    | Verdict                                         | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client_credentials`/`authorization_code`/`refresh_token`/token-exchange: unknown client_id vs. wrong secret vs. disabled client, by response | Mitigated                                       | `token.rs:376-448` (`client_credentials`), `:580-638` (`authenticate_client`, shared by the other three grants) — `get_by_client_id` runs unconditionally; every rejection branch (unknown `:396`, disabled/deleted `:403,605`, no secret `:419,425`) calls `crypto::generate_dummy_hash()` before returning the same `401 invalid_client` / `"client authentication failed"` body as a real wrong-secret rejection (`:437-448`, `:617-621`)                                                                                                                                                                                                                                                                                                                                      |
+| Argon2id timing (unknown client vs. known client, wrong secret)                                                                               | Mitigated (defense-in-depth, residual accepted) | `crypto.rs:81-107` — `generate_dummy_hash()` performs a real Argon2id **hash** (not a cheap early-return) with the same configured cost params as `verify_secret()`'s **verify**; hash and verify are comparable-cost Argon2id operations but not byte-identical code paths, and the DB lookup itself is faster for an unknown client_id than a known one. This residual gap is explicitly called out in-code (`token.rs:387-395`) and bounded by the pre-hash, raw-client_id-keyed rate limiter (`token.rs:367-373`, checked _before_ the DB lookup)                                                                                                                                                                                                                             |
+| `client_credentials` grant: existence+grant-type oracle                                                                                       | **Fixed**                                       | `token.rs` now checks `grant_types.contains(ClientCredentials)` **after** secret verification (moved below the `verify_secret`/`generate_dummy_hash` block), matching the shared `authenticate_client()` posture used by the other three grants. Covered by the existing `test_client_without_client_credentials_grant_is_unauthorized_client`                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `/authorize`: unknown client_id vs. unregistered `redirect_uri`                                                                               | Not vulnerable (by design)                      | `authorize.rs:257-302` — messages differ ("unknown or disabled client" vs. "redirect_uri is not registered"), but `client_id` is intentionally public (RFC 6749 §2.2) and client registration is admin/Tier-1/Tier-2-gated per domain (ADR 0020), not a global self-service namespace an outsider can probe cross-tenant the way Entra's is — the precondition that makes Entra's spoofing technique work (any `client_id`, from any tenant, reaches a password check without being registered) does not exist here: every `client_id` presented anywhere must already be a real `OAuth2Client` row in that domain                                                                                                                                                                |
+| Human login (`/authorize/login`, `/device/login`): username enumeration                                                                       | Mitigated                                       | `authorize.rs:470-521` — uniform `"invalid username or password"` on both bad-request-shape and `authenticate_by_password` failure; ADR 0010's per-user throttle applies inside `authenticate_by_password` itself regardless of entry point                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **`/device`, `/device/login`, `/device_authorization`: per-IP rate limiting**                                                                 | **Fixed**                                       | `device.rs`'s `device_login_code` (user_code submission) and `device_login` (password check) and `device_authorization.rs`'s `device_authorization` now call `state.rate_limiters.check_ip()` before any DB lookup or password hashing, mirroring `authorize.rs`'s `/authorize`/`/authorize/login` posture exactly. `/device/consent` intentionally left unguarded, mirroring `authorize_consent`'s precedent (only reachable with an already-authenticated session, so it carries no unauthenticated probing surface of its own). Covered by new tests `test_device_submit_code_rate_limited_by_ip_before_lookup`, `test_device_login_rate_limited_by_ip_before_password_check` (`device.rs`) and `test_rate_limit_returns_429_before_client_lookup` (`device_authorization.rs`) |
+| Refresh token lookup                                                                                                                          | Not vulnerable                                  | `oauth2_session/service.rs:70-73,275-287` — lookup key is `SHA-256(bearer)`, an indexed equality read, not a raw-value or prefix comparison; no partial-match timing leak                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+**Control (implemented 2026-07-16).**
+
+- Per-IP `check_ip` rate limiting, identical to
+  `/authorize`/`/authorize/login`'s, now gates `/device_authorization`,
+  `/device`, and `/device/login`, applied before any DB lookup or password
+  hashing — closing the one concrete gap this review found; everything else in
+  the OAuth2 provider was already either spec-correct-by-design or carrying a
+  matching defense.
+- `handle_client_credentials_grant` (`token.rs`) now checks `grant_types` after
+  secret verification, so it matches the uniform-response posture of the other
+  three grant handlers.
+- _Testing:_ negative tests asserting `429` under burst-exhaustion now exist for
+  `/device`, `/device/login`, `/device_authorization`, alongside the
+  pre-existing `/authorize`/`/token` coverage.
+- _Design:_ V6's "endpoints not yet covered by rate limiting" list (ADR 0022
+  follow-up) should still be updated to note the device-flow browser endpoints
+  are now covered, alongside the federation/app-cred/EC2/ token-validate
+  endpoints that remain open.
+- _Pentest:_ password-spray `/device/login` across many usernames from a single
+  IP; brute-force `/device` `user_code` guessing at volume; attempt to reach a
+  password check via any `client_id` value without it being a pre-registered
+  `OAuth2Client` row (expected: impossible, confirm it stays that way) — all
+  should now hit `429` after one request under a tight burst config, matching
+  `/authorize`'s behavior.
+
 ### V9 — Secret leakage into policy input, logs, and audit (P2, mitigated)
 
 **Attack.** Decrypted credential blobs (EC2 secret keys, TOTP seeds) reaching
@@ -521,6 +571,11 @@ A pentest engagement should be handed this prioritized scenario list rather than
 6. **WASM plugins (V7)** and **OAuth2 provider (V8)** — full dedicated suites
    when those features ship; treat both as internet-facing pre-auth surfaces.
 7. **Token lifecycle (V10).** Revocation-window and version-binding probing.
+8. **OAuth2 device-flow rate limiting (V8a, fixed 2026-07-16).** Password-spray
+   `/device/login` from a single IP across many usernames; brute-force `/device`
+   `user_code` guessing at volume — both should now hit `429` after burst
+   exhaustion; re-verify this holds after any future change to
+   `device.rs`/`device_authorization.rs`.
 
 ## 7. Prioritized recommendation
 


### PR DESCRIPTION
- /device, /device/login, and /device_authorization ran user_code
  lookups and password checks with no per-IP rate limiting at all,
  unlike every sibling endpoint (/authorize, /token). device_login in
  particular ran the same authenticate_by_password call as
  authorize_login but without the pre-hash IP throttle, leaving
  password-spray and user_code brute-force unthrottled beyond RFC
  8628's short TTL.

- The client_credentials grant checked grant_types before verifying
  the client secret, so an existing-but-unauthorized client returned
  a distinguishable unauthorized_client instead of the uniform
  invalid_client every other rejection path returns.

Add the same state.rate_limiters.check_ip() call used by
authorize.rs to device.rs's device_login_code/device_login and to
device_authorization.rs, before any DB lookup or password hashing.
/device/consent is left unguarded, mirroring authorize_consent's
precedent (only reachable behind an already-authenticated session).

Reorder the client_credentials grant-type check to run after secret
verification, matching authenticate_client()'s posture already used
by the other three grants.

Add regression tests asserting 429 under burst exhaustion for the
newly-guarded endpoints, and update the security review docs to
record the fix.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
