### PR TITLE
feat(cli-manage): Make catalog create idempotent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ You are a coding agent working on the OpenStack Keystone Rust implementation.
 - Follow Domain-Driven Design: domains (identity, catalog, role, etc.) are in
   separate crates
 - Policy files follow convention: `policy/<domain>/<resource>/<action>.rego`
+- When checking code, always run `cargo check --message-format=short` or pipe the
+  output to only show errors, e.g., `cargo check 2>&1 | grep -i "error"`.
 
 ## Workspace Structure
 
@@ -70,35 +72,34 @@ Backend traits in `crates/core/src/backend.rs` follow CRUD naming:
 ## Running `test_api` (live-server API tests)
 
 - `cargo nextest run --profile api -p test_api` spawns SPIRE + OPA + a real
-  `keystone` server via `tools/start-api.sh` as a nextest setup script, and
-  by default leaves them running after the run finishes (no auto-teardown).
+  `keystone` server via `tools/start-api.sh` as a nextest setup script, and by
+  default leaves them running after the run finishes (no auto-teardown).
   Re-running without cleanup can pile up stale daemons across sessions; check
-  `ps aux | grep -E 'tmp/nextest|spire-ci-test-harness'` and kill leftovers
-  (or run `tools/teardown-api.sh`) before starting a fresh run if a prior run
-  was interrupted/killed.
+  `ps aux | grep -E 'tmp/nextest|spire-ci-test-harness'` and kill leftovers (or
+  run `tools/teardown-api.sh`) before starting a fresh run if a prior run was
+  interrupted/killed.
 - **Never pipe the run through `tail`/`tail -N`** (e.g.
-  `cargo nextest run ... | tail -200`). `tail` without `-f` buffers until
-  EOF, and the setup script's long-running daemons (keystone/spire/opa)
-  inherit the pipe's write fd, so it never closes even after nextest itself
-  exits — the whole invocation looks permanently hung even though the test
-  run actually finished. Redirect to a file instead
+  `cargo nextest run ... | tail -200`). `tail` without `-f` buffers until EOF,
+  and the setup script's long-running daemons (keystone/spire/opa) inherit the
+  pipe's write fd, so it never closes even after nextest itself exits — the
+  whole invocation looks permanently hung even though the test run actually
+  finished. Redirect to a file instead
   (`cargo nextest run ... > /tmp/out.log 2>&1 &`) and read the file.
 - The `default` domain is seeded directly in the DB at bootstrap, **not**
-  created through `POST /v3/domains`. `Oauth2KeyHook` (ADR 0026) only
-  provisions a domain's OAuth2 signing keys on the domain-*creation event*,
-  so `default` never gets keys and `/v4/oauth2/default/jwks` and
+  created through `POST /v3/domains`. `Oauth2KeyHook` (ADR 0026) only provisions
+  a domain's OAuth2 signing keys on the domain-_creation event_, so `default`
+  never gets keys and `/v4/oauth2/default/jwks` and
   `/v4/oauth2/default/.well-known/openid-configuration` 404 forever. Tests
-  needing real OAuth2 signing/jwks/discovery must create a fresh domain via
-  the API first (key provisioning is async — poll before asserting).
+  needing real OAuth2 signing/jwks/discovery must create a fresh domain via the
+  API first (key provisioning is async — poll before asserting).
 - `AuthenticationResult.principal.identity` from
-  `authenticate_by_password`/password auth is always `IdentityInfo::User`,
-  never `IdentityInfo::Principal` (that variant is for SPIFFE/workload
-  identities only). Handler code and its unit-test mocks must agree on this
-  — a mismatch here doesn't fail to compile, it 500s silently at runtime
-  with no log line (an unlogged `Err(_) => error_page(500, ...)` branch), so
-  crate-level unit tests with a mock built the same wrong way won't catch
-  it. Only a live-server request through the real password-auth path
-  surfaces it.
+  `authenticate_by_password`/password auth is always `IdentityInfo::User`, never
+  `IdentityInfo::Principal` (that variant is for SPIFFE/workload identities
+  only). Handler code and its unit-test mocks must agree on this — a mismatch
+  here doesn't fail to compile, it 500s silently at runtime with no log line (an
+  unlogged `Err(_) => error_page(500, ...)` branch), so crate-level unit tests
+  with a mock built the same wrong way won't catch it. Only a live-server
+  request through the real password-auth path surfaces it.
 
 ## Commit Message Rules
 

--- a/crates/cli-manage/src/bootstrap.rs
+++ b/crates/cli-manage/src/bootstrap.rs
@@ -29,6 +29,8 @@ use openstack_keystone_api_types::v3::user::*;
 use openstack_keystone_config::Config;
 
 use crate::PerformAction;
+use crate::catalog::endpoint::create::CreateCommand as EndpointCreateCommand;
+use crate::catalog::service::create::CreateCommand as ServiceCreateCommand;
 use crate::common::{ADMIN_BASE_URL, build_admin_client, setup_logging};
 
 /// Bootstrap Keystone data.
@@ -459,53 +461,13 @@ impl BootstrapCommand {
         service_type: S,
         base_url: &str,
     ) -> Result<Service> {
-        let url = format!("{base_url}/v3/services");
-        let existing_services = client
-            .get(Url::parse_with_params(
-                &url,
-                &[("type", service_type.as_ref())],
-            )?)
-            .send()
-            .await?
-            .json::<ServiceList>()
-            .await?
-            .services;
-        if let Some(service) = existing_services.first() {
-            Ok(service.to_owned())
-        } else {
-            let res = client
-                .post(format!("{base_url}/v3/services"))
-                .json(&ServiceCreateRequest {
-                    service: ServiceCreateBuilder::default()
-                        .r#type(service_type.as_ref())
-                        .name("keystone")
-                        .enabled(true)
-                        .build()?,
-                })
-                .send()
-                .await?;
-            if res.status() == StatusCode::CONFLICT {
-                // Another bootstrap created the service concurrently; fetch it
-                let services = client
-                    .get(Url::parse_with_params(
-                        &format!("{base_url}/v3/services"),
-                        &[("type", service_type.as_ref())],
-                    )?)
-                    .send()
-                    .await?
-                    .json::<ServiceList>()
-                    .await?
-                    .services;
-                services.first().cloned().ok_or_else(|| {
-                    eyre!(
-                        "service of type '{}' not found after concurrent creation",
-                        service_type.as_ref()
-                    )
-                })
-            } else {
-                Ok(res.json::<ServiceResponse>().await?.service)
-            }
+        ServiceCreateCommand {
+            r#type: service_type.as_ref().to_string(),
+            name: Some("keystone".to_string()),
+            enabled: true,
         }
+        .create_with_client(client, base_url)
+        .await
     }
 
     /// Ensure the catalog endpoint exists.
@@ -524,65 +486,16 @@ impl BootstrapCommand {
         endpoint_url: U,
         base_url: &str,
     ) -> Result<Endpoint> {
-        let url = format!("{base_url}/v3/endpoints");
-        let existing_endpoints = client
-            .get(Url::parse_with_params(
-                &url,
-                &[
-                    ("service_id", service.id.as_str()),
-                    ("interface", interface.as_ref()),
-                ],
-            )?)
-            .send()
-            .await?
-            .json::<EndpointList>()
-            .await?
-            .endpoints;
-        if let Some(endpoint) = existing_endpoints.first() {
-            Ok(endpoint.to_owned())
-        } else {
-            let mut builder = EndpointCreateBuilder::default();
-            builder
-                .service_id(service.id.clone())
-                .interface(interface.as_ref())
-                .url(endpoint_url.as_ref())
-                .enabled(true);
-            if let Some(region_id) = &self.bootstrap_region_id {
-                builder.region_id(region_id.clone());
-            }
-            let res = client
-                .post(format!("{base_url}/v3/endpoints"))
-                .json(&EndpointCreateRequest {
-                    endpoint: builder.build()?,
-                })
-                .send()
-                .await?;
-            if res.status() == StatusCode::CONFLICT {
-                // Another bootstrap created the endpoint concurrently; fetch it
-                let endpoints = client
-                    .get(Url::parse_with_params(
-                        &format!("{base_url}/v3/endpoints"),
-                        &[
-                            ("service_id", service.id.as_str()),
-                            ("interface", interface.as_ref()),
-                        ],
-                    )?)
-                    .send()
-                    .await?
-                    .json::<EndpointList>()
-                    .await?
-                    .endpoints;
-                endpoints.first().cloned().ok_or_else(|| {
-                    eyre!(
-                        "'{}' endpoint for service '{}' not found after concurrent creation",
-                        interface.as_ref(),
-                        service.id
-                    )
-                })
-            } else {
-                Ok(res.json::<EndpointResponse>().await?.endpoint)
-            }
+        EndpointCreateCommand {
+            service_id: Some(service.id.clone()),
+            service_name: None,
+            interface: interface.as_ref().to_string(),
+            url: endpoint_url.as_ref().to_string(),
+            region_id: self.bootstrap_region_id.clone(),
+            enabled: true,
         }
+        .create_with_client(client, base_url)
+        .await
     }
 
     /// Ensure the role imply rule exist.

--- a/crates/cli-manage/src/catalog.rs
+++ b/crates/cli-manage/src/catalog.rs
@@ -19,8 +19,8 @@ use color_eyre::Report;
 
 use openstack_keystone_config::Config;
 
-mod endpoint;
-mod service;
+pub(crate) mod endpoint;
+pub(crate) mod service;
 
 use crate::PerformAction;
 use crate::catalog::endpoint::EndpointCommand;

--- a/crates/cli-manage/src/catalog/endpoint.rs
+++ b/crates/cli-manage/src/catalog/endpoint.rs
@@ -19,7 +19,7 @@ use color_eyre::Report;
 
 use openstack_keystone_config::Config;
 
-mod create;
+pub(crate) mod create;
 mod delete;
 mod list;
 mod show;

--- a/crates/cli-manage/src/catalog/endpoint/create.rs
+++ b/crates/cli-manage/src/catalog/endpoint/create.rs
@@ -26,38 +26,41 @@ use crate::PerformAction;
 use crate::common::{ADMIN_BASE_URL, build_admin_client, print_attribute_table};
 
 /// Create a new catalog endpoint.
+///
+/// Idempotent: if an endpoint with the same `service_id` and `interface`
+/// already exists, it is returned as-is instead of erroring.
 #[derive(Parser)]
 #[command(group(
     ArgGroup::new("service_ref")
         .required(true)
         .args(["service_id", "service_name"]),
 ))]
-pub(super) struct CreateCommand {
+pub struct CreateCommand {
     /// The ID of the service the endpoint belongs to.
     #[arg(long)]
-    service_id: Option<String>,
+    pub(crate) service_id: Option<String>,
 
     /// The name of the service the endpoint belongs to. Resolved to an ID via
     /// `GET /v3/services?name=...`; fails if zero or more than one service
     /// matches.
     #[arg(long)]
-    service_name: Option<String>,
+    pub(crate) service_name: Option<String>,
 
     /// The interface (`public`, `internal`, or `admin`).
     #[arg(long)]
-    interface: String,
+    pub(crate) interface: String,
 
     /// The endpoint URL.
     #[arg(long)]
-    url: String,
+    pub(crate) url: String,
 
     /// The ID of the region that contains the endpoint.
     #[arg(long)]
-    region_id: Option<String>,
+    pub(crate) region_id: Option<String>,
 
     /// Whether the endpoint appears in the service catalog.
     #[arg(long, default_value_t = true)]
-    enabled: bool,
+    pub(crate) enabled: bool,
 }
 
 impl CreateCommand {
@@ -95,16 +98,51 @@ impl CreateCommand {
         }
     }
 
+    /// Look up existing endpoints by `service_id` + `interface` via
+    /// `GET /v3/endpoints?service_id=...&interface=...`.
+    async fn find_by_service_and_interface(
+        &self,
+        client: &Client,
+        base_url: &str,
+        service_id: &str,
+    ) -> Result<Vec<Endpoint>> {
+        Ok(client
+            .get(Url::parse_with_params(
+                &format!("{base_url}/v3/endpoints"),
+                &[
+                    ("service_id", service_id),
+                    ("interface", self.interface.as_str()),
+                ],
+            )?)
+            .send()
+            .await?
+            .json::<EndpointList>()
+            .await?
+            .endpoints)
+    }
+
     /// Create the endpoint against a pre-built HTTP client.
+    ///
+    /// Idempotent: if an endpoint with the same `service_id` + `interface`
+    /// already exists, it is returned as-is instead of erroring.
     ///
     /// This is the public entry point for tests that inject a mock client.
     #[cfg_attr(not(test), doc(hidden))]
     pub async fn create_with_client(&self, client: &Client, base_url: &str) -> Result<Endpoint> {
         let service_id = self.resolve_service_id(client, base_url).await?;
 
+        if let Some(existing) = self
+            .find_by_service_and_interface(client, base_url, &service_id)
+            .await?
+            .into_iter()
+            .next()
+        {
+            return Ok(existing);
+        }
+
         let mut builder = EndpointCreateBuilder::default();
         builder
-            .service_id(service_id)
+            .service_id(service_id.clone())
             .interface(self.interface.clone())
             .url(self.url.clone())
             .enabled(self.enabled);
@@ -119,6 +157,22 @@ impl CreateCommand {
             })
             .send()
             .await?;
+
+        if res.status() == StatusCode::CONFLICT {
+            // Another process created the endpoint concurrently.
+            return self
+                .find_by_service_and_interface(client, base_url, &service_id)
+                .await?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    eyre!(
+                        "'{}' endpoint for service '{}' not found after concurrent creation",
+                        self.interface,
+                        service_id
+                    )
+                });
+        }
 
         if res.status() != StatusCode::CREATED {
             return Err(eyre!(
@@ -179,11 +233,24 @@ mod tests {
         }
     }
 
+    fn mock_empty_endpoint_lookup(server: &MockServer, service_id: &str, interface: &str) {
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/endpoints")
+                .query_param("service_id", service_id)
+                .query_param("interface", interface);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "endpoints": [] }));
+        });
+    }
+
     #[tokio::test]
     async fn test_create_endpoint_by_service_id() {
         let server = MockServer::start();
         let base = server.base_url();
 
+        mock_empty_endpoint_lookup(&server, "svc-1", "public");
         server.mock(|when, then| {
             when.method(Method::POST).path("/v3/endpoints");
             then.status(201)
@@ -218,6 +285,7 @@ mod tests {
                     "services": [{ "id": "svc-1", "type": "identity-rs", "enabled": true, "name": "identity-rs" }]
                 }));
         });
+        mock_empty_endpoint_lookup(&server, "svc-1", "public");
         server.mock(|when, then| {
             when.method(Method::POST).path("/v3/endpoints");
             then.status(201)
@@ -235,6 +303,71 @@ mod tests {
         let created = cmd.create_with_client(&client, &base).await;
         assert!(created.is_ok());
         assert_eq!(created.unwrap().service_id, "svc-1");
+    }
+
+    #[tokio::test]
+    async fn test_create_endpoint_already_exists() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/endpoints")
+                .query_param("service_id", "svc-1")
+                .query_param("interface", "public");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "endpoints": [{
+                        "id": "ep-existing", "interface": "public", "service_id": "svc-1",
+                        "url": "https://example.com", "enabled": true
+                    }]
+                }));
+        });
+        // No POST mock registered: httpmock fails the test if an
+        // unmatched request (e.g. an unexpected POST) is made.
+
+        let client = Client::new();
+        let cmd = command_by_id("svc-1");
+        let created = cmd.create_with_client(&client, &base).await;
+        assert!(created.is_ok());
+        assert_eq!(created.unwrap().id, "ep-existing");
+    }
+
+    #[tokio::test]
+    async fn test_create_endpoint_conflict_refetches() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        // Lookup stays empty both times (no concurrent creator actually won
+        // the race in this test double), so the post-conflict refetch is
+        // expected to come up empty and surface as an error - this proves
+        // the refetch happens rather than the 409 being swallowed silently.
+        let lookup = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/endpoints")
+                .query_param("service_id", "svc-1")
+                .query_param("interface", "public");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "endpoints": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/endpoints");
+            then.status(409).body("conflict");
+        });
+
+        let client = Client::new();
+        let cmd = command_by_id("svc-1");
+        let result = cmd.create_with_client(&client, &base).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("not found after concurrent creation")
+        );
+        assert_eq!(lookup.hits(), 2);
     }
 
     #[tokio::test]

--- a/crates/cli-manage/src/catalog/service.rs
+++ b/crates/cli-manage/src/catalog/service.rs
@@ -19,7 +19,7 @@ use color_eyre::Report;
 
 use openstack_keystone_config::Config;
 
-mod create;
+pub(crate) mod create;
 mod delete;
 mod list;
 mod show;

--- a/crates/cli-manage/src/catalog/service/create.rs
+++ b/crates/cli-manage/src/catalog/service/create.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use clap::Parser;
 use color_eyre::{Report, eyre::eyre};
 use eyre::Result;
-use reqwest::{Client, StatusCode};
+use reqwest::{Client, StatusCode, Url};
 
 use openstack_keystone_api_types::v3::service::*;
 use openstack_keystone_config::Config;
@@ -25,27 +25,56 @@ use crate::PerformAction;
 use crate::common::{ADMIN_BASE_URL, build_admin_client, print_attribute_table};
 
 /// Create a new catalog service.
+///
+/// Idempotent: if a service of the given `type` already exists, it is
+/// returned as-is instead of erroring.
 #[derive(Parser)]
-pub(super) struct CreateCommand {
+pub struct CreateCommand {
     /// Service type (e.g. `identity`).
     #[arg(long = "type")]
-    r#type: String,
+    pub(crate) r#type: String,
 
     /// Service name.
     #[arg(long)]
-    name: Option<String>,
+    pub(crate) name: Option<String>,
 
     /// Whether the service and its endpoints appear in the catalog.
     #[arg(long, default_value_t = true)]
-    enabled: bool,
+    pub(crate) enabled: bool,
 }
 
 impl CreateCommand {
+    /// Look up existing services by `type` via `GET /v3/services?type=...`.
+    async fn find_by_type(&self, client: &Client, base_url: &str) -> Result<Vec<Service>> {
+        Ok(client
+            .get(Url::parse_with_params(
+                &format!("{base_url}/v3/services"),
+                &[("type", self.r#type.as_str())],
+            )?)
+            .send()
+            .await?
+            .json::<ServiceList>()
+            .await?
+            .services)
+    }
+
     /// Create the service against a pre-built HTTP client.
+    ///
+    /// Idempotent: if a service of `type` already exists, it is returned
+    /// as-is instead of erroring.
     ///
     /// This is the public entry point for tests that inject a mock client.
     #[cfg_attr(not(test), doc(hidden))]
     pub async fn create_with_client(&self, client: &Client, base_url: &str) -> Result<Service> {
+        if let Some(existing) = self
+            .find_by_type(client, base_url)
+            .await?
+            .into_iter()
+            .next()
+        {
+            return Ok(existing);
+        }
+
         let mut builder = ServiceCreateBuilder::default();
         builder.r#type(self.r#type.clone()).enabled(self.enabled);
         if let Some(name) = &self.name {
@@ -59,6 +88,21 @@ impl CreateCommand {
             })
             .send()
             .await?;
+
+        if res.status() == StatusCode::CONFLICT {
+            // Another process created the service concurrently.
+            return self
+                .find_by_type(client, base_url)
+                .await?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    eyre!(
+                        "service of type '{}' not found after concurrent creation",
+                        self.r#type
+                    )
+                });
+        }
 
         if res.status() != StatusCode::CREATED {
             return Err(eyre!(
@@ -104,11 +148,23 @@ mod tests {
         }
     }
 
+    fn mock_empty_lookup(server: &MockServer, service_type: &str) {
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("type", service_type);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "services": [] }));
+        });
+    }
+
     #[tokio::test]
     async fn test_create_service() {
         let server = MockServer::start();
         let base = server.base_url();
 
+        mock_empty_lookup(&server, "identity-rs");
         server.mock(|when, then| {
             when.method(Method::POST).path("/v3/services");
             then.status(201)
@@ -132,6 +188,7 @@ mod tests {
         let server = MockServer::start();
         let base = server.base_url();
 
+        mock_empty_lookup(&server, "identity-rs");
         server.mock(|when, then| {
             when.method(Method::POST).path("/v3/services");
             then.status(201)
@@ -153,6 +210,7 @@ mod tests {
         let server = MockServer::start();
         let base = server.base_url();
 
+        mock_empty_lookup(&server, "identity-rs");
         server.mock(|when, then| {
             when.method(Method::POST).path("/v3/services");
             then.status(500).body("internal error");
@@ -162,5 +220,65 @@ mod tests {
         let cmd = command("identity-rs", None);
         let result = cmd.create_with_client(&client, &base).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_service_already_exists() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("type", "identity-rs");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({
+                    "services": [{ "id": "svc-existing", "type": "identity-rs", "enabled": true, "name": "keystone-rs" }]
+                }));
+        });
+        // No POST mock registered: httpmock fails the test if an
+        // unmatched request (e.g. an unexpected POST) is made.
+
+        let client = Client::new();
+        let cmd = command("identity-rs", Some("keystone-rs"));
+        let created = cmd.create_with_client(&client, &base).await;
+        assert!(created.is_ok());
+        assert_eq!(created.unwrap().id, "svc-existing");
+    }
+
+    #[tokio::test]
+    async fn test_create_service_conflict_refetches() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        // Lookup stays empty both times (no concurrent creator actually won
+        // the race in this test double), so the post-conflict refetch is
+        // expected to come up empty and surface as an error - this proves
+        // the refetch happens rather than the 409 being swallowed silently.
+        let lookup = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/v3/services")
+                .query_param("type", "identity-rs");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body_obj(&serde_json::json!({ "services": [] }));
+        });
+        server.mock(|when, then| {
+            when.method(Method::POST).path("/v3/services");
+            then.status(409).body("conflict");
+        });
+
+        let client = Client::new();
+        let cmd = command("identity-rs", Some("keystone-rs"));
+        let result = cmd.create_with_client(&client, &base).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("not found after concurrent creation")
+        );
+        assert_eq!(lookup.hits(), 2);
     }
 }

--- a/crates/cli-manage/src/oauth2.rs
+++ b/crates/cli-manage/src/oauth2.rs
@@ -48,6 +48,7 @@ impl PerformAction for Oauth2Command {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Subcommand)]
 enum Oauth2Commands {
     RotateSigningKey(RotateSigningKeyCommand),

--- a/crates/identity-driver-sql/src/local_user/get.rs
+++ b/crates/identity-driver-sql/src/local_user/get.rs
@@ -31,6 +31,7 @@ use crate::entity::{local_user, prelude::LocalUser};
 /// # Returns
 /// A `Result` containing an `Option` with the `local_user::Model` if found, or
 /// an `Error`.
+#[allow(unused)]
 pub async fn get_by_name_and_domain<N: AsRef<str>, D: AsRef<str>>(
     db: &DatabaseConnection,
     name: N,
@@ -53,6 +54,7 @@ pub async fn get_by_name_and_domain<N: AsRef<str>, D: AsRef<str>>(
 /// # Returns
 /// A `Result` containing an `Option` with the `local_user::Model` if found, or
 /// an `Error`.
+#[allow(unused)]
 pub async fn get_by_user_id<U: AsRef<str>>(
     db: &DatabaseConnection,
     user_id: U,

--- a/crates/identity-driver-sql/src/nonlocal_user/get.rs
+++ b/crates/identity-driver-sql/src/nonlocal_user/get.rs
@@ -31,6 +31,7 @@ use crate::entity::{nonlocal_user, prelude::NonlocalUser};
 /// # Returns
 /// A `Result` containing an `Option` with the `nonlocal_user::Model` if found,
 /// or an `Error`.
+#[allow(unused)]
 pub async fn get_by_name_and_domain<N: AsRef<str>, D: AsRef<str>>(
     db: &DatabaseConnection,
     name: N,

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -314,6 +314,7 @@ impl ClusterAdminServiceImpl {
     ///
     /// # Returns
     /// A new `ClusterAdminServiceImpl` instance.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         raft_node: Raft,
         node_id: u64,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -86,6 +86,7 @@ impl From<StoreError> for ApiStoreError {
 }
 
 pub mod protobuf {
+    #![allow(clippy::doc_paragraphs_missing_punctuation)]
     pub mod api {
         use serde::{Deserialize, Serialize};
         tonic::include_proto!("keystone.api");


### PR DESCRIPTION
Second create with same service type or service_id+interface now
returns existing record instead of erroring. bootstrap.rs's
upsert_service/upsert_endpoint duplicated this lookup-then-create
logic; they now delegate to the same CreateCommand::create_with_client.