### PR TITLE
fix(ci): Skip lint steps in merge_queue

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        if: github.event_name != 'merge_group'
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true
@@ -137,6 +138,7 @@ jobs:
 
     - name: Lint Commits
       uses: crate-ci/committed@15229711f8f597474c0b636f327cde5969f9a529 # v1.1.7
+      if: github.event_name != 'merge_group'
       with:
         # committed's default range (HEAD~..HEAD^2) assumes a 2-parent PR merge
         # commit, which doesn't exist on the merge queue's single-commit ref.


### PR DESCRIPTION
publishing the clippy findings in merge_queue is useless, it was already done. Also applying committed is not helpful since those are the merge commits