### PR TITLE
feat(catalog): Add service/endpoint CRUD API and bootstrap support

### DIFF
--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -233,6 +233,18 @@ impl From<CatalogProviderError> for KeystoneApiError {
     fn from(value: CatalogProviderError) -> Self {
         match value {
             ref err @ CatalogProviderError::Conflict(..) => Self::Conflict(err.to_string()),
+            CatalogProviderError::EndpointNotFound(x) => Self::NotFound {
+                resource: "endpoint".into(),
+                identifier: x,
+            },
+            CatalogProviderError::ServiceNotFound(x) => Self::NotFound {
+                resource: "service".into(),
+                identifier: x,
+            },
+            CatalogProviderError::RegionNotFound(x) => Self::NotFound {
+                resource: "region".into(),
+                identifier: x,
+            },
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/api-types/src/v3.rs
+++ b/crates/api-types/src/v3.rs
@@ -16,11 +16,13 @@ pub mod auth;
 pub mod credential;
 pub mod domain;
 pub mod ec2tokens;
+pub mod endpoint;
 pub mod group;
 pub mod os_ec2_credential;
 pub mod project;
 pub mod role;
 pub mod role_assignment;
+pub mod service;
 pub mod user;
 
 #[cfg(feature = "conv")]
@@ -30,6 +32,8 @@ mod credential_conv;
 #[cfg(feature = "conv")]
 mod domain_conv;
 #[cfg(feature = "conv")]
+mod endpoint_conv;
+#[cfg(feature = "conv")]
 mod group_conv;
 #[cfg(feature = "conv")]
 mod project_conv;
@@ -37,5 +41,7 @@ mod project_conv;
 mod role_assignment_conv;
 #[cfg(feature = "conv")]
 mod role_conv;
+#[cfg(feature = "conv")]
+mod service_conv;
 #[cfg(feature = "conv")]
 mod user_conv;

--- a/crates/api-types/src/v3/endpoint.rs
+++ b/crates/api-types/src/v3/endpoint.rs
@@ -1,0 +1,194 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+#[cfg(feature = "validate")]
+use validator::Validate;
+
+/// The endpoint data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct Endpoint {
+    /// Endpoint ID.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub id: String,
+    /// The interface type, which describes the visibility of the endpoint
+    /// (`public`, `internal`, or `admin`).
+    #[cfg_attr(feature = "validate", validate(length(max = 8)))]
+    pub interface: String,
+    /// The ID of the region that contains the service endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub region_id: Option<String>,
+    /// The UUID of the service to which the endpoint belongs.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub service_id: String,
+    /// The endpoint URL.
+    pub url: String,
+    /// Indicates whether the endpoint appears in the service catalog.
+    pub enabled: bool,
+
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct EndpointResponse {
+    /// Endpoint object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub endpoint: Endpoint,
+}
+
+/// Endpoints.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct EndpointList {
+    /// Collection of endpoint objects.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub endpoints: Vec<Endpoint>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct EndpointListParameters {
+    /// Filters the response by an interface.
+    #[cfg_attr(feature = "validate", validate(length(max = 8)))]
+    pub interface: Option<String>,
+    /// Filters the response by a service ID.
+    #[cfg_attr(feature = "validate", validate(length(max = 64)))]
+    pub service_id: Option<String>,
+    /// Filters the response by a region ID.
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub region_id: Option<String>,
+}
+
+/// Endpoint create request body.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct EndpointCreate {
+    /// The interface type, which describes the visibility of the endpoint
+    /// (`public`, `internal`, or `admin`).
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(max = 8)))]
+    pub interface: String,
+
+    /// The ID of the region that contains the service endpoint.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub region_id: Option<String>,
+
+    /// The UUID of the service to which the endpoint belongs.
+    #[cfg_attr(feature = "validate", validate(length(max = 64)))]
+    pub service_id: String,
+
+    /// The endpoint URL.
+    pub url: String,
+
+    /// Defines whether the endpoint appears in the service catalog.
+    #[cfg_attr(feature = "builder", builder(default))]
+    pub enabled: bool,
+
+    /// Extra attributes for the endpoint.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// New endpoint creation request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct EndpointCreateRequest {
+    /// Endpoint object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub endpoint: EndpointCreate,
+}
+
+/// Update endpoint data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct EndpointUpdate {
+    /// The interface type, which describes the visibility of the endpoint
+    /// (`public`, `internal`, or `admin`).
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 8)))]
+    pub interface: Option<String>,
+
+    /// The ID of the region that contains the service endpoint.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub region_id: Option<String>,
+
+    /// The UUID of the service to which the endpoint belongs.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 64)))]
+    pub service_id: Option<String>,
+
+    /// The endpoint URL.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// Defines whether the endpoint appears in the service catalog.
+    #[cfg_attr(feature = "builder", builder(default))]
+    pub enabled: Option<bool>,
+
+    /// Extra attributes for the endpoint (replaces the existing extra).
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Endpoint update request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct EndpointUpdateRequest {
+    /// Endpoint object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub endpoint: EndpointUpdate,
+}

--- a/crates/api-types/src/v3/endpoint_conv.rs
+++ b/crates/api-types/src/v3/endpoint_conv.rs
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use openstack_keystone_core_types::catalog as provider_types;
+
+use crate::v3::endpoint as api_types;
+
+impl From<provider_types::Endpoint> for api_types::Endpoint {
+    fn from(value: provider_types::Endpoint) -> Self {
+        Self {
+            id: value.id,
+            interface: value.interface,
+            region_id: value.region_id,
+            service_id: value.service_id,
+            url: value.url,
+            enabled: value.enabled,
+            extra: value.extra,
+        }
+    }
+}
+
+impl From<api_types::EndpointListParameters> for provider_types::EndpointListParameters {
+    fn from(value: api_types::EndpointListParameters) -> Self {
+        Self {
+            interface: value.interface,
+            service_id: value.service_id,
+            region_id: value.region_id,
+        }
+    }
+}
+
+impl From<api_types::EndpointCreateRequest> for provider_types::EndpointCreate {
+    fn from(value: api_types::EndpointCreateRequest) -> Self {
+        Self {
+            enabled: value.endpoint.enabled,
+            extra: value.endpoint.extra,
+            id: None,
+            interface: value.endpoint.interface,
+            region_id: value.endpoint.region_id,
+            service_id: value.endpoint.service_id,
+            url: value.endpoint.url,
+        }
+    }
+}
+
+impl From<api_types::EndpointUpdateRequest> for provider_types::EndpointUpdate {
+    fn from(value: api_types::EndpointUpdateRequest) -> Self {
+        Self {
+            enabled: value.endpoint.enabled,
+            extra: value.endpoint.extra,
+            interface: value.endpoint.interface,
+            region_id: value.endpoint.region_id,
+            service_id: value.endpoint.service_id,
+            url: value.endpoint.url,
+        }
+    }
+}

--- a/crates/api-types/src/v3/service.rs
+++ b/crates/api-types/src/v3/service.rs
@@ -1,0 +1,170 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+#[cfg(feature = "validate")]
+use validator::Validate;
+
+/// The service data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct Service {
+    /// Service ID.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub id: String,
+    /// The service type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub r#type: Option<String>,
+    /// Defines whether the service and its endpoints appear in the service
+    /// catalog.
+    pub enabled: bool,
+    /// The service name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub name: Option<String>,
+
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ServiceResponse {
+    /// Service object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub service: Service,
+}
+
+/// Services.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ServiceList {
+    /// Collection of service objects.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub services: Vec<Service>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ServiceListParameters {
+    /// Filters the response by a service name.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub name: Option<String>,
+    /// Filters the response by a service type.
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub r#type: Option<String>,
+}
+
+/// Service create request body.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ServiceCreate {
+    /// The service type.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub r#type: Option<String>,
+
+    /// Defines whether the service and its endpoints appear in the service
+    /// catalog.
+    #[cfg_attr(feature = "builder", builder(default))]
+    pub enabled: bool,
+
+    /// The service name.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub name: Option<String>,
+
+    /// Extra attributes for the service.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// New service creation request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ServiceCreateRequest {
+    /// Service object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub service: ServiceCreate,
+}
+
+/// Update service data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ServiceUpdate {
+    /// The service type.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub r#type: Option<String>,
+
+    /// Defines whether the service and its endpoints appear in the service
+    /// catalog.
+    #[cfg_attr(feature = "builder", builder(default))]
+    pub enabled: Option<bool>,
+
+    /// The service name.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub name: Option<String>,
+
+    /// Extra attributes for the service (replaces the existing extra).
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Service update request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ServiceUpdateRequest {
+    /// Service object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub service: ServiceUpdate,
+}

--- a/crates/api-types/src/v3/service_conv.rs
+++ b/crates/api-types/src/v3/service_conv.rs
@@ -1,0 +1,70 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use openstack_keystone_core_types::catalog as provider_types;
+
+use crate::v3::service as api_types;
+
+impl From<provider_types::Service> for api_types::Service {
+    fn from(value: provider_types::Service) -> Self {
+        let name = value.name();
+        let mut extra = value.extra;
+        extra.remove("name");
+        Self {
+            id: value.id,
+            r#type: value.r#type,
+            enabled: value.enabled,
+            name,
+            extra,
+        }
+    }
+}
+
+impl From<api_types::ServiceListParameters> for provider_types::ServiceListParameters {
+    fn from(value: api_types::ServiceListParameters) -> Self {
+        Self {
+            name: value.name,
+            r#type: value.r#type,
+        }
+    }
+}
+
+impl From<api_types::ServiceCreateRequest> for provider_types::ServiceCreate {
+    fn from(value: api_types::ServiceCreateRequest) -> Self {
+        let mut extra = value.service.extra;
+        if let Some(name) = value.service.name {
+            extra.insert("name".to_string(), serde_json::Value::String(name));
+        }
+        Self {
+            enabled: value.service.enabled,
+            extra,
+            id: None,
+            r#type: value.service.r#type,
+        }
+    }
+}
+
+impl From<api_types::ServiceUpdateRequest> for provider_types::ServiceUpdate {
+    fn from(value: api_types::ServiceUpdateRequest) -> Self {
+        let mut extra = value.service.extra;
+        if let Some(name) = value.service.name {
+            extra.insert("name".to_string(), serde_json::Value::String(name));
+        }
+        Self {
+            enabled: value.service.enabled,
+            extra,
+            r#type: value.service.r#type,
+        }
+    }
+}

--- a/crates/cli-manage/src/bootstrap.rs
+++ b/crates/cli-manage/src/bootstrap.rs
@@ -19,16 +19,17 @@ use color_eyre::{eyre::WrapErr, eyre::eyre};
 use eyre::Result;
 use reqwest::{Client, StatusCode, Url};
 use serde_json::json;
-use spiffe_rustls::{authorizer, mtls_client};
 
 use openstack_keystone_api_types::v3::domain::*;
+use openstack_keystone_api_types::v3::endpoint::*;
 use openstack_keystone_api_types::v3::project::*;
 use openstack_keystone_api_types::v3::role::*;
+use openstack_keystone_api_types::v3::service::*;
 use openstack_keystone_api_types::v3::user::*;
 use openstack_keystone_config::Config;
 
 use crate::PerformAction;
-use crate::common::setup_logging;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, setup_logging};
 
 /// Bootstrap Keystone data.
 #[derive(Parser)]
@@ -44,6 +45,22 @@ pub struct BootstrapCommand {
     /// Bootstrap user name.
     #[arg(long, default_value = "admin", env = "OS_BOOTSTRAP_USERNAME")]
     bootstrap_username: String,
+
+    /// Region ID to register the bootstrap `identity` service endpoints in.
+    #[arg(long, env = "OS_BOOTSTRAP_REGION_ID")]
+    bootstrap_region_id: Option<String>,
+
+    /// Public URL for the bootstrap `identity` service endpoint.
+    #[arg(long, env = "OS_BOOTSTRAP_PUBLIC_URL")]
+    bootstrap_public_url: Option<String>,
+
+    /// Internal URL for the bootstrap `identity` service endpoint.
+    #[arg(long, env = "OS_BOOTSTRAP_INTERNAL_URL")]
+    bootstrap_internal_url: Option<String>,
+
+    /// Admin URL for the bootstrap `identity` service endpoint.
+    #[arg(long, env = "OS_BOOTSTRAP_ADMIN_URL")]
+    bootstrap_admin_url: Option<String>,
 
     /// Verbosity level. Repeat to increase level.
     #[arg(short, long, action = clap::ArgAction::Count)]
@@ -61,32 +78,11 @@ impl PerformAction for BootstrapCommand {
             return Err(eyre!("--bootstrap-password must not be empty"));
         }
 
-        if let Some(admin_if) = &config.interface_admin {
-            let ks_admin_socket = admin_if.listener.socket_path.clone();
+        if config.interface_admin.is_some() {
+            let client = build_admin_client(config).await?;
 
-            // Fetch X.509 SVID dynamically from SPIFFE
-            let source = spiffe::X509Source::new().await?;
-
-            // Build mTLS ClientConfig with SPIFFE SVID
-            let client_config = mtls_client(source.clone())
-                .authorize(authorizer::any())
-                .build()
-                .wrap_err("Building SPIFFE mTLS client config failed")?;
-
-            // Create reqwest client with UDS + SPIFFE mTLS
-            let client = Client::builder()
-                .unix_socket(ks_admin_socket.clone())
-                .tls_backend_preconfigured(client_config)
-                .build()
-                .wrap_err("Building reqwest client failed")?;
-
-            self.bootstrap_with_client(
-                &client,
-                config,
-                "https://localhost",
-                &self.bootstrap_password,
-            )
-            .await?;
+            self.bootstrap_with_client(&client, config, ADMIN_BASE_URL, &self.bootstrap_password)
+                .await?;
 
             println!("Bootstrap complete:");
             println!("  admin user:    {}", self.bootstrap_username);
@@ -141,6 +137,23 @@ impl BootstrapCommand {
             .await?;
         self.upsert_user_role_system(client, &user, &admin_role, base_url)
             .await?;
+
+        if self.bootstrap_public_url.is_some()
+            || self.bootstrap_internal_url.is_some()
+            || self.bootstrap_admin_url.is_some()
+        {
+            let service = self.upsert_service(client, "identity", base_url).await?;
+            for (interface, url) in [
+                ("public", &self.bootstrap_public_url),
+                ("internal", &self.bootstrap_internal_url),
+                ("admin", &self.bootstrap_admin_url),
+            ] {
+                if let Some(url) = url {
+                    self.upsert_endpoint(client, &service, interface, url, base_url)
+                        .await?;
+                }
+            }
+        }
 
         Ok(())
     }
@@ -434,6 +447,144 @@ impl BootstrapCommand {
         }
     }
 
+    /// Ensure the catalog service exists.
+    ///
+    /// Create the service when it is not existing.
+    ///
+    /// # Parameters
+    /// * `service_type` - The type of the service (e.g. `identity`).
+    async fn upsert_service<S: AsRef<str>>(
+        &self,
+        client: &Client,
+        service_type: S,
+        base_url: &str,
+    ) -> Result<Service> {
+        let url = format!("{base_url}/v3/services");
+        let existing_services = client
+            .get(Url::parse_with_params(
+                &url,
+                &[("type", service_type.as_ref())],
+            )?)
+            .send()
+            .await?
+            .json::<ServiceList>()
+            .await?
+            .services;
+        if let Some(service) = existing_services.first() {
+            Ok(service.to_owned())
+        } else {
+            let res = client
+                .post(format!("{base_url}/v3/services"))
+                .json(&ServiceCreateRequest {
+                    service: ServiceCreateBuilder::default()
+                        .r#type(service_type.as_ref())
+                        .name("keystone")
+                        .enabled(true)
+                        .build()?,
+                })
+                .send()
+                .await?;
+            if res.status() == StatusCode::CONFLICT {
+                // Another bootstrap created the service concurrently; fetch it
+                let services = client
+                    .get(Url::parse_with_params(
+                        &format!("{base_url}/v3/services"),
+                        &[("type", service_type.as_ref())],
+                    )?)
+                    .send()
+                    .await?
+                    .json::<ServiceList>()
+                    .await?
+                    .services;
+                services.first().cloned().ok_or_else(|| {
+                    eyre!(
+                        "service of type '{}' not found after concurrent creation",
+                        service_type.as_ref()
+                    )
+                })
+            } else {
+                Ok(res.json::<ServiceResponse>().await?.service)
+            }
+        }
+    }
+
+    /// Ensure the catalog endpoint exists.
+    ///
+    /// Create the endpoint when it is not existing.
+    ///
+    /// # Parameters
+    /// * `service` - The service the endpoint belongs to.
+    /// * `interface` - The endpoint interface (`public`, `internal`, `admin`).
+    /// * `endpoint_url` - The endpoint URL.
+    async fn upsert_endpoint<S: AsRef<str>, U: AsRef<str>>(
+        &self,
+        client: &Client,
+        service: &Service,
+        interface: S,
+        endpoint_url: U,
+        base_url: &str,
+    ) -> Result<Endpoint> {
+        let url = format!("{base_url}/v3/endpoints");
+        let existing_endpoints = client
+            .get(Url::parse_with_params(
+                &url,
+                &[
+                    ("service_id", service.id.as_str()),
+                    ("interface", interface.as_ref()),
+                ],
+            )?)
+            .send()
+            .await?
+            .json::<EndpointList>()
+            .await?
+            .endpoints;
+        if let Some(endpoint) = existing_endpoints.first() {
+            Ok(endpoint.to_owned())
+        } else {
+            let mut builder = EndpointCreateBuilder::default();
+            builder
+                .service_id(service.id.clone())
+                .interface(interface.as_ref())
+                .url(endpoint_url.as_ref())
+                .enabled(true);
+            if let Some(region_id) = &self.bootstrap_region_id {
+                builder.region_id(region_id.clone());
+            }
+            let res = client
+                .post(format!("{base_url}/v3/endpoints"))
+                .json(&EndpointCreateRequest {
+                    endpoint: builder.build()?,
+                })
+                .send()
+                .await?;
+            if res.status() == StatusCode::CONFLICT {
+                // Another bootstrap created the endpoint concurrently; fetch it
+                let endpoints = client
+                    .get(Url::parse_with_params(
+                        &format!("{base_url}/v3/endpoints"),
+                        &[
+                            ("service_id", service.id.as_str()),
+                            ("interface", interface.as_ref()),
+                        ],
+                    )?)
+                    .send()
+                    .await?
+                    .json::<EndpointList>()
+                    .await?
+                    .endpoints;
+                endpoints.first().cloned().ok_or_else(|| {
+                    eyre!(
+                        "'{}' endpoint for service '{}' not found after concurrent creation",
+                        interface.as_ref(),
+                        service.id
+                    )
+                })
+            } else {
+                Ok(res.json::<EndpointResponse>().await?.endpoint)
+            }
+        }
+    }
+
     /// Ensure the role imply rule exist.
     ///
     /// # Parameters
@@ -544,6 +695,10 @@ mod tests {
             bootstrap_project_name: "admin".to_string(),
             bootstrap_password: "secret".to_string(),
             bootstrap_username: "admin".to_string(),
+            bootstrap_region_id: None,
+            bootstrap_public_url: None,
+            bootstrap_internal_url: None,
+            bootstrap_admin_url: None,
             verbose: 0,
         }
     }
@@ -923,6 +1078,10 @@ mod tests {
             bootstrap_project_name: "admin".to_string(),
             bootstrap_password: "secret".to_string(),
             bootstrap_username: "admin".to_string(),
+            bootstrap_region_id: None,
+            bootstrap_public_url: None,
+            bootstrap_internal_url: None,
+            bootstrap_admin_url: None,
             verbose: 0,
         };
 
@@ -1067,6 +1226,334 @@ mod tests {
         assert_eq!(role.unwrap().id, "new-role-id");
     }
 
+    // ─── upsert_service ──────────────────────────────────────────────────
+
+    fn make_service(id: &str) -> Service {
+        Service {
+            id: id.to_string(),
+            r#type: Some("identity".to_string()),
+            enabled: true,
+            name: Some("keystone".to_string()),
+            extra: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_upsert_service_existing_is_returned() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("type", "identity");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "services": [{ "id": "existing-svc", "type": "identity", "enabled": true, "name": "keystone" }]
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = test_command();
+
+        let service = cmd.upsert_service(&client, "identity", &base).await;
+        assert!(service.is_ok());
+        assert_eq!(service.unwrap().id, "existing-svc");
+    }
+
+    #[tokio::test]
+    async fn test_upsert_service_creation() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("type", "identity");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "services": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/services");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "service": { "id": "new-svc-id", "type": "identity", "enabled": true, "name": "keystone" }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = test_command();
+
+        let service = cmd.upsert_service(&client, "identity", &base).await;
+        assert!(service.is_ok());
+        assert_eq!(service.unwrap().id, "new-svc-id");
+    }
+
+    #[tokio::test]
+    async fn test_upsert_service_conflict_errors_when_not_found_on_refetch() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        // Every GET (both the initial lookup and the post-conflict refetch)
+        // returns empty — simulates the concurrent-creation-then-deleted edge
+        // case, which must surface as an error rather than panic.
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("type", "identity");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "services": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/services");
+            then.status(409);
+        });
+
+        let client = Client::new();
+        let cmd = test_command();
+
+        let service = cmd.upsert_service(&client, "identity", &base).await;
+        assert!(service.is_err());
+    }
+
+    // ─── upsert_endpoint ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_upsert_endpoint_existing_is_returned() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/endpoints")
+                .query_param("service_id", "svc-1")
+                .query_param("interface", "public");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoints": [{
+                        "id": "existing-ep", "interface": "public", "service_id": "svc-1",
+                        "url": "https://example.com", "enabled": true
+                    }]
+                }));
+        });
+
+        let service = make_service("svc-1");
+        let client = Client::new();
+        let cmd = test_command();
+
+        let endpoint = cmd
+            .upsert_endpoint(&client, &service, "public", "https://example.com", &base)
+            .await;
+        assert!(endpoint.is_ok());
+        assert_eq!(endpoint.unwrap().id, "existing-ep");
+    }
+
+    #[tokio::test]
+    async fn test_upsert_endpoint_creation() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/endpoints")
+                .query_param("service_id", "svc-1")
+                .query_param("interface", "public");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "endpoints": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/endpoints");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoint": {
+                        "id": "new-ep-id", "interface": "public", "service_id": "svc-1",
+                        "url": "https://example.com", "enabled": true
+                    }
+                }));
+        });
+
+        let service = make_service("svc-1");
+        let client = Client::new();
+        let cmd = test_command();
+
+        let endpoint = cmd
+            .upsert_endpoint(&client, &service, "public", "https://example.com", &base)
+            .await;
+        assert!(endpoint.is_ok());
+        assert_eq!(endpoint.unwrap().id, "new-ep-id");
+    }
+
+    #[tokio::test]
+    async fn test_upsert_endpoint_conflict_errors_when_not_found_on_refetch() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        // Every GET (both the initial lookup and the post-conflict refetch)
+        // returns empty — simulates the concurrent-creation-then-deleted edge
+        // case, which must surface as an error rather than panic.
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/endpoints")
+                .query_param("service_id", "svc-1")
+                .query_param("interface", "public");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "endpoints": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/endpoints");
+            then.status(409);
+        });
+
+        let service = make_service("svc-1");
+        let client = Client::new();
+        let cmd = test_command();
+
+        let endpoint = cmd
+            .upsert_endpoint(&client, &service, "public", "https://example.com", &base)
+            .await;
+        assert!(endpoint.is_err());
+    }
+
+    // ─── bootstrap_with_client catalog registration ─────────────────────
+
+    #[tokio::test]
+    async fn test_bootstrap_registers_catalog_when_urls_given() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        // User list empty + user creation
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/users")
+                .query_param("domain_id", "default")
+                .query_param("name", "admin");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "users": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/users");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "user": {
+                        "id": "user-1",
+                        "name": "admin",
+                        "enabled": true,
+                        "domain_id": "default"
+                    }
+                }));
+        });
+
+        mock_full_bootstrap(&server);
+
+        // Catalog: service list empty + create
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("type", "identity");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "services": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/services");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "service": { "id": "svc-1", "type": "identity", "enabled": true, "name": "keystone" }
+                }));
+        });
+        // Catalog: endpoint list empty + create (matches any interface)
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/endpoints")
+                .query_param("service_id", "svc-1");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "endpoints": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/endpoints");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoint": {
+                        "id": "ep-1", "interface": "public", "service_id": "svc-1",
+                        "url": "https://example.com/public", "enabled": true
+                    }
+                }));
+        });
+
+        let client = Client::new();
+        let config = test_config();
+        let mut cmd = test_command();
+        cmd.bootstrap_public_url = Some("https://example.com/public".to_string());
+        cmd.bootstrap_region_id = Some("region1".to_string());
+
+        let result = cmd
+            .bootstrap_with_client(&client, &config, &base, "secret")
+            .await;
+        assert!(
+            result.is_ok(),
+            "bootstrap with catalog urls should succeed: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bootstrap_skips_catalog_when_no_urls_given() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        // User list empty + user creation
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/users")
+                .query_param("domain_id", "default")
+                .query_param("name", "admin");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "users": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/users");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "user": {
+                        "id": "user-1",
+                        "name": "admin",
+                        "enabled": true,
+                        "domain_id": "default"
+                    }
+                }));
+        });
+
+        mock_full_bootstrap(&server);
+        // Deliberately no /v3/services or /v3/endpoints mocks — the request
+        // would fail if bootstrap tried to call them.
+
+        let client = Client::new();
+        let config = test_config();
+        let result = test_command()
+            .bootstrap_with_client(&client, &config, &base, "secret")
+            .await;
+        assert!(
+            result.is_ok(),
+            "bootstrap without catalog urls should succeed: {:?}",
+            result
+        );
+    }
+
     // ─── take_action ─────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -1087,6 +1574,10 @@ mod tests {
             bootstrap_project_name: "admin".to_string(),
             bootstrap_password: "".to_string(),
             bootstrap_username: "admin".to_string(),
+            bootstrap_region_id: None,
+            bootstrap_public_url: None,
+            bootstrap_internal_url: None,
+            bootstrap_admin_url: None,
             verbose: 0,
         };
 
@@ -1434,6 +1925,78 @@ mod tests {
                 let cmd = BootstrapCommand::parse_from(["keystone-manage"]);
                 assert_eq!(cmd.bootstrap_project_name, "env-project");
             })
+        });
+    }
+
+    #[tokio::test]
+    async fn test_bootstrap_region_id_from_env() {
+        temp_env::with_var("OS_BOOTSTRAP_REGION_ID", Some("region1"), || {
+            temp_env::with_var("OS_BOOTSTRAP_PASSWORD", Some("secret"), || {
+                let cmd = BootstrapCommand::parse_from(["keystone-manage"]);
+                assert_eq!(cmd.bootstrap_region_id.as_deref(), Some("region1"));
+            })
+        });
+    }
+
+    #[tokio::test]
+    async fn test_bootstrap_public_url_from_env() {
+        temp_env::with_var(
+            "OS_BOOTSTRAP_PUBLIC_URL",
+            Some("https://example.com/public"),
+            || {
+                temp_env::with_var("OS_BOOTSTRAP_PASSWORD", Some("secret"), || {
+                    let cmd = BootstrapCommand::parse_from(["keystone-manage"]);
+                    assert_eq!(
+                        cmd.bootstrap_public_url.as_deref(),
+                        Some("https://example.com/public")
+                    );
+                })
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bootstrap_internal_url_from_env() {
+        temp_env::with_var(
+            "OS_BOOTSTRAP_INTERNAL_URL",
+            Some("https://example.com/internal"),
+            || {
+                temp_env::with_var("OS_BOOTSTRAP_PASSWORD", Some("secret"), || {
+                    let cmd = BootstrapCommand::parse_from(["keystone-manage"]);
+                    assert_eq!(
+                        cmd.bootstrap_internal_url.as_deref(),
+                        Some("https://example.com/internal")
+                    );
+                })
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bootstrap_admin_url_from_env() {
+        temp_env::with_var(
+            "OS_BOOTSTRAP_ADMIN_URL",
+            Some("https://example.com/admin"),
+            || {
+                temp_env::with_var("OS_BOOTSTRAP_PASSWORD", Some("secret"), || {
+                    let cmd = BootstrapCommand::parse_from(["keystone-manage"]);
+                    assert_eq!(
+                        cmd.bootstrap_admin_url.as_deref(),
+                        Some("https://example.com/admin")
+                    );
+                })
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bootstrap_catalog_urls_default_to_none() {
+        temp_env::with_var("OS_BOOTSTRAP_PASSWORD", Some("secret"), || {
+            let cmd = BootstrapCommand::parse_from(["keystone-manage"]);
+            assert!(cmd.bootstrap_region_id.is_none());
+            assert!(cmd.bootstrap_public_url.is_none());
+            assert!(cmd.bootstrap_internal_url.is_none());
+            assert!(cmd.bootstrap_admin_url.is_none());
         });
     }
 }

--- a/crates/cli-manage/src/catalog.rs
+++ b/crates/cli-manage/src/catalog.rs
@@ -1,0 +1,56 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Catalog subcommand of the keystone-manage cli.
+
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+use color_eyre::Report;
+
+use openstack_keystone_config::Config;
+
+mod endpoint;
+mod service;
+
+use crate::PerformAction;
+use crate::catalog::endpoint::EndpointCommand;
+use crate::catalog::service::ServiceCommand;
+
+/// Service catalog (service/endpoint) management.
+///
+/// Registers services and endpoints directly against the admin API, outside
+/// of the `bootstrap` flow — e.g. to register additional services in tests
+/// or dev environments.
+#[derive(Parser)]
+pub struct CatalogCommand {
+    #[command(subcommand)]
+    command: CatalogCommands,
+}
+
+#[async_trait]
+impl PerformAction for CatalogCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        match self.command {
+            CatalogCommands::Service(e) => e.take_action(config).await,
+            CatalogCommands::Endpoint(e) => e.take_action(config).await,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+enum CatalogCommands {
+    /// Catalog services.
+    Service(ServiceCommand),
+    /// Catalog service endpoints.
+    Endpoint(EndpointCommand),
+}

--- a/crates/cli-manage/src/catalog/endpoint.rs
+++ b/crates/cli-manage/src/catalog/endpoint.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `keystone-manage catalog endpoint` subcommand.
+
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+use color_eyre::Report;
+
+use openstack_keystone_config::Config;
+
+mod create;
+mod delete;
+mod list;
+mod show;
+mod update;
+
+use crate::PerformAction;
+use crate::catalog::endpoint::create::CreateCommand;
+use crate::catalog::endpoint::delete::DeleteCommand;
+use crate::catalog::endpoint::list::ListCommand;
+use crate::catalog::endpoint::show::ShowCommand;
+use crate::catalog::endpoint::update::UpdateCommand;
+
+#[derive(Parser)]
+pub(super) struct EndpointCommand {
+    #[command(subcommand)]
+    command: EndpointCommands,
+}
+
+#[async_trait]
+impl PerformAction for EndpointCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        match self.command {
+            EndpointCommands::Create(e) => e.take_action(config).await,
+            EndpointCommands::Show(e) => e.take_action(config).await,
+            EndpointCommands::List(e) => e.take_action(config).await,
+            EndpointCommands::Update(e) => e.take_action(config).await,
+            EndpointCommands::Delete(e) => e.take_action(config).await,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+enum EndpointCommands {
+    /// Create a new catalog endpoint.
+    Create(CreateCommand),
+    /// Show a catalog endpoint.
+    Show(ShowCommand),
+    /// List catalog endpoints.
+    List(ListCommand),
+    /// Update a catalog endpoint.
+    Update(UpdateCommand),
+    /// Delete a catalog endpoint.
+    Delete(DeleteCommand),
+}

--- a/crates/cli-manage/src/catalog/endpoint/create.rs
+++ b/crates/cli-manage/src/catalog/endpoint/create.rs
@@ -1,0 +1,302 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::{ArgGroup, Parser};
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode, Url};
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_api_types::v3::service::ServiceList;
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, print_attribute_table};
+
+/// Create a new catalog endpoint.
+#[derive(Parser)]
+#[command(group(
+    ArgGroup::new("service_ref")
+        .required(true)
+        .args(["service_id", "service_name"]),
+))]
+pub(super) struct CreateCommand {
+    /// The ID of the service the endpoint belongs to.
+    #[arg(long)]
+    service_id: Option<String>,
+
+    /// The name of the service the endpoint belongs to. Resolved to an ID via
+    /// `GET /v3/services?name=...`; fails if zero or more than one service
+    /// matches.
+    #[arg(long)]
+    service_name: Option<String>,
+
+    /// The interface (`public`, `internal`, or `admin`).
+    #[arg(long)]
+    interface: String,
+
+    /// The endpoint URL.
+    #[arg(long)]
+    url: String,
+
+    /// The ID of the region that contains the endpoint.
+    #[arg(long)]
+    region_id: Option<String>,
+
+    /// Whether the endpoint appears in the service catalog.
+    #[arg(long, default_value_t = true)]
+    enabled: bool,
+}
+
+impl CreateCommand {
+    /// Resolve `--service-name` to a service ID via `GET
+    /// /v3/services?name=...`.
+    async fn resolve_service_id(&self, client: &Client, base_url: &str) -> Result<String> {
+        if let Some(id) = &self.service_id {
+            return Ok(id.clone());
+        }
+
+        // clap's ArgGroup guarantees exactly one of `service_id`/`service_name`
+        // is set, but avoid panicking if that invariant is ever violated
+        // (e.g. by constructing `CreateCommand` directly in a test).
+        let Some(name) = self.service_name.as_ref() else {
+            return Err(eyre!("either --service-id or --service-name must be set"));
+        };
+
+        let services = client
+            .get(Url::parse_with_params(
+                &format!("{base_url}/v3/services"),
+                &[("name", name.as_str())],
+            )?)
+            .send()
+            .await?
+            .json::<ServiceList>()
+            .await?
+            .services;
+
+        match services.len() {
+            0 => Err(eyre!("no service found with name '{name}'")),
+            1 => Ok(services[0].id.clone()),
+            n => Err(eyre!(
+                "ambiguous service name '{name}': {n} services match, use --service-id instead"
+            )),
+        }
+    }
+
+    /// Create the endpoint against a pre-built HTTP client.
+    ///
+    /// This is the public entry point for tests that inject a mock client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn create_with_client(&self, client: &Client, base_url: &str) -> Result<Endpoint> {
+        let service_id = self.resolve_service_id(client, base_url).await?;
+
+        let mut builder = EndpointCreateBuilder::default();
+        builder
+            .service_id(service_id)
+            .interface(self.interface.clone())
+            .url(self.url.clone())
+            .enabled(self.enabled);
+        if let Some(region_id) = &self.region_id {
+            builder.region_id(region_id.clone());
+        }
+
+        let res = client
+            .post(format!("{base_url}/v3/endpoints"))
+            .json(&EndpointCreateRequest {
+                endpoint: builder.build()?,
+            })
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::CREATED {
+            return Err(eyre!(
+                "failed to create endpoint: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(res.json::<EndpointResponse>().await?.endpoint)
+    }
+}
+
+#[async_trait]
+impl PerformAction for CreateCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        let created = self.create_with_client(&client, ADMIN_BASE_URL).await?;
+
+        print_attribute_table(vec![
+            ("id", created.id),
+            ("interface", created.interface),
+            ("service_id", created.service_id),
+            ("url", created.url),
+            ("enabled", created.enabled.to_string()),
+        ]);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    fn command_by_id(service_id: &str) -> CreateCommand {
+        CreateCommand {
+            service_id: Some(service_id.to_string()),
+            service_name: None,
+            interface: "public".to_string(),
+            url: "https://example.com".to_string(),
+            region_id: None,
+            enabled: true,
+        }
+    }
+
+    fn command_by_name(service_name: &str) -> CreateCommand {
+        CreateCommand {
+            service_id: None,
+            service_name: Some(service_name.to_string()),
+            interface: "public".to_string(),
+            url: "https://example.com".to_string(),
+            region_id: None,
+            enabled: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_endpoint_by_service_id() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/endpoints");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoint": {
+                        "id": "ep-1", "interface": "public", "service_id": "svc-1",
+                        "url": "https://example.com", "enabled": true
+                    }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = command_by_id("svc-1");
+        let created = cmd.create_with_client(&client, &base).await;
+        assert!(created.is_ok());
+        assert_eq!(created.unwrap().service_id, "svc-1");
+    }
+
+    #[tokio::test]
+    async fn test_create_endpoint_by_service_name() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("name", "identity-rs");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "services": [{ "id": "svc-1", "type": "identity-rs", "enabled": true, "name": "identity-rs" }]
+                }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/endpoints");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoint": {
+                        "id": "ep-1", "interface": "public", "service_id": "svc-1",
+                        "url": "https://example.com", "enabled": true
+                    }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = command_by_name("identity-rs");
+        let created = cmd.create_with_client(&client, &base).await;
+        assert!(created.is_ok());
+        assert_eq!(created.unwrap().service_id, "svc-1");
+    }
+
+    #[tokio::test]
+    async fn test_create_endpoint_service_name_not_found() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("name", "missing");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "services": [] }));
+        });
+
+        let client = Client::new();
+        let cmd = command_by_name("missing");
+        let result = cmd.create_with_client(&client, &base).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no service found"));
+    }
+
+    #[tokio::test]
+    async fn test_create_endpoint_service_name_ambiguous() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("name", "dup");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "services": [
+                        { "id": "svc-1", "type": "identity-rs", "enabled": true, "name": "dup" },
+                        { "id": "svc-2", "type": "identity-rs", "enabled": true, "name": "dup" }
+                    ]
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = command_by_name("dup");
+        let result = cmd.create_with_client(&client, &base).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ambiguous"));
+    }
+
+    #[tokio::test]
+    async fn test_create_endpoint_error_status() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/endpoints");
+            then.status(500).body("internal error");
+        });
+
+        let client = Client::new();
+        let cmd = command_by_id("svc-1");
+        let result = cmd.create_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/endpoint/delete.rs
+++ b/crates/cli-manage/src/catalog/endpoint/delete.rs
@@ -1,0 +1,106 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode};
+
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client};
+
+/// Delete a catalog endpoint.
+#[derive(Parser)]
+pub(super) struct DeleteCommand {
+    /// The ID of the endpoint to delete.
+    id: String,
+}
+
+impl DeleteCommand {
+    /// Delete the endpoint against a pre-built HTTP client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn delete_with_client(&self, client: &Client, base_url: &str) -> Result<()> {
+        let res = client
+            .delete(format!("{base_url}/v3/endpoints/{}", self.id))
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::NO_CONTENT {
+            return Err(eyre!(
+                "failed to delete endpoint: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl PerformAction for DeleteCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        self.delete_with_client(&client, ADMIN_BASE_URL).await?;
+        println!("Deleted endpoint {}", self.id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_delete_endpoint() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::DELETE).path("/v3/endpoints/ep-1");
+            then.status(204);
+        });
+
+        let client = Client::new();
+        let cmd = DeleteCommand {
+            id: "ep-1".to_string(),
+        };
+        let result = cmd.delete_with_client(&client, &base).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_endpoint_not_found() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::DELETE).path("/v3/endpoints/missing");
+            then.status(404).body("not found");
+        });
+
+        let client = Client::new();
+        let cmd = DeleteCommand {
+            id: "missing".to_string(),
+        };
+        let result = cmd.delete_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/endpoint/list.rs
+++ b/crates/cli-manage/src/catalog/endpoint/list.rs
@@ -1,0 +1,184 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode, Url};
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, print_list_table};
+
+/// List catalog endpoints.
+#[derive(Parser)]
+pub(super) struct ListCommand {
+    /// Filter by interface (`public`, `internal`, or `admin`).
+    #[arg(long)]
+    interface: Option<String>,
+
+    /// Filter by service ID.
+    #[arg(long)]
+    service_id: Option<String>,
+
+    /// Filter by region ID.
+    #[arg(long)]
+    region_id: Option<String>,
+}
+
+impl ListCommand {
+    /// List endpoints against a pre-built HTTP client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn list_with_client(&self, client: &Client, base_url: &str) -> Result<Vec<Endpoint>> {
+        let mut params: Vec<(&str, &str)> = Vec::new();
+        if let Some(interface) = &self.interface {
+            params.push(("interface", interface));
+        }
+        if let Some(service_id) = &self.service_id {
+            params.push(("service_id", service_id));
+        }
+        if let Some(region_id) = &self.region_id {
+            params.push(("region_id", region_id));
+        }
+
+        let res = client
+            .get(Url::parse_with_params(
+                &format!("{base_url}/v3/endpoints"),
+                &params,
+            )?)
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::OK {
+            return Err(eyre!(
+                "failed to list endpoints: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(res.json::<EndpointList>().await?.endpoints)
+    }
+}
+
+#[async_trait]
+impl PerformAction for ListCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        let endpoints = self.list_with_client(&client, ADMIN_BASE_URL).await?;
+
+        print_list_table(
+            vec!["ID", "Interface", "Service ID", "URL", "Enabled"],
+            endpoints
+                .into_iter()
+                .map(|endpoint| {
+                    vec![
+                        endpoint.id,
+                        endpoint.interface,
+                        endpoint.service_id,
+                        endpoint.url,
+                        endpoint.enabled.to_string(),
+                    ]
+                })
+                .collect(),
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_list_endpoints() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET).path("/v3/endpoints");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoints": [
+                        { "id": "ep-1", "interface": "public", "service_id": "svc-1",
+                          "url": "https://example.com", "enabled": true }
+                    ]
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = ListCommand {
+            interface: None,
+            service_id: None,
+            region_id: None,
+        };
+        let result = cmd.list_with_client(&client, &base).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_endpoints_with_filters() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/endpoints")
+                .query_param("interface", "public")
+                .query_param("service_id", "svc-1");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "endpoints": [] }));
+        });
+
+        let client = Client::new();
+        let cmd = ListCommand {
+            interface: Some("public".to_string()),
+            service_id: Some("svc-1".to_string()),
+            region_id: None,
+        };
+        let result = cmd.list_with_client(&client, &base).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_endpoints_error() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET).path("/v3/endpoints");
+            then.status(500).body("internal error");
+        });
+
+        let client = Client::new();
+        let cmd = ListCommand {
+            interface: None,
+            service_id: None,
+            region_id: None,
+        };
+        let result = cmd.list_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/endpoint/show.rs
+++ b/crates/cli-manage/src/catalog/endpoint/show.rs
@@ -1,0 +1,123 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode};
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, print_attribute_table};
+
+/// Show a catalog endpoint.
+#[derive(Parser)]
+pub(super) struct ShowCommand {
+    /// The ID of the endpoint to show.
+    id: String,
+}
+
+impl ShowCommand {
+    /// Fetch the endpoint against a pre-built HTTP client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn show_with_client(&self, client: &Client, base_url: &str) -> Result<Endpoint> {
+        let res = client
+            .get(format!("{base_url}/v3/endpoints/{}", self.id))
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::OK {
+            return Err(eyre!(
+                "failed to show endpoint: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(res.json::<EndpointResponse>().await?.endpoint)
+    }
+}
+
+#[async_trait]
+impl PerformAction for ShowCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        let endpoint = self.show_with_client(&client, ADMIN_BASE_URL).await?;
+
+        print_attribute_table(vec![
+            ("id", endpoint.id),
+            ("interface", endpoint.interface),
+            ("service_id", endpoint.service_id),
+            ("url", endpoint.url),
+            ("enabled", endpoint.enabled.to_string()),
+        ]);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_show_endpoint() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET).path("/v3/endpoints/ep-1");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoint": {
+                        "id": "ep-1", "interface": "public", "service_id": "svc-1",
+                        "url": "https://example.com", "enabled": true
+                    }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = ShowCommand {
+            id: "ep-1".to_string(),
+        };
+        let result = cmd.show_with_client(&client, &base).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, "ep-1");
+    }
+
+    #[tokio::test]
+    async fn test_show_endpoint_not_found() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET).path("/v3/endpoints/missing");
+            then.status(404).body("not found");
+        });
+
+        let client = Client::new();
+        let cmd = ShowCommand {
+            id: "missing".to_string(),
+        };
+        let result = cmd.show_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/endpoint/update.rs
+++ b/crates/cli-manage/src/catalog/endpoint/update.rs
@@ -1,0 +1,187 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::{Parser, ValueEnum};
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode};
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, print_attribute_table};
+
+#[derive(Clone, Copy, ValueEnum)]
+enum BoolArg {
+    True,
+    False,
+}
+
+impl From<BoolArg> for bool {
+    fn from(value: BoolArg) -> Self {
+        matches!(value, BoolArg::True)
+    }
+}
+
+/// Update a catalog endpoint.
+#[derive(Parser)]
+pub(super) struct UpdateCommand {
+    /// The ID of the endpoint to update.
+    id: String,
+
+    /// New interface (`public`, `internal`, or `admin`).
+    #[arg(long)]
+    interface: Option<String>,
+
+    /// New region ID.
+    #[arg(long)]
+    region_id: Option<String>,
+
+    /// New service ID.
+    #[arg(long)]
+    service_id: Option<String>,
+
+    /// New endpoint URL.
+    #[arg(long)]
+    url: Option<String>,
+
+    /// Whether the endpoint appears in the service catalog.
+    #[arg(long)]
+    enabled: Option<BoolArg>,
+}
+
+impl UpdateCommand {
+    /// Update the endpoint against a pre-built HTTP client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn update_with_client(&self, client: &Client, base_url: &str) -> Result<Endpoint> {
+        let mut builder = EndpointUpdateBuilder::default();
+        if let Some(interface) = &self.interface {
+            builder.interface(interface.clone());
+        }
+        if let Some(region_id) = &self.region_id {
+            builder.region_id(region_id.clone());
+        }
+        if let Some(service_id) = &self.service_id {
+            builder.service_id(service_id.clone());
+        }
+        if let Some(url) = &self.url {
+            builder.url(url.clone());
+        }
+        if let Some(enabled) = self.enabled {
+            builder.enabled(bool::from(enabled));
+        }
+
+        let res = client
+            .patch(format!("{base_url}/v3/endpoints/{}", self.id))
+            .json(&EndpointUpdateRequest {
+                endpoint: builder.build()?,
+            })
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::OK {
+            return Err(eyre!(
+                "failed to update endpoint: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(res.json::<EndpointResponse>().await?.endpoint)
+    }
+}
+
+#[async_trait]
+impl PerformAction for UpdateCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        let updated = self.update_with_client(&client, ADMIN_BASE_URL).await?;
+
+        print_attribute_table(vec![
+            ("id", updated.id),
+            ("interface", updated.interface),
+            ("service_id", updated.service_id),
+            ("url", updated.url),
+            ("enabled", updated.enabled.to_string()),
+        ]);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update_endpoint() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::PATCH).path("/v3/endpoints/ep-1");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoint": {
+                        "id": "ep-1", "interface": "internal", "service_id": "svc-1",
+                        "url": "https://new.example.com", "enabled": false
+                    }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = UpdateCommand {
+            id: "ep-1".to_string(),
+            interface: Some("internal".to_string()),
+            region_id: None,
+            service_id: None,
+            url: Some("https://new.example.com".to_string()),
+            enabled: Some(BoolArg::False),
+        };
+        let result = cmd.update_with_client(&client, &base).await;
+        assert!(result.is_ok());
+        let updated = result.unwrap();
+        assert_eq!(updated.interface, "internal");
+        assert!(!updated.enabled);
+    }
+
+    #[tokio::test]
+    async fn test_update_endpoint_error() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::PATCH).path("/v3/endpoints/missing");
+            then.status(404).body("not found");
+        });
+
+        let client = Client::new();
+        let cmd = UpdateCommand {
+            id: "missing".to_string(),
+            interface: None,
+            region_id: None,
+            service_id: None,
+            url: None,
+            enabled: None,
+        };
+        let result = cmd.update_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/service.rs
+++ b/crates/cli-manage/src/catalog/service.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `keystone-manage catalog service` subcommand.
+
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+use color_eyre::Report;
+
+use openstack_keystone_config::Config;
+
+mod create;
+mod delete;
+mod list;
+mod show;
+mod update;
+
+use crate::PerformAction;
+use crate::catalog::service::create::CreateCommand;
+use crate::catalog::service::delete::DeleteCommand;
+use crate::catalog::service::list::ListCommand;
+use crate::catalog::service::show::ShowCommand;
+use crate::catalog::service::update::UpdateCommand;
+
+#[derive(Parser)]
+pub(super) struct ServiceCommand {
+    #[command(subcommand)]
+    command: ServiceCommands,
+}
+
+#[async_trait]
+impl PerformAction for ServiceCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        match self.command {
+            ServiceCommands::Create(e) => e.take_action(config).await,
+            ServiceCommands::Show(e) => e.take_action(config).await,
+            ServiceCommands::List(e) => e.take_action(config).await,
+            ServiceCommands::Update(e) => e.take_action(config).await,
+            ServiceCommands::Delete(e) => e.take_action(config).await,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+enum ServiceCommands {
+    /// Create a new catalog service.
+    Create(CreateCommand),
+    /// Show a catalog service.
+    Show(ShowCommand),
+    /// List catalog services.
+    List(ListCommand),
+    /// Update a catalog service.
+    Update(UpdateCommand),
+    /// Delete a catalog service.
+    Delete(DeleteCommand),
+}

--- a/crates/cli-manage/src/catalog/service/create.rs
+++ b/crates/cli-manage/src/catalog/service/create.rs
@@ -1,0 +1,166 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode};
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, print_attribute_table};
+
+/// Create a new catalog service.
+#[derive(Parser)]
+pub(super) struct CreateCommand {
+    /// Service type (e.g. `identity`).
+    #[arg(long = "type")]
+    r#type: String,
+
+    /// Service name.
+    #[arg(long)]
+    name: Option<String>,
+
+    /// Whether the service and its endpoints appear in the catalog.
+    #[arg(long, default_value_t = true)]
+    enabled: bool,
+}
+
+impl CreateCommand {
+    /// Create the service against a pre-built HTTP client.
+    ///
+    /// This is the public entry point for tests that inject a mock client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn create_with_client(&self, client: &Client, base_url: &str) -> Result<Service> {
+        let mut builder = ServiceCreateBuilder::default();
+        builder.r#type(self.r#type.clone()).enabled(self.enabled);
+        if let Some(name) = &self.name {
+            builder.name(name.clone());
+        }
+
+        let res = client
+            .post(format!("{base_url}/v3/services"))
+            .json(&ServiceCreateRequest {
+                service: builder.build()?,
+            })
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::CREATED {
+            return Err(eyre!(
+                "failed to create service: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(res.json::<ServiceResponse>().await?.service)
+    }
+}
+
+#[async_trait]
+impl PerformAction for CreateCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        let created = self.create_with_client(&client, ADMIN_BASE_URL).await?;
+
+        print_attribute_table(vec![
+            ("id", created.id),
+            ("type", created.r#type.unwrap_or_default()),
+            ("name", created.name.unwrap_or_default()),
+            ("enabled", created.enabled.to_string()),
+        ]);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    fn command(r#type: &str, name: Option<&str>) -> CreateCommand {
+        CreateCommand {
+            r#type: r#type.to_string(),
+            name: name.map(str::to_string),
+            enabled: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_service() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/services");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "service": { "id": "svc-1", "type": "identity-rs", "enabled": true, "name": "keystone-rs" }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = command("identity-rs", Some("keystone-rs"));
+        let created = cmd.create_with_client(&client, &base).await;
+        assert!(created.is_ok());
+        let created = created.unwrap();
+        assert_eq!(created.id, "svc-1");
+        assert_eq!(created.name.as_deref(), Some("keystone-rs"));
+    }
+
+    #[tokio::test]
+    async fn test_create_service_without_name() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/services");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "service": { "id": "svc-2", "type": "identity-rs", "enabled": true }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = command("identity-rs", None);
+        let created = cmd.create_with_client(&client, &base).await;
+        assert!(created.is_ok());
+        assert_eq!(created.unwrap().id, "svc-2");
+    }
+
+    #[tokio::test]
+    async fn test_create_service_error() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/services");
+            then.status(500).body("internal error");
+        });
+
+        let client = Client::new();
+        let cmd = command("identity-rs", None);
+        let result = cmd.create_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/service/delete.rs
+++ b/crates/cli-manage/src/catalog/service/delete.rs
@@ -1,0 +1,106 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode};
+
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client};
+
+/// Delete a catalog service.
+#[derive(Parser)]
+pub(super) struct DeleteCommand {
+    /// The ID of the service to delete.
+    id: String,
+}
+
+impl DeleteCommand {
+    /// Delete the service against a pre-built HTTP client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn delete_with_client(&self, client: &Client, base_url: &str) -> Result<()> {
+        let res = client
+            .delete(format!("{base_url}/v3/services/{}", self.id))
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::NO_CONTENT {
+            return Err(eyre!(
+                "failed to delete service: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl PerformAction for DeleteCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        self.delete_with_client(&client, ADMIN_BASE_URL).await?;
+        println!("Deleted service {}", self.id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_delete_service() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::DELETE).path("/v3/services/svc-1");
+            then.status(204);
+        });
+
+        let client = Client::new();
+        let cmd = DeleteCommand {
+            id: "svc-1".to_string(),
+        };
+        let result = cmd.delete_with_client(&client, &base).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_service_not_found() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::DELETE).path("/v3/services/missing");
+            then.status(404).body("not found");
+        });
+
+        let client = Client::new();
+        let cmd = DeleteCommand {
+            id: "missing".to_string(),
+        };
+        let result = cmd.delete_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/service/list.rs
+++ b/crates/cli-manage/src/catalog/service/list.rs
@@ -1,0 +1,172 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode, Url};
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, print_list_table};
+
+/// List catalog services.
+#[derive(Parser)]
+pub(super) struct ListCommand {
+    /// Filter by service name.
+    #[arg(long)]
+    name: Option<String>,
+
+    /// Filter by service type.
+    #[arg(long = "type")]
+    r#type: Option<String>,
+}
+
+impl ListCommand {
+    /// List services against a pre-built HTTP client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn list_with_client(&self, client: &Client, base_url: &str) -> Result<Vec<Service>> {
+        let mut params: Vec<(&str, &str)> = Vec::new();
+        if let Some(name) = &self.name {
+            params.push(("name", name));
+        }
+        if let Some(r#type) = &self.r#type {
+            params.push(("type", r#type));
+        }
+
+        let res = client
+            .get(Url::parse_with_params(
+                &format!("{base_url}/v3/services"),
+                &params,
+            )?)
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::OK {
+            return Err(eyre!(
+                "failed to list services: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(res.json::<ServiceList>().await?.services)
+    }
+}
+
+#[async_trait]
+impl PerformAction for ListCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        let services = self.list_with_client(&client, ADMIN_BASE_URL).await?;
+
+        print_list_table(
+            vec!["ID", "Type", "Name", "Enabled"],
+            services
+                .into_iter()
+                .map(|service| {
+                    vec![
+                        service.id,
+                        service.r#type.unwrap_or_default(),
+                        service.name.unwrap_or_default(),
+                        service.enabled.to_string(),
+                    ]
+                })
+                .collect(),
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_list_services() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET).path("/v3/services");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "services": [
+                        { "id": "svc-1", "type": "identity-rs", "enabled": true, "name": "keystone-rs" }
+                    ]
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = ListCommand {
+            name: None,
+            r#type: None,
+        };
+        let result = cmd.list_with_client(&client, &base).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_services_with_filters() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("name", "keystone-rs")
+                .query_param("type", "identity-rs");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "services": [] }));
+        });
+
+        let client = Client::new();
+        let cmd = ListCommand {
+            name: Some("keystone-rs".to_string()),
+            r#type: Some("identity-rs".to_string()),
+        };
+        let result = cmd.list_with_client(&client, &base).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_services_error() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET).path("/v3/services");
+            then.status(500).body("internal error");
+        });
+
+        let client = Client::new();
+        let cmd = ListCommand {
+            name: None,
+            r#type: None,
+        };
+        let result = cmd.list_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/service/show.rs
+++ b/crates/cli-manage/src/catalog/service/show.rs
@@ -1,0 +1,119 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode};
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, print_attribute_table};
+
+/// Show a catalog service.
+#[derive(Parser)]
+pub(super) struct ShowCommand {
+    /// The ID of the service to show.
+    id: String,
+}
+
+impl ShowCommand {
+    /// Fetch the service against a pre-built HTTP client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn show_with_client(&self, client: &Client, base_url: &str) -> Result<Service> {
+        let res = client
+            .get(format!("{base_url}/v3/services/{}", self.id))
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::OK {
+            return Err(eyre!(
+                "failed to show service: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(res.json::<ServiceResponse>().await?.service)
+    }
+}
+
+#[async_trait]
+impl PerformAction for ShowCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        let service = self.show_with_client(&client, ADMIN_BASE_URL).await?;
+
+        print_attribute_table(vec![
+            ("id", service.id),
+            ("type", service.r#type.unwrap_or_default()),
+            ("name", service.name.unwrap_or_default()),
+            ("enabled", service.enabled.to_string()),
+        ]);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_show_service() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET).path("/v3/services/svc-1");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "service": { "id": "svc-1", "type": "identity-rs", "enabled": true, "name": "keystone-rs" }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = ShowCommand {
+            id: "svc-1".to_string(),
+        };
+        let result = cmd.show_with_client(&client, &base).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, "svc-1");
+    }
+
+    #[tokio::test]
+    async fn test_show_service_not_found() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET).path("/v3/services/missing");
+            then.status(404).body("not found");
+        });
+
+        let client = Client::new();
+        let cmd = ShowCommand {
+            id: "missing".to_string(),
+        };
+        let result = cmd.show_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/catalog/service/update.rs
+++ b/crates/cli-manage/src/catalog/service/update.rs
@@ -1,0 +1,165 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::{Parser, ValueEnum};
+use color_eyre::{Report, eyre::eyre};
+use eyre::Result;
+use reqwest::{Client, StatusCode};
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_keystone_config::Config;
+
+use crate::PerformAction;
+use crate::common::{ADMIN_BASE_URL, build_admin_client, print_attribute_table};
+
+#[derive(Clone, Copy, ValueEnum)]
+enum BoolArg {
+    True,
+    False,
+}
+
+impl From<BoolArg> for bool {
+    fn from(value: BoolArg) -> Self {
+        matches!(value, BoolArg::True)
+    }
+}
+
+/// Update a catalog service.
+#[derive(Parser)]
+pub(super) struct UpdateCommand {
+    /// The ID of the service to update.
+    id: String,
+
+    /// New service type.
+    #[arg(long = "type")]
+    r#type: Option<String>,
+
+    /// New service name.
+    #[arg(long)]
+    name: Option<String>,
+
+    /// Whether the service and its endpoints appear in the catalog.
+    #[arg(long)]
+    enabled: Option<BoolArg>,
+}
+
+impl UpdateCommand {
+    /// Update the service against a pre-built HTTP client.
+    #[cfg_attr(not(test), doc(hidden))]
+    pub async fn update_with_client(&self, client: &Client, base_url: &str) -> Result<Service> {
+        let mut builder = ServiceUpdateBuilder::default();
+        if let Some(r#type) = &self.r#type {
+            builder.r#type(r#type.clone());
+        }
+        if let Some(name) = &self.name {
+            builder.name(name.clone());
+        }
+        if let Some(enabled) = self.enabled {
+            builder.enabled(bool::from(enabled));
+        }
+
+        let res = client
+            .patch(format!("{base_url}/v3/services/{}", self.id))
+            .json(&ServiceUpdateRequest {
+                service: builder.build()?,
+            })
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::OK {
+            return Err(eyre!(
+                "failed to update service: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        Ok(res.json::<ServiceResponse>().await?.service)
+    }
+}
+
+#[async_trait]
+impl PerformAction for UpdateCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = build_admin_client(config).await?;
+        let updated = self.update_with_client(&client, ADMIN_BASE_URL).await?;
+
+        print_attribute_table(vec![
+            ("id", updated.id),
+            ("type", updated.r#type.unwrap_or_default()),
+            ("name", updated.name.unwrap_or_default()),
+            ("enabled", updated.enabled.to_string()),
+        ]);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method, MockServer};
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update_service() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::PATCH).path("/v3/services/svc-1");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "service": { "id": "svc-1", "type": "identity-rs", "enabled": false, "name": "renamed" }
+                }));
+        });
+
+        let client = Client::new();
+        let cmd = UpdateCommand {
+            id: "svc-1".to_string(),
+            r#type: None,
+            name: Some("renamed".to_string()),
+            enabled: Some(BoolArg::False),
+        };
+        let result = cmd.update_with_client(&client, &base).await;
+        assert!(result.is_ok());
+        let updated = result.unwrap();
+        assert_eq!(updated.name.as_deref(), Some("renamed"));
+        assert!(!updated.enabled);
+    }
+
+    #[tokio::test]
+    async fn test_update_service_error() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::PATCH).path("/v3/services/missing");
+            then.status(404).body("not found");
+        });
+
+        let client = Client::new();
+        let cmd = UpdateCommand {
+            id: "missing".to_string(),
+            r#type: None,
+            name: None,
+            enabled: None,
+        };
+        let result = cmd.update_with_client(&client, &base).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli-manage/src/common.rs
+++ b/crates/cli-manage/src/common.rs
@@ -16,18 +16,24 @@
 
 use std::io;
 
-use color_eyre::eyre::WrapErr;
+use color_eyre::eyre::{WrapErr, eyre};
+use comfy_table::{ContentArrangement, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use eyre::Result;
+use reqwest::Client;
 use sea_orm::ConnectOptions;
 use sea_orm::Database;
 use sea_orm::DatabaseConnection;
 use secrecy::ExposeSecret;
+use spiffe_rustls::{authorizer, mtls_client};
 use tracing_subscriber::{
     filter::{LevelFilter, Targets},
     prelude::*,
 };
 
 use openstack_keystone_config::Config;
+
+/// Base URL used by [`build_admin_client`]'s Unix-socket-backed client.
+pub const ADMIN_BASE_URL: &str = "https://localhost";
 
 /// Install a stderr-writing tracing subscriber at the verbosity implied by
 /// `-v` repeats.
@@ -69,4 +75,63 @@ pub async fn connect_db(config: &Config) -> Result<DatabaseConnection> {
     Database::connect(opt)
         .await
         .wrap_err("Database connection failed")
+}
+
+/// Build a `reqwest` client that talks to the admin API over the
+/// SPIFFE-mTLS Unix socket configured in `[interface_admin]`.
+///
+/// The returned client should be pointed at [`ADMIN_BASE_URL`].
+pub async fn build_admin_client(config: &Config) -> Result<Client> {
+    let admin_if = config.interface_admin.as_ref().ok_or_else(|| {
+        eyre!("admin interface not configured; this command requires [interface_admin]")
+    })?;
+    let ks_admin_socket = admin_if.listener.socket_path.clone();
+
+    // Fetch X.509 SVID dynamically from SPIFFE
+    let source = spiffe::X509Source::new().await?;
+
+    // Build mTLS ClientConfig with SPIFFE SVID
+    let client_config = mtls_client(source.clone())
+        .authorize(authorizer::any())
+        .build()
+        .wrap_err("Building SPIFFE mTLS client config failed")?;
+
+    // Create reqwest client with UDS + SPIFFE mTLS
+    Client::builder()
+        .unix_socket(ks_admin_socket)
+        .tls_backend_preconfigured(client_config)
+        .build()
+        .wrap_err("Building reqwest client failed")
+}
+
+/// Build a `comfy_table::Table` with the project's default styling.
+fn new_table() -> Table {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+    table
+}
+
+/// Print a collection of resources as a table, one row per resource and one
+/// column per attribute.
+pub fn print_list_table(headers: Vec<&str>, rows: Vec<Vec<String>>) {
+    let mut table = new_table();
+    table.set_header(headers);
+    for row in rows {
+        table.add_row(row);
+    }
+    println!("{table}");
+}
+
+/// Print a single resource as a two-column `Attribute`/`Value` table, one
+/// row per attribute.
+pub fn print_attribute_table(rows: Vec<(&str, String)>) {
+    let mut table = new_table();
+    table.set_header(vec!["Attribute", "Value"]);
+    for (attribute, value) in rows {
+        table.add_row(vec![attribute.to_string(), value]);
+    }
+    println!("{table}");
 }

--- a/crates/cli-manage/src/main.rs
+++ b/crates/cli-manage/src/main.rs
@@ -23,6 +23,7 @@ use color_eyre::Report;
 use openstack_keystone_config::Config;
 
 mod bootstrap;
+mod catalog;
 mod common;
 mod credential;
 mod db;
@@ -31,6 +32,7 @@ mod storage;
 mod token;
 
 use crate::bootstrap::*;
+use crate::catalog::*;
 use crate::credential::*;
 use crate::db::*;
 use crate::oauth2::*;
@@ -62,6 +64,9 @@ enum Command {
     /// Bootstrap.
     Bootstrap(BootstrapCommand),
 
+    /// Service catalog (service/endpoint) management.
+    Catalog(CatalogCommand),
+
     /// Credential encryption key management (ADR 0019 §4).
     Credential(CredentialCommand),
 
@@ -90,6 +95,7 @@ async fn main() -> Result<(), Report> {
     let cfg = Config::load_all(args.config)?;
     match args.command {
         Command::Bootstrap(x) => x.take_action(&cfg).await?,
+        Command::Catalog(x) => x.take_action(&cfg).await?,
         Command::Credential(x) => x.take_action(&cfg).await?,
         Command::Db(x) => x.take_action(&cfg).await?,
         Command::Oauth2(x) => x.take_action(&cfg).await?,

--- a/crates/config/src/interface.rs
+++ b/crates/config/src/interface.rs
@@ -69,7 +69,8 @@ impl Default for PublicInterface {
 /// Keystone health/metrics API interface.
 #[derive(Debug, Deserialize, Clone)]
 pub struct MetricsInterface {
-    /// Default address for the health/metrics endpoint. Defaults to `0.0.0.0:8099`.
+    /// Default address for the health/metrics endpoint. Defaults to
+    /// `0.0.0.0:8099`.
     #[serde(default = "default_metrics_tcp_address")]
     pub tcp_address: SocketAddr,
 }

--- a/crates/core-types/src/catalog/endpoint.rs
+++ b/crates/core-types/src/catalog/endpoint.rs
@@ -15,12 +15,13 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
+use serde::Serialize;
 use serde_json::Value;
 use validator::Validate;
 
 use crate::error::BuilderError;
 
-#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[derive(Builder, Clone, Debug, Default, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Endpoint {

--- a/crates/core-types/src/catalog/service.rs
+++ b/crates/core-types/src/catalog/service.rs
@@ -15,12 +15,13 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
+use serde::Serialize;
 use serde_json::Value;
 use validator::Validate;
 
 use crate::error::BuilderError;
 
-#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[derive(Builder, Clone, Debug, Default, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Service {

--- a/crates/keystone/src/api/v3/endpoint/create.rs
+++ b/crates/keystone/src/api/v3/endpoint/create.rs
@@ -1,0 +1,324 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Create endpoint API
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{EndpointCreateRequest, EndpointResponse};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Create a new Endpoint.
+#[utoipa::path(
+    post,
+    path = "/",
+    responses(
+        (status = CREATED, description = "Endpoint created", body = EndpointResponse),
+        (status = 400, description = "Invalid input"),
+        (status = 404, description = "Service not found"),
+        (status = 500, description = "Internal error")
+    ),
+    tag="endpoints"
+)]
+#[tracing::instrument(name = "api::v3::endpoint_create", level = "debug", skip(state))]
+pub(super) async fn create(
+    Auth(user_auth): Auth,
+    State(state): State<ServiceState>,
+    Json(payload): Json<EndpointCreateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    // Validate the request
+    payload.validate()?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/endpoint/create",
+            &user_auth,
+            json!({"endpoint": payload.endpoint}),
+            None,
+        )
+        .await?;
+
+    let exec = ExecutionContext::from_auth(&state, &user_auth);
+
+    // Ensure the referenced service actually exists before creating the
+    // endpoint.
+    if state
+        .provider
+        .get_catalog_provider()
+        .get_service(&exec, &payload.endpoint.service_id)
+        .await?
+        .is_none()
+    {
+        return Err(KeystoneApiError::NotFound {
+            resource: "service".into(),
+            identifier: payload.endpoint.service_id.clone(),
+        });
+    }
+
+    // Create the endpoint
+    let created_endpoint = state
+        .provider
+        .get_catalog_provider()
+        .create_endpoint(&exec, payload.into())
+        .await?;
+
+    // Return response with 201 Created status
+    Ok((
+        StatusCode::CREATED,
+        Json(EndpointResponse {
+            endpoint: created_endpoint.into(),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt; // for `collect`
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::{EndpointBuilder, EndpointCreate, ServiceBuilder};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::endpoint::types::{Endpoint as ApiEndpoint, EndpointResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_create() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "svc1")
+            .returning(|_, _| {
+                Ok(Some(
+                    ServiceBuilder::default()
+                        .id("svc1")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        catalog_mock
+            .expect_create_endpoint()
+            .withf(|_, endpoint_create: &EndpointCreate| {
+                endpoint_create.service_id == "svc1"
+                    && endpoint_create.interface == "public"
+                    && endpoint_create.url == "https://example.com"
+                    && endpoint_create.id.is_none()
+            })
+            .returning(|_, _| {
+                Ok(EndpointBuilder::default()
+                    .id("new_endpoint_id")
+                    .interface("public")
+                    .service_id("svc1")
+                    .url("https://example.com")
+                    .enabled(true)
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = crate::api::v3::endpoint::types::EndpointCreateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointCreateBuilder::default()
+                .interface("public")
+                .service_id("svc1")
+                .url("https://example.com")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: EndpointResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiEndpoint {
+                id: "new_endpoint_id".into(),
+                interface: "public".into(),
+                region_id: None,
+                service_id: "svc1".into(),
+                url: "https://example.com".into(),
+                enabled: true,
+                extra: std::collections::HashMap::new(),
+            },
+            res.endpoint,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_service_not_found() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "missing")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::endpoint::types::EndpointCreateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointCreateBuilder::default()
+                .interface("public")
+                .service_id("missing")
+                .url("https://example.com")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_create_forbidden() {
+        let catalog_mock = MockCatalogProvider::default();
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::endpoint::types::EndpointCreateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointCreateBuilder::default()
+                .interface("public")
+                .service_id("svc1")
+                .url("https://example.com")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_create_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::endpoint::types::EndpointCreateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointCreateBuilder::default()
+                .interface("public")
+                .service_id("svc1")
+                .url("https://example.com")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/endpoint/delete.rs
+++ b/crates/keystone/src/api/v3/endpoint/delete.rs
@@ -1,0 +1,258 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Delete endpoint API.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Delete an endpoint.
+#[utoipa::path(
+    delete,
+    path = "/{endpoint_id}",
+    description = "Delete endpoint by ID",
+    params(),
+    responses(
+        (status = NO_CONTENT, description = "Endpoint deleted"),
+        (status = 404, description = "Endpoint not found", example = json!(KeystoneApiError::NotFound{resource: "endpoint".into(), identifier: "id = 1".into()}))
+    ),
+    tag="endpoints"
+)]
+#[tracing::instrument(name = "api::endpoint_delete", level = "debug", skip(state))]
+pub(super) async fn delete(
+    Auth(user_auth): Auth,
+    Path(endpoint_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_endpoint(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &endpoint_id,
+        )
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/endpoint/delete",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(json!({"endpoint": current})),
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            state
+                .provider
+                .get_catalog_provider()
+                .delete_endpoint(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &endpoint_id,
+                )
+                .await?;
+
+            Ok(StatusCode::NO_CONTENT.into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "endpoint".into(),
+            identifier: endpoint_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::EndpointBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_delete_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    EndpointBuilder::default()
+                        .id("foo")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        catalog_mock
+            .expect_delete_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(()));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_delete_forbidden() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    EndpointBuilder::default()
+                        .id("foo")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_delete_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/endpoint/list.rs
+++ b/crates/keystone/src/api/v3/endpoint/list.rs
@@ -1,0 +1,210 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use super::types::{Endpoint, EndpointList, EndpointListParameters};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// List endpoints
+#[utoipa::path(
+    get,
+    path = "/",
+    params(EndpointListParameters),
+    description = "List endpoints",
+    responses(
+        (status = OK, description = "List of endpoints", body = EndpointList),
+        (status = 500, description = "Internal error", example = json!(KeystoneApiError::InternalError(String::from("id = 1"))))
+    ),
+    tag="endpoints"
+)]
+#[tracing::instrument(name = "api::endpoint_list", level = "debug", skip(state))]
+pub(super) async fn list(
+    Auth(user_auth): Auth,
+    Query(query): Query<EndpointListParameters>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/endpoint/list",
+            &user_auth,
+            json!({"endpoint": query}),
+            None,
+        )
+        .await?;
+    let endpoints: Vec<Endpoint> = state
+        .provider
+        .get_catalog_provider()
+        .list_endpoints(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    Ok((StatusCode::OK, Json(EndpointList { endpoints })).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt; // for `collect`
+
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::{EndpointBuilder, EndpointListParameters};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::endpoint::types::{Endpoint as ApiEndpoint, EndpointList};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_list() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_endpoints()
+            .withf(|_, _: &EndpointListParameters| true)
+            .returning(|_, _| {
+                Ok(vec![
+                    EndpointBuilder::default()
+                        .id("1")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: EndpointList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            vec![ApiEndpoint {
+                id: "1".into(),
+                interface: "public".into(),
+                region_id: None,
+                service_id: "svc1".into(),
+                url: "https://example.com".into(),
+                enabled: true,
+                extra: std::collections::HashMap::new(),
+            }],
+            res.endpoints
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_qp() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_endpoints()
+            .withf(|_, qp: &EndpointListParameters| {
+                EndpointListParameters {
+                    interface: Some("public".into()),
+                    service_id: Some("svc1".into()),
+                    region_id: Some("region1".into()),
+                } == *qp
+            })
+            .returning(|_, _| Ok(Vec::new()));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?interface=public&service_id=svc1&region_id=region1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let _res: EndpointList = serde_json::from_slice(&body).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_unauth() {
+        let state = get_mocked_state(Provider::mocked_builder(), false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/endpoint/mod.rs
+++ b/crates/keystone/src/api/v3/endpoint/mod.rs
@@ -11,26 +11,22 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-pub mod api_key;
-pub mod assignment;
-pub mod auth;
-pub mod common;
-pub mod credential;
-pub mod endpoint;
-pub mod federation;
-pub mod guard;
-pub mod identity;
-pub mod mapping;
-pub mod oauth2;
-pub mod resource;
-pub mod role;
-pub mod scim;
-pub mod scim_realm;
-pub mod service;
-pub mod token_restriction;
-pub mod webauthn;
+//! # Endpoint API
 
-pub mod k8s_auth {
-    pub mod auth;
-    pub mod instance;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::keystone::ServiceState;
+
+mod create;
+mod delete;
+mod list;
+mod show;
+pub mod types;
+mod update;
+
+pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new()
+        .routes(routes!(list::list, create::create))
+        .routes(routes!(show::show, delete::delete))
+        .routes(routes!(update::update))
 }

--- a/crates/keystone/src/api/v3/endpoint/show.rs
+++ b/crates/keystone/src/api/v3/endpoint/show.rs
@@ -1,0 +1,212 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use openstack_keystone_api_types::v3::endpoint::{Endpoint, EndpointResponse};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Get single endpoint
+#[utoipa::path(
+    get,
+    path = "/{endpoint_id}",
+    description = "Get endpoint by ID",
+    params(),
+    responses(
+        (status = OK, description = "Endpoint object", body = EndpointResponse),
+        (status = 404, description = "Endpoint not found", example = json!(KeystoneApiError::NotFound{resource: "endpoint".into(), identifier: "id = 1".into()}))
+    ),
+    tag="endpoints"
+)]
+#[tracing::instrument(name = "api::endpoint_get", level = "debug", skip(state))]
+pub(super) async fn show(
+    Auth(user_auth): Auth,
+    Path(endpoint_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_endpoint(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &endpoint_id,
+        )
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/endpoint/show",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(json!({"endpoint": current})),
+        )
+        .await?;
+
+    match current {
+        Some(current) => Ok((
+            StatusCode::OK,
+            Json(EndpointResponse {
+                endpoint: Endpoint::from(current),
+            }),
+        )
+            .into_response()),
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "endpoint".into(),
+            identifier: endpoint_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::EndpointBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::endpoint::types::{Endpoint as ApiEndpoint, EndpointResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_show_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    EndpointBuilder::default()
+                        .id("foo")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: EndpointResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiEndpoint {
+                id: "foo".into(),
+                interface: "public".into(),
+                region_id: None,
+                service_id: "svc1".into(),
+                url: "https://example.com".into(),
+                enabled: true,
+                extra: std::collections::HashMap::new(),
+            },
+            res.endpoint,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_show_not_found_not_allowed() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_show_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(Request::builder().uri("/foo").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/endpoint/types.rs
+++ b/crates/keystone/src/api/v3/endpoint/types.rs
@@ -11,26 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-pub mod api_key;
-pub mod assignment;
-pub mod auth;
-pub mod common;
-pub mod credential;
-pub mod endpoint;
-pub mod federation;
-pub mod guard;
-pub mod identity;
-pub mod mapping;
-pub mod oauth2;
-pub mod resource;
-pub mod role;
-pub mod scim;
-pub mod scim_realm;
-pub mod service;
-pub mod token_restriction;
-pub mod webauthn;
 
-pub mod k8s_auth {
-    pub mod auth;
-    pub mod instance;
-}
+pub use openstack_keystone_api_types::v3::endpoint::*;

--- a/crates/keystone/src/api/v3/endpoint/update.rs
+++ b/crates/keystone/src/api/v3/endpoint/update.rs
@@ -1,0 +1,399 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{Endpoint, EndpointResponse, EndpointUpdateRequest};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Update existing endpoint
+#[utoipa::path(
+    put,
+    path = "/{endpoint_id}",
+    description = "Update endpoint by ID",
+    params(),
+    responses(
+        (status = OK, description = "Updated endpoint", body = EndpointResponse),
+        (status = 404, description = "Endpoint not found", example = json!(KeystoneApiError::NotFound{resource: "endpoint".into(), identifier: "id = 1".into()}))
+    ),
+    tag="endpoints"
+)]
+#[tracing::instrument(name = "api::update_endpoint", level = "debug", skip(state))]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path(endpoint_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<EndpointUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    // Validate the request
+    req.validate()?;
+
+    let exec = ExecutionContext::from_auth(&state, &user_auth);
+
+    // Fetch the current endpoint to pass it as existing object into the
+    // policy evaluation
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_endpoint(&exec, &endpoint_id)
+        .await?;
+
+    let existing_endpoint = current.as_ref().map(|c| json!({"endpoint": c}));
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/endpoint/update",
+            &user_auth,
+            json!({"endpoint": req.endpoint}),
+            existing_endpoint,
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            if let Some(service_id) = &req.endpoint.service_id
+                && state
+                    .provider
+                    .get_catalog_provider()
+                    .get_service(&exec, service_id)
+                    .await?
+                    .is_none()
+            {
+                return Err(KeystoneApiError::NotFound {
+                    resource: "service".into(),
+                    identifier: service_id.clone(),
+                });
+            }
+
+            let endpoint = state
+                .provider
+                .get_catalog_provider()
+                .update_endpoint(&exec, &endpoint_id, req.into())
+                .await?;
+            Ok((
+                StatusCode::OK,
+                Json(EndpointResponse {
+                    endpoint: Endpoint::from(endpoint),
+                }),
+            )
+                .into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "endpoint".into(),
+            identifier: endpoint_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::EndpointBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::endpoint::types::{Endpoint as ApiEndpoint, EndpointResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_update_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    EndpointBuilder::default()
+                        .id("foo")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        catalog_mock
+            .expect_update_endpoint()
+            .withf(|_, id: &'_ str, _| id == "foo")
+            .returning(|_, _, _| {
+                Ok(EndpointBuilder::default()
+                    .id("foo")
+                    .interface("public")
+                    .service_id("svc1")
+                    .url("https://example.com")
+                    .enabled(false)
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::endpoint::types::EndpointUpdateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointUpdateBuilder::default()
+                .enabled(false)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: EndpointResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiEndpoint {
+                id: "foo".into(),
+                interface: "public".into(),
+                region_id: None,
+                service_id: "svc1".into(),
+                url: "https://example.com".into(),
+                enabled: false,
+                extra: std::collections::HashMap::new(),
+            },
+            res.endpoint,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_new_service_not_found() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    EndpointBuilder::default()
+                        .id("foo")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "missing")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::endpoint::types::EndpointUpdateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointUpdateBuilder::default()
+                .service_id("missing")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::endpoint::types::EndpointUpdateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointUpdateBuilder::default()
+                .enabled(false)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_forbidden() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_endpoint()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    EndpointBuilder::default()
+                        .id("foo")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::endpoint::types::EndpointUpdateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointUpdateBuilder::default()
+                .enabled(false)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::endpoint::types::EndpointUpdateRequest {
+            endpoint: crate::api::v3::endpoint::types::EndpointUpdateBuilder::default()
+                .enabled(false)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/mod.rs
+++ b/crates/keystone/src/api/v3/mod.rs
@@ -30,11 +30,13 @@ pub mod auth;
 pub mod credential;
 pub mod domain;
 pub mod ec2tokens;
+pub mod endpoint;
 pub mod group;
 pub mod project;
 pub mod role;
 pub mod role_assignment;
 pub mod role_inferences;
+pub mod service;
 pub mod user;
 
 use crate::api::types::*;
@@ -54,10 +56,12 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
         .nest("/credentials", credential::openapi_router())
         .nest("/domains", domain::openapi_router())
         .nest("/ec2tokens", ec2tokens::openapi_router())
+        .nest("/endpoints", endpoint::openapi_router())
         .nest("/groups", group::openapi_router())
         .nest("/projects", project::openapi_router())
         .nest("/roles", role::openapi_router())
         .nest("/role_inferences", role_inferences::openapi_router())
+        .nest("/services", service::openapi_router())
         .nest("/users", user::openapi_router())
         .merge(role_assignment::openapi_router())
         .routes(routes!(version))

--- a/crates/keystone/src/api/v3/service/create.rs
+++ b/crates/keystone/src/api/v3/service/create.rs
@@ -1,0 +1,244 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Create service API
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{ServiceCreateRequest, ServiceResponse};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Create a new Service.
+#[utoipa::path(
+    post,
+    path = "/",
+    responses(
+        (status = CREATED, description = "Service created", body = ServiceResponse),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal error")
+    ),
+    tag="services"
+)]
+#[tracing::instrument(name = "api::v3::service_create", level = "debug", skip(state))]
+pub(super) async fn create(
+    Auth(user_auth): Auth,
+    State(state): State<ServiceState>,
+    Json(payload): Json<ServiceCreateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    // Validate the request
+    payload.validate()?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/service/create",
+            &user_auth,
+            json!({"service": payload.service}),
+            None,
+        )
+        .await?;
+    // Create the service
+    let created_service = state
+        .provider
+        .get_catalog_provider()
+        .create_service(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            payload.into(),
+        )
+        .await?;
+
+    // Return response with 201 Created status
+    Ok((
+        StatusCode::CREATED,
+        Json(ServiceResponse {
+            service: created_service.into(),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt; // for `collect`
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::{ServiceBuilder, ServiceCreate};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::service::types::{Service as ApiService, ServiceResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_create() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_create_service()
+            .withf(|_, service_create: &ServiceCreate| {
+                service_create.r#type.as_deref() == Some("identity")
+                    && service_create.enabled
+                    && service_create.id.is_none()
+                    && service_create.extra.get("name").and_then(|v| v.as_str())
+                        == Some("new_service")
+            })
+            .returning(|_, _| {
+                Ok(ServiceBuilder::default()
+                    .id("new_service_id")
+                    .r#type("identity")
+                    .enabled(true)
+                    .extra(std::collections::HashMap::from([(
+                        "name".to_string(),
+                        serde_json::json!("new_service"),
+                    )]))
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = crate::api::v3::service::types::ServiceCreateRequest {
+            service: crate::api::v3::service::types::ServiceCreateBuilder::default()
+                .r#type("identity")
+                .enabled(true)
+                .name("new_service")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ServiceResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiService {
+                id: "new_service_id".into(),
+                r#type: Some("identity".into()),
+                enabled: true,
+                name: Some("new_service".into()),
+                extra: std::collections::HashMap::new(),
+            },
+            res.service,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_forbidden() {
+        let catalog_mock = MockCatalogProvider::default();
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::service::types::ServiceCreateRequest {
+            service: crate::api::v3::service::types::ServiceCreateBuilder::default()
+                .r#type("identity")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_create_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::service::types::ServiceCreateRequest {
+            service: crate::api::v3::service::types::ServiceCreateBuilder::default()
+                .r#type("identity")
+                .enabled(true)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/service/delete.rs
+++ b/crates/keystone/src/api/v3/service/delete.rs
@@ -1,0 +1,254 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Delete service API.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Delete a service.
+#[utoipa::path(
+    delete,
+    path = "/{service_id}",
+    description = "Delete service by ID",
+    params(),
+    responses(
+        (status = NO_CONTENT, description = "Service deleted"),
+        (status = 404, description = "Service not found", example = json!(KeystoneApiError::NotFound{resource: "service".into(), identifier: "id = 1".into()}))
+    ),
+    tag="services"
+)]
+#[tracing::instrument(name = "api::service_delete", level = "debug", skip(state))]
+pub(super) async fn delete(
+    Auth(user_auth): Auth,
+    Path(service_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_service(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &service_id,
+        )
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/service/delete",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(json!({"service": current})),
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            state
+                .provider
+                .get_catalog_provider()
+                .delete_service(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &service_id,
+                )
+                .await?;
+
+            Ok(StatusCode::NO_CONTENT.into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "service".into(),
+            identifier: service_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::ServiceBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_delete_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    ServiceBuilder::default()
+                        .id("foo")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        catalog_mock
+            .expect_delete_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(()));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_delete_forbidden() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    ServiceBuilder::default()
+                        .id("foo")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_delete_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/service/list.rs
+++ b/crates/keystone/src/api/v3/service/list.rs
@@ -1,0 +1,205 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use super::types::{Service, ServiceList, ServiceListParameters};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// List services
+#[utoipa::path(
+    get,
+    path = "/",
+    params(ServiceListParameters),
+    description = "List services",
+    responses(
+        (status = OK, description = "List of services", body = ServiceList),
+        (status = 500, description = "Internal error", example = json!(KeystoneApiError::InternalError(String::from("id = 1"))))
+    ),
+    tag="services"
+)]
+#[tracing::instrument(name = "api::service_list", level = "debug", skip(state))]
+pub(super) async fn list(
+    Auth(user_auth): Auth,
+    Query(query): Query<ServiceListParameters>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/service/list",
+            &user_auth,
+            json!({"service": query}),
+            None,
+        )
+        .await?;
+    let services: Vec<Service> = state
+        .provider
+        .get_catalog_provider()
+        .list_services(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    Ok((StatusCode::OK, Json(ServiceList { services })).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt; // for `collect`
+
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::{ServiceBuilder, ServiceListParameters};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::service::types::{Service as ApiService, ServiceList};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_list() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_services()
+            .withf(|_, _: &ServiceListParameters| true)
+            .returning(|_, _| {
+                Ok(vec![
+                    ServiceBuilder::default()
+                        .id("1")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ServiceList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            vec![ApiService {
+                id: "1".into(),
+                r#type: Some("identity".into()),
+                enabled: true,
+                name: None,
+                extra: std::collections::HashMap::new(),
+            }],
+            res.services
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_qp() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_services()
+            .withf(|_, qp: &ServiceListParameters| {
+                ServiceListParameters {
+                    name: Some("name".into()),
+                    r#type: Some("identity".into()),
+                } == *qp
+            })
+            .returning(|_, _| Ok(Vec::new()));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?name=name&type=identity")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let _res: ServiceList = serde_json::from_slice(&body).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_unauth() {
+        let state = get_mocked_state(Provider::mocked_builder(), false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/service/mod.rs
+++ b/crates/keystone/src/api/v3/service/mod.rs
@@ -11,26 +11,22 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-pub mod api_key;
-pub mod assignment;
-pub mod auth;
-pub mod common;
-pub mod credential;
-pub mod endpoint;
-pub mod federation;
-pub mod guard;
-pub mod identity;
-pub mod mapping;
-pub mod oauth2;
-pub mod resource;
-pub mod role;
-pub mod scim;
-pub mod scim_realm;
-pub mod service;
-pub mod token_restriction;
-pub mod webauthn;
+//! # Service API
 
-pub mod k8s_auth {
-    pub mod auth;
-    pub mod instance;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::keystone::ServiceState;
+
+mod create;
+mod delete;
+mod list;
+mod show;
+pub mod types;
+mod update;
+
+pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new()
+        .routes(routes!(list::list, create::create))
+        .routes(routes!(show::show, delete::delete))
+        .routes(routes!(update::update))
 }

--- a/crates/keystone/src/api/v3/service/show.rs
+++ b/crates/keystone/src/api/v3/service/show.rs
@@ -1,0 +1,208 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use openstack_keystone_api_types::v3::service::{Service, ServiceResponse};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Get single service
+#[utoipa::path(
+    get,
+    path = "/{service_id}",
+    description = "Get service by ID",
+    params(),
+    responses(
+        (status = OK, description = "Service object", body = ServiceResponse),
+        (status = 404, description = "Service not found", example = json!(KeystoneApiError::NotFound{resource: "service".into(), identifier: "id = 1".into()}))
+    ),
+    tag="services"
+)]
+#[tracing::instrument(name = "api::service_get", level = "debug", skip(state))]
+pub(super) async fn show(
+    Auth(user_auth): Auth,
+    Path(service_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_service(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &service_id,
+        )
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/service/show",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(json!({"service": current})),
+        )
+        .await?;
+
+    match current {
+        Some(current) => Ok((
+            StatusCode::OK,
+            Json(ServiceResponse {
+                service: Service::from(current),
+            }),
+        )
+            .into_response()),
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "service".into(),
+            identifier: service_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::ServiceBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::service::types::{Service as ApiService, ServiceResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_show_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    ServiceBuilder::default()
+                        .id("foo")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ServiceResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiService {
+                id: "foo".into(),
+                r#type: Some("identity".into()),
+                enabled: true,
+                name: None,
+                extra: std::collections::HashMap::new(),
+            },
+            res.service,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_show_not_found_not_allowed() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_show_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(Request::builder().uri("/foo").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/service/types.rs
+++ b/crates/keystone/src/api/v3/service/types.rs
@@ -11,26 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-pub mod api_key;
-pub mod assignment;
-pub mod auth;
-pub mod common;
-pub mod credential;
-pub mod endpoint;
-pub mod federation;
-pub mod guard;
-pub mod identity;
-pub mod mapping;
-pub mod oauth2;
-pub mod resource;
-pub mod role;
-pub mod scim;
-pub mod scim_realm;
-pub mod service;
-pub mod token_restriction;
-pub mod webauthn;
 
-pub mod k8s_auth {
-    pub mod auth;
-    pub mod instance;
-}
+pub use openstack_keystone_api_types::v3::service::*;

--- a/crates/keystone/src/api/v3/service/update.rs
+++ b/crates/keystone/src/api/v3/service/update.rs
@@ -1,0 +1,323 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{Service, ServiceResponse, ServiceUpdateRequest};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Update existing service
+#[utoipa::path(
+    put,
+    path = "/{service_id}",
+    description = "Update service by ID",
+    params(),
+    responses(
+        (status = OK, description = "Updated service", body = ServiceResponse),
+        (status = 404, description = "Service not found", example = json!(KeystoneApiError::NotFound{resource: "service".into(), identifier: "id = 1".into()}))
+    ),
+    tag="services"
+)]
+#[tracing::instrument(name = "api::update_service", level = "debug", skip(state))]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path(service_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<ServiceUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    // Validate the request
+    req.validate()?;
+
+    // Fetch the current service to pass it as existing object into the
+    // policy evaluation
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_service(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &service_id,
+        )
+        .await?;
+
+    let existing_service = current.as_ref().map(|c| json!({"service": c}));
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/service/update",
+            &user_auth,
+            json!({"service": req.service}),
+            existing_service,
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            let service = state
+                .provider
+                .get_catalog_provider()
+                .update_service(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &service_id,
+                    req.into(),
+                )
+                .await?;
+            Ok((
+                StatusCode::OK,
+                Json(ServiceResponse {
+                    service: Service::from(service),
+                }),
+            )
+                .into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "service".into(),
+            identifier: service_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::ServiceBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::service::types::{Service as ApiService, ServiceResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_update_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    ServiceBuilder::default()
+                        .id("foo")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        catalog_mock
+            .expect_update_service()
+            .withf(|_, id: &'_ str, _| id == "foo")
+            .returning(|_, _, _| {
+                Ok(ServiceBuilder::default()
+                    .id("foo")
+                    .r#type("identity")
+                    .enabled(false)
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::service::types::ServiceUpdateRequest {
+            service: crate::api::v3::service::types::ServiceUpdateBuilder::default()
+                .enabled(false)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ServiceResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiService {
+                id: "foo".into(),
+                r#type: Some("identity".into()),
+                enabled: false,
+                name: None,
+                extra: std::collections::HashMap::new(),
+            },
+            res.service,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::service::types::ServiceUpdateRequest {
+            service: crate::api::v3::service::types::ServiceUpdateBuilder::default()
+                .enabled(false)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_forbidden() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_service()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    ServiceBuilder::default()
+                        .id("foo")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::service::types::ServiceUpdateRequest {
+            service: crate::api::v3::service::types::ServiceUpdateBuilder::default()
+                .enabled(false)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::service::types::ServiceUpdateRequest {
+            service: crate::api::v3::service::types::ServiceUpdateBuilder::default()
+                .enabled(false)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/policy/endpoint/create.rego
+++ b/policy/endpoint/create.rego
@@ -1,0 +1,29 @@
+# METADATA
+# title: Create endpoint
+# description: Policy for creating a catalog endpoint
+package identity.endpoint.create
+
+import data.identity
+
+# Create endpoint.
+#
+# The `input.target.endpoint` is the new endpoint object (EndpointCreate):
+#   interface:   string            The interface (public, internal, admin).
+#   region_id:   string (optional) The ID of the region.
+#   service_id:  string            The UUID of the service.
+#   url:         string            The endpoint URL.
+#   enabled:     bool              Whether the endpoint appears in the catalog.
+#
+# The `input.existing` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/endpoint/create_test.rego
+++ b/policy/endpoint/create_test.rego
@@ -1,0 +1,14 @@
+package test_endpoint_create
+
+import data.identity.endpoint.create
+
+test_allowed if {
+	create.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"endpoint": {"enabled": true}}}
+	create.allow with input as {"credentials": {"is_admin": true}, "target": {"endpoint": {"enabled": true}}}
+}
+
+test_forbidden if {
+	not create.allow with input as {"credentials": {"roles": []}}
+	not create.allow with input as {"credentials": {"roles": ["reader"]}, "target": {"endpoint": {"enabled": true}}}
+	not create.allow with input as {"credentials": {"roles": ["manager"]}, "target": {"endpoint": {"enabled": true}}}
+}

--- a/policy/endpoint/delete.rego
+++ b/policy/endpoint/delete.rego
@@ -1,0 +1,30 @@
+# METADATA
+# title: Delete endpoint
+# description: Policy for deleting a catalog endpoint
+package identity.endpoint.delete
+
+import data.identity
+
+# Delete endpoint.
+#
+# The `input.existing.endpoint` is the stored endpoint object (Endpoint):
+#   id:          string            Endpoint ID.
+#   interface:   string            The interface (public, internal, admin).
+#   region_id:   string (optional) The ID of the region.
+#   service_id:  string            The UUID of the service.
+#   url:         string            The endpoint URL.
+#   enabled:     bool              Whether the endpoint appears in the catalog.
+#
+# The `input.target` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/endpoint/delete_test.rego
+++ b/policy/endpoint/delete_test.rego
@@ -1,0 +1,14 @@
+package test_endpoint_delete
+
+import data.identity.endpoint.delete
+
+test_allowed if {
+	delete.allow with input as {"credentials": {"roles": ["admin"]}}
+	delete.allow with input as {"credentials": {"is_admin": true}}
+}
+
+test_forbidden if {
+	not delete.allow with input as {"credentials": {"roles": []}}
+	not delete.allow with input as {"credentials": {"roles": ["reader"]}}
+	not delete.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/endpoint/list.rego
+++ b/policy/endpoint/list.rego
@@ -1,0 +1,35 @@
+# METADATA
+# title: List endpoints
+# description: Policy for listing catalog endpoints
+package identity.endpoint.list
+
+import data.identity
+
+# List endpoints.
+#
+# The `input.target.endpoint` contains query parameters (EndpointListParameters):
+#   interface:   string (optional)  Filters the response by an interface.
+#   service_id:  string (optional)  Filters the response by a service ID.
+#   region_id:   string (optional)  Filters the response by a region ID.
+#
+# The `input.existing` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+# METADATA
+# description: "'reader' in the system scope can list any endpoints."
+allow if {
+	"reader" in input.credentials.roles
+	input.credentials.system_scope != null
+	"all" == input.credentials.system_scope
+}

--- a/policy/endpoint/list_test.rego
+++ b/policy/endpoint/list_test.rego
@@ -1,0 +1,16 @@
+package test_endpoint_list
+
+import data.identity.endpoint.list
+
+test_allowed if {
+	list.allow with input as {"credentials": {"roles": ["admin"]}}
+	list.allow with input as {"credentials": {"is_admin": true}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+}
+
+test_forbidden if {
+	not list.allow with input as {"credentials": {"roles": []}}
+	not list.allow with input as {"credentials": {"roles": ["reader"]}}
+	not list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not list.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/endpoint/show.rego
+++ b/policy/endpoint/show.rego
@@ -1,0 +1,38 @@
+# METADATA
+# title: Show endpoint
+# description: Policy for fetching a single catalog endpoint
+package identity.endpoint.show
+
+import data.identity
+
+# Show endpoint.
+#
+# The `input.existing.endpoint` is the stored endpoint object (Endpoint):
+#   id:          string            Endpoint ID.
+#   interface:   string            The interface (public, internal, admin).
+#   region_id:   string (optional) The ID of the region.
+#   service_id:  string            The UUID of the service.
+#   url:         string            The endpoint URL.
+#   enabled:     bool              Whether the endpoint appears in the catalog.
+#
+# The `input.target` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+# METADATA
+# description: "'reader' in the system scope can show any endpoint."
+allow if {
+	"reader" in input.credentials.roles
+	input.credentials.system_scope != null
+	"all" == input.credentials.system_scope
+}

--- a/policy/endpoint/show_test.rego
+++ b/policy/endpoint/show_test.rego
@@ -1,0 +1,16 @@
+package test_endpoint_show
+
+import data.identity.endpoint.show
+
+test_allowed if {
+	show.allow with input as {"credentials": {"roles": ["admin"]}}
+	show.allow with input as {"credentials": {"is_admin": true}}
+	show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+}
+
+test_forbidden if {
+	not show.allow with input as {"credentials": {"roles": []}}
+	not show.allow with input as {"credentials": {"roles": ["reader"]}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not show.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/endpoint/update.rego
+++ b/policy/endpoint/update.rego
@@ -1,0 +1,30 @@
+# METADATA
+# title: Update endpoint
+# description: Policy for updating a catalog endpoint
+package identity.endpoint.update
+
+import data.identity
+
+# Update endpoint.
+#
+# The `input.target.endpoint` contains the fields to change (EndpointUpdate):
+#   interface:   string (optional)  New interface.
+#   region_id:   string (optional)  New region ID.
+#   service_id:  string (optional)  New service ID.
+#   url:         string (optional)  New endpoint URL.
+#   enabled:     bool (optional)    New enabled flag.
+#
+# The `input.existing.endpoint` is the stored endpoint object (Endpoint), or
+# null if it does not exist.
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/endpoint/update_test.rego
+++ b/policy/endpoint/update_test.rego
@@ -1,0 +1,14 @@
+package test_endpoint_update
+
+import data.identity.endpoint.update
+
+test_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"endpoint": {"enabled": false}}}
+	update.allow with input as {"credentials": {"is_admin": true}, "target": {"endpoint": {"enabled": false}}}
+}
+
+test_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["reader"]}, "target": {"endpoint": {"enabled": false}}}
+	not update.allow with input as {"credentials": {"roles": ["manager"]}, "target": {"endpoint": {"enabled": false}}}
+}

--- a/policy/service/create.rego
+++ b/policy/service/create.rego
@@ -1,0 +1,27 @@
+# METADATA
+# title: Create service
+# description: Policy for creating a catalog service
+package identity.service.create
+
+import data.identity
+
+# Create service.
+#
+# The `input.target.service` is the new service object (ServiceCreate):
+#   type:     string (optional)  The service type.
+#   enabled:  bool               Whether the service appears in the catalog.
+#   name:     string (optional)  The service name.
+#
+# The `input.existing` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/service/create_test.rego
+++ b/policy/service/create_test.rego
@@ -1,0 +1,14 @@
+package test_service_create
+
+import data.identity.service.create
+
+test_allowed if {
+	create.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"service": {"enabled": true}}}
+	create.allow with input as {"credentials": {"is_admin": true}, "target": {"service": {"enabled": true}}}
+}
+
+test_forbidden if {
+	not create.allow with input as {"credentials": {"roles": []}}
+	not create.allow with input as {"credentials": {"roles": ["reader"]}, "target": {"service": {"enabled": true}}}
+	not create.allow with input as {"credentials": {"roles": ["manager"]}, "target": {"service": {"enabled": true}}}
+}

--- a/policy/service/delete.rego
+++ b/policy/service/delete.rego
@@ -1,0 +1,28 @@
+# METADATA
+# title: Delete service
+# description: Policy for deleting a catalog service
+package identity.service.delete
+
+import data.identity
+
+# Delete service.
+#
+# The `input.existing.service` is the stored service object (Service):
+#   id:       string            Service ID.
+#   type:     string (optional) The service type.
+#   enabled:  bool              Whether the service appears in the catalog.
+#   name:     string (optional) The service name.
+#
+# The `input.target` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/service/delete_test.rego
+++ b/policy/service/delete_test.rego
@@ -1,0 +1,14 @@
+package test_service_delete
+
+import data.identity.service.delete
+
+test_allowed if {
+	delete.allow with input as {"credentials": {"roles": ["admin"]}}
+	delete.allow with input as {"credentials": {"is_admin": true}}
+}
+
+test_forbidden if {
+	not delete.allow with input as {"credentials": {"roles": []}}
+	not delete.allow with input as {"credentials": {"roles": ["reader"]}}
+	not delete.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/service/list.rego
+++ b/policy/service/list.rego
@@ -1,0 +1,34 @@
+# METADATA
+# title: List services
+# description: Policy for listing catalog services
+package identity.service.list
+
+import data.identity
+
+# List services.
+#
+# The `input.target.service` contains query parameters (ServiceListParameters):
+#   name:  string (optional)  Filters the response by a service name.
+#   type:  string (optional)  Filters the response by a service type.
+#
+# The `input.existing` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+# METADATA
+# description: "'reader' in the system scope can list any services."
+allow if {
+	"reader" in input.credentials.roles
+	input.credentials.system_scope != null
+	"all" == input.credentials.system_scope
+}

--- a/policy/service/list_test.rego
+++ b/policy/service/list_test.rego
@@ -1,0 +1,16 @@
+package test_service_list
+
+import data.identity.service.list
+
+test_allowed if {
+	list.allow with input as {"credentials": {"roles": ["admin"]}}
+	list.allow with input as {"credentials": {"is_admin": true}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+}
+
+test_forbidden if {
+	not list.allow with input as {"credentials": {"roles": []}}
+	not list.allow with input as {"credentials": {"roles": ["reader"]}}
+	not list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not list.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/service/show.rego
+++ b/policy/service/show.rego
@@ -1,0 +1,36 @@
+# METADATA
+# title: Show service
+# description: Policy for fetching a single catalog service
+package identity.service.show
+
+import data.identity
+
+# Show service.
+#
+# The `input.existing.service` is the stored service object (Service):
+#   id:       string            Service ID.
+#   type:     string (optional) The service type.
+#   enabled:  bool              Whether the service appears in the catalog.
+#   name:     string (optional) The service name.
+#
+# The `input.target` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+# METADATA
+# description: "'reader' in the system scope can show any service."
+allow if {
+	"reader" in input.credentials.roles
+	input.credentials.system_scope != null
+	"all" == input.credentials.system_scope
+}

--- a/policy/service/show_test.rego
+++ b/policy/service/show_test.rego
@@ -1,0 +1,16 @@
+package test_service_show
+
+import data.identity.service.show
+
+test_allowed if {
+	show.allow with input as {"credentials": {"roles": ["admin"]}}
+	show.allow with input as {"credentials": {"is_admin": true}}
+	show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+}
+
+test_forbidden if {
+	not show.allow with input as {"credentials": {"roles": []}}
+	not show.allow with input as {"credentials": {"roles": ["reader"]}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not show.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/service/update.rego
+++ b/policy/service/update.rego
@@ -1,0 +1,28 @@
+# METADATA
+# title: Update service
+# description: Policy for updating a catalog service
+package identity.service.update
+
+import data.identity
+
+# Update service.
+#
+# The `input.target.service` contains the fields to change (ServiceUpdate):
+#   type:     string (optional)  New service type.
+#   enabled:  bool (optional)    New enabled flag.
+#   name:     string (optional)  New service name.
+#
+# The `input.existing.service` is the stored service object (Service), or
+# null if it does not exist.
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/service/update_test.rego
+++ b/policy/service/update_test.rego
@@ -1,0 +1,14 @@
+package test_service_update
+
+import data.identity.service.update
+
+test_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"service": {"enabled": false}}}
+	update.allow with input as {"credentials": {"is_admin": true}, "target": {"service": {"enabled": false}}}
+}
+
+test_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["reader"]}, "target": {"service": {"enabled": false}}}
+	not update.allow with input as {"credentials": {"roles": ["manager"]}, "target": {"service": {"enabled": false}}}
+}

--- a/tests/api/src/endpoint.rs
+++ b/tests/api/src/endpoint.rs
@@ -1,0 +1,225 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
+
+use crate::guard::*;
+
+#[derive(Clone, Debug)]
+struct EndpointCreateRequestInternal {
+    endpoint: EndpointCreate,
+}
+
+impl RestEndpoint for EndpointCreateRequestInternal {
+    fn method(&self) -> http::Method {
+        http::Method::POST
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "endpoints".to_string().into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("endpoint", serde_json::to_value(&self.endpoint)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("endpoint".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EndpointShowRequest<'a> {
+    id: Cow<'a, str>,
+}
+
+impl RestEndpoint for EndpointShowRequest<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("endpoints/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("endpoint".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+struct EndpointListRequest {}
+
+impl RestEndpoint for EndpointListRequest {
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "endpoints".into()
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("endpoints".into())
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EndpointUpdateRequestInternal<'a> {
+    id: Cow<'a, str>,
+    endpoint: EndpointUpdate,
+}
+
+impl RestEndpoint for EndpointUpdateRequestInternal<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::PUT
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("endpoints/{id}", id = self.id).into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("endpoint", serde_json::to_value(&self.endpoint)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("endpoint".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+struct EndpointDeleteRequest<'a> {
+    id: Cow<'a, str>,
+}
+
+impl RestEndpoint for EndpointDeleteRequest<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("endpoints/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Create an endpoint.
+pub async fn create_endpoint(
+    tc: &Arc<AsyncOpenStack>,
+    endpoint: EndpointCreate,
+) -> Result<AsyncResourceGuard<Endpoint>> {
+    let obj: Endpoint = EndpointCreateRequestInternal { endpoint }
+        .query_async(tc.as_ref())
+        .await?;
+    Ok(AsyncResourceGuard::new(obj, tc.clone()))
+}
+
+/// Get an endpoint by ID.
+pub async fn show_endpoint<I: AsRef<str>>(tc: &Arc<AsyncOpenStack>, id: I) -> Result<Endpoint> {
+    Ok(EndpointShowRequest {
+        id: id.as_ref().into(),
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+/// List endpoints.
+pub async fn list_endpoints(tc: &Arc<AsyncOpenStack>) -> Result<Vec<Endpoint>> {
+    Ok(EndpointListRequest::default()
+        .query_async(tc.as_ref())
+        .await?)
+}
+
+/// Update an endpoint.
+pub async fn update_endpoint<I: AsRef<str>>(
+    tc: &Arc<AsyncOpenStack>,
+    id: I,
+    endpoint: EndpointUpdate,
+) -> Result<Endpoint> {
+    Ok(EndpointUpdateRequestInternal {
+        id: id.as_ref().into(),
+        endpoint,
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+/// Delete an endpoint.
+pub async fn delete_endpoint<I: AsRef<str>>(tc: &Arc<AsyncOpenStack>, id: I) -> Result<()> {
+    Ok(openstack_sdk::api::ignore(EndpointDeleteRequest {
+        id: id.as_ref().into(),
+    })
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+#[async_trait::async_trait]
+impl DeletableResource for Endpoint {
+    async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
+        Ok(openstack_sdk::api::ignore(EndpointDeleteRequest {
+            id: self.id.clone().into(),
+        })
+        .query_async(state.as_ref())
+        .await?)
+    }
+}

--- a/tests/api/src/service.rs
+++ b/tests/api/src/service.rs
@@ -1,0 +1,225 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
+
+use crate::guard::*;
+
+#[derive(Clone, Debug)]
+struct ServiceCreateRequestInternal {
+    service: ServiceCreate,
+}
+
+impl RestEndpoint for ServiceCreateRequestInternal {
+    fn method(&self) -> http::Method {
+        http::Method::POST
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "services".to_string().into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("service", serde_json::to_value(&self.service)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("service".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ServiceShowRequest<'a> {
+    id: Cow<'a, str>,
+}
+
+impl RestEndpoint for ServiceShowRequest<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("services/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("service".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+struct ServiceListRequest {}
+
+impl RestEndpoint for ServiceListRequest {
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "services".into()
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("services".into())
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ServiceUpdateRequestInternal<'a> {
+    id: Cow<'a, str>,
+    service: ServiceUpdate,
+}
+
+impl RestEndpoint for ServiceUpdateRequestInternal<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::PUT
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("services/{id}", id = self.id).into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("service", serde_json::to_value(&self.service)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("service".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+struct ServiceDeleteRequest<'a> {
+    id: Cow<'a, str>,
+}
+
+impl RestEndpoint for ServiceDeleteRequest<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("services/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Create a service.
+pub async fn create_service(
+    tc: &Arc<AsyncOpenStack>,
+    service: ServiceCreate,
+) -> Result<AsyncResourceGuard<Service>> {
+    let obj: Service = ServiceCreateRequestInternal { service }
+        .query_async(tc.as_ref())
+        .await?;
+    Ok(AsyncResourceGuard::new(obj, tc.clone()))
+}
+
+/// Get a service by ID.
+pub async fn show_service<I: AsRef<str>>(tc: &Arc<AsyncOpenStack>, id: I) -> Result<Service> {
+    Ok(ServiceShowRequest {
+        id: id.as_ref().into(),
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+/// List services.
+pub async fn list_services(tc: &Arc<AsyncOpenStack>) -> Result<Vec<Service>> {
+    Ok(ServiceListRequest::default()
+        .query_async(tc.as_ref())
+        .await?)
+}
+
+/// Update a service.
+pub async fn update_service<I: AsRef<str>>(
+    tc: &Arc<AsyncOpenStack>,
+    id: I,
+    service: ServiceUpdate,
+) -> Result<Service> {
+    Ok(ServiceUpdateRequestInternal {
+        id: id.as_ref().into(),
+        service,
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+/// Delete a service.
+pub async fn delete_service<I: AsRef<str>>(tc: &Arc<AsyncOpenStack>, id: I) -> Result<()> {
+    Ok(openstack_sdk::api::ignore(ServiceDeleteRequest {
+        id: id.as_ref().into(),
+    })
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+#[async_trait::async_trait]
+impl DeletableResource for Service {
+    async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
+        Ok(openstack_sdk::api::ignore(ServiceDeleteRequest {
+            id: self.id.clone().into(),
+        })
+        .query_async(state.as_ref())
+        .await?)
+    }
+}

--- a/tests/api/tests/api_v3.rs
+++ b/tests/api/tests/api_v3.rs
@@ -20,7 +20,9 @@ mod api_v3 {
     mod assignment;
     mod auth;
     mod credential;
+    mod endpoint;
     mod identity;
     mod resource;
     mod role;
+    mod service;
 }

--- a/tests/api/tests/api_v3/endpoint.rs
+++ b/tests/api/tests/api_v3/endpoint.rs
@@ -11,26 +11,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-pub mod api_key;
-pub mod assignment;
-pub mod auth;
-pub mod common;
-pub mod credential;
-pub mod endpoint;
-pub mod federation;
-pub mod guard;
-pub mod identity;
-pub mod mapping;
-pub mod oauth2;
-pub mod resource;
-pub mod role;
-pub mod scim;
-pub mod scim_realm;
-pub mod service;
-pub mod token_restriction;
-pub mod webauthn;
-
-pub mod k8s_auth {
-    pub mod auth;
-    pub mod instance;
-}
+mod create;
+mod delete;
+mod list;
+mod show;
+mod update;

--- a/tests/api/tests/api_v3/endpoint/create.rs
+++ b/tests/api/tests/api_v3/endpoint/create.rs
@@ -1,0 +1,89 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::endpoint::create_endpoint;
+use test_api::guard::ResourceGuard;
+use test_api::service::create_service;
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_endpoint() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let service_name = format!("service_{}", Uuid::new_v4().simple());
+
+    let service_guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(service_name)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let url = format!("https://example.com/{}", Uuid::new_v4().simple());
+    let endpoint_guard = create_endpoint(
+        &tc,
+        EndpointCreateBuilder::default()
+            .interface("public")
+            .service_id(service_guard.id.clone())
+            .url(url.clone())
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    assert_eq!(endpoint_guard.service_id, service_guard.id);
+    assert_eq!(endpoint_guard.interface, "public");
+    assert_eq!(endpoint_guard.url, url);
+    assert!(!endpoint_guard.id.is_empty());
+
+    endpoint_guard.delete().await?;
+    service_guard.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_endpoint_missing_service_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let url = format!("https://example.com/{}", Uuid::new_v4().simple());
+
+    let result = create_endpoint(
+        &tc,
+        EndpointCreateBuilder::default()
+            .interface("public")
+            .service_id(format!("missing-{}", Uuid::new_v4().simple()))
+            .url(url)
+            .enabled(true)
+            .build()?,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "creating an endpoint for a missing service must fail"
+    );
+    Ok(())
+}

--- a/tests/api/tests/api_v3/endpoint/delete.rs
+++ b/tests/api/tests/api_v3/endpoint/delete.rs
@@ -1,0 +1,65 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::endpoint::{create_endpoint, show_endpoint};
+use test_api::guard::ResourceGuard;
+use test_api::service::create_service;
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_endpoint() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let service_name = format!("service_{}", Uuid::new_v4().simple());
+
+    let service_guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(service_name)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let url = format!("https://example.com/{}", Uuid::new_v4().simple());
+    let endpoint_guard = create_endpoint(
+        &tc,
+        EndpointCreateBuilder::default()
+            .interface("public")
+            .service_id(service_guard.id.clone())
+            .url(url)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+    let id = endpoint_guard.id.clone();
+
+    endpoint_guard.delete().await?;
+
+    let result = show_endpoint(&tc, &id).await;
+    assert!(result.is_err(), "endpoint must be gone after deletion");
+
+    service_guard.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/endpoint/list.rs
+++ b/tests/api/tests/api_v3/endpoint/list.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::endpoint::{create_endpoint, list_endpoints};
+use test_api::guard::ResourceGuard;
+use test_api::service::create_service;
+
+#[tokio::test]
+#[traced_test]
+async fn test_list_includes_created_endpoint() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let service_name = format!("service_{}", Uuid::new_v4().simple());
+
+    let service_guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(service_name)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let url = format!("https://example.com/{}", Uuid::new_v4().simple());
+    let endpoint_guard = create_endpoint(
+        &tc,
+        EndpointCreateBuilder::default()
+            .interface("public")
+            .service_id(service_guard.id.clone())
+            .url(url)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let all = list_endpoints(&tc).await?;
+    assert!(
+        all.iter().any(|e| e.id == endpoint_guard.id),
+        "created endpoint must appear in the unfiltered list"
+    );
+
+    endpoint_guard.delete().await?;
+    service_guard.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/endpoint/show.rs
+++ b/tests/api/tests/api_v3/endpoint/show.rs
@@ -1,0 +1,75 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::endpoint::{create_endpoint, show_endpoint};
+use test_api::guard::ResourceGuard;
+use test_api::service::create_service;
+
+#[tokio::test]
+#[traced_test]
+async fn test_show_endpoint() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let service_name = format!("service_{}", Uuid::new_v4().simple());
+
+    let service_guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(service_name)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let url = format!("https://example.com/{}", Uuid::new_v4().simple());
+    let endpoint_guard = create_endpoint(
+        &tc,
+        EndpointCreateBuilder::default()
+            .interface("public")
+            .service_id(service_guard.id.clone())
+            .url(url.clone())
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let fetched = show_endpoint(&tc, &endpoint_guard.id).await?;
+    assert_eq!(fetched.id, endpoint_guard.id);
+    assert_eq!(fetched.url, url);
+
+    endpoint_guard.delete().await?;
+    service_guard.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_show_missing_endpoint_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let result = show_endpoint(&tc, format!("missing-{}", Uuid::new_v4().simple())).await;
+
+    assert!(result.is_err(), "showing a missing endpoint must fail");
+    Ok(())
+}

--- a/tests/api/tests/api_v3/endpoint/update.rs
+++ b/tests/api/tests/api_v3/endpoint/update.rs
@@ -1,0 +1,94 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::endpoint::*;
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::endpoint::{create_endpoint, show_endpoint, update_endpoint};
+use test_api::guard::ResourceGuard;
+use test_api::service::create_service;
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_url() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let service_name = format!("service_{}", Uuid::new_v4().simple());
+
+    let service_guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(service_name)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let old_url = format!("https://example.com/{}", Uuid::new_v4().simple());
+    let new_url = format!("https://example.com/{}", Uuid::new_v4().simple());
+
+    let endpoint_guard = create_endpoint(
+        &tc,
+        EndpointCreateBuilder::default()
+            .interface("public")
+            .service_id(service_guard.id.clone())
+            .url(old_url)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let updated = update_endpoint(
+        &tc,
+        &endpoint_guard.id,
+        EndpointUpdateBuilder::default()
+            .url(new_url.clone())
+            .build()?,
+    )
+    .await?;
+
+    assert_eq!(updated.id, endpoint_guard.id);
+    assert_eq!(updated.url, new_url);
+
+    // Re-fetch to verify the change is persisted, not just echoed back.
+    let fetched = show_endpoint(&tc, &endpoint_guard.id).await?;
+    assert_eq!(fetched.url, new_url);
+
+    endpoint_guard.delete().await?;
+    service_guard.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_missing_endpoint_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let result = update_endpoint(
+        &tc,
+        format!("missing-{}", Uuid::new_v4().simple()),
+        EndpointUpdateBuilder::default().enabled(false).build()?,
+    )
+    .await;
+
+    assert!(result.is_err(), "updating a missing endpoint must fail");
+    Ok(())
+}

--- a/tests/api/tests/api_v3/service.rs
+++ b/tests/api/tests/api_v3/service.rs
@@ -11,26 +11,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-pub mod api_key;
-pub mod assignment;
-pub mod auth;
-pub mod common;
-pub mod credential;
-pub mod endpoint;
-pub mod federation;
-pub mod guard;
-pub mod identity;
-pub mod mapping;
-pub mod oauth2;
-pub mod resource;
-pub mod role;
-pub mod scim;
-pub mod scim_realm;
-pub mod service;
-pub mod token_restriction;
-pub mod webauthn;
-
-pub mod k8s_auth {
-    pub mod auth;
-    pub mod instance;
-}
+mod create;
+mod delete;
+mod list;
+mod show;
+mod update;

--- a/tests/api/tests/api_v3/service/create.rs
+++ b/tests/api/tests/api_v3/service/create.rs
@@ -1,0 +1,50 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::service::create_service;
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_service() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("service_{}", Uuid::new_v4().simple());
+
+    let guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(name.clone())
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    assert_eq!(guard.r#type.as_deref(), Some("identity-rs"));
+    assert_eq!(guard.name.as_deref(), Some(name.as_str()));
+    assert!(guard.enabled);
+    assert!(!guard.id.is_empty());
+
+    guard.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/service/delete.rs
+++ b/tests/api/tests/api_v3/service/delete.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::service::{create_service, show_service};
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_service() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("service_{}", Uuid::new_v4().simple());
+
+    let guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(name)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+    let id = guard.id.clone();
+
+    guard.delete().await?;
+
+    let result = show_service(&tc, &id).await;
+    assert!(result.is_err(), "service must be gone after deletion");
+    Ok(())
+}

--- a/tests/api/tests/api_v3/service/list.rs
+++ b/tests/api/tests/api_v3/service/list.rs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::service::{create_service, list_services};
+
+#[tokio::test]
+#[traced_test]
+async fn test_list_includes_created_service() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("service_{}", Uuid::new_v4().simple());
+
+    let guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(name)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let all = list_services(&tc).await?;
+    assert!(
+        all.iter().any(|s| s.id == guard.id),
+        "created service must appear in the unfiltered list"
+    );
+
+    guard.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/service/show.rs
+++ b/tests/api/tests/api_v3/service/show.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::service::{create_service, show_service};
+
+#[tokio::test]
+#[traced_test]
+async fn test_show_service() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("service_{}", Uuid::new_v4().simple());
+
+    let guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(name.clone())
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let fetched = show_service(&tc, &guard.id).await?;
+    assert_eq!(fetched.id, guard.id);
+    assert_eq!(fetched.name.as_deref(), Some(name.as_str()));
+
+    guard.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_show_missing_service_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let result = show_service(&tc, format!("missing-{}", Uuid::new_v4().simple())).await;
+
+    assert!(result.is_err(), "showing a missing service must fail");
+    Ok(())
+}

--- a/tests/api/tests/api_v3/service/update.rs
+++ b/tests/api/tests/api_v3/service/update.rs
@@ -1,0 +1,75 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::service::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::service::{create_service, show_service, update_service};
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_enabled() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("service_{}", Uuid::new_v4().simple());
+
+    let guard = create_service(
+        &tc,
+        ServiceCreateBuilder::default()
+            .r#type("identity-rs")
+            .name(name)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let updated = update_service(
+        &tc,
+        &guard.id,
+        ServiceUpdateBuilder::default().enabled(false).build()?,
+    )
+    .await?;
+
+    assert_eq!(updated.id, guard.id);
+    assert!(!updated.enabled);
+
+    // Re-fetch to verify the change is persisted, not just echoed back.
+    let fetched = show_service(&tc, &guard.id).await?;
+    assert!(!fetched.enabled);
+
+    guard.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_missing_service_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let result = update_service(
+        &tc,
+        format!("missing-{}", Uuid::new_v4().simple()),
+        ServiceUpdateBuilder::default().enabled(false).build()?,
+    )
+    .await;
+
+    assert!(result.is_err(), "updating a missing service must fail");
+    Ok(())
+}

--- a/tools/start-api.sh
+++ b/tools/start-api.sh
@@ -164,7 +164,7 @@ for i in {1..30}; do
           sleep 0.5
         done
         echo "✅ Keystone socket appeared!"
-        KEYSTONE_DEV_KEK=4242424242424242424242424242424242424242424242424242424242424242 KEYSTONE_ALLOW_ENV_KEK=1 SPIFFE_ENDPOINT_SOCKET=${SPIFFE_ENDPOINT_SOCKET} ./target/debug/keystone-manage --config "${CONFIG_FILE}" bootstrap --bootstrap-password password
+        KEYSTONE_DEV_KEK=4242424242424242424242424242424242424242424242424242424242424242 KEYSTONE_ALLOW_ENV_KEK=1 SPIFFE_ENDPOINT_SOCKET=${SPIFFE_ENDPOINT_SOCKET} ./target/debug/keystone-manage --config "${CONFIG_FILE}" bootstrap --bootstrap-password password --bootstrap-public-url http://localhost:8080
 
         echo "✅ Keystone bootstrap completed!"
 


### PR DESCRIPTION
## Summary

Implements #932: catalog (service/endpoint) CRUD over the v3 HTTP API, plus `keystone-manage bootstrap` catalog registration and a new `keystone-manage catalog` subcommand.

- **API types** (`crates/api-types/src/v3/{service,endpoint}.rs` + `_conv.rs`): `Service`/`Endpoint` request/response types mirroring `role.rs`'s shape. `Service.name` is synthesized from/to the core type's `extra["name"]`.
- **HTTP handlers** (`crates/keystone/src/api/v3/{service,endpoint}/`): create/show/list/delete mirror `role`'s handlers; `update` mirrors `user/update.rs` since `role` has no update endpoint. Endpoint create/update validate the referenced `service_id` exists (404 if not). Each handler has unit tests covering valid-auth positive, policy-denied, and invalid-auth cases (36 tests total).
- **Policy** (`policy/service/`, `policy/endpoint/`): admin-only for create/update/delete; admin + system-scope reader for show/list (reader clause copied from `policy/assignment/list.rego`). 20 new `opa test` cases, all passing.
- **Fix**: `CatalogProviderError::{Service,Endpoint,Region}NotFound` was falling through to a 500 in `error_conv.rs`; now maps to 404. Required for correct show/delete/update responses and the endpoint's service-existence check.
- **Live API tests** (`tests/api/`): new `tests/api/src/{service,endpoint}.rs` REST-client helpers and `tests/api/tests/api_v3/{service,endpoint}/` smoke tests for all five CRUD operations.
- **Bootstrap** (`crates/cli-manage/src/bootstrap.rs`): new optional `--bootstrap-region-id`/`--bootstrap-public-url`/`--bootstrap-internal-url`/`--bootstrap-admin-url` flags (env `OS_BOOTSTRAP_*`) that idempotently register an `identity` service and its endpoints, following the existing `upsert_role` GET-then-POST-then-409-refetch idiom.
- **`keystone-manage catalog`**: new nested subcommand (`catalog service create`, `catalog endpoint create`) for direct catalog mutation outside bootstrap. Endpoint creation supports `--service-id` or `--service-name` (mutually exclusive, resolved via `GET /v3/services?name=`).
- Factored the SPIFFE-mTLS admin-client-builder (previously duplicated in `bootstrap.rs`) into `common::build_admin_client`, shared by both `bootstrap` and the new `catalog` subcommand.

## Test plan

- [x] `cargo build -p openstack-keystone-api-types -p keystone -p cli-manage -p test_api`
- [x] `cargo test -p openstack-keystone-api-types -p keystone` — 36 new service/endpoint handler unit tests pass
- [x] `cargo test -p cli-manage` — 60 tests pass (24 new: bootstrap catalog + `keystone-manage catalog` subcommand)
- [x] `opa test policy` — 291/291 pass (20 new service/endpoint policy tests)
- [x] `opa fmt -d` — no diff on new rego files
- [x] `cargo fmt` / `cargo clippy --all-targets` — clean on all touched crates (no new warnings)
- [x] `pre-commit run` — passes (typos, cargo fmt, gitleaks)
- [x] `cargo nextest run --profile api -p test_api` 
- [x] Manual bootstrap run with `--bootstrap-public-url` etc. against a scratch DB