### PR TITLE
chore: Silence some clippy warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ You are a coding agent working on the OpenStack Keystone Rust implementation.
 - Follow Domain-Driven Design: domains (identity, catalog, role, etc.) are in
   separate crates
 - Policy files follow convention: `policy/<domain>/<resource>/<action>.rego`
+- When checking code, always run `cargo check --message-format=short` or pipe the
+  output to only show errors, e.g., `cargo check 2>&1 | grep -i "error"`.
 
 ## Workspace Structure
 
@@ -70,35 +72,34 @@ Backend traits in `crates/core/src/backend.rs` follow CRUD naming:
 ## Running `test_api` (live-server API tests)
 
 - `cargo nextest run --profile api -p test_api` spawns SPIRE + OPA + a real
-  `keystone` server via `tools/start-api.sh` as a nextest setup script, and
-  by default leaves them running after the run finishes (no auto-teardown).
+  `keystone` server via `tools/start-api.sh` as a nextest setup script, and by
+  default leaves them running after the run finishes (no auto-teardown).
   Re-running without cleanup can pile up stale daemons across sessions; check
-  `ps aux | grep -E 'tmp/nextest|spire-ci-test-harness'` and kill leftovers
-  (or run `tools/teardown-api.sh`) before starting a fresh run if a prior run
-  was interrupted/killed.
+  `ps aux | grep -E 'tmp/nextest|spire-ci-test-harness'` and kill leftovers (or
+  run `tools/teardown-api.sh`) before starting a fresh run if a prior run was
+  interrupted/killed.
 - **Never pipe the run through `tail`/`tail -N`** (e.g.
-  `cargo nextest run ... | tail -200`). `tail` without `-f` buffers until
-  EOF, and the setup script's long-running daemons (keystone/spire/opa)
-  inherit the pipe's write fd, so it never closes even after nextest itself
-  exits — the whole invocation looks permanently hung even though the test
-  run actually finished. Redirect to a file instead
+  `cargo nextest run ... | tail -200`). `tail` without `-f` buffers until EOF,
+  and the setup script's long-running daemons (keystone/spire/opa) inherit the
+  pipe's write fd, so it never closes even after nextest itself exits — the
+  whole invocation looks permanently hung even though the test run actually
+  finished. Redirect to a file instead
   (`cargo nextest run ... > /tmp/out.log 2>&1 &`) and read the file.
 - The `default` domain is seeded directly in the DB at bootstrap, **not**
-  created through `POST /v3/domains`. `Oauth2KeyHook` (ADR 0026) only
-  provisions a domain's OAuth2 signing keys on the domain-*creation event*,
-  so `default` never gets keys and `/v4/oauth2/default/jwks` and
+  created through `POST /v3/domains`. `Oauth2KeyHook` (ADR 0026) only provisions
+  a domain's OAuth2 signing keys on the domain-_creation event_, so `default`
+  never gets keys and `/v4/oauth2/default/jwks` and
   `/v4/oauth2/default/.well-known/openid-configuration` 404 forever. Tests
-  needing real OAuth2 signing/jwks/discovery must create a fresh domain via
-  the API first (key provisioning is async — poll before asserting).
+  needing real OAuth2 signing/jwks/discovery must create a fresh domain via the
+  API first (key provisioning is async — poll before asserting).
 - `AuthenticationResult.principal.identity` from
-  `authenticate_by_password`/password auth is always `IdentityInfo::User`,
-  never `IdentityInfo::Principal` (that variant is for SPIFFE/workload
-  identities only). Handler code and its unit-test mocks must agree on this
-  — a mismatch here doesn't fail to compile, it 500s silently at runtime
-  with no log line (an unlogged `Err(_) => error_page(500, ...)` branch), so
-  crate-level unit tests with a mock built the same wrong way won't catch
-  it. Only a live-server request through the real password-auth path
-  surfaces it.
+  `authenticate_by_password`/password auth is always `IdentityInfo::User`, never
+  `IdentityInfo::Principal` (that variant is for SPIFFE/workload identities
+  only). Handler code and its unit-test mocks must agree on this — a mismatch
+  here doesn't fail to compile, it 500s silently at runtime with no log line (an
+  unlogged `Err(_) => error_page(500, ...)` branch), so crate-level unit tests
+  with a mock built the same wrong way won't catch it. Only a live-server
+  request through the real password-auth path surfaces it.
 
 ## Commit Message Rules
 

--- a/crates/identity-driver-sql/src/local_user/get.rs
+++ b/crates/identity-driver-sql/src/local_user/get.rs
@@ -31,6 +31,7 @@ use crate::entity::{local_user, prelude::LocalUser};
 /// # Returns
 /// A `Result` containing an `Option` with the `local_user::Model` if found, or
 /// an `Error`.
+#[allow(unused)]
 pub async fn get_by_name_and_domain<N: AsRef<str>, D: AsRef<str>>(
     db: &DatabaseConnection,
     name: N,
@@ -53,6 +54,7 @@ pub async fn get_by_name_and_domain<N: AsRef<str>, D: AsRef<str>>(
 /// # Returns
 /// A `Result` containing an `Option` with the `local_user::Model` if found, or
 /// an `Error`.
+#[allow(unused)]
 pub async fn get_by_user_id<U: AsRef<str>>(
     db: &DatabaseConnection,
     user_id: U,

--- a/crates/identity-driver-sql/src/nonlocal_user/get.rs
+++ b/crates/identity-driver-sql/src/nonlocal_user/get.rs
@@ -31,6 +31,7 @@ use crate::entity::{nonlocal_user, prelude::NonlocalUser};
 /// # Returns
 /// A `Result` containing an `Option` with the `nonlocal_user::Model` if found,
 /// or an `Error`.
+#[allow(unused)]
 pub async fn get_by_name_and_domain<N: AsRef<str>, D: AsRef<str>>(
     db: &DatabaseConnection,
     name: N,

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -314,6 +314,7 @@ impl ClusterAdminServiceImpl {
     ///
     /// # Returns
     /// A new `ClusterAdminServiceImpl` instance.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         raft_node: Raft,
         node_id: u64,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -86,6 +86,7 @@ impl From<StoreError> for ApiStoreError {
 }
 
 pub mod protobuf {
+    #![allow(clippy::doc_paragraphs_missing_punctuation)]
     pub mod api {
         use serde::{Deserialize, Serialize};
         tonic::include_proto!("keystone.api");


### PR DESCRIPTION
Clippy warnings (missing punctuation) are useless for the generated
code - silence them. Also silence few more unused method warnings and
add agent instructions to use short format when checking the code to
reduce consumption.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
