### PR TITLE
feat(adr0028): Add local-quorum-bypass emergency rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4861,6 +4861,7 @@ dependencies = [
  "openstack-keystone-config",
  "openstack-keystone-core-types",
  "openstack-keystone-key-repository",
+ "openstack-keystone-local-emergency-store",
  "openstack-keystone-storage-api",
  "p256",
  "rand 0.10.1",
@@ -4950,6 +4951,7 @@ dependencies = [
  "nix 0.31.3",
  "openraft",
  "openstack-keystone-config",
+ "openstack-keystone-local-emergency-store",
  "openstack-keystone-storage-api",
  "openstack-keystone-storage-crypto",
  "openstack-keystone-storage-crypto-pkcs11",
@@ -5098,6 +5100,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "openstack-keystone-local-emergency-store"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "openstack-keystone-mapping-driver-raft"
 version = "0.1.0"
 dependencies = [
@@ -5134,11 +5147,15 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "openstack-keystone-audit",
+ "openstack-keystone-config",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "openstack-keystone-distributed-storage",
  "openstack-keystone-key-repository",
+ "openstack-keystone-local-emergency-store",
  "rmp-serde",
+ "sea-orm",
  "secrecy",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "crates/k8s-auth-driver-sql",
   "crates/key-repository",
   "crates/keystone",
+  "crates/local-emergency-store",
   "crates/mapping-driver-raft",
   "crates/oauth2-client-driver-raft",
   "crates/oauth2-key-driver-raft",
@@ -131,6 +132,7 @@ openstack-keystone-federation-driver-sql = { version = "0.1", path = "crates/fed
 openstack-keystone-k8s-auth-driver-sql = { version = "0.1", path = "crates/k8s-auth-driver-sql/" }
 openstack-keystone-k8s-auth-driver-raft = { version = "0.1", path = "crates/k8s-auth-driver-raft/" }
 openstack-keystone-key-repository = { version = "0.1.0", path = "crates/key-repository" }
+openstack-keystone-local-emergency-store = { version = "0.1.0", path = "crates/local-emergency-store" }
 openstack-keystone-mapping-driver-raft = { version = "0.1", path = "crates/mapping-driver-raft/" }
 openstack-keystone-oauth2-client-driver-raft = { version = "0.1", path = "crates/oauth2-client-driver-raft/" }
 openstack-keystone-oauth2-key-driver-raft = { version = "0.1", path = "crates/oauth2-key-driver-raft/" }

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -370,6 +370,19 @@ impl From<Oauth2KeyProviderError> for KeystoneApiError {
             Oauth2KeyProviderError::EmergencyRotationAlreadyPending(x) => Self::Conflict(format!(
                 "an emergency rotation (id {x}) is already pending for this domain"
             )),
+            Oauth2KeyProviderError::LocalEmergencyBypassNotAllowed => Self::Forbidden {
+                source: Box::new(value),
+            },
+            Oauth2KeyProviderError::LocalEmergencyAlreadyStaged(x) => Self::Conflict(format!(
+                "a local emergency rotation candidate (id {x}) already exists for this domain on this node"
+            )),
+            Oauth2KeyProviderError::LocalEmergencyCandidateNotFound(x) => Self::NotFound {
+                resource: "oauth2_local_emergency_candidate".into(),
+                identifier: x,
+            },
+            Oauth2KeyProviderError::LocalEmergencyCandidateRevoked(x) => Self::Conflict(format!(
+                "local emergency rotation candidate {x} has been revoked and cannot be reconciled"
+            )),
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/api-types/src/v4/oauth2_key.rs
+++ b/crates/api-types/src/v4/oauth2_key.rs
@@ -23,6 +23,17 @@ pub struct RotateSigningKeyRequest {
     /// immediately.
     #[serde(default)]
     pub emergency: bool,
+    /// Stage a `--local-quorum-bypass` rotation (ADR 0028 §2): written only
+    /// to this node's local emergency store, bypassing Raft/quorum
+    /// entirely. Mutually exclusive with `emergency` (Raft-backed staging);
+    /// when set, `emergency` is ignored. Requires `justification` and a
+    /// node whose `[local_emergency]` guardrail currently permits it.
+    #[serde(default)]
+    pub local_quorum_bypass: bool,
+    /// Required when `local_quorum_bypass` is set: the operator's reason
+    /// for invoking the bypass, recorded with the candidate for audit.
+    #[serde(default)]
+    pub justification: Option<String>,
 }
 
 /// Response body for `POST /v4/oauth2/{domain_id}/rotate-signing-key`.
@@ -41,6 +52,10 @@ pub struct RotateSigningKeyResponse {
     /// pending rotation auto-aborts.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<i64>,
+    /// Set when `local_quorum_bypass` was `true`: the candidate's
+    /// `rotation_id`, for later reconciliation once quorum returns.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_rotation_id: Option<String>,
 }
 
 /// Request body for `POST /v4/oauth2/{domain_id}/confirm-rotate-signing-key`.
@@ -69,5 +84,58 @@ pub struct ConfirmRotateSigningKeyResponse {
 pub struct EnsureSigningKeyResponse {
     /// The domain's `Primary` key's `kid` -- pre-existing if one was
     /// already provisioned, freshly generated otherwise.
+    pub kid: String,
+}
+
+/// One node-local emergency rotation candidate (ADR 0028 §6).
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct LocalEmergencyCandidateSummary {
+    /// Opaque identifier to pass to `reconcile-local-emergency-key`.
+    pub rotation_id: String,
+    /// Identity of the operator who staged this candidate.
+    pub initiator: String,
+    /// The operator-supplied justification recorded with the candidate.
+    pub justification: String,
+    /// Unix epoch seconds the candidate was created.
+    pub created_at_unix: i64,
+    /// `None` if staged on the node answering this request; `Some(node_id)`
+    /// if it arrived via gossip from another node (ADR 0028 §5).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin_node_id: Option<u64>,
+    /// Set if gossip detected a different active candidate for this domain
+    /// on another node -- the operator must explicitly pick one side.
+    pub conflicted: bool,
+    /// Set once this candidate has lost reconciliation. Never reconcilable.
+    pub revoked: bool,
+}
+
+/// Response body for
+/// `GET /v4/oauth2/{domain_id}/local-emergency-candidates`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ListLocalEmergencyCandidatesResponse {
+    /// Every candidate on this node for the requested domain (including
+    /// revoked ones, for audit visibility).
+    pub candidates: Vec<LocalEmergencyCandidateSummary>,
+}
+
+/// Request body for
+/// `POST /v4/oauth2/{domain_id}/reconcile-local-emergency-key`.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReconcileLocalEmergencyKeyRequest {
+    /// The `rotation_id` of the node-local candidate to promote, from
+    /// `GET .../local-emergency-candidates`. The operator's explicit choice
+    /// when multiple (possibly conflicting) candidates exist (ADR 0028 §6).
+    pub rotation_id: String,
+}
+
+/// Response body for
+/// `POST /v4/oauth2/{domain_id}/reconcile-local-emergency-key`.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReconcileLocalEmergencyKeyResponse {
+    /// The newly active `Primary` key's `kid`.
     pub kid: String,
 }

--- a/crates/cli-manage/src/oauth2.rs
+++ b/crates/cli-manage/src/oauth2.rs
@@ -23,11 +23,15 @@ use openstack_keystone_config::Config;
 
 mod confirm_rotate_signing_key;
 mod ensure_signing_key;
+mod list_local_emergency_candidates;
+mod reconcile_local_emergency_key;
 mod rotate_signing_key;
 
 use crate::PerformAction;
 use crate::oauth2::confirm_rotate_signing_key::ConfirmRotateSigningKeyCommand;
 use crate::oauth2::ensure_signing_key::EnsureSigningKeyCommand;
+use crate::oauth2::list_local_emergency_candidates::ListLocalEmergencyCandidatesCommand;
+use crate::oauth2::reconcile_local_emergency_key::ReconcileLocalEmergencyKeyCommand;
 use crate::oauth2::rotate_signing_key::RotateSigningKeyCommand;
 
 /// OAuth2/OIDC provider administration (ADR 0026).
@@ -44,6 +48,8 @@ impl PerformAction for Oauth2Command {
             Oauth2Commands::RotateSigningKey(e) => e.take_action(config).await,
             Oauth2Commands::ConfirmRotateSigningKey(e) => e.take_action(config).await,
             Oauth2Commands::EnsureSigningKey(e) => e.take_action(config).await,
+            Oauth2Commands::ListLocalEmergencyCandidates(e) => e.take_action(config).await,
+            Oauth2Commands::ReconcileLocalEmergencyKey(e) => e.take_action(config).await,
         }
     }
 }
@@ -54,6 +60,8 @@ enum Oauth2Commands {
     RotateSigningKey(RotateSigningKeyCommand),
     ConfirmRotateSigningKey(ConfirmRotateSigningKeyCommand),
     EnsureSigningKey(EnsureSigningKeyCommand),
+    ListLocalEmergencyCandidates(ListLocalEmergencyCandidatesCommand),
+    ReconcileLocalEmergencyKey(ReconcileLocalEmergencyKeyCommand),
 }
 
 /// Build a `reqwest::Client` bound to the admin interface's Unix domain

--- a/crates/cli-manage/src/oauth2/list_local_emergency_candidates.rs
+++ b/crates/cli-manage/src/oauth2/list_local_emergency_candidates.rs
@@ -1,0 +1,121 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::WrapErr, eyre::eyre};
+
+use openstack_keystone_api_types::v4::oauth2_key::ListLocalEmergencyCandidatesResponse;
+use openstack_keystone_config::Config;
+
+use super::get_admin_client;
+use crate::PerformAction;
+
+/// List node-local, quorum-bypass emergency signing-key rotation candidates
+/// on the responding node (ADR 0028 §6).
+///
+/// Run this against every node that may have been reachable during the
+/// outage before choosing a `rotation_id` to pass to
+/// `reconcile-local-emergency-key` -- a `conflicted: true` entry means
+/// gossip observed a different active candidate for this domain elsewhere,
+/// and the operator must make an explicit choice.
+#[derive(Parser)]
+pub(super) struct ListLocalEmergencyCandidatesCommand {
+    /// Domain to list local emergency candidates for.
+    #[arg(long)]
+    pub domain: String,
+}
+
+#[async_trait]
+impl PerformAction for ListLocalEmergencyCandidatesCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = get_admin_client(config).await?;
+
+        let res = client
+            .get(format!(
+                "https://localhost/v4/oauth2/{}/local-emergency-candidates",
+                self.domain
+            ))
+            .send()
+            .await
+            .wrap_err("list-local-emergency-candidates request failed")?;
+
+        if !res.status().is_success() {
+            return Err(eyre!(
+                "list-local-emergency-candidates failed: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        let body: ListLocalEmergencyCandidatesResponse = res.json().await?;
+        if body.candidates.is_empty() {
+            println!(
+                "No local emergency candidates on this node for domain {}.",
+                self.domain
+            );
+            return Ok(());
+        }
+
+        for c in &body.candidates {
+            println!(
+                "rotation_id={}\n  initiator={}\n  justification={}\n  created_at_unix={}\n  origin_node_id={}\n  conflicted={}\n  revoked={}\n",
+                c.rotation_id,
+                c.initiator,
+                c.justification,
+                c.created_at_unix,
+                c.origin_node_id
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "local".to_string()),
+                c.conflicted,
+                c.revoked,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        inner: ListLocalEmergencyCandidatesCommand,
+    }
+
+    #[test]
+    fn test_parses_domain() {
+        let wrapper = Wrapper::parse_from(["oauth2", "--domain", "domain-1"]);
+        assert_eq!(wrapper.inner.domain, "domain-1");
+    }
+
+    #[tokio::test]
+    async fn test_take_action_rejects_missing_admin_interface_config() {
+        let cfg = Config::default();
+        let command = ListLocalEmergencyCandidatesCommand {
+            domain: "domain-1".to_string(),
+        };
+
+        let err = command.take_action(&cfg).await.unwrap_err();
+        assert!(
+            err.to_string().contains("admin interface not configured"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/cli-manage/src/oauth2/reconcile_local_emergency_key.rs
+++ b/crates/cli-manage/src/oauth2/reconcile_local_emergency_key.rs
@@ -1,0 +1,119 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::{Report, eyre::WrapErr, eyre::eyre};
+
+use openstack_keystone_api_types::v4::oauth2_key::{
+    ReconcileLocalEmergencyKeyRequest, ReconcileLocalEmergencyKeyResponse,
+};
+use openstack_keystone_config::Config;
+
+use super::get_admin_client;
+use crate::PerformAction;
+
+/// Reconcile a node-local, quorum-bypass emergency signing-key rotation
+/// candidate into Raft-replicated state (ADR 0028 §6).
+///
+/// Must be run against the specific node that holds `rotation_id` (see
+/// `list-local-emergency-candidates`) -- reconciliation does not fan out
+/// across the cluster. Promotes the candidate's key to `Primary`, demoting
+/// the current `Primary` to `Previous`, via the normal Raft transaction
+/// path; this requires quorum to be available again. The confirming
+/// operator must differ from the one who staged the candidate
+/// (dual-control, same as `confirm-rotate-signing-key`). On success, the
+/// candidate is cleared from this node and any other active candidate for
+/// the same domain on this node is revoked.
+#[derive(Parser)]
+pub(super) struct ReconcileLocalEmergencyKeyCommand {
+    /// Domain whose local emergency candidate is being reconciled.
+    #[arg(long)]
+    pub domain: String,
+
+    /// The rotation_id to promote, from `list-local-emergency-candidates`.
+    #[arg(long)]
+    pub rotation_id: String,
+}
+
+#[async_trait]
+impl PerformAction for ReconcileLocalEmergencyKeyCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let client = get_admin_client(config).await?;
+
+        let res = client
+            .post(format!(
+                "https://localhost/v4/oauth2/{}/reconcile-local-emergency-key",
+                self.domain
+            ))
+            .json(&ReconcileLocalEmergencyKeyRequest {
+                rotation_id: self.rotation_id.clone(),
+            })
+            .send()
+            .await
+            .wrap_err("reconcile-local-emergency-key request failed")?;
+
+        if !res.status().is_success() {
+            return Err(eyre!(
+                "reconcile-local-emergency-key failed: {} ({})",
+                res.status(),
+                res.text().await.unwrap_or_default()
+            ));
+        }
+
+        let body: ReconcileLocalEmergencyKeyResponse = res.json().await?;
+        println!(
+            "Local emergency rotation {} reconciled for domain {}. New kid: {}",
+            self.rotation_id, self.domain, body.kid
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        inner: ReconcileLocalEmergencyKeyCommand,
+    }
+
+    #[test]
+    fn test_parses_domain_and_rotation_id() {
+        let wrapper =
+            Wrapper::parse_from(["oauth2", "--domain", "domain-1", "--rotation-id", "rot-1"]);
+        assert_eq!(wrapper.inner.domain, "domain-1");
+        assert_eq!(wrapper.inner.rotation_id, "rot-1");
+    }
+
+    #[tokio::test]
+    async fn test_take_action_rejects_missing_admin_interface_config() {
+        let cfg = Config::default();
+        let command = ReconcileLocalEmergencyKeyCommand {
+            domain: "domain-1".to_string(),
+            rotation_id: "rot-1".to_string(),
+        };
+
+        let err = command.take_action(&cfg).await.unwrap_err();
+        assert!(
+            err.to_string().contains("admin interface not configured"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/cli-manage/src/oauth2/rotate_signing_key.rs
+++ b/crates/cli-manage/src/oauth2/rotate_signing_key.rs
@@ -34,6 +34,14 @@ use crate::PerformAction;
 /// compromised. Emergency rotation only stages the new key: a second
 /// operator must run `confirm-rotate-signing-key` with the returned
 /// rotation-id within 15 minutes, or the rotation is automatically aborted.
+///
+/// Use `--local-quorum-bypass` (with `--justification`) instead of
+/// `--emergency` when the cluster has lost Raft quorum and the ordinary
+/// emergency path -- itself a Raft proposal -- would block forever
+/// (ADR 0028 §2). The candidate is written only to the responding node's
+/// local emergency store; it must be explicitly reconciled once quorum
+/// returns (not yet implemented). Refused unless that node's
+/// `[local_emergency]` guardrail currently permits it.
 #[derive(Parser)]
 pub(super) struct RotateSigningKeyCommand {
     /// Domain whose signing key should be rotated.
@@ -43,11 +51,28 @@ pub(super) struct RotateSigningKeyCommand {
     /// Initiate an emergency rotation (dual-control required).
     #[arg(long, default_value_t = false)]
     pub emergency: bool,
+
+    /// Stage a node-local, quorum-bypass emergency rotation instead
+    /// (ADR 0028 §2). Mutually exclusive in effect with `--emergency`: when
+    /// set, `--emergency` is ignored. Requires `--justification`.
+    #[arg(long, default_value_t = false)]
+    pub local_quorum_bypass: bool,
+
+    /// Required with `--local-quorum-bypass`: the operator's reason for
+    /// invoking the bypass, recorded with the candidate for audit.
+    #[arg(long)]
+    pub justification: Option<String>,
 }
 
 #[async_trait]
 impl PerformAction for RotateSigningKeyCommand {
     async fn take_action(self, config: &Config) -> Result<(), Report> {
+        if self.local_quorum_bypass && self.justification.is_none() {
+            return Err(eyre!(
+                "--justification is required when --local-quorum-bypass is set"
+            ));
+        }
+
         let client = get_admin_client(config).await?;
 
         let res = client
@@ -57,6 +82,8 @@ impl PerformAction for RotateSigningKeyCommand {
             ))
             .json(&RotateSigningKeyRequest {
                 emergency: self.emergency,
+                local_quorum_bypass: self.local_quorum_bypass,
+                justification: self.justification.clone(),
             })
             .send()
             .await
@@ -72,7 +99,22 @@ impl PerformAction for RotateSigningKeyCommand {
 
         let body: RotateSigningKeyResponse = res.json().await?;
 
-        if self.emergency {
+        if self.local_quorum_bypass {
+            match body.local_rotation_id {
+                Some(rotation_id) => {
+                    println!(
+                        "Local quorum-bypass signing-key rotation staged for domain {} on the \
+                         responding node.\nrotation_id={rotation_id}\n\n\
+                         This candidate is NOT yet replicated. Once quorum returns, an operator \
+                         must explicitly reconcile it.",
+                        self.domain,
+                    );
+                }
+                None => {
+                    println!("Local quorum-bypass rotation staged but no rotation_id returned.");
+                }
+            }
+        } else if self.emergency {
             match (body.pending_rotation_id, body.expires_at) {
                 (Some(rotation_id), Some(expires_at)) => {
                     println!(
@@ -137,11 +179,55 @@ mod tests {
         let command = RotateSigningKeyCommand {
             domain: "domain-1".to_string(),
             emergency: false,
+            local_quorum_bypass: false,
+            justification: None,
         };
 
         let err = command.take_action(&cfg).await.unwrap_err();
         assert!(
             err.to_string().contains("admin interface not configured"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parses_local_quorum_bypass_and_justification() {
+        let wrapper = Wrapper::parse_from([
+            "oauth2",
+            "--domain",
+            "domain-1",
+            "--local-quorum-bypass",
+            "--justification",
+            "suspected key compromise",
+        ]);
+        assert_eq!(wrapper.inner.domain, "domain-1");
+        assert!(wrapper.inner.local_quorum_bypass);
+        assert_eq!(
+            wrapper.inner.justification.as_deref(),
+            Some("suspected key compromise")
+        );
+    }
+
+    #[test]
+    fn test_local_quorum_bypass_defaults_to_false() {
+        let wrapper = Wrapper::parse_from(["oauth2", "--domain", "domain-1"]);
+        assert!(!wrapper.inner.local_quorum_bypass);
+        assert!(wrapper.inner.justification.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_take_action_rejects_local_quorum_bypass_without_justification() {
+        let cfg = Config::default();
+        let command = RotateSigningKeyCommand {
+            domain: "domain-1".to_string(),
+            emergency: false,
+            local_quorum_bypass: true,
+            justification: None,
+        };
+
+        let err = command.take_action(&cfg).await.unwrap_err();
+        assert!(
+            err.to_string().contains("--justification is required"),
             "unexpected error: {err}"
         );
     }

--- a/crates/cli-manage/src/storage.rs
+++ b/crates/cli-manage/src/storage.rs
@@ -30,9 +30,11 @@ mod confirm_rotate_dek;
 mod demote;
 mod init;
 mod join;
+mod list_dek_local_emergency_candidates;
 mod list_peers;
 mod metrics;
 mod promote;
+mod reconcile_dek_local_emergency;
 mod remove_peer;
 mod restore;
 mod rotate_dek;
@@ -44,9 +46,11 @@ use crate::storage::confirm_rotate_dek::ConfirmRotateDekCommand;
 use crate::storage::demote::DemoteCommand;
 use crate::storage::init::InitCommand;
 use crate::storage::join::JoinCommand;
+use crate::storage::list_dek_local_emergency_candidates::ListDekLocalEmergencyCandidatesCommand;
 use crate::storage::list_peers::ListPeersCommand;
 use crate::storage::metrics::MetricsCommand;
 use crate::storage::promote::PromoteCommand;
+use crate::storage::reconcile_dek_local_emergency::ReconcileDekLocalEmergencyCommand;
 use crate::storage::remove_peer::RemovePeerCommand;
 use crate::storage::restore::RestoreCommand;
 use crate::storage::rotate_dek::RotateDekCommand;
@@ -77,6 +81,8 @@ impl PerformAction for StorageCommand {
             StorageCommands::RemovePeer(e) => e.take_action(config).await,
             StorageCommands::Restore(e) => e.take_action(config).await,
             StorageCommands::RotateDek(e) => e.take_action(config).await,
+            StorageCommands::ListDekLocalEmergencyCandidates(e) => e.take_action(config).await,
+            StorageCommands::ReconcileDekLocalEmergency(e) => e.take_action(config).await,
         }
     }
 }
@@ -95,6 +101,8 @@ enum StorageCommands {
     RemovePeer(RemovePeerCommand),
     Restore(RestoreCommand),
     RotateDek(RotateDekCommand),
+    ListDekLocalEmergencyCandidates(ListDekLocalEmergencyCandidatesCommand),
+    ReconcileDekLocalEmergency(ReconcileDekLocalEmergencyCommand),
 }
 
 async fn get_grpc_client(

--- a/crates/cli-manage/src/storage/list_dek_local_emergency_candidates.rs
+++ b/crates/cli-manage/src/storage/list_dek_local_emergency_candidates.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::Report;
+use tonic::transport::Uri;
+
+use openstack_keystone_config::Config;
+
+use super::get_grpc_client;
+use crate::PerformAction;
+
+/// List node-local, quorum-bypass emergency DEK rotation candidates on the
+/// responding node (ADR 0028 §6).
+///
+/// Run this against every node that may have been reachable during the
+/// outage before choosing a `rotation_id` to pass to
+/// `reconcile-dek-local-emergency` -- a `conflicted: true` entry means
+/// gossip observed a different active candidate elsewhere, and the operator
+/// must make an explicit choice.
+#[derive(Parser)]
+pub(super) struct ListDekLocalEmergencyCandidatesCommand {
+    /// Address of the target cluster node (e.g. `https://127.0.0.1:50051`).
+    #[arg(long)]
+    pub cluster_addr: Option<Uri>,
+}
+
+#[async_trait]
+impl PerformAction for ListDekLocalEmergencyCandidatesCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let mut client = get_grpc_client(config, self.cluster_addr).await?;
+
+        let resp = client
+            .list_dek_local_emergency_candidates(())
+            .await?
+            .into_inner();
+
+        if resp.candidates.is_empty() {
+            println!("No local emergency DEK candidates on this node.");
+            return Ok(());
+        }
+
+        for c in &resp.candidates {
+            println!(
+                "rotation_id={}\n  initiator={}\n  justification={}\n  created_at_unix={}\n  origin_node_id={}\n  conflicted={}\n  revoked={}\n",
+                c.rotation_id,
+                c.initiator,
+                c.justification,
+                c.created_at_unix,
+                if c.origin_node_id == 0 {
+                    "local".to_string()
+                } else {
+                    c.origin_node_id.to_string()
+                },
+                c.conflicted,
+                c.revoked,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        inner: ListDekLocalEmergencyCandidatesCommand,
+    }
+
+    #[test]
+    fn test_cluster_addr_defaults_to_none() {
+        let wrapper = Wrapper::parse_from(["storage"]);
+        assert!(wrapper.inner.cluster_addr.is_none());
+    }
+
+    #[test]
+    fn test_parses_cluster_addr() {
+        let wrapper = Wrapper::parse_from(["storage", "--cluster-addr", "https://127.0.0.1:50051"]);
+        assert!(wrapper.inner.cluster_addr.is_some());
+    }
+}

--- a/crates/cli-manage/src/storage/reconcile_dek_local_emergency.rs
+++ b/crates/cli-manage/src/storage/reconcile_dek_local_emergency.rs
@@ -1,0 +1,85 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use clap::Parser;
+use color_eyre::Report;
+use tonic::transport::Uri;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_distributed_storage::protobuf as pb;
+
+use super::get_grpc_client;
+use crate::PerformAction;
+
+/// Reconcile a node-local, quorum-bypass emergency DEK rotation candidate
+/// into Raft-replicated state (ADR 0028 §6).
+///
+/// Must be run against the specific node that holds `rotation_id` (see
+/// `list-dek-local-emergency-candidates`) -- reconciliation does not fan out
+/// across the cluster. Installs the candidate's DEK via the normal Raft
+/// transaction path, which requires quorum to be available again. The
+/// confirming operator must differ from the one who staged the candidate
+/// (dual-control, same as `confirm-rotate-dek`). On success, the candidate
+/// is cleared from this node and any other active candidate on this node is
+/// revoked.
+#[derive(Parser)]
+pub(super) struct ReconcileDekLocalEmergencyCommand {
+    /// Address of the target cluster node (e.g. `https://127.0.0.1:50051`).
+    #[arg(long)]
+    pub cluster_addr: Option<Uri>,
+
+    /// The rotation_id to promote, from `list-dek-local-emergency-candidates`.
+    #[arg(long)]
+    pub rotation_id: String,
+}
+
+#[async_trait]
+impl PerformAction for ReconcileDekLocalEmergencyCommand {
+    async fn take_action(self, config: &Config) -> Result<(), Report> {
+        let mut client = get_grpc_client(config, self.cluster_addr).await?;
+
+        client
+            .reconcile_dek_local_emergency(pb::raft::ReconcileDekLocalEmergencyRequest {
+                rotation_id: self.rotation_id.clone(),
+            })
+            .await?;
+
+        println!(
+            "Local emergency DEK rotation {} reconciled. The new DEK is now active.",
+            self.rotation_id
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        inner: ReconcileDekLocalEmergencyCommand,
+    }
+
+    #[test]
+    fn test_parses_rotation_id() {
+        let wrapper = Wrapper::parse_from(["storage", "--rotation-id", "rot-1"]);
+        assert_eq!(wrapper.inner.rotation_id, "rot-1");
+        assert!(wrapper.inner.cluster_addr.is_none());
+    }
+}

--- a/crates/cli-manage/src/storage/rotate_dek.rs
+++ b/crates/cli-manage/src/storage/rotate_dek.rs
@@ -14,7 +14,7 @@
 
 use async_trait::async_trait;
 use clap::Parser;
-use color_eyre::Report;
+use color_eyre::{Report, eyre::eyre};
 use tonic::transport::Uri;
 
 use openstack_keystone_config::Config;
@@ -33,6 +33,14 @@ use crate::PerformAction;
 /// compromised. Emergency rotation requires dual-control: a second
 /// `storage-operator` must run `confirm-rotate-dek` with the returned
 /// rotation-id within 5 minutes, or the rotation is automatically aborted.
+///
+/// Use `--local-quorum-bypass` (with `--justification`) instead of
+/// `--emergency` when the cluster has lost Raft quorum and the ordinary
+/// emergency path -- itself a Raft proposal -- would block forever
+/// (ADR 0028 §3). The candidate is written only to the responding node's
+/// local emergency store; it must be explicitly reconciled once quorum
+/// returns (not yet implemented). Refused unless that node's
+/// `[local_emergency]` guardrail currently permits it.
 #[derive(Parser)]
 pub(super) struct RotateDekCommand {
     /// Address of the target cluster node (e.g. `https://127.0.0.1:50051`).
@@ -46,12 +54,46 @@ pub(super) struct RotateDekCommand {
     /// within 5 minutes the rotation is automatically aborted.
     #[arg(long, default_value_t = false)]
     pub emergency: bool,
+
+    /// Stage a node-local, quorum-bypass emergency rotation instead
+    /// (ADR 0028 §3). Mutually exclusive in effect with `--emergency`: when
+    /// set, `--emergency` is ignored. Requires `--justification`.
+    #[arg(long, default_value_t = false)]
+    pub local_quorum_bypass: bool,
+
+    /// Required with `--local-quorum-bypass`: the operator's reason for
+    /// invoking the bypass, recorded with the candidate for audit.
+    #[arg(long)]
+    pub justification: Option<String>,
 }
 
 #[async_trait]
 impl PerformAction for RotateDekCommand {
     async fn take_action(self, config: &Config) -> Result<(), Report> {
+        if self.local_quorum_bypass && self.justification.is_none() {
+            return Err(eyre!(
+                "--justification is required when --local-quorum-bypass is set"
+            ));
+        }
+
         let mut client = get_grpc_client(config, self.cluster_addr).await?;
+
+        if self.local_quorum_bypass {
+            let resp = client
+                .rotate_dek_local_emergency(pb::raft::RotateDekLocalEmergencyRequest {
+                    justification: self.justification.clone().unwrap_or_default(),
+                })
+                .await?
+                .into_inner();
+            println!(
+                "Local quorum-bypass DEK rotation staged on the responding node.\n\
+                 rotation_id={}\n\n\
+                 This candidate is NOT yet replicated. Once quorum returns, an operator \
+                 must explicitly reconcile it.",
+                resp.rotation_id,
+            );
+            return Ok(());
+        }
 
         let resp = client
             .rotate_dek(pb::raft::RotateDekRequest {
@@ -78,5 +120,57 @@ impl PerformAction for RotateDekCommand {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        inner: RotateDekCommand,
+    }
+
+    #[test]
+    fn test_parses_local_quorum_bypass_and_justification() {
+        let wrapper = Wrapper::parse_from([
+            "storage",
+            "--local-quorum-bypass",
+            "--justification",
+            "suspected key compromise",
+        ]);
+        assert!(wrapper.inner.local_quorum_bypass);
+        assert_eq!(
+            wrapper.inner.justification.as_deref(),
+            Some("suspected key compromise")
+        );
+    }
+
+    #[test]
+    fn test_local_quorum_bypass_defaults_to_false() {
+        let wrapper = Wrapper::parse_from(["storage"]);
+        assert!(!wrapper.inner.local_quorum_bypass);
+        assert!(wrapper.inner.justification.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_take_action_rejects_local_quorum_bypass_without_justification() {
+        let cfg = Config::default();
+        let command = RotateDekCommand {
+            cluster_addr: None,
+            emergency: false,
+            local_quorum_bypass: true,
+            justification: None,
+        };
+
+        let err = command.take_action(&cfg).await.unwrap_err();
+        assert!(
+            err.to_string().contains("--justification is required"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -78,6 +78,7 @@ mod interface;
 mod jws_token;
 mod k8s_auth;
 mod listener;
+mod local_emergency;
 mod mapping;
 mod oauth2;
 mod oslo_middleware;
@@ -116,6 +117,7 @@ pub use interface::*;
 pub use jws_token::*;
 pub use k8s_auth::*;
 pub use listener::*;
+pub use local_emergency::*;
 pub use mapping::*;
 pub use oauth2::*;
 pub use oslo_middleware::*;
@@ -219,6 +221,11 @@ pub struct Config {
     /// K8s Auth provider configuration.
     #[serde(default)]
     pub k8s_auth: K8sAuthProvider,
+
+    /// Node-local, quorum-bypass emergency write path configuration
+    /// (ADR 0028).
+    #[serde(default)]
+    pub local_emergency: LocalEmergencyProvider,
 
     /// Mapping provider configuration.
     #[serde(default)]

--- a/crates/config/src/local_emergency.rs
+++ b/crates/config/src/local_emergency.rs
@@ -1,0 +1,101 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! `[local_emergency]` configuration section (ADR 0028).
+//!
+//! Governs the node-local, quorum-bypass emergency write path shared by
+//! OAuth2 signing-key and DEK emergency rotation. Disabled by default: an
+//! operator must opt in per-node before `--local-quorum-bypass` requests are
+//! accepted.
+
+use serde::Deserialize;
+
+/// Default guardrail: how long the Raft leader must be unknown before the
+/// local-write path unlocks, in seconds.
+fn default_leaderless_grace_period_seconds() -> u64 {
+    30
+}
+
+/// Default best-effort gossip fan-out interval, in seconds.
+fn default_gossip_interval_seconds() -> u64 {
+    10
+}
+
+/// `[local_emergency]` INI section.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct LocalEmergencyProvider {
+    /// When `false` (the default), every `--local-quorum-bypass` request is
+    /// rejected regardless of cluster state. Operators must explicitly opt a
+    /// node into the bypass path.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// How long the Raft leader must be unknown (per
+    /// `StorageApi::current_leader`) before the guardrail allows a local
+    /// write. Guards against using the bypass merely because of a transient
+    /// leader-election blip.
+    #[serde(default = "default_leaderless_grace_period_seconds")]
+    pub leaderless_grace_period_seconds: u64,
+
+    /// Interval between best-effort gossip fan-out attempts to reachable
+    /// peers while partitioned.
+    #[serde(default = "default_gossip_interval_seconds")]
+    pub gossip_interval_seconds: u64,
+}
+
+impl Default for LocalEmergencyProvider {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            leaderless_grace_period_seconds: default_leaderless_grace_period_seconds(),
+            gossip_interval_seconds: default_gossip_interval_seconds(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn default_is_disabled() {
+        let s = LocalEmergencyProvider::default();
+        assert!(!s.enabled);
+        assert_eq!(s.leaderless_grace_period_seconds, 30);
+        assert_eq!(s.gossip_interval_seconds, 10);
+    }
+
+    #[test]
+    fn deserialize_enabled_section() {
+        let s: LocalEmergencyProvider = serde_json::from_value(json!({
+            "enabled": true,
+            "leaderless_grace_period_seconds": 5,
+            "gossip_interval_seconds": 2
+        }))
+        .unwrap();
+        assert!(s.enabled);
+        assert_eq!(s.leaderless_grace_period_seconds, 5);
+        assert_eq!(s.gossip_interval_seconds, 2);
+    }
+
+    #[test]
+    fn deserialize_defaults_when_fields_absent() {
+        let s: LocalEmergencyProvider = serde_json::from_value(json!({})).unwrap();
+        assert!(!s.enabled);
+        assert_eq!(s.leaderless_grace_period_seconds, 30);
+        assert_eq!(s.gossip_interval_seconds, 10);
+    }
+}

--- a/crates/core-types/src/oauth2_key.rs
+++ b/crates/core-types/src/oauth2_key.rs
@@ -17,4 +17,6 @@ mod error;
 mod rotation;
 
 pub use error::*;
-pub use rotation::PendingRotationInfo;
+pub use rotation::{
+    LocalEmergencyCandidateSummary, LocalEmergencyRotationInfo, PendingRotationInfo,
+};

--- a/crates/core-types/src/oauth2_key/error.rs
+++ b/crates/core-types/src/oauth2_key/error.rs
@@ -74,6 +74,41 @@ pub enum Oauth2KeyProviderError {
     /// first's `rotation_id`.
     #[error("an emergency rotation (id {0}) is already pending for this domain")]
     EmergencyRotationAlreadyPending(String),
+
+    /// `--local-quorum-bypass` was requested but the node's quorum-bypass
+    /// guardrail refused it (ADR 0028 §1): either `[local_emergency]` is
+    /// disabled on this node, or Raft quorum is currently reachable, or the
+    /// leaderless grace period has not yet elapsed.
+    #[error("local quorum-bypass emergency rotation is not permitted on this node right now")]
+    LocalEmergencyBypassNotAllowed,
+
+    /// A local (non-revoked) emergency rotation candidate already exists for
+    /// this domain on this node (ADR 0028 §2). Staging a second one would
+    /// make reconciliation ambiguous about which candidate the operator
+    /// meant.
+    #[error(
+        "a local emergency rotation candidate (id {0}) already exists for this domain on this node"
+    )]
+    LocalEmergencyAlreadyStaged(String),
+
+    /// The local emergency store rejected the write (Fjall I/O, etc).
+    #[error("local emergency store error in the oauth2 key provider: {source}")]
+    LocalEmergencyStoreError {
+        /// The source of the error.
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// No local emergency rotation candidate exists with this `rotation_id`
+    /// on this node (ADR 0028 §6). Reconciliation must be run against the
+    /// specific node that holds the chosen candidate.
+    #[error("no local emergency rotation candidate with id {0} on this node")]
+    LocalEmergencyCandidateNotFound(String),
+
+    /// The chosen candidate was already revoked (e.g. it lost a prior
+    /// reconciliation or gossip conflict) and must never be promoted
+    /// (ADR 0028 §6).
+    #[error("local emergency rotation candidate {0} has been revoked and cannot be reconciled")]
+    LocalEmergencyCandidateRevoked(String),
 }
 
 impl Oauth2KeyProviderError {
@@ -91,6 +126,16 @@ impl Oauth2KeyProviderError {
         E: std::error::Error + Send + Sync + 'static,
     {
         Self::RaftStoreError {
+            source: Box::new(source),
+        }
+    }
+
+    /// Wrap a local emergency store error (ADR 0028).
+    pub fn local_emergency<E>(source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::LocalEmergencyStoreError {
             source: Box::new(source),
         }
     }

--- a/crates/core-types/src/oauth2_key/rotation.rs
+++ b/crates/core-types/src/oauth2_key/rotation.rs
@@ -24,3 +24,44 @@ pub struct PendingRotationInfo {
     /// Unix epoch seconds after which this pending rotation auto-aborts.
     pub expires_at: i64,
 }
+
+/// Returned when a `--local-quorum-bypass` emergency rotation is staged
+/// (ADR 0028 §2).
+///
+/// Unlike [`PendingRotationInfo`], there is no `expires_at`: a local
+/// candidate persists until an operator explicitly reconciles it once Raft
+/// quorum returns (ADR 0028 §4) — there is no fixed confirmation window to
+/// auto-abort against, since the whole point is that it may stay
+/// unreachable for an unknown, possibly long, duration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalEmergencyRotationInfo {
+    /// Opaque identifier the reconciliation tool/operator uses to select
+    /// this candidate among any others staged during the same outage.
+    pub rotation_id: String,
+    /// The operator-supplied justification recorded with the candidate.
+    pub justification: String,
+}
+
+/// One node-local emergency rotation candidate, as surfaced to an operator
+/// deciding which `rotation_id` to reconcile (ADR 0028 §6).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalEmergencyCandidateSummary {
+    /// Opaque identifier to pass to reconciliation.
+    pub rotation_id: String,
+    /// Identity of the operator who staged this candidate.
+    pub initiator: String,
+    /// The operator-supplied justification recorded with the candidate.
+    pub justification: String,
+    /// Unix epoch seconds the candidate was created.
+    pub created_at_unix: i64,
+    /// `None` if staged on the node answering this request; `Some(node_id)`
+    /// if it arrived via gossip from another node (ADR 0028 §5).
+    pub origin_node_id: Option<u64>,
+    /// Set if gossip detected a different active candidate for this domain
+    /// on another node (`LOCAL_EMERGENCY_CONFLICT`) — the operator must
+    /// explicitly pick one side.
+    pub conflicted: bool,
+    /// Set once this candidate has lost reconciliation (superseded by a
+    /// sibling that was promoted instead). Never reconcilable.
+    pub revoked: bool,
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ openstack-keystone-api-types = { workspace = true, optional = true }
 openstack-keystone-core-types.workspace = true
 openstack-keystone-config.workspace = true
 openstack-keystone-key-repository.workspace = true
+openstack-keystone-local-emergency-store.workspace = true
 openstack-keystone-storage-api.workspace = true
 jsonwebtoken.workspace = true
 mockall = { workspace = true, optional = true }

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -232,6 +232,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            local_emergency_store: tokio::sync::RwLock::new(None),
+            local_emergency_leaderless_tracker:
+                openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
                 governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
             )),
@@ -351,6 +354,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            local_emergency_store: tokio::sync::RwLock::new(None),
+            local_emergency_leaderless_tracker:
+                openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
                 governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
             )),
@@ -464,6 +470,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            local_emergency_store: tokio::sync::RwLock::new(None),
+            local_emergency_leaderless_tracker:
+                openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
                 governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
             )),
@@ -541,6 +550,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            local_emergency_store: tokio::sync::RwLock::new(None),
+            local_emergency_leaderless_tracker:
+                openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
                 governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
             )),
@@ -617,6 +629,9 @@ mod tests {
             audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
 
             storage: None,
+            local_emergency_store: tokio::sync::RwLock::new(None),
+            local_emergency_leaderless_tracker:
+                openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
                 governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
             )),

--- a/crates/core/src/keystone.rs
+++ b/crates/core/src/keystone.rs
@@ -23,6 +23,7 @@ use tracing::info;
 use openstack_keystone_audit::AuditDispatcher;
 use openstack_keystone_auth_plugin_runtime::WasmPluginRegistry;
 use openstack_keystone_config::ConfigManager;
+use openstack_keystone_local_emergency_store::{LeaderlessTracker, LocalEmergencyStore};
 use openstack_keystone_storage_api::StorageApi;
 
 use crate::auth_plugin::{CoreHostFunctions, PluginInvocationLimiter};
@@ -56,6 +57,23 @@ pub struct Service {
 
     /// Distributed storage instance (when configured).
     pub storage: Option<Arc<dyn StorageApi>>,
+
+    /// Node-local, quorum-bypass emergency write path (ADR 0028).
+    ///
+    /// `None` unless a distributed storage backend was configured and
+    /// `[local_emergency]` is available on this node. Populated
+    /// post-construction (like `core_host_functions` below) since the real
+    /// Fjall-backed store needs the same database handle
+    /// `StateMachineStore` uses, which isn't available until distributed
+    /// storage itself finishes initializing in
+    /// `crates/keystone/src/bin/keystone.rs`.
+    pub local_emergency_store: RwLock<Option<Arc<dyn LocalEmergencyStore>>>,
+
+    /// Tracks how long this node's Raft leader has been unknown, feeding
+    /// the `[local_emergency]` quorum-bypass guardrail (ADR 0028 §1).
+    /// Always present (harmless/unused if `local_emergency_store` is
+    /// `None`) since it carries no state until observations are recorded.
+    pub local_emergency_leaderless_tracker: LeaderlessTracker,
 
     /// Sliding-window rate limiter for the API Key (SCIM ingress)
     /// authentication path, keyed on `lookup_hash` (or source IP when the
@@ -181,6 +199,8 @@ impl Service {
             db,
             policy_enforcer,
             storage,
+            local_emergency_store: RwLock::new(None),
+            local_emergency_leaderless_tracker: LeaderlessTracker::new(),
             api_key_rate_limiter,
             oauth2_token_rate_limiter,
             auth_plugin_registry: RwLock::new(Arc::new(WasmPluginRegistry::default())),
@@ -190,6 +210,14 @@ impl Service {
             auth_plugin_load_failures: RwLock::new(HashMap::new()),
             shutdown: false,
         })
+    }
+
+    /// Install the node-local emergency store, once distributed storage has
+    /// finished initializing (ADR 0028). A no-op path (`local_emergency_store`
+    /// stays `None`) if this is never called, e.g. on a node with no
+    /// distributed storage configured.
+    pub async fn set_local_emergency_store(&self, store: Arc<dyn LocalEmergencyStore>) {
+        *self.local_emergency_store.write().await = Some(store);
     }
 
     /// Terminates the Keystone service.

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -182,7 +182,9 @@ mod oauth2_key {
 
     use std::collections::HashSet;
 
-    use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
+    use openstack_keystone_core_types::oauth2_key::{
+        LocalEmergencyCandidateSummary, LocalEmergencyRotationInfo, PendingRotationInfo,
+    };
     use openstack_keystone_key_repository::asymmetric::KeyMaterial;
 
     use crate::oauth2_key::{Oauth2KeyApi, Oauth2KeyProviderError};
@@ -230,6 +232,28 @@ mod oauth2_key {
                 rotation_id: &str,
                 confirmer: &str,
                 revoke_jtis: Vec<String>,
+            ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+            async fn stage_local_emergency_rotation(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+                initiator: &str,
+                justification: &str,
+            ) -> Result<LocalEmergencyRotationInfo, Oauth2KeyProviderError>;
+
+            async fn list_local_emergency_candidates(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+            ) -> Result<Vec<LocalEmergencyCandidateSummary>, Oauth2KeyProviderError>;
+
+            async fn reconcile_local_emergency_rotation(
+                &self,
+                state: &ServiceState,
+                domain_id: &str,
+                rotation_id: &str,
+                confirmer: &str,
             ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
 
             async fn revoked_jtis(

--- a/crates/core/src/oauth2_key/backend.rs
+++ b/crates/core/src/oauth2_key/backend.rs
@@ -20,7 +20,9 @@ use openstack_keystone_key_repository::asymmetric::{ActiveKeys, KeyMaterial, Sig
 
 use crate::keystone::ServiceState;
 use crate::oauth2_key::Oauth2KeyProviderError;
-use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
+use openstack_keystone_core_types::oauth2_key::{
+    LocalEmergencyCandidateSummary, LocalEmergencyRotationInfo, PendingRotationInfo,
+};
 
 /// OAuth2 signing key Backend trait.
 ///
@@ -86,6 +88,35 @@ pub trait Oauth2KeyBackend: Send + Sync {
         rotation_id: &str,
         confirmer: &str,
         revoke_jtis: Vec<String>,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+    /// Stage stage 1 of a `--local-quorum-bypass` emergency rotation.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::stage_local_emergency_rotation`].
+    async fn stage_local_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+        initiator: &str,
+        justification: &str,
+    ) -> Result<LocalEmergencyRotationInfo, Oauth2KeyProviderError>;
+
+    /// List local emergency candidates on this node.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::list_local_emergency_candidates`].
+    async fn list_local_emergency_candidates(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<Vec<LocalEmergencyCandidateSummary>, Oauth2KeyProviderError>;
+
+    /// Reconcile a node-local emergency candidate into Raft-replicated state.
+    /// See [`crate::oauth2_key::Oauth2KeyApi::reconcile_local_emergency_rotation`].
+    async fn reconcile_local_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
     ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
 
     /// Fetch the domain's current (non-expired) JTI revocation list.

--- a/crates/core/src/oauth2_key/provider_api.rs
+++ b/crates/core/src/oauth2_key/provider_api.rs
@@ -20,7 +20,9 @@ use openstack_keystone_key_repository::asymmetric::{ActiveKeys, KeyMaterial};
 
 use crate::keystone::ServiceState;
 use crate::oauth2_key::Oauth2KeyProviderError;
-use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
+use openstack_keystone_core_types::oauth2_key::{
+    LocalEmergencyCandidateSummary, LocalEmergencyRotationInfo, PendingRotationInfo,
+};
 
 /// The trait for managing per-domain OAuth2 signing keys (ADR 0026 §3).
 #[async_trait]
@@ -130,6 +132,64 @@ pub trait Oauth2KeyApi: Send + Sync {
         rotation_id: &str,
         confirmer: &str,
         revoke_jtis: Vec<String>,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
+
+    /// Stage a `--local-quorum-bypass` emergency rotation (ADR 0028 §2):
+    /// generate a fresh keypair and persist it as a node-local candidate,
+    /// bypassing Raft/`StorageApi` entirely. Unlike
+    /// [`Self::stage_emergency_rotation`], this never touches distributed
+    /// storage — the whole point is that it works even when the node
+    /// cannot reach Raft quorum.
+    ///
+    /// # Errors
+    /// * [`Oauth2KeyProviderError::LocalEmergencyBypassNotAllowed`] if the
+    ///   node's quorum-bypass guardrail refuses the request (bypass
+    ///   disabled, quorum currently reachable, or grace period not yet
+    ///   elapsed).
+    /// * [`Oauth2KeyProviderError::LocalEmergencyAlreadyStaged`] if a
+    ///   non-revoked local candidate already exists for this domain on this
+    ///   node.
+    async fn stage_local_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        initiator: &str,
+        justification: &str,
+    ) -> Result<LocalEmergencyRotationInfo, Oauth2KeyProviderError>;
+
+    /// List every node-local emergency rotation candidate staged or adopted
+    /// (via gossip) on this node for `domain_id` (ADR 0028 §6), so an
+    /// operator can see any `LOCAL_EMERGENCY_CONFLICT` before choosing which
+    /// `rotation_id` to reconcile.
+    async fn list_local_emergency_candidates(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<Vec<LocalEmergencyCandidateSummary>, Oauth2KeyProviderError>;
+
+    /// Reconcile a node-local emergency candidate into the Raft-replicated
+    /// state once quorum has returned (ADR 0028 §6): promotes the chosen
+    /// candidate's key to `Primary` (demoting the current `Primary` to
+    /// `Previous`) via the normal Raft transaction path, then clears it from
+    /// this node's local store and revokes any other active candidate for
+    /// the same domain on this node (they lost).
+    ///
+    /// Must be called against the specific node holding `rotation_id` --
+    /// reconciliation does not fan out across the cluster.
+    ///
+    /// # Errors
+    /// * [`Oauth2KeyProviderError::LocalEmergencyCandidateNotFound`] if no
+    ///   candidate with `rotation_id` exists on this node.
+    /// * [`Oauth2KeyProviderError::LocalEmergencyCandidateRevoked`] if the
+    ///   candidate already lost a prior reconciliation.
+    /// * [`Oauth2KeyProviderError::DualControlViolation`] if `confirmer ==
+    ///   initiator` (the operator who staged the candidate).
+    async fn reconcile_local_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
     ) -> Result<KeyMaterial, Oauth2KeyProviderError>;
 
     /// Fetch the domain's current JTI revocation list for

--- a/crates/core/src/oauth2_key/service.rs
+++ b/crates/core/src/oauth2_key/service.rs
@@ -18,7 +18,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use openstack_keystone_config::Config;
-use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
+use openstack_keystone_core_types::oauth2_key::{
+    LocalEmergencyCandidateSummary, LocalEmergencyRotationInfo, PendingRotationInfo,
+};
 use openstack_keystone_key_repository::asymmetric::{
     ActiveKeys, KeyMaterial, SigningAlgorithm as KeySigningAlgorithm,
 };
@@ -120,6 +122,46 @@ impl Oauth2KeyApi for Oauth2KeyService {
     ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
         self.backend_driver
             .confirm_emergency_rotation(state, domain_id, rotation_id, confirmer, revoke_jtis)
+            .await
+    }
+
+    async fn stage_local_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        initiator: &str,
+        justification: &str,
+    ) -> Result<LocalEmergencyRotationInfo, Oauth2KeyProviderError> {
+        self.backend_driver
+            .stage_local_emergency_rotation(
+                state,
+                domain_id,
+                self.signing_algorithm,
+                initiator,
+                justification,
+            )
+            .await
+    }
+
+    async fn list_local_emergency_candidates(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<Vec<LocalEmergencyCandidateSummary>, Oauth2KeyProviderError> {
+        self.backend_driver
+            .list_local_emergency_candidates(state, domain_id)
+            .await
+    }
+
+    async fn reconcile_local_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        self.backend_driver
+            .reconcile_local_emergency_rotation(state, domain_id, rotation_id, confirmer)
             .await
     }
 
@@ -326,5 +368,48 @@ mod tests {
 
         let revoked = service.revoked_jtis(&state, "domain-1").await.unwrap();
         assert!(revoked.contains("jti-1"));
+    }
+
+    #[tokio::test]
+    async fn test_stage_local_emergency_rotation_delegates_configured_algorithm() {
+        let mut backend = MockOauth2KeyBackend::default();
+        backend
+            .expect_stage_local_emergency_rotation()
+            .withf(
+                |_,
+                 domain_id: &str,
+                 algorithm: &KeySigningAlgorithm,
+                 initiator: &str,
+                 justification: &str| {
+                    domain_id == "domain-1"
+                        && *algorithm == KeySigningAlgorithm::Es256
+                        && initiator == "operator-a"
+                        && justification == "suspected key compromise"
+                },
+            )
+            .returning(|_, _, _, _, justification| {
+                Ok(
+                    openstack_keystone_core_types::oauth2_key::LocalEmergencyRotationInfo {
+                        rotation_id: "rotation-1".to_string(),
+                        justification: justification.to_string(),
+                    },
+                )
+            });
+        let service = Oauth2KeyService {
+            backend_driver: Arc::new(backend),
+            signing_algorithm: KeySigningAlgorithm::Es256,
+        };
+        let state = get_mocked_state(None, None).await;
+
+        let info = service
+            .stage_local_emergency_rotation(
+                &state,
+                "domain-1",
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap();
+        assert_eq!(info.rotation_id, "rotation-1");
     }
 }

--- a/crates/keystone/src/api/v4/oauth2/local_emergency_key.rs
+++ b/crates/keystone/src/api/v4/oauth2/local_emergency_key.rs
@@ -1,0 +1,375 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `GET /v4/oauth2/{domain_id}/local-emergency-candidates` and
+//! `POST /v4/oauth2/{domain_id}/reconcile-local-emergency-key` (ADR 0028 §6).
+//!
+//! Reconciliation of a `--local-quorum-bypass` candidate (staged via
+//! `rotate-signing-key` with `local_quorum_bypass: true`, see
+//! `rotate_signing_key.rs`) once Raft quorum has returned. Both handlers
+//! must be called against the specific node holding the chosen candidate --
+//! reconciliation does not fan out across the cluster. The list endpoint
+//! exists so an operator can see any `LOCAL_EMERGENCY_CONFLICT` (ADR 0028
+//! §5) before picking a `rotation_id`.
+//!
+//! SystemAdmin-only, same posture as `rotate-signing-key`.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use openstack_keystone_api_types::v4::oauth2_key::{
+    ListLocalEmergencyCandidatesResponse, LocalEmergencyCandidateSummary,
+    ReconcileLocalEmergencyKeyRequest, ReconcileLocalEmergencyKeyResponse,
+};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::audit::{
+    CorrelationId, build_initiator_from_vsc, emit_oauth2_local_emergency_key_reconciled_event,
+};
+use crate::keystone::ServiceState;
+
+#[utoipa::path(
+    get,
+    path = "/{domain_id}/local-emergency-candidates",
+    operation_id = "/oauth2/key:list_local_emergency_candidates",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    responses(
+        (status = OK, description = "Local emergency candidates on this node", body = ListLocalEmergencyCandidatesResponse),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::list_local_emergency_candidates",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn list_local_emergency_candidates(
+    Auth(user_auth): Auth,
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/key/list_local_emergency_candidates",
+            &user_auth,
+            serde_json::Value::Null,
+            None,
+        )
+        .await?;
+
+    let candidates = state
+        .provider
+        .get_oauth2_key_provider()
+        .list_local_emergency_candidates(&state, &domain_id)
+        .await?
+        .into_iter()
+        .map(|c| LocalEmergencyCandidateSummary {
+            rotation_id: c.rotation_id,
+            initiator: c.initiator,
+            justification: c.justification,
+            created_at_unix: c.created_at_unix,
+            origin_node_id: c.origin_node_id,
+            conflicted: c.conflicted,
+            revoked: c.revoked,
+        })
+        .collect();
+
+    Ok((
+        StatusCode::OK,
+        Json(ListLocalEmergencyCandidatesResponse { candidates }),
+    )
+        .into_response())
+}
+
+#[utoipa::path(
+    post,
+    path = "/{domain_id}/reconcile-local-emergency-key",
+    operation_id = "/oauth2/key:reconcile_local_emergency_key",
+    params(
+        ("domain_id" = String, Path, description = "Domain ID"),
+    ),
+    request_body = ReconcileLocalEmergencyKeyRequest,
+    responses(
+        (status = OK, description = "Reconciliation result", body = ReconcileLocalEmergencyKeyResponse),
+    ),
+    security(("x-auth" = [])),
+    tag = "oauth2_key"
+)]
+#[tracing::instrument(
+    name = "api::v4::oauth2::reconcile_local_emergency_key",
+    level = "debug",
+    skip(state, user_auth),
+    err(Debug)
+)]
+pub(super) async fn reconcile_local_emergency_key(
+    Auth(user_auth): Auth,
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    CorrelationId(correlation_id): CorrelationId,
+    Json(req): Json<ReconcileLocalEmergencyKeyRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/oauth2/key/reconcile_local_emergency_key",
+            &user_auth,
+            serde_json::Value::Null,
+            None,
+        )
+        .await?;
+
+    let confirmer = user_auth.inner().principal().get_user_id();
+
+    let key = state
+        .provider
+        .get_oauth2_key_provider()
+        .reconcile_local_emergency_rotation(&state, &domain_id, &req.rotation_id, &confirmer)
+        .await?;
+
+    let event_id = emit_oauth2_local_emergency_key_reconciled_event(
+        &state.audit_dispatcher,
+        &correlation_id,
+        build_initiator_from_vsc(&user_auth),
+        &domain_id,
+        &req.rotation_id,
+        &key.kid,
+    )
+    .await;
+    // Design gap 2 (ADR 0028 implementation plan): record the pointer from
+    // rotation_id to this audit event so reconciliation/audit tooling can
+    // find it without scanning the whole spool. Best-effort -- the audit
+    // event itself (dispatched above) is the durable record; a missing
+    // pointer only costs a spool scan, never audit visibility.
+    if let Some(store) = state.local_emergency_store.read().await.as_ref()
+        && let Err(e) = store.put_audit_pointer(&req.rotation_id, &event_id).await
+    {
+        tracing::warn!(
+            rotation_id = req.rotation_id,
+            error = %e,
+            "failed to record local emergency audit pointer"
+        );
+    }
+
+    Ok((
+        StatusCode::OK,
+        Json(ReconcileLocalEmergencyKeyResponse { kid: key.kid }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::oauth2_key::{
+        LocalEmergencyCandidateSummary as CoreLocalEmergencyCandidateSummary,
+        Oauth2KeyProviderError,
+    };
+    use openstack_keystone_key_repository::asymmetric::{SigningAlgorithm, generate_keypair};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::oauth2_key::MockOauth2KeyProvider;
+    use crate::provider::Provider;
+
+    fn get_request(uri: &str) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .extension(test_fixture_scoped())
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn post_request(uri: &str, body: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .extension(test_fixture_scoped())
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_list_returns_candidates() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_list_local_emergency_candidates()
+            .returning(|_, _| {
+                Ok(vec![CoreLocalEmergencyCandidateSummary {
+                    rotation_id: "rot-1".to_string(),
+                    initiator: "operator-a".to_string(),
+                    justification: "suspected key compromise".to_string(),
+                    created_at_unix: 1_000_000,
+                    origin_node_id: None,
+                    conflicted: false,
+                    revoked: false,
+                }])
+            });
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(get_request("/domain-1/local-emergency-candidates"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["candidates"][0]["rotation_id"], "rot-1");
+        assert_eq!(json["candidates"][0]["conflicted"], false);
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized_without_auth_extension() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/domain-1/local-emergency-candidates")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_success_returns_kid() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_reconcile_local_emergency_rotation()
+            .returning(|_, _, _, _| Ok(generate_keypair(SigningAlgorithm::Es256).unwrap()));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(post_request(
+                "/domain-1/reconcile-local-emergency-key",
+                r#"{"rotation_id": "rot-1"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["kid"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_unknown_rotation_id_is_not_found() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_reconcile_local_emergency_rotation()
+            .returning(|_, _, _, _| {
+                Err(Oauth2KeyProviderError::LocalEmergencyCandidateNotFound(
+                    "rot-unknown".to_string(),
+                ))
+            });
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(post_request(
+                "/domain-1/reconcile-local-emergency-key",
+                r#"{"rotation_id": "rot-unknown"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_dual_control_violation_is_forbidden() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_reconcile_local_emergency_rotation()
+            .returning(|_, _, _, _| Err(Oauth2KeyProviderError::DualControlViolation));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(post_request(
+                "/domain-1/reconcile-local-emergency-key",
+                r#"{"rotation_id": "rot-1"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_unauthorized_without_auth_extension() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/domain-1/reconcile-local-emergency-key")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"rotation_id": "rot-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v4/oauth2/mod.rs
+++ b/crates/keystone/src/api/v4/oauth2/mod.rs
@@ -33,6 +33,7 @@ mod ensure_signing_key;
 mod html;
 mod jwks;
 mod jwks_revocation;
+mod local_emergency_key;
 mod rotate_signing_key;
 mod token;
 mod well_known;
@@ -66,5 +67,9 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
             confirm_rotate_signing_key::confirm_rotate_signing_key
         ))
         .routes(routes!(ensure_signing_key::ensure_signing_key))
+        .routes(routes!(
+            local_emergency_key::list_local_emergency_candidates
+        ))
+        .routes(routes!(local_emergency_key::reconcile_local_emergency_key))
         .merge(clients::openapi_router())
 }

--- a/crates/keystone/src/api/v4/oauth2/rotate_signing_key.rs
+++ b/crates/keystone/src/api/v4/oauth2/rotate_signing_key.rs
@@ -23,6 +23,16 @@
 //! second operator must call
 //! `POST /v4/oauth2/{domain_id}/confirm-rotate-signing-key` within 15
 //! minutes.
+//!
+//! `local_quorum_bypass: true` (ADR 0028 §2) stages a candidate written only
+//! to this node's local emergency store, entirely bypassing Raft/quorum --
+//! for use when the cluster has lost quorum and the ordinary `emergency`
+//! path (a Raft proposal) would block forever. Requires `justification` and
+//! is refused unless the node's `[local_emergency]` guardrail currently
+//! permits it (bypass enabled, quorum unreachable, leaderless grace period
+//! elapsed). The response carries `local_rotation_id`; reconciliation once
+//! quorum returns is a separate operation (ADR 0028 §4, not yet
+//! implemented).
 
 use axum::{
     Json,
@@ -79,7 +89,24 @@ pub(super) async fn rotate_signing_key(
 
     let initiator = user_auth.inner().principal().get_user_id();
 
-    let response = if req.emergency {
+    let response = if req.local_quorum_bypass {
+        let justification = req.justification.clone().ok_or_else(|| {
+            KeystoneApiError::BadRequest(
+                "justification is required when local_quorum_bypass is set".to_string(),
+            )
+        })?;
+        let staged = state
+            .provider
+            .get_oauth2_key_provider()
+            .stage_local_emergency_rotation(&state, &domain_id, &initiator, &justification)
+            .await?;
+        RotateSigningKeyResponse {
+            kid: None,
+            pending_rotation_id: None,
+            expires_at: None,
+            local_rotation_id: Some(staged.rotation_id),
+        }
+    } else if req.emergency {
         let pending = state
             .provider
             .get_oauth2_key_provider()
@@ -89,6 +116,7 @@ pub(super) async fn rotate_signing_key(
             kid: None,
             pending_rotation_id: Some(pending.rotation_id),
             expires_at: Some(pending.expires_at),
+            local_rotation_id: None,
         }
     } else {
         let key = state
@@ -107,6 +135,7 @@ pub(super) async fn rotate_signing_key(
             kid: Some(key.kid),
             pending_rotation_id: None,
             expires_at: None,
+            local_rotation_id: None,
         }
     };
 
@@ -123,7 +152,7 @@ mod tests {
     use tower::ServiceExt;
     use tower_http::trace::TraceLayer;
 
-    use openstack_keystone_core_types::oauth2_key::PendingRotationInfo;
+    use openstack_keystone_core_types::oauth2_key::{Oauth2KeyProviderError, PendingRotationInfo};
     use openstack_keystone_key_repository::asymmetric::{SigningAlgorithm, generate_keypair};
 
     use super::super::openapi_router;
@@ -208,6 +237,87 @@ mod tests {
         assert_eq!(json["pending_rotation_id"], "rotation-1");
         assert_eq!(json["expires_at"], 1_000_900);
         assert!(json.get("kid").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_local_quorum_bypass_returns_local_rotation_id() {
+        use openstack_keystone_core_types::oauth2_key::LocalEmergencyRotationInfo;
+
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_stage_local_emergency_rotation()
+            .withf(
+                |_, domain_id: &str, _initiator: &str, justification: &str| {
+                    domain_id == "domain-1" && justification == "suspected key compromise"
+                },
+            )
+            .returning(|_, _, _, justification| {
+                Ok(LocalEmergencyRotationInfo {
+                    rotation_id: "local-rotation-1".to_string(),
+                    justification: justification.to_string(),
+                })
+            });
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(
+                r#"{"local_quorum_bypass": true, "justification": "suspected key compromise"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["local_rotation_id"], "local-rotation-1");
+        assert!(json.get("kid").is_none());
+        assert!(json.get("pending_rotation_id").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_local_quorum_bypass_without_justification_is_rejected() {
+        // No `expect_stage_local_emergency_rotation()` set: the handler
+        // must reject before ever calling the provider.
+        let mock = MockOauth2KeyProvider::default();
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(r#"{"local_quorum_bypass": true}"#))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_local_quorum_bypass_refused_by_guardrail_surfaces_forbidden() {
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_stage_local_emergency_rotation()
+            .returning(|_, _, _, _| Err(Oauth2KeyProviderError::LocalEmergencyBypassNotAllowed));
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(request(
+                r#"{"local_quorum_bypass": true, "justification": "suspected key compromise"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/crates/keystone/src/audit.rs
+++ b/crates/keystone/src/audit.rs
@@ -426,6 +426,65 @@ pub async fn emit_oauth2_emergency_key_rotation_critical_event(
     }
 }
 
+/// Emit the critical `OAUTH2_LOCAL_EMERGENCY_KEY_RECONCILED` CADF event
+/// (ADR 0028 §6) once a node-local, quorum-bypass emergency rotation
+/// candidate is reconciled into Raft-replicated state. Fail-closed dispatch
+/// via [`AuditDispatcher::dispatch_critical`], same posture as
+/// [`emit_oauth2_emergency_key_rotation_critical_event`] -- mirrors that
+/// event's "confirm" step rather than `stage_local_emergency_rotation`'s
+/// staging step, since staging an ordinary emergency rotation
+/// (`stage_emergency_rotation`) is likewise unaudited until confirmed.
+///
+/// Returns the CADF event id so the caller can persist the
+/// `_local:emergency:audit:<rotation_id>` pointer record (ADR 0028
+/// implementation plan, design gap 2), letting reconciliation/audit tooling
+/// find this spool entry without scanning the whole spool.
+pub async fn emit_oauth2_local_emergency_key_reconciled_event(
+    dispatcher: &Arc<AuditDispatcher>,
+    correlation_id: &str,
+    initiator: Initiator,
+    domain_id: &str,
+    rotation_id: &str,
+    new_kid: &str,
+) -> String {
+    let node_id = dispatcher.node_id().to_string();
+    let event_id = format!("{}:{}", node_id, Uuid::new_v4());
+    let payload = CadfEventPayload::new(
+        event_id.clone(),
+        "1.0".to_string(),
+        "default".to_string(),
+        correlation_id.to_string(),
+        chrono::Utc::now().to_rfc3339(),
+        "OAUTH2_LOCAL_EMERGENCY_KEY_RECONCILED".to_string(),
+        "success".to_string(),
+        Some(format!(
+            "domain {domain_id} reconciled local emergency rotation {rotation_id} to new \
+             signing key {new_kid}"
+        )),
+        initiator,
+        Target {
+            id: domain_id.to_string(),
+            type_uri: "data/security/keystone/oauth2_signing_key".to_string(),
+        },
+        Observer {
+            node_id: node_id.clone(),
+            id: format!("service/security/keystone/{node_id}"),
+        },
+    );
+    let event = payload.sign(dispatcher);
+    if dispatcher.dispatch_critical(event).await.is_err() {
+        dispatcher.record_postaudit_drop();
+        tracing::error!(
+            domain_id,
+            rotation_id,
+            new_kid,
+            "failed to dispatch OAUTH2_LOCAL_EMERGENCY_KEY_RECONCILED critical audit event: \
+             audit channel dead"
+        );
+    }
+    event_id
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -551,6 +610,23 @@ mod tests {
             &["jti-1".to_string()],
         )
         .await;
+        assert_eq!(dispatcher.postaudit_dropped_count(), before + 1);
+    }
+
+    #[tokio::test]
+    async fn emit_oauth2_local_emergency_key_reconciled_event_records_drop_on_dead_channel() {
+        let dispatcher = AuditDispatcher::noop();
+        let before = dispatcher.postaudit_dropped_count();
+        let event_id = emit_oauth2_local_emergency_key_reconciled_event(
+            &dispatcher,
+            "req-1",
+            build_initiator_unknown(),
+            "domain-1",
+            "rot-1",
+            "kid-new",
+        )
+        .await;
+        assert!(!event_id.is_empty());
         assert_eq!(dispatcher.postaudit_dropped_count(), before + 1);
     }
 }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -263,6 +263,18 @@ async fn main() -> Result<(), Report> {
         .await?,
     );
 
+    // Wire the node-local, quorum-bypass emergency store (ADR 0028) into the
+    // shared service state so `--local-quorum-bypass` OAuth2 signing-key
+    // rotation can reach it. Same underlying Fjall-backed store DEK's
+    // RotateDekLocalEmergency RPC writes to, so gossip's periodic sweep
+    // (which reads directly off `Storage`) sees candidates staged either
+    // way.
+    if let Some(storage) = &concrete_storage {
+        shared_state
+            .set_local_emergency_store(storage.local_emergency_store.clone())
+            .await;
+    }
+
     // Also evicts stale rate-limit keyed-store entries (ADR-0022) and
     // shrinks idle auth-plugin invocation limiters (ADR-0025 §7) on the
     // same 60 s tick.

--- a/crates/local-emergency-store/Cargo.toml
+++ b/crates/local-emergency-store/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "openstack-keystone-local-emergency-store"
+description = "Node-local, quorum-bypass emergency write path shared by OAuth2 signing-key and DEK emergency rotation"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+chrono = { workspace = true, features = ["clock", "serde"] }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/local-emergency-store/src/gossip.rs
+++ b/crates/local-emergency-store/src/gossip.rs
@@ -1,0 +1,135 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Gossip conflict detection (ADR 0028 §5).
+//!
+//! Pure decision logic only — the actual peer enumeration, network probe,
+//! and RPC transport live in the consuming crate (`storage`), which already
+//! owns the Raft membership handle and gRPC client. Kept here so the
+//! decision of "is this a conflict" is defined once and tested without any
+//! network machinery.
+
+use crate::EmergencyCandidate;
+
+/// Outcome of receiving a gossiped candidate against this node's existing
+/// candidates for the same `(subsystem, scope_id)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GossipOutcome {
+    /// No active candidate exists locally for this scope yet: adopt the
+    /// incoming candidate as-is.
+    Adopt,
+    /// An active local candidate with the same `rotation_id` already exists
+    /// (a re-gossip, e.g. after a retry or a peer reconnecting) — no-op.
+    AlreadyPresent,
+    /// An active local candidate exists for the same scope but with a
+    /// *different* `rotation_id` — both candidates must be marked
+    /// conflicted; reconciliation makes the final call (ADR 0028 §6).
+    Conflict {
+        /// `rotation_id` of the pre-existing local candidate that conflicts
+        /// with the incoming one.
+        existing_rotation_id: String,
+    },
+}
+
+/// Decide how to handle a gossiped candidate given this node's existing,
+/// non-revoked candidates for the same `(subsystem, scope_id)`.
+///
+/// `existing_active` must already be filtered to the same subsystem/scope
+/// and to non-revoked candidates; this function does not do that filtering
+/// itself so callers can reuse a single `list_candidates` result across
+/// several incoming gossip messages.
+pub fn decide_gossip_outcome(
+    existing_active: &[EmergencyCandidate],
+    incoming: &EmergencyCandidate,
+) -> GossipOutcome {
+    match existing_active
+        .iter()
+        .find(|c| !c.revoked && c.rotation_id != incoming.rotation_id)
+    {
+        Some(conflicting) => GossipOutcome::Conflict {
+            existing_rotation_id: conflicting.rotation_id.clone(),
+        },
+        None => {
+            if existing_active
+                .iter()
+                .any(|c| c.rotation_id == incoming.rotation_id)
+            {
+                GossipOutcome::AlreadyPresent
+            } else {
+                GossipOutcome::Adopt
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+    use crate::Subsystem;
+
+    fn candidate(rotation_id: &str, revoked: bool) -> EmergencyCandidate {
+        EmergencyCandidate {
+            subsystem: Subsystem::Dek,
+            scope_id: "cluster".to_string(),
+            rotation_id: rotation_id.to_string(),
+            payload: vec![1, 2, 3],
+            initiator: "spiffe://example.org/operator/alice".to_string(),
+            justification: "suspected key compromise".to_string(),
+            created_at: Utc::now(),
+            revoked,
+            origin_node_id: None,
+            conflicted: false,
+        }
+    }
+
+    #[test]
+    fn adopts_when_nothing_active_locally() {
+        let incoming = candidate("rot-remote", false);
+        assert_eq!(decide_gossip_outcome(&[], &incoming), GossipOutcome::Adopt);
+    }
+
+    #[test]
+    fn adopts_when_only_revoked_candidates_present() {
+        let existing = vec![candidate("rot-old", true)];
+        let incoming = candidate("rot-remote", false);
+        assert_eq!(
+            decide_gossip_outcome(&existing, &incoming),
+            GossipOutcome::Adopt
+        );
+    }
+
+    #[test]
+    fn already_present_is_a_noop() {
+        let existing = vec![candidate("rot-remote", false)];
+        let incoming = candidate("rot-remote", false);
+        assert_eq!(
+            decide_gossip_outcome(&existing, &incoming),
+            GossipOutcome::AlreadyPresent
+        );
+    }
+
+    #[test]
+    fn different_active_rotation_is_a_conflict() {
+        let existing = vec![candidate("rot-local", false)];
+        let incoming = candidate("rot-remote", false);
+        assert_eq!(
+            decide_gossip_outcome(&existing, &incoming),
+            GossipOutcome::Conflict {
+                existing_rotation_id: "rot-local".to_string()
+            }
+        );
+    }
+}

--- a/crates/local-emergency-store/src/guardrail.rs
+++ b/crates/local-emergency-store/src/guardrail.rs
@@ -1,0 +1,241 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Quorum-bypass guardrail (ADR 0028 §1).
+//!
+//! The local-write path must only unlock when the node genuinely cannot
+//! reach Raft quorum, not merely on operator say-so — `--local-quorum-bypass`
+//! is refused unless the guardrail agrees. This module intentionally depends
+//! on nothing beyond `chrono`, so it can be unit-tested with synthetic
+//! inputs; callers translate their real `RaftMetrics`/`StorageApi` state
+//! into the plain parameters below.
+
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+
+/// Guardrail policy, sourced from the `[local_emergency]` config section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuardrailConfig {
+    /// Node-local opt-in: `[local_emergency].enabled`. When `false`, the
+    /// bypass is refused unconditionally.
+    pub enabled: bool,
+    /// How long the leader must have been unknown before the bypass
+    /// unlocks, in seconds (`[local_emergency].leaderless_grace_period_seconds`).
+    pub leaderless_grace_period_seconds: u64,
+}
+
+/// Decide whether a `--local-quorum-bypass` request may proceed.
+///
+/// # Parameters
+/// - `config`: the node's `[local_emergency]` policy
+/// - `current_leader`: `StorageApi::current_leader()` result — `Some` means
+///   quorum is healthy and the bypass must be refused regardless of grace
+///   period
+/// - `leaderless_since`: when the leader was first observed to be unknown;
+///   `None` means it just became unknown this instant (grace period starts
+///   now, so the request is refused)
+/// - `now`: caller-supplied clock, so tests don't need to sleep in wall time
+///
+/// # Returns
+/// `true` only if the node opted in *and* quorum has been unreachable for at
+/// least the configured grace period.
+pub fn is_quorum_bypass_allowed(
+    config: &GuardrailConfig,
+    current_leader: Option<u64>,
+    leaderless_since: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> bool {
+    if !config.enabled {
+        return false;
+    }
+    if current_leader.is_some() {
+        return false;
+    }
+    let Some(since) = leaderless_since else {
+        return false;
+    };
+    let elapsed = (now - since).num_seconds().max(0) as u64;
+    elapsed >= config.leaderless_grace_period_seconds
+}
+
+/// Tracks how long the Raft leader has been unknown, so the quorum-bypass
+/// guardrail can require a sustained outage rather than unlocking on a
+/// single transient election blip.
+///
+/// `StorageApi::current_leader()` (defined in the much heavier
+/// `storage-api`/`storage` crates, deliberately not a dependency of this
+/// one) only reports the leader at the instant it's called; this wrapper is
+/// what turns repeated `None` observations into the "since when" timestamp
+/// [`is_quorum_bypass_allowed`] needs.
+pub struct LeaderlessTracker {
+    leaderless_since: Mutex<Option<DateTime<Utc>>>,
+}
+
+impl Default for LeaderlessTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LeaderlessTracker {
+    /// Create a tracker that has not yet observed a leaderless state.
+    pub fn new() -> Self {
+        Self {
+            leaderless_since: Mutex::new(None),
+        }
+    }
+
+    /// Record the latest `current_leader()` observation.
+    ///
+    /// Call this on every poll of Raft state (or at least whenever the
+    /// guardrail is evaluated) — a `Some(_)` observation resets the tracked
+    /// outage start, so a leader re-election immediately re-arms the grace
+    /// period.
+    pub fn observe(&self, current_leader: Option<u64>, now: DateTime<Utc>) {
+        let mut guard = match self.leaderless_since.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        match current_leader {
+            Some(_) => *guard = None,
+            None => {
+                if guard.is_none() {
+                    *guard = Some(now);
+                }
+            }
+        }
+    }
+
+    /// Evaluate the guardrail using the latest observation recorded via
+    /// [`Self::observe`].
+    pub fn is_bypass_allowed(
+        &self,
+        config: &GuardrailConfig,
+        current_leader: Option<u64>,
+        now: DateTime<Utc>,
+    ) -> bool {
+        let leaderless_since = match self.leaderless_since.lock() {
+            Ok(g) => *g,
+            Err(poisoned) => *poisoned.into_inner(),
+        };
+        is_quorum_bypass_allowed(config, current_leader, leaderless_since, now)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration;
+
+    use super::*;
+
+    fn config(enabled: bool) -> GuardrailConfig {
+        GuardrailConfig {
+            enabled,
+            leaderless_grace_period_seconds: 30,
+        }
+    }
+
+    #[test]
+    fn refused_when_disabled() {
+        let now = Utc::now();
+        assert!(!is_quorum_bypass_allowed(
+            &config(false),
+            None,
+            Some(now - Duration::seconds(60)),
+            now
+        ));
+    }
+
+    #[test]
+    fn refused_when_leader_known() {
+        let now = Utc::now();
+        assert!(!is_quorum_bypass_allowed(
+            &config(true),
+            Some(1),
+            Some(now - Duration::seconds(60)),
+            now
+        ));
+    }
+
+    #[test]
+    fn refused_when_leaderless_since_unknown() {
+        let now = Utc::now();
+        assert!(!is_quorum_bypass_allowed(&config(true), None, None, now));
+    }
+
+    #[test]
+    fn refused_within_grace_period() {
+        let now = Utc::now();
+        assert!(!is_quorum_bypass_allowed(
+            &config(true),
+            None,
+            Some(now - Duration::seconds(5)),
+            now
+        ));
+    }
+
+    #[test]
+    fn allowed_after_grace_period() {
+        let now = Utc::now();
+        assert!(is_quorum_bypass_allowed(
+            &config(true),
+            None,
+            Some(now - Duration::seconds(31)),
+            now
+        ));
+    }
+
+    #[test]
+    fn leaderless_tracker_refuses_before_grace_period() {
+        let tracker = LeaderlessTracker::new();
+        let t0 = Utc::now();
+        tracker.observe(None, t0);
+
+        assert!(!tracker.is_bypass_allowed(&config(true), None, t0 + Duration::seconds(5)));
+    }
+
+    #[test]
+    fn leaderless_tracker_allows_after_grace_period() {
+        let tracker = LeaderlessTracker::new();
+        let t0 = Utc::now();
+        tracker.observe(None, t0);
+
+        assert!(tracker.is_bypass_allowed(&config(true), None, t0 + Duration::seconds(31)));
+    }
+
+    #[test]
+    fn leaderless_tracker_resets_on_leader_observed() {
+        let tracker = LeaderlessTracker::new();
+        let t0 = Utc::now();
+        tracker.observe(None, t0);
+        // Leader comes back before the grace period elapses.
+        tracker.observe(Some(1), t0 + Duration::seconds(10));
+        // And is lost again — the outage clock must restart from here, not
+        // from t0.
+        tracker.observe(None, t0 + Duration::seconds(20));
+
+        assert!(!tracker.is_bypass_allowed(&config(true), None, t0 + Duration::seconds(40)));
+        assert!(tracker.is_bypass_allowed(&config(true), None, t0 + Duration::seconds(51)));
+    }
+
+    #[test]
+    fn leaderless_tracker_refused_when_leader_currently_known() {
+        let tracker = LeaderlessTracker::new();
+        let t0 = Utc::now();
+        tracker.observe(None, t0);
+
+        assert!(!tracker.is_bypass_allowed(&config(true), Some(1), t0 + Duration::seconds(60)));
+    }
+}

--- a/crates/local-emergency-store/src/key.rs
+++ b/crates/local-emergency-store/src/key.rs
@@ -1,0 +1,88 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Key-namespace builders for the local emergency store (ADR 0028 §2).
+//!
+//! Every implementation and every subsystem must build keys through these
+//! functions rather than formatting the `_local:...` prefix by hand, so the
+//! namespace stays consistent across the Fjall-backed store, gossip
+//! payloads, and the reconciliation/audit pointer records.
+
+use crate::Subsystem;
+
+/// Prefix for every key this crate owns, so a generic prefix scan can find
+/// all locally-written emergency state regardless of subsystem.
+pub const ROOT_PREFIX: &str = "_local";
+
+/// Prefix for every candidate written under a given subsystem, regardless of
+/// scope. Distinct from [`ROOT_PREFIX`] alone so a subsystem-wide scan never
+/// picks up unrelated `_local:...` records (e.g. the audit pointer keys from
+/// [`audit_pointer_key`], which do not have a scope segment).
+pub fn candidate_subsystem_prefix(subsystem: Subsystem) -> String {
+    format!("{ROOT_PREFIX}:{}:", subsystem.as_str())
+}
+
+/// Prefix for every candidate written under a given subsystem/scope, without
+/// a trailing rotation id. Used to list/scan all candidates for that scope.
+pub fn candidate_scope_prefix(subsystem: Subsystem, scope_id: &str) -> String {
+    format!(
+        "{}{scope_id}:emergency:",
+        candidate_subsystem_prefix(subsystem)
+    )
+}
+
+/// Full key for one emergency rotation candidate.
+pub fn candidate_key(subsystem: Subsystem, scope_id: &str, rotation_id: &str) -> String {
+    format!(
+        "{}{rotation_id}",
+        candidate_scope_prefix(subsystem, scope_id)
+    )
+}
+
+/// Full key for the compact audit pointer record for a rotation id
+/// (ADR 0028 implementation plan, design gap 2) — kept separate from the
+/// candidate record itself so reconciliation tooling can enumerate audit
+/// entries without touching (or accidentally clearing) candidate data.
+pub fn audit_pointer_key(rotation_id: &str) -> String {
+    format!("{ROOT_PREFIX}:emergency:audit:{rotation_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn candidate_key_layout() {
+        assert_eq!(
+            candidate_key(Subsystem::Oauth2SigningKey, "default", "rot-1"),
+            "_local:oauth2_signing_key:default:emergency:rot-1"
+        );
+        assert_eq!(
+            candidate_key(Subsystem::Dek, "cluster", "rot-2"),
+            "_local:dek:cluster:emergency:rot-2"
+        );
+    }
+
+    #[test]
+    fn candidate_key_is_prefixed_by_scope_prefix() {
+        let prefix = candidate_scope_prefix(Subsystem::Dek, "cluster");
+        let key = candidate_key(Subsystem::Dek, "cluster", "rot-2");
+        assert!(key.starts_with(&prefix));
+    }
+
+    #[test]
+    fn audit_pointer_key_layout() {
+        assert_eq!(audit_pointer_key("rot-1"), "_local:emergency:audit:rot-1");
+    }
+}

--- a/crates/local-emergency-store/src/lib.rs
+++ b/crates/local-emergency-store/src/lib.rs
@@ -1,0 +1,242 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Local emergency store (ADR 0028)
+//!
+//! Generic, node-local write path used by an emergency rotation subsystem
+//! (OAuth2 signing keys, DEKs) when Raft quorum is unavailable. Values
+//! written through this crate never go through `StorageApi`/Raft — they live
+//! only in the local node's own storage until an operator explicitly
+//! reconciles them back into the replicated state once quorum returns
+//! (ADR 0028 §4).
+//!
+//! This crate provides only the shared, subsystem-agnostic pieces:
+//!
+//! - [`LocalEmergencyStore`] — the storage trait candidates are written
+//!   through
+//! - [`key`] — the `_local:<subsystem>:<scope_id>:emergency:<rotation_id>`
+//!   namespace key-builders, so every backend and every subsystem agrees on
+//!   the same layout
+//! - [`EmergencyCandidate`] — the record shape stored per rotation attempt
+//! - [`Subsystem`] — the two ADR 0028 instantiations
+//!
+//! Subsystem-specific logic (key generation, DEK re-encryption sweeps,
+//! reconciliation-to-Raft) lives in the consuming crates
+//! (`oauth2-key-driver-raft`, `storage`), which depend on this crate rather
+//! than duplicating the namespace/guardrail/gossip plumbing.
+
+pub mod gossip;
+mod guardrail;
+pub mod key;
+mod mock;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub use gossip::{GossipOutcome, decide_gossip_outcome};
+pub use guardrail::{GuardrailConfig, LeaderlessTracker, is_quorum_bypass_allowed};
+pub use mock::InMemoryLocalEmergencyStore;
+
+/// The two ADR 0028 subsystem instantiations.
+///
+/// Deliberately a closed enum, not a free-form string: every namespace
+/// segment must be agreed on ahead of time so gossip/reconciliation code
+/// never has to guess how to interpret an unrecognized subsystem tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Subsystem {
+    /// OAuth2 signing-key emergency rotation (amends ADR 0026 §3).
+    Oauth2SigningKey,
+    /// DEK emergency rotation (amends ADR 0016-v2 §6.2).
+    Dek,
+}
+
+impl Subsystem {
+    /// The namespace segment used in local emergency store keys.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Oauth2SigningKey => "oauth2_signing_key",
+            Self::Dek => "dek",
+        }
+    }
+}
+
+/// A single locally-written emergency rotation candidate.
+///
+/// The `payload` is opaque to this crate — subsystem crates serialize their
+/// own candidate shape (e.g. the staged signing key, or the wrapped DEK)
+/// into it. Only bookkeeping fields needed by the shared guardrail, gossip,
+/// and reconciliation logic are typed here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmergencyCandidate {
+    /// Subsystem this candidate belongs to.
+    pub subsystem: Subsystem,
+    /// Scope the rotation applies to (e.g. domain id).
+    pub scope_id: String,
+    /// Unique id for this rotation attempt, chosen by the initiating
+    /// operator/CLI invocation.
+    pub rotation_id: String,
+    /// Opaque, subsystem-serialized candidate payload.
+    pub payload: Vec<u8>,
+    /// Identity of the operator who staged this candidate (from the SPIFFE
+    /// identity on the admin UDS connection, never from request body).
+    pub initiator: String,
+    /// Mandatory operator-supplied justification for the bypass
+    /// (ADR 0028 §1).
+    pub justification: String,
+    /// When this candidate was written.
+    pub created_at: DateTime<Utc>,
+    /// Set once reconciliation determines this candidate lost to a
+    /// conflicting candidate from another node (ADR 0028 §4). A revoked
+    /// candidate is retained for operator visibility/audit but must never be
+    /// promoted.
+    pub revoked: bool,
+    /// `None` if this candidate was staged locally on the node that is
+    /// currently storing it; `Some(node_id)` if it arrived via gossip from
+    /// another node (ADR 0028 §5).
+    #[serde(default)]
+    pub origin_node_id: Option<u64>,
+    /// Set when gossip observes another node holding an active candidate
+    /// for the same `(subsystem, scope_id)` with a different `rotation_id`
+    /// (`LOCAL_EMERGENCY_CONFLICT`, ADR 0028 §5). Surfaced to operators so
+    /// reconciliation (ADR 0028 §6) can make an explicit choice rather than
+    /// silently picking one side.
+    #[serde(default)]
+    pub conflicted: bool,
+}
+
+/// Errors returned by [`LocalEmergencyStore`] implementations.
+#[derive(Error, Debug)]
+pub enum LocalEmergencyStoreError {
+    /// A candidate already exists for this exact
+    /// `(subsystem, scope_id, rotation_id)` triple.
+    #[error("emergency candidate already exists: {0}")]
+    AlreadyExists(String),
+
+    /// No candidate exists for this key.
+    #[error("no emergency candidate found: {0}")]
+    NotFound(String),
+
+    /// Implementation-specific storage failure (Fjall I/O, etc).
+    #[error("{0}")]
+    Other(Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+impl LocalEmergencyStoreError {
+    /// Wrap an implementation-specific error into [`Self::Other`].
+    pub fn other<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self::Other(err.into())
+    }
+}
+
+/// Storage trait for the node-local emergency write path.
+///
+/// Implementations must never route writes through Raft/`StorageApi` — that
+/// would defeat the purpose of a quorum-bypass path. The reference
+/// production implementation (Phase 2 of the ADR 0028 implementation plan)
+/// wraps a dedicated Fjall keyspace opened directly off the same
+/// `fjall::Database` handle `StateMachineStore` uses, but never touched by
+/// its `apply()`.
+#[async_trait]
+pub trait LocalEmergencyStore: Send + Sync {
+    /// Write a new candidate. Fails with
+    /// [`LocalEmergencyStoreError::AlreadyExists`] if the same
+    /// `(subsystem, scope_id, rotation_id)` triple is already present —
+    /// callers must pick a fresh `rotation_id` per attempt, never overwrite.
+    async fn put_candidate(
+        &self,
+        candidate: EmergencyCandidate,
+    ) -> Result<(), LocalEmergencyStoreError>;
+
+    /// Fetch a single candidate by its full key.
+    async fn get_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<Option<EmergencyCandidate>, LocalEmergencyStoreError>;
+
+    /// List every candidate (including revoked ones) for a given
+    /// subsystem/scope, e.g. to detect that two operators raced and staged
+    /// conflicting candidates on different nodes (`LOCAL_EMERGENCY_CONFLICT`,
+    /// ADR 0028 §3).
+    async fn list_candidates(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+    ) -> Result<Vec<EmergencyCandidate>, LocalEmergencyStoreError>;
+
+    /// List every candidate for a subsystem across all scopes, e.g. so a
+    /// background gossip sweep (ADR 0028 §5) can find every locally-staged
+    /// candidate without needing to know which scopes (domains) exist.
+    async fn list_candidates_for_subsystem(
+        &self,
+        subsystem: Subsystem,
+    ) -> Result<Vec<EmergencyCandidate>, LocalEmergencyStoreError>;
+
+    /// Mark a candidate as revoked (lost reconciliation to another
+    /// candidate). The record is kept, not deleted, so operators and audit
+    /// tooling retain visibility into what was rejected and why.
+    async fn revoke_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError>;
+
+    /// Mark a candidate as conflicted: gossip observed another node with an
+    /// active candidate for the same `(subsystem, scope_id)` but a different
+    /// `rotation_id` (ADR 0028 §5). Does not revoke it — reconciliation (ADR
+    /// 0028 §6) makes the explicit choice between conflicting candidates.
+    async fn mark_conflicted(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError>;
+
+    /// Permanently remove a candidate. Only valid once reconciliation has
+    /// promoted it into a committed Raft rotation (or once it is revoked and
+    /// no longer needed for audit) — this is local storage housekeeping, not
+    /// a state-machine mutation.
+    async fn clear_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError>;
+
+    /// Record the CADF audit event id emitted for a reconciled `rotation_id`
+    /// (ADR 0028 implementation plan, design gap 2), at
+    /// [`key::audit_pointer_key`]. Lets reconciliation/audit tooling find
+    /// the spool entry for a given rotation without scanning the whole
+    /// audit spool -- the event id itself is an opaque, unrelated UUID
+    /// minted at emission time, not derivable from `rotation_id`.
+    async fn put_audit_pointer(
+        &self,
+        rotation_id: &str,
+        event_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError>;
+
+    /// Fetch the audit event id previously recorded for `rotation_id`, if
+    /// any.
+    async fn get_audit_pointer(
+        &self,
+        rotation_id: &str,
+    ) -> Result<Option<String>, LocalEmergencyStoreError>;
+}

--- a/crates/local-emergency-store/src/mock.rs
+++ b/crates/local-emergency-store/src/mock.rs
@@ -1,0 +1,353 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory [`LocalEmergencyStore`] used by subsystem crates' unit tests
+//! (`oauth2-key-driver-raft`, `storage`) so they don't need a real Fjall
+//! database to exercise staging/reconciliation logic. The Fjall-backed
+//! production implementation lands in Phase 2 of the ADR 0028 implementation
+//! plan, in `crates/storage`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::{EmergencyCandidate, LocalEmergencyStore, LocalEmergencyStoreError, Subsystem, key};
+
+/// In-memory, process-local [`LocalEmergencyStore`] implementation.
+#[derive(Default)]
+pub struct InMemoryLocalEmergencyStore {
+    candidates: Mutex<HashMap<String, EmergencyCandidate>>,
+    audit_pointers: Mutex<HashMap<String, String>>,
+}
+
+impl InMemoryLocalEmergencyStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl LocalEmergencyStore for InMemoryLocalEmergencyStore {
+    async fn put_candidate(
+        &self,
+        candidate: EmergencyCandidate,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(
+            candidate.subsystem,
+            &candidate.scope_id,
+            &candidate.rotation_id,
+        );
+        let mut guard = self
+            .candidates
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        if guard.contains_key(&full_key) {
+            return Err(LocalEmergencyStoreError::AlreadyExists(full_key));
+        }
+        guard.insert(full_key, candidate);
+        Ok(())
+    }
+
+    async fn get_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<Option<EmergencyCandidate>, LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(subsystem, scope_id, rotation_id);
+        let guard = self
+            .candidates
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        Ok(guard.get(&full_key).cloned())
+    }
+
+    async fn list_candidates(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+    ) -> Result<Vec<EmergencyCandidate>, LocalEmergencyStoreError> {
+        let prefix = key::candidate_scope_prefix(subsystem, scope_id);
+        let guard = self
+            .candidates
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        Ok(guard
+            .iter()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(_, v)| v.clone())
+            .collect())
+    }
+
+    async fn list_candidates_for_subsystem(
+        &self,
+        subsystem: Subsystem,
+    ) -> Result<Vec<EmergencyCandidate>, LocalEmergencyStoreError> {
+        let prefix = key::candidate_subsystem_prefix(subsystem);
+        let guard = self
+            .candidates
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        Ok(guard
+            .iter()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(_, v)| v.clone())
+            .collect())
+    }
+
+    async fn revoke_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(subsystem, scope_id, rotation_id);
+        let mut guard = self
+            .candidates
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        let candidate = guard
+            .get_mut(&full_key)
+            .ok_or_else(|| LocalEmergencyStoreError::NotFound(full_key.clone()))?;
+        candidate.revoked = true;
+        Ok(())
+    }
+
+    async fn mark_conflicted(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(subsystem, scope_id, rotation_id);
+        let mut guard = self
+            .candidates
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        let candidate = guard
+            .get_mut(&full_key)
+            .ok_or_else(|| LocalEmergencyStoreError::NotFound(full_key.clone()))?;
+        candidate.conflicted = true;
+        Ok(())
+    }
+
+    async fn clear_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(subsystem, scope_id, rotation_id);
+        let mut guard = self
+            .candidates
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        guard
+            .remove(&full_key)
+            .ok_or(LocalEmergencyStoreError::NotFound(full_key))?;
+        Ok(())
+    }
+
+    async fn put_audit_pointer(
+        &self,
+        rotation_id: &str,
+        event_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let mut guard = self
+            .audit_pointers
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        guard.insert(key::audit_pointer_key(rotation_id), event_id.to_string());
+        Ok(())
+    }
+
+    async fn get_audit_pointer(
+        &self,
+        rotation_id: &str,
+    ) -> Result<Option<String>, LocalEmergencyStoreError> {
+        let guard = self
+            .audit_pointers
+            .lock()
+            .map_err(|e| LocalEmergencyStoreError::other(e.to_string()))?;
+        Ok(guard.get(&key::audit_pointer_key(rotation_id)).cloned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+
+    fn candidate(subsystem: Subsystem, scope_id: &str, rotation_id: &str) -> EmergencyCandidate {
+        EmergencyCandidate {
+            subsystem,
+            scope_id: scope_id.to_string(),
+            rotation_id: rotation_id.to_string(),
+            payload: vec![1, 2, 3],
+            initiator: "spiffe://example.org/operator/alice".to_string(),
+            justification: "suspected key compromise".to_string(),
+            created_at: Utc::now(),
+            revoked: false,
+            origin_node_id: None,
+            conflicted: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn put_then_get_roundtrips() {
+        let store = InMemoryLocalEmergencyStore::new();
+        let c = candidate(Subsystem::Oauth2SigningKey, "default", "rot-1");
+        store.put_candidate(c.clone()).await.unwrap();
+
+        let fetched = store
+            .get_candidate(Subsystem::Oauth2SigningKey, "default", "rot-1")
+            .await
+            .unwrap();
+        assert_eq!(fetched, Some(c));
+    }
+
+    #[tokio::test]
+    async fn get_missing_returns_none() {
+        let store = InMemoryLocalEmergencyStore::new();
+        let fetched = store
+            .get_candidate(Subsystem::Dek, "cluster", "missing")
+            .await
+            .unwrap();
+        assert_eq!(fetched, None);
+    }
+
+    #[tokio::test]
+    async fn put_duplicate_rotation_id_fails() {
+        let store = InMemoryLocalEmergencyStore::new();
+        let c = candidate(Subsystem::Dek, "cluster", "rot-1");
+        store.put_candidate(c.clone()).await.unwrap();
+
+        let err = store.put_candidate(c).await.unwrap_err();
+        assert!(matches!(err, LocalEmergencyStoreError::AlreadyExists(_)));
+    }
+
+    #[tokio::test]
+    async fn list_candidates_scopes_by_subsystem_and_scope() {
+        let store = InMemoryLocalEmergencyStore::new();
+        store
+            .put_candidate(candidate(Subsystem::Dek, "cluster", "rot-1"))
+            .await
+            .unwrap();
+        store
+            .put_candidate(candidate(Subsystem::Dek, "cluster", "rot-2"))
+            .await
+            .unwrap();
+        store
+            .put_candidate(candidate(Subsystem::Dek, "other-cluster", "rot-3"))
+            .await
+            .unwrap();
+        store
+            .put_candidate(candidate(Subsystem::Oauth2SigningKey, "cluster", "rot-4"))
+            .await
+            .unwrap();
+
+        let mut ids: Vec<String> = store
+            .list_candidates(Subsystem::Dek, "cluster")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.rotation_id)
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["rot-1".to_string(), "rot-2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn revoke_marks_candidate_without_deleting_it() {
+        let store = InMemoryLocalEmergencyStore::new();
+        store
+            .put_candidate(candidate(Subsystem::Oauth2SigningKey, "default", "rot-1"))
+            .await
+            .unwrap();
+
+        store
+            .revoke_candidate(Subsystem::Oauth2SigningKey, "default", "rot-1")
+            .await
+            .unwrap();
+
+        let fetched = store
+            .get_candidate(Subsystem::Oauth2SigningKey, "default", "rot-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(fetched.revoked);
+    }
+
+    #[tokio::test]
+    async fn revoke_missing_candidate_fails() {
+        let store = InMemoryLocalEmergencyStore::new();
+        let err = store
+            .revoke_candidate(Subsystem::Dek, "cluster", "missing")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LocalEmergencyStoreError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn clear_removes_candidate() {
+        let store = InMemoryLocalEmergencyStore::new();
+        store
+            .put_candidate(candidate(Subsystem::Dek, "cluster", "rot-1"))
+            .await
+            .unwrap();
+
+        store
+            .clear_candidate(Subsystem::Dek, "cluster", "rot-1")
+            .await
+            .unwrap();
+
+        let fetched = store
+            .get_candidate(Subsystem::Dek, "cluster", "rot-1")
+            .await
+            .unwrap();
+        assert_eq!(fetched, None);
+    }
+
+    #[tokio::test]
+    async fn clear_missing_candidate_fails() {
+        let store = InMemoryLocalEmergencyStore::new();
+        let err = store
+            .clear_candidate(Subsystem::Dek, "cluster", "missing")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LocalEmergencyStoreError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn audit_pointer_put_then_get_roundtrips() {
+        let store = InMemoryLocalEmergencyStore::new();
+        store
+            .put_audit_pointer("rot-1", "node-1:event-uuid")
+            .await
+            .unwrap();
+
+        let fetched = store.get_audit_pointer("rot-1").await.unwrap();
+        assert_eq!(fetched, Some("node-1:event-uuid".to_string()));
+    }
+
+    #[tokio::test]
+    async fn audit_pointer_missing_returns_none() {
+        let store = InMemoryLocalEmergencyStore::new();
+        let fetched = store.get_audit_pointer("rot-missing").await.unwrap();
+        assert_eq!(fetched, None);
+    }
+}

--- a/crates/oauth2-key-driver-raft/Cargo.toml
+++ b/crates/oauth2-key-driver-raft/Cargo.toml
@@ -17,6 +17,7 @@ openstack-keystone-core.workspace = true
 openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage.workspace = true
 openstack-keystone-key-repository.workspace = true
+openstack-keystone-local-emergency-store.workspace = true
 rmp-serde.workspace = true
 secrecy.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -25,7 +26,11 @@ tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
+openstack-keystone-audit = { workspace = true, features = ["testing"] }
+openstack-keystone-config.workspace = true
+openstack-keystone-core = { workspace = true, features = ["mock"] }
 openstack-keystone-distributed-storage = { workspace = true, features = ["mock"] }
+sea-orm.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/crates/oauth2-key-driver-raft/src/lib.rs
+++ b/crates/oauth2-key-driver-raft/src/lib.rs
@@ -21,13 +21,19 @@ use serde::{Deserialize, Serialize};
 
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::oauth2_key::backend::Oauth2KeyBackend;
-use openstack_keystone_core_types::oauth2_key::{Oauth2KeyProviderError, PendingRotationInfo};
+use openstack_keystone_core_types::oauth2_key::{
+    LocalEmergencyCandidateSummary, LocalEmergencyRotationInfo, Oauth2KeyProviderError,
+    PendingRotationInfo,
+};
 use openstack_keystone_distributed_storage::{
     ApiStoreError as StoreError, Metadata, StorageApi, StoreDataEnvelope, store_command::Mutation,
 };
 use openstack_keystone_key_repository::asymmetric::{
     ActiveKeys, AsymmetricKeyRepository, AsymmetricKeySource, KeyMaterial, KeyRole,
-    SigningAlgorithm,
+    SigningAlgorithm, generate_keypair,
+};
+use openstack_keystone_local_emergency_store::{
+    EmergencyCandidate, GuardrailConfig, LocalEmergencyStore, Subsystem,
 };
 
 /// Dual-control confirmation window for an emergency rotation (ADR 0026 §3):
@@ -435,6 +441,168 @@ impl RaftOauth2KeyBackend {
         })
     }
 
+    /// `--local-quorum-bypass` emergency rotation stage 1 (ADR 0028 §2):
+    /// generate the replacement keypair and persist it as a node-local
+    /// candidate, entirely bypassing `storage`/Raft. The guardrail decision
+    /// (is a bypass permitted right now) is the caller's responsibility —
+    /// this method only stages, the same separation
+    /// `stage_emergency_rotation_impl` draws between staging and the
+    /// dual-control confirmation check.
+    ///
+    /// Rejects if a non-revoked local candidate already exists for this
+    /// domain on this node, for the same reason as the Raft-backed
+    /// counterpart: a second concurrent stage must not silently orphan the
+    /// first's `rotation_id` mid-incident.
+    async fn stage_local_emergency_rotation_impl(
+        &self,
+        local_store: &dyn LocalEmergencyStore,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+        initiator: &str,
+        justification: &str,
+    ) -> Result<LocalEmergencyRotationInfo, Oauth2KeyProviderError> {
+        let existing = local_store
+            .list_candidates(Subsystem::Oauth2SigningKey, domain_id)
+            .await
+            .map_err(Oauth2KeyProviderError::local_emergency)?;
+        if let Some(active) = existing.iter().find(|c| !c.revoked) {
+            return Err(Oauth2KeyProviderError::LocalEmergencyAlreadyStaged(
+                active.rotation_id.clone(),
+            ));
+        }
+
+        let fresh = generate_keypair(algorithm).map_err(Oauth2KeyProviderError::crypto)?;
+        let rotation_id = uuid::Uuid::new_v4().to_string();
+        let payload = rmp_serde::to_vec(&StoredKeyMaterial::from(&fresh))
+            .map_err(|e| Oauth2KeyProviderError::Crypto(e.to_string()))?;
+
+        let candidate = EmergencyCandidate {
+            subsystem: Subsystem::Oauth2SigningKey,
+            scope_id: domain_id.to_string(),
+            rotation_id: rotation_id.clone(),
+            payload,
+            initiator: initiator.to_string(),
+            justification: justification.to_string(),
+            created_at: chrono::Utc::now(),
+            revoked: false,
+            origin_node_id: None,
+            conflicted: false,
+        };
+        local_store
+            .put_candidate(candidate)
+            .await
+            .map_err(Oauth2KeyProviderError::local_emergency)?;
+
+        Ok(LocalEmergencyRotationInfo {
+            rotation_id,
+            justification: justification.to_string(),
+        })
+    }
+
+    /// List every node-local emergency candidate for `domain_id` on this
+    /// node (ADR 0028 §6).
+    async fn list_local_emergency_candidates_impl(
+        &self,
+        local_store: &dyn LocalEmergencyStore,
+        domain_id: &str,
+    ) -> Result<Vec<LocalEmergencyCandidateSummary>, Oauth2KeyProviderError> {
+        let candidates = local_store
+            .list_candidates(Subsystem::Oauth2SigningKey, domain_id)
+            .await
+            .map_err(Oauth2KeyProviderError::local_emergency)?;
+        Ok(candidates
+            .into_iter()
+            .map(|c| LocalEmergencyCandidateSummary {
+                rotation_id: c.rotation_id,
+                initiator: c.initiator,
+                justification: c.justification,
+                created_at_unix: c.created_at.timestamp(),
+                origin_node_id: c.origin_node_id,
+                conflicted: c.conflicted,
+                revoked: c.revoked,
+            })
+            .collect())
+    }
+
+    /// Reconcile a node-local emergency candidate into Raft-replicated state
+    /// (ADR 0028 §6): promotes the chosen candidate's key to `Primary` via
+    /// the normal transaction path `rotate_signing_key_impl` and
+    /// `confirm_emergency_rotation_impl` already use, then clears it from
+    /// this node's local store and revokes any other active sibling
+    /// candidate for the same domain (they lost).
+    async fn reconcile_local_emergency_rotation_impl(
+        &self,
+        storage: &dyn StorageApi,
+        local_store: &dyn LocalEmergencyStore,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        let candidate = local_store
+            .get_candidate(Subsystem::Oauth2SigningKey, domain_id, rotation_id)
+            .await
+            .map_err(Oauth2KeyProviderError::local_emergency)?
+            .ok_or_else(|| {
+                Oauth2KeyProviderError::LocalEmergencyCandidateNotFound(rotation_id.to_string())
+            })?;
+        if candidate.revoked {
+            return Err(Oauth2KeyProviderError::LocalEmergencyCandidateRevoked(
+                rotation_id.to_string(),
+            ));
+        }
+        if candidate.initiator == confirmer {
+            return Err(Oauth2KeyProviderError::DualControlViolation);
+        }
+
+        let staged: StoredKeyMaterial = rmp_serde::from_slice(&candidate.payload)
+            .map_err(|e| Oauth2KeyProviderError::Crypto(e.to_string()))?;
+        let new_primary = KeyMaterial::from(staged);
+        let active = self.active_keys_impl(storage, domain_id).await?;
+        let demoted_primary = KeyMaterial {
+            demoted_at: Some(chrono::Utc::now()),
+            ..active.primary
+        };
+
+        let mutations = vec![
+            key_set_mutation(domain_id, KeyRole::Primary, &new_primary)
+                .map_err(store_err_to_key_repo_err)
+                .map_err(Oauth2KeyProviderError::crypto)?,
+            key_set_mutation(domain_id, KeyRole::Previous, &demoted_primary)
+                .map_err(store_err_to_key_repo_err)
+                .map_err(Oauth2KeyProviderError::crypto)?,
+        ];
+        storage
+            .transaction(mutations)
+            .await
+            .map_err(|e| Oauth2KeyProviderError::raft(store_err_to_key_repo_err(e)))?;
+
+        // The candidate is now durably committed to Raft; clear it and any
+        // other active sibling for this domain on this node (they lost --
+        // ADR 0028 §6's explicit-choice reconciliation).
+        local_store
+            .clear_candidate(Subsystem::Oauth2SigningKey, domain_id, rotation_id)
+            .await
+            .map_err(Oauth2KeyProviderError::local_emergency)?;
+        let siblings = local_store
+            .list_candidates(Subsystem::Oauth2SigningKey, domain_id)
+            .await
+            .map_err(Oauth2KeyProviderError::local_emergency)?;
+        for sibling in siblings.iter().filter(|c| !c.revoked) {
+            if let Err(e) = local_store
+                .revoke_candidate(Subsystem::Oauth2SigningKey, domain_id, &sibling.rotation_id)
+                .await
+            {
+                tracing::warn!(
+                    rotation_id = sibling.rotation_id,
+                    error = %e,
+                    "failed to revoke superseded local emergency candidate after reconciliation"
+                );
+            }
+        }
+
+        Ok(new_primary)
+    }
+
     /// Load the pending emergency rotation record for `domain_id`, if any
     /// (regardless of expiry -- callers decide how to treat an expired
     /// record). Shared by [`Self::stage_emergency_rotation_impl`]'s
@@ -752,6 +920,97 @@ impl Oauth2KeyBackend for RaftOauth2KeyBackend {
         .await
     }
 
+    async fn stage_local_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        algorithm: SigningAlgorithm,
+        initiator: &str,
+        justification: &str,
+    ) -> Result<LocalEmergencyRotationInfo, Oauth2KeyProviderError> {
+        let local_emergency_cfg = state
+            .config_manager
+            .config
+            .read()
+            .await
+            .local_emergency
+            .clone();
+        let guardrail_cfg = GuardrailConfig {
+            enabled: local_emergency_cfg.enabled,
+            leaderless_grace_period_seconds: local_emergency_cfg.leaderless_grace_period_seconds,
+        };
+        let current_leader = match state.storage.as_deref() {
+            Some(storage) => storage.current_leader().await,
+            None => None,
+        };
+        let now = chrono::Utc::now();
+        state
+            .local_emergency_leaderless_tracker
+            .observe(current_leader, now);
+        if !state.local_emergency_leaderless_tracker.is_bypass_allowed(
+            &guardrail_cfg,
+            current_leader,
+            now,
+        ) {
+            return Err(Oauth2KeyProviderError::LocalEmergencyBypassNotAllowed);
+        }
+
+        let local_store_guard = state.local_emergency_store.read().await;
+        let local_store = local_store_guard
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::LocalEmergencyBypassNotAllowed)?;
+
+        self.stage_local_emergency_rotation_impl(
+            local_store,
+            domain_id,
+            algorithm,
+            initiator,
+            justification,
+        )
+        .await
+    }
+
+    async fn list_local_emergency_candidates(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<Vec<LocalEmergencyCandidateSummary>, Oauth2KeyProviderError> {
+        let local_store_guard = state.local_emergency_store.read().await;
+        let local_store = local_store_guard
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::LocalEmergencyBypassNotAllowed)?;
+        self.list_local_emergency_candidates_impl(local_store, domain_id)
+            .await
+    }
+
+    async fn reconcile_local_emergency_rotation(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        rotation_id: &str,
+        confirmer: &str,
+    ) -> Result<KeyMaterial, Oauth2KeyProviderError> {
+        // Reconciliation is not guardrail-gated (unlike staging): it is the
+        // operation an operator runs *after* quorum has returned, to commit
+        // a candidate that was staged while it was unavailable.
+        let storage = state
+            .storage
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::RaftNotAvailable)?;
+        let local_store_guard = state.local_emergency_store.read().await;
+        let local_store = local_store_guard
+            .as_deref()
+            .ok_or(Oauth2KeyProviderError::LocalEmergencyBypassNotAllowed)?;
+        self.reconcile_local_emergency_rotation_impl(
+            storage,
+            local_store,
+            domain_id,
+            rotation_id,
+            confirmer,
+        )
+        .await
+    }
+
     async fn revoked_jtis(
         &self,
         state: &ServiceState,
@@ -819,6 +1078,28 @@ mod tests {
     use super::*;
     use openstack_keystone_distributed_storage::mock::MockStorage;
     use openstack_keystone_key_repository::asymmetric::generate_keypair;
+
+    /// Minimal `ServiceState` for exercising the trait-level
+    /// `Oauth2KeyBackend` methods (as opposed to the `_impl` methods tested
+    /// directly against `MockStorage` elsewhere in this module), with no
+    /// distributed storage configured -- the local-emergency guardrail path
+    /// must work even then.
+    async fn test_service_state(config: openstack_keystone_config::Config) -> ServiceState {
+        std::sync::Arc::new(
+            openstack_keystone_core::keystone::Service::new(
+                openstack_keystone_config::ConfigManager::not_watched(config),
+                sea_orm::DatabaseConnection::Disconnected,
+                openstack_keystone_core::provider::Provider::mocked_builder()
+                    .build()
+                    .unwrap(),
+                std::sync::Arc::new(openstack_keystone_core::policy::MockPolicy::default()),
+                openstack_keystone_audit::AuditDispatcher::noop(),
+                None,
+            )
+            .await
+            .unwrap(),
+        )
+    }
 
     #[tokio::test]
     async fn test_setup_generates_and_load_active_round_trips() {
@@ -1070,6 +1351,484 @@ mod tests {
             .await
             .unwrap();
         assert_ne!(second.rotation_id, first.rotation_id);
+    }
+
+    #[tokio::test]
+    async fn test_stage_local_emergency_rotation_writes_a_candidate() {
+        let backend = RaftOauth2KeyBackend::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+
+        let info = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap();
+
+        let candidate = local_store
+            .get_candidate(Subsystem::Oauth2SigningKey, "domain-1", &info.rotation_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(candidate.initiator, "operator-a");
+        assert_eq!(candidate.justification, "suspected key compromise");
+        assert!(!candidate.revoked);
+        // The payload must be a usable staged keypair, not just opaque
+        // bytes: round-trip it back through `StoredKeyMaterial`.
+        let staged: StoredKeyMaterial = rmp_serde::from_slice(&candidate.payload).unwrap();
+        assert!(!staged.kid.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_stage_local_emergency_rotation_never_touches_raft_storage() {
+        // Never construct or reach for a `dyn StorageApi` in this test at
+        // all: the local-write path's whole point is that it works with no
+        // storage/Raft handle available.
+        let backend = RaftOauth2KeyBackend::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+
+        let result = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_stage_local_emergency_rotation_rejects_second_concurrent_candidate() {
+        let backend = RaftOauth2KeyBackend::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+
+        backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap();
+
+        let err = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-b",
+                "second, independent suspicion",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Oauth2KeyProviderError::LocalEmergencyAlreadyStaged(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stage_local_emergency_rotation_allowed_after_revocation() {
+        let backend = RaftOauth2KeyBackend::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+
+        let first = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap();
+
+        // Reconciliation revoked the first candidate (lost to a conflicting
+        // one on another node) -- a fresh stage on this node must not be
+        // blocked by it forever.
+        local_store
+            .revoke_candidate(Subsystem::Oauth2SigningKey, "domain-1", &first.rotation_id)
+            .await
+            .unwrap();
+
+        let second = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-b",
+                "new incident",
+            )
+            .await
+            .unwrap();
+        assert_ne!(second.rotation_id, first.rotation_id);
+    }
+
+    #[tokio::test]
+    async fn test_stage_local_emergency_rotation_isolates_domains() {
+        let backend = RaftOauth2KeyBackend::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+
+        backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-a",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "justification-a",
+            )
+            .await
+            .unwrap();
+
+        // A candidate already staged for `domain-a` must not block staging
+        // an unrelated domain on the same node.
+        let result = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-b",
+                SigningAlgorithm::Es256,
+                "operator-b",
+                "justification-b",
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_local_emergency_rotation_promotes_candidate_and_clears_it() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+        let staged = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap();
+        let staged_candidate = local_store
+            .get_candidate(Subsystem::Oauth2SigningKey, "domain-1", &staged.rotation_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let staged_key: StoredKeyMaterial =
+            rmp_serde::from_slice(&staged_candidate.payload).unwrap();
+
+        let promoted = backend
+            .reconcile_local_emergency_rotation_impl(
+                &storage,
+                &local_store,
+                "domain-1",
+                &staged.rotation_id,
+                "operator-b",
+            )
+            .await
+            .unwrap();
+        assert_eq!(promoted.kid, staged_key.kid);
+
+        let active = backend
+            .active_keys_impl(&storage, "domain-1")
+            .await
+            .unwrap();
+        assert_eq!(active.primary.kid, staged_key.kid);
+
+        let cleared = local_store
+            .get_candidate(Subsystem::Oauth2SigningKey, "domain-1", &staged.rotation_id)
+            .await
+            .unwrap();
+        assert!(cleared.is_none(), "reconciled candidate must be cleared");
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_local_emergency_rotation_revokes_conflicting_sibling() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+
+        // Two candidates for the same domain -- as if gossip adopted a
+        // conflicting one from another node (Phase 5). The operator picks
+        // `winner` explicitly; `loser` must end up revoked, never promoted.
+        let winner = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "reason-a",
+            )
+            .await
+            .unwrap();
+        // Bypass the "one active candidate" guard directly via the store,
+        // simulating a conflicting candidate gossiped in from another node.
+        local_store
+            .put_candidate(
+                openstack_keystone_local_emergency_store::EmergencyCandidate {
+                    subsystem: Subsystem::Oauth2SigningKey,
+                    scope_id: "domain-1".to_string(),
+                    rotation_id: "rot-loser".to_string(),
+                    payload: rmp_serde::to_vec(&StoredKeyMaterial::from(
+                        &generate_keypair(SigningAlgorithm::Es256).unwrap(),
+                    ))
+                    .unwrap(),
+                    initiator: "operator-c".to_string(),
+                    justification: "reason-c".to_string(),
+                    created_at: chrono::Utc::now(),
+                    revoked: false,
+                    origin_node_id: Some(2),
+                    conflicted: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        backend
+            .reconcile_local_emergency_rotation_impl(
+                &storage,
+                &local_store,
+                "domain-1",
+                &winner.rotation_id,
+                "operator-b",
+            )
+            .await
+            .unwrap();
+
+        let loser = local_store
+            .get_candidate(Subsystem::Oauth2SigningKey, "domain-1", "rot-loser")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(loser.revoked, "the unpicked sibling must be revoked");
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_local_emergency_rotation_rejects_same_operator() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+        let staged = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap();
+
+        let err = backend
+            .reconcile_local_emergency_rotation_impl(
+                &storage,
+                &local_store,
+                "domain-1",
+                &staged.rotation_id,
+                "operator-a",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Oauth2KeyProviderError::DualControlViolation));
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_local_emergency_rotation_rejects_unknown_rotation_id() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+
+        let err = backend
+            .reconcile_local_emergency_rotation_impl(
+                &storage,
+                &local_store,
+                "domain-1",
+                "rot-unknown",
+                "operator-b",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Oauth2KeyProviderError::LocalEmergencyCandidateNotFound(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_local_emergency_rotation_rejects_revoked_candidate() {
+        let backend = RaftOauth2KeyBackend::default();
+        let storage = MockStorage::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+        backend
+            .ensure_domain_keys_impl(&storage, "domain-1", SigningAlgorithm::Es256)
+            .await
+            .unwrap();
+        let staged = backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap();
+        local_store
+            .revoke_candidate(Subsystem::Oauth2SigningKey, "domain-1", &staged.rotation_id)
+            .await
+            .unwrap();
+
+        let err = backend
+            .reconcile_local_emergency_rotation_impl(
+                &storage,
+                &local_store,
+                "domain-1",
+                &staged.rotation_id,
+                "operator-b",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Oauth2KeyProviderError::LocalEmergencyCandidateRevoked(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_list_local_emergency_candidates_surfaces_conflict_flag() {
+        let backend = RaftOauth2KeyBackend::default();
+        let local_store =
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new();
+        backend
+            .stage_local_emergency_rotation_impl(
+                &local_store,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "reason-a",
+            )
+            .await
+            .unwrap();
+        local_store
+            .put_candidate(
+                openstack_keystone_local_emergency_store::EmergencyCandidate {
+                    subsystem: Subsystem::Oauth2SigningKey,
+                    scope_id: "domain-1".to_string(),
+                    rotation_id: "rot-gossiped".to_string(),
+                    payload: vec![1, 2, 3],
+                    initiator: "operator-c".to_string(),
+                    justification: "reason-c".to_string(),
+                    created_at: chrono::Utc::now(),
+                    revoked: false,
+                    origin_node_id: Some(2),
+                    conflicted: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        let summaries = backend
+            .list_local_emergency_candidates_impl(&local_store, "domain-1")
+            .await
+            .unwrap();
+        assert_eq!(summaries.len(), 2);
+        let gossiped = summaries
+            .iter()
+            .find(|s| s.rotation_id == "rot-gossiped")
+            .unwrap();
+        assert_eq!(gossiped.origin_node_id, Some(2));
+        assert!(gossiped.conflicted);
+    }
+
+    #[tokio::test]
+    async fn test_stage_local_emergency_rotation_refused_when_guardrail_disabled() {
+        // `[local_emergency]` is disabled by default -- the trait-level
+        // method must refuse before ever touching the local store, even
+        // though `stage_local_emergency_rotation_impl` alone (tested above)
+        // would happily stage it.
+        let backend = RaftOauth2KeyBackend::default();
+        let state = test_service_state(openstack_keystone_config::Config::default()).await;
+
+        let err = backend
+            .stage_local_emergency_rotation(
+                &state,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Oauth2KeyProviderError::LocalEmergencyBypassNotAllowed
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stage_local_emergency_rotation_allowed_when_guardrail_satisfied() {
+        let backend = RaftOauth2KeyBackend::default();
+        let mut config = openstack_keystone_config::Config::default();
+        config.local_emergency.enabled = true;
+        config.local_emergency.leaderless_grace_period_seconds = 0;
+        let state = test_service_state(config).await;
+        let local_store = std::sync::Arc::new(
+            openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore::new(),
+        );
+        state.set_local_emergency_store(local_store.clone()).await;
+
+        let info = backend
+            .stage_local_emergency_rotation(
+                &state,
+                "domain-1",
+                SigningAlgorithm::Es256,
+                "operator-a",
+                "suspected key compromise",
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            local_store
+                .get_candidate(Subsystem::Oauth2SigningKey, "domain-1", &info.rotation_id)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -51,6 +51,7 @@ mockall.workspace = true
 nix = { workspace = true, features = ["process", "resource"] }
 openraft = { workspace = true, features = ["serde", "type-alias"] }
 openstack-keystone-config.workspace = true
+openstack-keystone-local-emergency-store.workspace = true
 openstack-keystone-storage-api.workspace = true
 openstack-keystone-storage-crypto.workspace = true
 openstack-keystone-storage-crypto-pkcs11 = { workspace = true, optional = true }

--- a/crates/storage/proto/raft.proto
+++ b/crates/storage/proto/raft.proto
@@ -244,6 +244,36 @@ service ClusterAdminService {
   // RotateDekRequest{emergency: true} by a second storage-operator.
   rpc ConfirmRotateDek(ConfirmRotateDekRequest) returns (AdminResponse) {}
 
+  // RotateDekLocalEmergency stages a node-local, quorum-bypass DEK rotation
+  // candidate (ADR 0028 §3, amending ADR 0016-v2 §6.2): written only to this
+  // node's local Fjall `local_emergency` keyspace, entirely bypassing Raft.
+  // Refused unless this node's `[local_emergency]` guardrail currently
+  // permits it (bypass enabled, quorum unreachable, leaderless grace period
+  // elapsed). Reconciliation once quorum returns is a separate operation
+  // (ADR 0028 §4, not yet implemented).
+  rpc RotateDekLocalEmergency(RotateDekLocalEmergencyRequest) returns (RotateDekLocalEmergencyResponse) {}
+
+  // ListDekLocalEmergencyCandidates lists node-local DEK emergency rotation
+  // candidates on the responding node (ADR 0028 §6), so an operator can see
+  // any LOCAL_EMERGENCY_CONFLICT before choosing which rotation_id to
+  // reconcile.
+  rpc ListDekLocalEmergencyCandidates(google.protobuf.Empty) returns (ListDekLocalEmergencyCandidatesResponse) {}
+
+  // ReconcileDekLocalEmergency promotes a node-local DEK emergency rotation
+  // candidate into Raft-replicated state once quorum has returned (ADR 0028
+  // §6). Must be called against the specific node holding rotation_id --
+  // reconciliation does not fan out across the cluster.
+  rpc ReconcileDekLocalEmergency(ReconcileDekLocalEmergencyRequest) returns (AdminResponse) {}
+
+  // GossipLocalEmergencyCandidate is a best-effort, peer-to-peer push of a
+  // node-local emergency candidate (ADR 0028 §5). Called by the node that
+  // originated the candidate against each reachable peer from the Raft
+  // membership list, independent of Raft/quorum. The receiving node adopts
+  // the candidate if it has none active for the same subsystem/scope, marks
+  // both as conflicted if it already holds a different active candidate for
+  // that scope, or no-ops if it already has this exact candidate.
+  rpc GossipLocalEmergencyCandidate(GossipLocalEmergencyCandidateRequest) returns (GossipLocalEmergencyCandidateResponse) {}
+
   // Backup builds a fresh Fjall snapshot, encrypts it with the Backup DEK, and
   // streams the encrypted bytes to the operator. The final chunk carries the
   // snapshot_utc_epoch and dek_version from the backup envelope header for
@@ -273,6 +303,67 @@ message RotateDekRequest {
 message ConfirmRotateDekRequest {
   // The rotation_id of the pending emergency rotation that requires confirmation.
   string rotation_id = 1;
+}
+
+message RotateDekLocalEmergencyRequest {
+  // The operator's reason for invoking the bypass, recorded with the
+  // candidate for audit. Required.
+  string justification = 1;
+}
+
+message RotateDekLocalEmergencyResponse {
+  // The candidate's rotation_id, for later reconciliation once quorum
+  // returns.
+  string rotation_id = 1;
+}
+
+message DekLocalEmergencyCandidateSummary {
+  string rotation_id = 1;
+  string initiator = 2;
+  string justification = 3;
+  // Unix epoch seconds the candidate was created.
+  int64 created_at_unix = 4;
+  // 0 means staged locally on the node answering this request; nonzero
+  // means it arrived via gossip from that node id (ADR 0028 §5).
+  uint64 origin_node_id = 5;
+  bool conflicted = 6;
+  bool revoked = 7;
+}
+
+message ListDekLocalEmergencyCandidatesResponse {
+  repeated DekLocalEmergencyCandidateSummary candidates = 1;
+}
+
+message ReconcileDekLocalEmergencyRequest {
+  // The rotation_id of the node-local candidate to promote, from
+  // ListDekLocalEmergencyCandidates. The operator's explicit choice when
+  // multiple (possibly conflicting) candidates exist (ADR 0028 §6).
+  string rotation_id = 1;
+}
+
+// Subsystem mirrors openstack_keystone_local_emergency_store::Subsystem.
+enum EmergencySubsystem {
+  EMERGENCY_SUBSYSTEM_OAUTH2_SIGNING_KEY = 0;
+  EMERGENCY_SUBSYSTEM_DEK = 1;
+}
+
+message GossipLocalEmergencyCandidateRequest {
+  // The originating node's own Raft node_id.
+  uint64 origin_node_id = 1;
+  EmergencySubsystem subsystem = 2;
+  string scope_id = 3;
+  string rotation_id = 4;
+  bytes payload = 5;
+  string initiator = 6;
+  string justification = 7;
+  // Unix epoch seconds the candidate was created on the originating node.
+  int64 created_at_unix = 8;
+}
+
+message GossipLocalEmergencyCandidateResponse {
+  // True if this candidate conflicted with a different active candidate
+  // already held by the receiving node for the same subsystem/scope.
+  bool conflict = 1;
 }
 
 // BackupRequest initiates a server-side operator snapshot export.

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -40,6 +40,7 @@ use crate::audit::{AuditForwarder, AuditRecord};
 use crate::grpc::cluster_admin_service::ClusterAdminServiceImpl;
 use crate::grpc::raft_service::RaftServiceImpl;
 use crate::grpc::storage_service::StorageServiceImpl;
+use crate::local_emergency::FjallLocalEmergencyStore;
 use crate::network::{CertExpiryWatchdog, NetworkManager, RaftTlsClient, init_tls_watcher};
 use crate::pb::raft::cluster_admin_service_server::ClusterAdminServiceServer;
 use crate::pb::raft::raft_service_server::RaftServiceServer;
@@ -501,6 +502,16 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Arc<Sto
             (None, String::new(), String::new(), Vec::new())
         };
 
+    // ADR 0028: dedicated Fjall keyspace for node-local, quorum-bypass
+    // emergency writes, opened off the same database handle the state
+    // machine uses but never touched by Raft's `apply()`.
+    let local_emergency_store = Arc::new(
+        FjallLocalEmergencyStore::new(state_machine_store.db()).map_err(|e| {
+            StoreError::Other(eyre!("failed to open local_emergency keyspace: {e}"))
+        })?,
+    );
+    let local_emergency_config = config_manager.config.read().await.local_emergency.clone();
+
     let storage = Arc::new(Storage {
         connection_pool: DashMap::new(),
         raft,
@@ -515,6 +526,8 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Arc<Sto
         spiffe_path_prefix,
         operator_role,
         allowed_peer_svids,
+        local_emergency_store,
+        local_emergency_config,
     });
 
     // Best-effort background forwarding of Raft-committed quarantine events
@@ -625,6 +638,58 @@ pub async fn init_storage(config_manager: &Arc<ConfigManager>) -> Result<Arc<Sto
         });
     }
 
+    // Best-effort periodic gossip sweep (ADR 0028 §5): push every candidate
+    // this node originated (not one it adopted via gossip) to every current
+    // Raft membership peer, so a candidate staged during a partition still
+    // reaches other nodes as reachability changes. Runs regardless of
+    // `[local_emergency].enabled`, since gossip itself is not the
+    // quorum-bypass write -- only staging a fresh candidate is gated by the
+    // guardrail.
+    {
+        let storage_weak = Arc::downgrade(&storage);
+        let gossip_interval = std::time::Duration::from_secs(
+            storage
+                .local_emergency_config
+                .gossip_interval_seconds
+                .max(1),
+        );
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(gossip_interval);
+            ticker.tick().await; // first tick fires immediately; skip it
+            loop {
+                ticker.tick().await;
+                let Some(storage) = storage_weak.upgrade() else {
+                    break;
+                };
+                for subsystem in [
+                    openstack_keystone_local_emergency_store::Subsystem::Oauth2SigningKey,
+                    openstack_keystone_local_emergency_store::Subsystem::Dek,
+                ] {
+                    let candidates = match storage
+                        .local_emergency_store
+                        .list_candidates_for_subsystem(subsystem)
+                        .await
+                    {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "local emergency gossip: failed to list candidates"
+                            );
+                            continue;
+                        }
+                    };
+                    for candidate in candidates
+                        .into_iter()
+                        .filter(|c| !c.revoked && c.origin_node_id.is_none())
+                    {
+                        storage.gossip_candidate_to_peers(&candidate).await;
+                    }
+                }
+            }
+        });
+    }
+
     Ok(storage)
 }
 
@@ -649,6 +714,8 @@ pub async fn get_app_server(storage: &Storage) -> Result<Routes, StoreError> {
         storage.spiffe_path_prefix.clone(),
         storage.operator_role.clone(),
         storage.allowed_peer_svids.clone(),
+        storage.local_emergency_store.clone(),
+        storage.local_emergency_config.clone(),
     );
     let storage_svc_impl =
         StorageServiceImpl::new(storage.raft.clone(), storage.state_machine_store.clone());
@@ -697,6 +764,18 @@ pub struct Storage {
     /// Allow-list of SPIFFE SVIDs accepted for peer-to-peer Raft operations.
     /// Empty list means trust-domain-only validation is used.
     pub allowed_peer_svids: Vec<String>,
+    /// ADR 0028 node-local, quorum-bypass emergency write store (Fjall,
+    /// never touched by Raft's `apply()`). `pub` (not `pub(crate)`) so the
+    /// `keystone` binary can wire it into `core::keystone::Service` at
+    /// startup for the OAuth2 `--local-quorum-bypass` path, which shares
+    /// this same store with `RotateDekLocalEmergency`.
+    pub local_emergency_store:
+        Arc<dyn openstack_keystone_local_emergency_store::LocalEmergencyStore>,
+    /// `[local_emergency]` config, snapshotted at storage init. Config
+    /// hot-reload is out of scope for the bypass path (ADR 0028): a node
+    /// must be restarted to flip `enabled`, same as other security-critical
+    /// distributed-storage settings.
+    pub(crate) local_emergency_config: openstack_keystone_config::LocalEmergencyProvider,
 }
 
 #[async_trait]
@@ -1145,6 +1224,90 @@ impl Storage {
     /// Return the current Raft leader node id, if elected.
     pub fn current_leader(&self) -> Option<u64> {
         self.raft.metrics().borrow_watched().current_leader
+    }
+
+    /// Enumerate current Raft membership peers (excluding self) from the
+    /// live metrics snapshot, for the ADR 0028 §5 gossip sweep. Reuses the
+    /// same membership source `Metrics`/`list_peers` already expose --
+    /// gossip does not maintain its own peer list.
+    fn local_emergency_peers(&self) -> Vec<(u64, String)> {
+        self.raft
+            .metrics()
+            .borrow_watched()
+            .membership_config
+            .membership()
+            .nodes()
+            .filter(|(nid, _)| **nid != self.node_id)
+            .map(|(nid, node)| (*nid, node.rpc_addr.clone()))
+            .collect()
+    }
+
+    /// Best-effort push of one local-origin emergency candidate to every
+    /// current Raft membership peer (ADR 0028 §5). Independent of Raft/quorum
+    /// -- reachability failures are logged and otherwise ignored; the next
+    /// gossip sweep tick retries.
+    async fn gossip_candidate_to_peers(
+        &self,
+        candidate: &openstack_keystone_local_emergency_store::EmergencyCandidate,
+    ) {
+        let subsystem = match candidate.subsystem {
+            openstack_keystone_local_emergency_store::Subsystem::Oauth2SigningKey => {
+                pb::raft::EmergencySubsystem::Oauth2SigningKey
+            }
+            openstack_keystone_local_emergency_store::Subsystem::Dek => {
+                pb::raft::EmergencySubsystem::Dek
+            }
+        };
+        let req = pb::raft::GossipLocalEmergencyCandidateRequest {
+            origin_node_id: self.node_id,
+            subsystem: subsystem as i32,
+            scope_id: candidate.scope_id.clone(),
+            rotation_id: candidate.rotation_id.clone(),
+            payload: candidate.payload.clone(),
+            initiator: candidate.initiator.clone(),
+            justification: candidate.justification.clone(),
+            created_at_unix: candidate.created_at.timestamp(),
+        };
+
+        for (peer_id, peer_addr) in self.local_emergency_peers() {
+            let channel = match self.tls_client.connect(&peer_addr).await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::debug!(
+                        peer_id,
+                        peer_addr,
+                        error = %e,
+                        "local emergency gossip: peer unreachable"
+                    );
+                    continue;
+                }
+            };
+            let mut client = ClusterAdminServiceClient::new(channel);
+            match client
+                .gossip_local_emergency_candidate(tonic::Request::new(req.clone()))
+                .await
+            {
+                Ok(resp) => {
+                    if resp.into_inner().conflict {
+                        tracing::warn!(
+                            peer_id,
+                            rotation_id = candidate.rotation_id,
+                            "SECURITY: LOCAL_EMERGENCY_CONFLICT -- peer holds a different \
+                             active emergency candidate for this subsystem/scope; \
+                             reconciliation must make an explicit choice (ADR 0028 §6)"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        peer_id,
+                        peer_addr,
+                        error = %e,
+                        "local emergency gossip push failed"
+                    );
+                }
+            }
+        }
     }
 
     /// Join this node to the Raft cluster by calling [`add_learner`] on the

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -18,6 +18,10 @@ use std::sync::{Arc, Mutex, RwLock};
 use governor::{DefaultKeyedRateLimiter, Quota, RateLimiter};
 use openraft::RaftSnapshotBuilder;
 use openraft::async_runtime::WatchReceiver;
+use openstack_keystone_config::LocalEmergencyProvider;
+use openstack_keystone_local_emergency_store::{
+    EmergencyCandidate, LeaderlessTracker, LocalEmergencyStore, Subsystem,
+};
 use openstack_keystone_storage_crypto::{DekEpoch, KekProvider, generate_dek};
 use tonic::Request;
 use tonic::Response;
@@ -28,6 +32,7 @@ use tracing::trace;
 use crate::StoreError;
 use crate::app::normalize_rpc_addr;
 use crate::audit::{AuditForwarder, AuditRecord};
+use crate::local_emergency::{DEK_SCOPE_ID, DekEmergencyPayload, GuardrailConfig};
 use crate::network::{check_svid_ttl_der, now_unix_secs};
 use crate::pb;
 use crate::protobuf::raft::cluster_admin_service_server::ClusterAdminService;
@@ -261,6 +266,164 @@ fn check_svid_ttl<T>(request: &tonic::Request<T>) -> Result<(), Status> {
     check_svid_ttl_der(&der, now_unix_secs())
 }
 
+/// Stages a node-local, quorum-bypass DEK rotation candidate in
+/// `local_store` (ADR 0028 §3, amending ADR 0016-v2 §6.2). Pure business
+/// logic, deliberately independent of the Raft handle and gRPC types so it
+/// can be unit-tested without standing up a cluster; the guardrail check
+/// (whether the bypass is currently permitted at all) is the caller's
+/// responsibility.
+///
+/// Returns the fresh candidate's `(rotation_id, dek_version)` on success.
+async fn stage_dek_local_emergency_candidate(
+    local_store: &dyn LocalEmergencyStore,
+    kek: &dyn KekProvider,
+    current_version: u32,
+    initiator: &str,
+    justification: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(String, u32), Status> {
+    let existing = local_store
+        .list_candidates(Subsystem::Dek, DEK_SCOPE_ID)
+        .await
+        .map_err(|e| Status::internal(format!("local emergency store error: {e}")))?;
+    if let Some(active) = existing.iter().find(|c| !c.revoked) {
+        return Err(Status::already_exists(format!(
+            "a local emergency DEK rotation candidate (id {}) already exists on this node",
+            active.rotation_id
+        )));
+    }
+
+    let new_version = current_version.checked_add(1).ok_or_else(|| {
+        Status::internal("DEK version space exhausted — cannot rotate beyond u32::MAX")
+    })?;
+    let new_raw = generate_dek();
+    let wrapped_dek = kek
+        .wrap_dek(new_raw.as_bytes())
+        .map_err(|e| Status::internal(format!("failed to wrap new DEK: {e}")))?;
+
+    let rotation_id = uuid::Uuid::new_v4().to_string();
+    let payload = rmp_serde::to_vec(&DekEmergencyPayload {
+        wrapped_dek,
+        dek_version: new_version,
+    })
+    .map_err(|e| Status::internal(format!("failed to encode candidate payload: {e}")))?;
+
+    let candidate = EmergencyCandidate {
+        subsystem: Subsystem::Dek,
+        scope_id: DEK_SCOPE_ID.to_string(),
+        rotation_id: rotation_id.clone(),
+        payload,
+        initiator: initiator.to_string(),
+        justification: justification.to_string(),
+        created_at: now,
+        revoked: false,
+        origin_node_id: None,
+        conflicted: false,
+    };
+    local_store
+        .put_candidate(candidate)
+        .await
+        .map_err(|e| Status::internal(format!("local emergency store error: {e}")))?;
+
+    Ok((rotation_id, new_version))
+}
+
+/// Validates a DEK local-emergency candidate is reconcilable and decodes its
+/// payload (ADR 0028 §6): must exist, must not be revoked, the confirming
+/// operator must differ from the initiator (dual-control), and its target
+/// `dek_version` must be exactly one past `current_version` (otherwise a
+/// different rotation already committed while this candidate was staged and
+/// installing it would silently regress or duplicate a version). Pure
+/// validation, independent of Raft/gRPC, so it can be unit-tested without a
+/// live cluster.
+async fn validate_dek_reconcile_candidate(
+    local_store: &dyn LocalEmergencyStore,
+    rotation_id: &str,
+    confirmer: &str,
+    current_version: u32,
+) -> Result<DekEmergencyPayload, Status> {
+    let candidate = local_store
+        .get_candidate(Subsystem::Dek, DEK_SCOPE_ID, rotation_id)
+        .await
+        .map_err(|e| Status::internal(format!("local emergency store error: {e}")))?
+        .ok_or_else(|| {
+            Status::not_found(format!(
+                "no local emergency DEK rotation candidate with id {rotation_id} on this node"
+            ))
+        })?;
+    if candidate.revoked {
+        return Err(Status::failed_precondition(format!(
+            "local emergency rotation candidate {rotation_id} has been revoked and cannot be reconciled"
+        )));
+    }
+    if candidate.initiator == confirmer {
+        return Err(Status::permission_denied(
+            "the confirming operator must differ from the initiating operator \
+             (dual-control requirement)",
+        ));
+    }
+
+    let payload: DekEmergencyPayload = rmp_serde::from_slice(&candidate.payload)
+        .map_err(|e| Status::internal(format!("failed to decode candidate payload: {e}")))?;
+    if Some(payload.dek_version) != current_version.checked_add(1) {
+        return Err(Status::failed_precondition(format!(
+            "candidate {rotation_id} targets DEK version {} but the current version is \
+             {current_version} (another rotation committed while this candidate was staged); \
+             re-stage a fresh local-quorum-bypass rotation instead",
+            payload.dek_version
+        )));
+    }
+
+    Ok(payload)
+}
+
+/// Applies a gossiped candidate (ADR 0028 §5) to `local_store`: adopts it if
+/// nothing active exists locally for the same `(subsystem, scope_id)`,
+/// marks both the existing and incoming candidate conflicted if a
+/// *different* active one exists, or no-ops on an exact re-gossip. Returns
+/// `true` if a conflict was recorded.
+///
+/// Independent of gRPC/tonic types (beyond the return being a plain `bool`)
+/// so it can be unit-tested without standing up a cluster or a gRPC
+/// transport.
+async fn receive_gossiped_candidate(
+    local_store: &dyn LocalEmergencyStore,
+    incoming: EmergencyCandidate,
+) -> Result<bool, openstack_keystone_local_emergency_store::LocalEmergencyStoreError> {
+    let existing_active: Vec<EmergencyCandidate> = local_store
+        .list_candidates(incoming.subsystem, &incoming.scope_id)
+        .await?
+        .into_iter()
+        .filter(|c| !c.revoked)
+        .collect();
+
+    match openstack_keystone_local_emergency_store::decide_gossip_outcome(
+        &existing_active,
+        &incoming,
+    ) {
+        openstack_keystone_local_emergency_store::GossipOutcome::Adopt => {
+            local_store.put_candidate(incoming).await?;
+            Ok(false)
+        }
+        openstack_keystone_local_emergency_store::GossipOutcome::AlreadyPresent => Ok(false),
+        openstack_keystone_local_emergency_store::GossipOutcome::Conflict {
+            existing_rotation_id,
+        } => {
+            local_store
+                .mark_conflicted(
+                    incoming.subsystem,
+                    &incoming.scope_id,
+                    &existing_rotation_id,
+                )
+                .await?;
+            let mut incoming = incoming;
+            incoming.conflicted = true;
+            local_store.put_candidate(incoming).await?;
+            Ok(true)
+        }
+    }
+}
+
 /// Raft cluster administrative operations.
 ///
 /// # Responsibilities
@@ -300,6 +463,13 @@ pub struct ClusterAdminServiceImpl {
     /// Allow-list of SVIDs permitted for peer-to-peer Raft operations.
     /// When empty falls back to trust-domain-only check.
     allowed_peer_svids: Vec<String>,
+    /// ADR 0028 node-local, quorum-bypass emergency write store.
+    local_emergency_store: Arc<dyn LocalEmergencyStore>,
+    /// `[local_emergency]` config, snapshotted at storage init.
+    local_emergency_config: LocalEmergencyProvider,
+    /// Tracks how long the Raft leader has been unknown, feeding the
+    /// quorum-bypass guardrail (ADR 0028 §2).
+    local_emergency_leaderless_tracker: LeaderlessTracker,
 }
 
 impl ClusterAdminServiceImpl {
@@ -327,6 +497,8 @@ impl ClusterAdminServiceImpl {
         spiffe_path_prefix: String,
         operator_role: String,
         allowed_peer_svids: Vec<String>,
+        local_emergency_store: Arc<dyn LocalEmergencyStore>,
+        local_emergency_config: LocalEmergencyProvider,
     ) -> Self {
         Self {
             raft_node,
@@ -344,6 +516,9 @@ impl ClusterAdminServiceImpl {
             clear_quarantine_limiter: Arc::new(RateLimiter::keyed(Quota::per_hour(
                 CLEAR_QUARANTINE_PER_HOUR,
             ))),
+            local_emergency_store,
+            local_emergency_config,
+            local_emergency_leaderless_tracker: LeaderlessTracker::new(),
         }
     }
 
@@ -835,6 +1010,292 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
         Ok(Response::new(pb::raft::AdminResponse::default()))
     }
 
+    /// Stages a node-local, quorum-bypass DEK rotation candidate (ADR 0028
+    /// §3, amending ADR 0016-v2 §6.2). Written only to this node's local
+    /// Fjall `local_emergency` keyspace — never proposed to Raft. Refused
+    /// unless this node's `[local_emergency]` guardrail currently permits it.
+    ///
+    /// # Security
+    /// Same operator/mTLS boundary as `RotateDek`. Unlike `RotateDek`, this
+    /// path bypasses Raft entirely by design — it exists only for use when
+    /// the cluster has lost quorum and `RotateDek{emergency: true}` (a Raft
+    /// proposal) would block forever.
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn rotate_dek_local_emergency(
+        &self,
+        request: Request<pb::raft::RotateDekLocalEmergencyRequest>,
+    ) -> Result<Response<pb::raft::RotateDekLocalEmergencyResponse>, Status> {
+        let actor = require_operator(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.spiffe_path_prefix,
+            &self.operator_role,
+        )?;
+        let req = request.into_inner();
+        if req.justification.trim().is_empty() {
+            return Err(Status::invalid_argument(
+                "justification is required for a local-quorum-bypass DEK rotation",
+            ));
+        }
+
+        let guardrail_cfg = GuardrailConfig {
+            enabled: self.local_emergency_config.enabled,
+            leaderless_grace_period_seconds: self
+                .local_emergency_config
+                .leaderless_grace_period_seconds,
+        };
+        let current_leader = self.raft_node.metrics().borrow_watched().current_leader;
+        let now = chrono::Utc::now();
+        self.local_emergency_leaderless_tracker
+            .observe(current_leader, now);
+        if !self.local_emergency_leaderless_tracker.is_bypass_allowed(
+            &guardrail_cfg,
+            current_leader,
+            now,
+        ) {
+            return Err(Status::failed_precondition(
+                "local quorum-bypass rotation is not currently permitted on this node \
+                 (disabled, or quorum has not been unreachable long enough)",
+            ));
+        }
+
+        let current_version = {
+            self.current_dek
+                .read()
+                .unwrap_or_else(|p| p.into_inner())
+                .version
+        };
+        let (rotation_id, new_version) = stage_dek_local_emergency_candidate(
+            self.local_emergency_store.as_ref(),
+            self.kek.as_ref(),
+            current_version,
+            &actor,
+            &req.justification,
+            now,
+        )
+        .await?;
+
+        self.audit.emit(AuditRecord::now(
+            "DEK_ROTATION_LOCAL_EMERGENCY_STAGED",
+            &actor,
+            self.node_id,
+            new_version,
+            serde_json::json!({
+                "rotation_id": rotation_id,
+                "justification": req.justification,
+            }),
+        ));
+        tracing::warn!(
+            rotation_id,
+            new_version,
+            initiator = actor,
+            "SECURITY: node-local quorum-bypass DEK rotation staged; NOT replicated, \
+             requires explicit reconciliation once quorum returns"
+        );
+
+        Ok(Response::new(pb::raft::RotateDekLocalEmergencyResponse {
+            rotation_id,
+        }))
+    }
+
+    /// Lists node-local DEK emergency rotation candidates on this node
+    /// (ADR 0028 §6), so an operator can see any `LOCAL_EMERGENCY_CONFLICT`
+    /// before choosing which `rotation_id` to reconcile.
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn list_dek_local_emergency_candidates(
+        &self,
+        request: Request<()>,
+    ) -> Result<Response<pb::raft::ListDekLocalEmergencyCandidatesResponse>, Status> {
+        require_operator(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.spiffe_path_prefix,
+            &self.operator_role,
+        )?;
+
+        let candidates = self
+            .local_emergency_store
+            .list_candidates(Subsystem::Dek, DEK_SCOPE_ID)
+            .await
+            .map_err(|e| Status::internal(format!("local emergency store error: {e}")))?
+            .into_iter()
+            .map(|c| pb::raft::DekLocalEmergencyCandidateSummary {
+                rotation_id: c.rotation_id,
+                initiator: c.initiator,
+                justification: c.justification,
+                created_at_unix: c.created_at.timestamp(),
+                origin_node_id: c.origin_node_id.unwrap_or(0),
+                conflicted: c.conflicted,
+                revoked: c.revoked,
+            })
+            .collect();
+
+        Ok(Response::new(
+            pb::raft::ListDekLocalEmergencyCandidatesResponse { candidates },
+        ))
+    }
+
+    /// Reconciles a node-local DEK emergency rotation candidate into
+    /// Raft-replicated state (ADR 0028 §6): installs the chosen candidate's
+    /// DEK via the normal `InstallDek` transaction (same mutation `RotateDek`
+    /// commits for a non-emergency rotation), then clears it from this
+    /// node's local store and revokes any other active candidate (they
+    /// lost).
+    ///
+    /// # Security
+    /// Same operator/mTLS boundary as `RotateDek`. Not guardrail-gated
+    /// (unlike staging): reconciliation is the operation an operator runs
+    /// *after* quorum has returned.
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn reconcile_dek_local_emergency(
+        &self,
+        request: Request<pb::raft::ReconcileDekLocalEmergencyRequest>,
+    ) -> Result<Response<pb::raft::AdminResponse>, Status> {
+        let actor = require_operator(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.spiffe_path_prefix,
+            &self.operator_role,
+        )?;
+        let req = request.into_inner();
+        let current_version = {
+            self.current_dek
+                .read()
+                .unwrap_or_else(|p| p.into_inner())
+                .version
+        };
+        let payload = validate_dek_reconcile_candidate(
+            self.local_emergency_store.as_ref(),
+            &req.rotation_id,
+            &actor,
+            current_version,
+        )
+        .await?;
+
+        let cmd = StoreCommand::Transaction(vec![MutationInner::InstallDek {
+            wrapped_dek: payload.wrapped_dek,
+            dek_version: payload.dek_version,
+            is_emergency: true,
+        }]);
+        let install_payload =
+            pb::api::CommandRequest::try_from(cmd).map_err(|e| Status::internal(e.to_string()))?;
+
+        self.audit.emit(AuditRecord::now(
+            "DEK_ROTATION_LOCAL_EMERGENCY_RECONCILED",
+            &actor,
+            self.node_id,
+            payload.dek_version,
+            serde_json::json!({ "rotation_id": req.rotation_id }),
+        ));
+
+        self.raft_node
+            .client_write(install_payload)
+            .await
+            .map_err(|e| Status::internal(format!("Raft write failed: {e}")))?;
+
+        tracing::warn!(
+            rotation_id = req.rotation_id,
+            new_version = payload.dek_version,
+            confirmer = actor,
+            "SECURITY: node-local quorum-bypass DEK rotation reconciled into Raft"
+        );
+
+        // Durably committed; clear this candidate and revoke any other
+        // active sibling for this scope on this node (ADR 0028 §6).
+        if let Err(e) = self
+            .local_emergency_store
+            .clear_candidate(Subsystem::Dek, DEK_SCOPE_ID, &req.rotation_id)
+            .await
+        {
+            tracing::warn!(
+                rotation_id = req.rotation_id,
+                error = %e,
+                "failed to clear reconciled local emergency DEK candidate"
+            );
+        }
+        match self
+            .local_emergency_store
+            .list_candidates(Subsystem::Dek, DEK_SCOPE_ID)
+            .await
+        {
+            Ok(siblings) => {
+                for sibling in siblings.iter().filter(|c| !c.revoked) {
+                    if let Err(e) = self
+                        .local_emergency_store
+                        .revoke_candidate(Subsystem::Dek, DEK_SCOPE_ID, &sibling.rotation_id)
+                        .await
+                    {
+                        tracing::warn!(
+                            rotation_id = sibling.rotation_id,
+                            error = %e,
+                            "failed to revoke superseded local emergency DEK candidate"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "failed to list local emergency DEK candidates for post-reconcile cleanup"
+                );
+            }
+        }
+
+        Ok(Response::new(pb::raft::AdminResponse::default()))
+    }
+
+    /// Receives a best-effort, peer-to-peer gossip push of another node's
+    /// local emergency candidate (ADR 0028 §5). Adopts it if this node holds
+    /// no active candidate for the same subsystem/scope, marks both as
+    /// conflicted if it holds a *different* active one, or no-ops if it
+    /// already has this exact candidate (idempotent re-gossip).
+    ///
+    /// # Security
+    /// Called peer-to-peer between storage nodes, not by a human operator —
+    /// authenticated the same way as Raft's own inter-node RPCs
+    /// (`check_peer_trust_domain`), not `require_operator`.
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn gossip_local_emergency_candidate(
+        &self,
+        request: Request<pb::raft::GossipLocalEmergencyCandidateRequest>,
+    ) -> Result<Response<pb::raft::GossipLocalEmergencyCandidateResponse>, Status> {
+        check_peer_trust_domain(
+            &request,
+            self.spiffe_trust_domains.as_deref(),
+            &self.allowed_peer_svids,
+        )?;
+        let req = request.into_inner();
+        let subsystem = match pb::raft::EmergencySubsystem::try_from(req.subsystem) {
+            Ok(pb::raft::EmergencySubsystem::Oauth2SigningKey) => Subsystem::Oauth2SigningKey,
+            Ok(pb::raft::EmergencySubsystem::Dek) => Subsystem::Dek,
+            Err(_) => {
+                return Err(Status::invalid_argument("unknown emergency subsystem tag"));
+            }
+        };
+        let created_at = chrono::DateTime::from_timestamp(req.created_at_unix, 0)
+            .unwrap_or_else(chrono::Utc::now);
+        let incoming = EmergencyCandidate {
+            subsystem,
+            scope_id: req.scope_id.clone(),
+            rotation_id: req.rotation_id.clone(),
+            payload: req.payload,
+            initiator: req.initiator,
+            justification: req.justification,
+            created_at,
+            revoked: false,
+            origin_node_id: Some(req.origin_node_id),
+            conflicted: false,
+        };
+
+        let conflict = receive_gossiped_candidate(self.local_emergency_store.as_ref(), incoming)
+            .await
+            .map_err(|e| Status::internal(format!("local emergency store error: {e}")))?;
+
+        Ok(Response::new(
+            pb::raft::GossipLocalEmergencyCandidateResponse { conflict },
+        ))
+    }
+
     type BackupStream = std::pin::Pin<
         Box<dyn futures::Stream<Item = Result<pb::raft::BackupChunk, Status>> + Send>,
     >;
@@ -1299,5 +1760,332 @@ mod tests {
         let err = check_svid_ttl_der(&der, NOT_AFTER_2100_UNIX + 1)
             .expect_err("should fail when expired");
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    // stage_dek_local_emergency_candidate (ADR 0028 §3) — pure business
+    // logic, independent of Raft/gRPC.
+
+    mod stage_dek_local_emergency {
+        use chrono::Utc;
+        use openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore;
+        use openstack_keystone_storage_crypto::EnvKek;
+
+        use super::*;
+
+        fn kek() -> EnvKek {
+            EnvKek::from_bytes([7u8; 32])
+        }
+
+        #[tokio::test]
+        async fn stages_a_fresh_candidate_and_bumps_version() {
+            let store = InMemoryLocalEmergencyStore::new();
+            let (rotation_id, new_version) = stage_dek_local_emergency_candidate(
+                &store,
+                &kek(),
+                3,
+                "spiffe://example.org/keystone/storage/storage-operator",
+                "suspected key compromise",
+                Utc::now(),
+            )
+            .await
+            .expect("should stage");
+
+            assert_eq!(new_version, 4);
+            let candidates = store
+                .list_candidates(Subsystem::Dek, DEK_SCOPE_ID)
+                .await
+                .unwrap();
+            assert_eq!(candidates.len(), 1);
+            assert_eq!(candidates[0].rotation_id, rotation_id);
+            assert_eq!(candidates[0].justification, "suspected key compromise");
+            assert!(!candidates[0].revoked);
+
+            let decoded: DekEmergencyPayload =
+                rmp_serde::from_slice(&candidates[0].payload).unwrap();
+            assert_eq!(decoded.dek_version, 4);
+        }
+
+        #[tokio::test]
+        async fn refuses_a_second_candidate_while_one_is_active() {
+            let store = InMemoryLocalEmergencyStore::new();
+            stage_dek_local_emergency_candidate(&store, &kek(), 3, "op-a", "reason-1", Utc::now())
+                .await
+                .expect("first stage should succeed");
+
+            let err = stage_dek_local_emergency_candidate(
+                &store,
+                &kek(),
+                3,
+                "op-b",
+                "reason-2",
+                Utc::now(),
+            )
+            .await
+            .expect_err("second stage should be refused while one is active");
+            assert_eq!(err.code(), tonic::Code::AlreadyExists);
+        }
+
+        #[tokio::test]
+        async fn allows_a_new_candidate_after_the_prior_one_is_revoked() {
+            let store = InMemoryLocalEmergencyStore::new();
+            let (first_id, _) = stage_dek_local_emergency_candidate(
+                &store,
+                &kek(),
+                3,
+                "op-a",
+                "reason-1",
+                Utc::now(),
+            )
+            .await
+            .expect("first stage should succeed");
+            store
+                .revoke_candidate(Subsystem::Dek, DEK_SCOPE_ID, &first_id)
+                .await
+                .unwrap();
+
+            let (second_id, new_version) = stage_dek_local_emergency_candidate(
+                &store,
+                &kek(),
+                3,
+                "op-b",
+                "reason-2",
+                Utc::now(),
+            )
+            .await
+            .expect("should stage after revocation");
+            assert_ne!(first_id, second_id);
+            assert_eq!(new_version, 4);
+        }
+
+        #[tokio::test]
+        async fn refuses_when_dek_version_space_is_exhausted() {
+            let store = InMemoryLocalEmergencyStore::new();
+            let err = stage_dek_local_emergency_candidate(
+                &store,
+                &kek(),
+                u32::MAX,
+                "op-a",
+                "reason",
+                Utc::now(),
+            )
+            .await
+            .expect_err("version overflow should be refused");
+            assert_eq!(err.code(), tonic::Code::Internal);
+        }
+    }
+
+    // validate_dek_reconcile_candidate (ADR 0028 §6) — pure validation
+    // logic, independent of Raft/gRPC.
+
+    mod validate_dek_reconcile_candidate_tests {
+        use chrono::Utc;
+        use openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore;
+        use openstack_keystone_storage_crypto::EnvKek;
+
+        use super::*;
+
+        async fn stage(store: &InMemoryLocalEmergencyStore, initiator: &str) -> String {
+            stage_dek_local_emergency_candidate(
+                store,
+                &EnvKek::from_bytes([7u8; 32]),
+                3,
+                initiator,
+                "suspected key compromise",
+                Utc::now(),
+            )
+            .await
+            .unwrap()
+            .0
+        }
+
+        #[tokio::test]
+        async fn accepts_a_fresh_candidate_from_a_different_operator() {
+            let store = InMemoryLocalEmergencyStore::new();
+            let rotation_id = stage(&store, "op-a").await;
+
+            let payload = validate_dek_reconcile_candidate(&store, &rotation_id, "op-b", 3)
+                .await
+                .unwrap();
+            assert_eq!(payload.dek_version, 4);
+        }
+
+        #[tokio::test]
+        async fn rejects_unknown_rotation_id() {
+            let store = InMemoryLocalEmergencyStore::new();
+            let err = validate_dek_reconcile_candidate(&store, "rot-unknown", "op-b", 3)
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::NotFound);
+        }
+
+        #[tokio::test]
+        async fn rejects_revoked_candidate() {
+            let store = InMemoryLocalEmergencyStore::new();
+            let rotation_id = stage(&store, "op-a").await;
+            store
+                .revoke_candidate(Subsystem::Dek, DEK_SCOPE_ID, &rotation_id)
+                .await
+                .unwrap();
+
+            let err = validate_dek_reconcile_candidate(&store, &rotation_id, "op-b", 3)
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        }
+
+        #[tokio::test]
+        async fn rejects_same_operator_as_initiator() {
+            let store = InMemoryLocalEmergencyStore::new();
+            let rotation_id = stage(&store, "op-a").await;
+
+            let err = validate_dek_reconcile_candidate(&store, &rotation_id, "op-a", 3)
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        }
+
+        #[tokio::test]
+        async fn rejects_stale_candidate_when_version_has_moved_on() {
+            let store = InMemoryLocalEmergencyStore::new();
+            // Staged when current_version was 3 (so it targets version 4),
+            // but by the time reconciliation runs the live version has
+            // already advanced to 5 (e.g. a normal RotateDek committed while
+            // this candidate was staged).
+            let rotation_id = stage(&store, "op-a").await;
+
+            let err = validate_dek_reconcile_candidate(&store, &rotation_id, "op-b", 5)
+                .await
+                .unwrap_err();
+            assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        }
+    }
+
+    // receive_gossiped_candidate (ADR 0028 §5) — pure business logic,
+    // independent of Raft/gRPC.
+
+    mod receive_gossiped_candidate_tests {
+        use chrono::Utc;
+        use openstack_keystone_local_emergency_store::InMemoryLocalEmergencyStore;
+
+        use super::*;
+
+        fn incoming(rotation_id: &str, origin_node_id: u64) -> EmergencyCandidate {
+            EmergencyCandidate {
+                subsystem: Subsystem::Dek,
+                scope_id: DEK_SCOPE_ID.to_string(),
+                rotation_id: rotation_id.to_string(),
+                payload: vec![4, 5, 6],
+                initiator: "spiffe://example.org/keystone/storage/storage-operator".to_string(),
+                justification: "suspected key compromise".to_string(),
+                created_at: Utc::now(),
+                revoked: false,
+                origin_node_id: Some(origin_node_id),
+                conflicted: false,
+            }
+        }
+
+        #[tokio::test]
+        async fn adopts_first_gossiped_candidate() {
+            let store = InMemoryLocalEmergencyStore::new();
+            let conflict = receive_gossiped_candidate(&store, incoming("rot-remote", 2))
+                .await
+                .unwrap();
+            assert!(!conflict);
+
+            let stored = store
+                .get_candidate(Subsystem::Dek, DEK_SCOPE_ID, "rot-remote")
+                .await
+                .unwrap()
+                .expect("candidate should be adopted");
+            assert_eq!(stored.origin_node_id, Some(2));
+            assert!(!stored.conflicted);
+        }
+
+        #[tokio::test]
+        async fn re_gossip_of_the_same_candidate_is_a_noop() {
+            let store = InMemoryLocalEmergencyStore::new();
+            receive_gossiped_candidate(&store, incoming("rot-remote", 2))
+                .await
+                .unwrap();
+
+            let conflict = receive_gossiped_candidate(&store, incoming("rot-remote", 2))
+                .await
+                .unwrap();
+            assert!(!conflict);
+        }
+
+        #[tokio::test]
+        async fn conflicting_candidate_marks_both_sides() {
+            let store = InMemoryLocalEmergencyStore::new();
+            // This node already has its own locally-staged active candidate.
+            stage_dek_local_emergency_candidate(
+                &store,
+                &openstack_keystone_storage_crypto::EnvKek::from_bytes([7u8; 32]),
+                3,
+                "spiffe://example.org/keystone/storage/storage-operator",
+                "suspected key compromise",
+                Utc::now(),
+            )
+            .await
+            .unwrap();
+            let local_candidates = store
+                .list_candidates(Subsystem::Dek, DEK_SCOPE_ID)
+                .await
+                .unwrap();
+            assert_eq!(local_candidates.len(), 1);
+            let local_rotation_id = local_candidates[0].rotation_id.clone();
+
+            let conflict = receive_gossiped_candidate(&store, incoming("rot-remote", 2))
+                .await
+                .unwrap();
+            assert!(conflict);
+
+            let local_after = store
+                .get_candidate(Subsystem::Dek, DEK_SCOPE_ID, &local_rotation_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(local_after.conflicted);
+            assert!(!local_after.revoked, "conflict must not itself revoke");
+
+            let remote_after = store
+                .get_candidate(Subsystem::Dek, DEK_SCOPE_ID, "rot-remote")
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(remote_after.conflicted);
+        }
+
+        #[tokio::test]
+        async fn adopts_after_local_candidate_is_revoked() {
+            let store = InMemoryLocalEmergencyStore::new();
+            stage_dek_local_emergency_candidate(
+                &store,
+                &openstack_keystone_storage_crypto::EnvKek::from_bytes([7u8; 32]),
+                3,
+                "op-a",
+                "reason",
+                Utc::now(),
+            )
+            .await
+            .unwrap();
+            let local_candidates = store
+                .list_candidates(Subsystem::Dek, DEK_SCOPE_ID)
+                .await
+                .unwrap();
+            store
+                .revoke_candidate(
+                    Subsystem::Dek,
+                    DEK_SCOPE_ID,
+                    &local_candidates[0].rotation_id,
+                )
+                .await
+                .unwrap();
+
+            let conflict = receive_gossiped_candidate(&store, incoming("rot-remote", 2))
+                .await
+                .unwrap();
+            assert!(!conflict, "a revoked local candidate must not conflict");
+        }
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -31,6 +31,7 @@ pub mod api;
 pub mod app;
 pub mod audit;
 pub mod grpc;
+pub mod local_emergency;
 #[cfg(feature = "mock")]
 pub mod mock;
 pub mod network;

--- a/crates/storage/src/local_emergency.rs
+++ b/crates/storage/src/local_emergency.rs
@@ -1,0 +1,420 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fjall-backed [`LocalEmergencyStore`] (ADR 0028 implementation plan, Phase
+//! 2).
+//!
+//! Wraps a dedicated `local_emergency` Fjall keyspace, opened directly off
+//! the same [`Database`] handle [`crate::store::state_machine::FjallStateMachine`]
+//! uses — but never touched by Raft's `apply()`, and never written through
+//! [`crate::StorageApi`]. That is the whole point of the quorum-bypass path:
+//! writes here succeed even when the node cannot reach Raft quorum.
+//!
+//! The quorum-bypass guardrail itself ([`LeaderlessTracker`],
+//! `GuardrailConfig`, `is_quorum_bypass_allowed`) lives in the lightweight
+//! `openstack-keystone-local-emergency-store` crate, not here, so that
+//! `core` (and other crates that need to evaluate the guardrail without
+//! pulling in `fjall`/`openraft`) can depend on it directly. Re-exported here
+//! for convenience since callers of this module already need the rest of
+//! that crate's API.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fjall::{Database, Keyspace, KeyspaceCreateOptions};
+use openstack_keystone_local_emergency_store::{
+    EmergencyCandidate, LocalEmergencyStore, LocalEmergencyStoreError, Subsystem, key,
+};
+pub use openstack_keystone_local_emergency_store::{
+    GuardrailConfig, LeaderlessTracker, is_quorum_bypass_allowed,
+};
+use serde::{Deserialize, Serialize};
+
+/// Name of the dedicated Fjall keyspace backing the local emergency store.
+pub const KEYSPACE_NAME: &str = "local_emergency";
+
+/// Scope id used for DEK candidates: unlike OAuth2 signing keys (scoped per
+/// domain), there is exactly one DEK per cluster.
+pub const DEK_SCOPE_ID: &str = "cluster";
+
+/// Opaque payload stored inside a DEK [`EmergencyCandidate`] (ADR 0028 §3,
+/// amending ADR 0016-v2 §6.2): the freshly-generated, KEK-wrapped DEK and its
+/// intended version, awaiting reconciliation into the Raft-backed
+/// `PendingRotation` flow once quorum returns.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DekEmergencyPayload {
+    /// The new DEK, wrapped by this node's KEK.
+    pub wrapped_dek: Vec<u8>,
+    /// The DEK version this candidate would install if reconciled.
+    pub dek_version: u32,
+}
+
+/// Fjall-backed [`LocalEmergencyStore`] implementation.
+pub struct FjallLocalEmergencyStore {
+    keyspace: Keyspace,
+}
+
+impl FjallLocalEmergencyStore {
+    /// Open (creating if absent) the `local_emergency` keyspace on the given
+    /// database handle.
+    pub fn new(db: &Arc<Database>) -> Result<Self, LocalEmergencyStoreError> {
+        let keyspace = db
+            .keyspace(KEYSPACE_NAME, KeyspaceCreateOptions::default)
+            .map_err(LocalEmergencyStoreError::other)?;
+        Ok(Self { keyspace })
+    }
+}
+
+#[async_trait]
+impl LocalEmergencyStore for FjallLocalEmergencyStore {
+    async fn put_candidate(
+        &self,
+        candidate: EmergencyCandidate,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(
+            candidate.subsystem,
+            &candidate.scope_id,
+            &candidate.rotation_id,
+        );
+        if self
+            .keyspace
+            .get(full_key.as_bytes())
+            .map_err(LocalEmergencyStoreError::other)?
+            .is_some()
+        {
+            return Err(LocalEmergencyStoreError::AlreadyExists(full_key));
+        }
+        let bytes = rmp_serde::to_vec(&candidate).map_err(LocalEmergencyStoreError::other)?;
+        self.keyspace
+            .insert(full_key.as_bytes(), bytes)
+            .map_err(LocalEmergencyStoreError::other)?;
+        Ok(())
+    }
+
+    async fn get_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<Option<EmergencyCandidate>, LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(subsystem, scope_id, rotation_id);
+        let Some(bytes) = self
+            .keyspace
+            .get(full_key.as_bytes())
+            .map_err(LocalEmergencyStoreError::other)?
+        else {
+            return Ok(None);
+        };
+        let candidate = rmp_serde::from_slice(&bytes).map_err(LocalEmergencyStoreError::other)?;
+        Ok(Some(candidate))
+    }
+
+    async fn list_candidates(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+    ) -> Result<Vec<EmergencyCandidate>, LocalEmergencyStoreError> {
+        let prefix = key::candidate_scope_prefix(subsystem, scope_id);
+        let mut out = Vec::new();
+        for item in self.keyspace.prefix(prefix.as_bytes()) {
+            let (_, value) = item.into_inner().map_err(LocalEmergencyStoreError::other)?;
+            let candidate =
+                rmp_serde::from_slice(&value).map_err(LocalEmergencyStoreError::other)?;
+            out.push(candidate);
+        }
+        Ok(out)
+    }
+
+    async fn list_candidates_for_subsystem(
+        &self,
+        subsystem: Subsystem,
+    ) -> Result<Vec<EmergencyCandidate>, LocalEmergencyStoreError> {
+        let prefix = key::candidate_subsystem_prefix(subsystem);
+        let mut out = Vec::new();
+        for item in self.keyspace.prefix(prefix.as_bytes()) {
+            let (_, value) = item.into_inner().map_err(LocalEmergencyStoreError::other)?;
+            let candidate =
+                rmp_serde::from_slice(&value).map_err(LocalEmergencyStoreError::other)?;
+            out.push(candidate);
+        }
+        Ok(out)
+    }
+
+    async fn revoke_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(subsystem, scope_id, rotation_id);
+        let Some(bytes) = self
+            .keyspace
+            .get(full_key.as_bytes())
+            .map_err(LocalEmergencyStoreError::other)?
+        else {
+            return Err(LocalEmergencyStoreError::NotFound(full_key));
+        };
+        let mut candidate: EmergencyCandidate =
+            rmp_serde::from_slice(&bytes).map_err(LocalEmergencyStoreError::other)?;
+        candidate.revoked = true;
+        let bytes = rmp_serde::to_vec(&candidate).map_err(LocalEmergencyStoreError::other)?;
+        self.keyspace
+            .insert(full_key.as_bytes(), bytes)
+            .map_err(LocalEmergencyStoreError::other)?;
+        Ok(())
+    }
+
+    async fn mark_conflicted(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(subsystem, scope_id, rotation_id);
+        let Some(bytes) = self
+            .keyspace
+            .get(full_key.as_bytes())
+            .map_err(LocalEmergencyStoreError::other)?
+        else {
+            return Err(LocalEmergencyStoreError::NotFound(full_key));
+        };
+        let mut candidate: EmergencyCandidate =
+            rmp_serde::from_slice(&bytes).map_err(LocalEmergencyStoreError::other)?;
+        candidate.conflicted = true;
+        let bytes = rmp_serde::to_vec(&candidate).map_err(LocalEmergencyStoreError::other)?;
+        self.keyspace
+            .insert(full_key.as_bytes(), bytes)
+            .map_err(LocalEmergencyStoreError::other)?;
+        Ok(())
+    }
+
+    async fn clear_candidate(
+        &self,
+        subsystem: Subsystem,
+        scope_id: &str,
+        rotation_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::candidate_key(subsystem, scope_id, rotation_id);
+        if self
+            .keyspace
+            .get(full_key.as_bytes())
+            .map_err(LocalEmergencyStoreError::other)?
+            .is_none()
+        {
+            return Err(LocalEmergencyStoreError::NotFound(full_key));
+        }
+        self.keyspace
+            .remove(full_key.as_bytes())
+            .map_err(LocalEmergencyStoreError::other)?;
+        Ok(())
+    }
+
+    async fn put_audit_pointer(
+        &self,
+        rotation_id: &str,
+        event_id: &str,
+    ) -> Result<(), LocalEmergencyStoreError> {
+        let full_key = key::audit_pointer_key(rotation_id);
+        self.keyspace
+            .insert(full_key.as_bytes(), event_id.as_bytes())
+            .map_err(LocalEmergencyStoreError::other)?;
+        Ok(())
+    }
+
+    async fn get_audit_pointer(
+        &self,
+        rotation_id: &str,
+    ) -> Result<Option<String>, LocalEmergencyStoreError> {
+        let full_key = key::audit_pointer_key(rotation_id);
+        let Some(bytes) = self
+            .keyspace
+            .get(full_key.as_bytes())
+            .map_err(LocalEmergencyStoreError::other)?
+        else {
+            return Ok(None);
+        };
+        let event_id =
+            String::from_utf8(bytes.to_vec()).map_err(LocalEmergencyStoreError::other)?;
+        Ok(Some(event_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn candidate(subsystem: Subsystem, scope_id: &str, rotation_id: &str) -> EmergencyCandidate {
+        EmergencyCandidate {
+            subsystem,
+            scope_id: scope_id.to_string(),
+            rotation_id: rotation_id.to_string(),
+            payload: vec![9, 9, 9],
+            initiator: "spiffe://example.org/operator/alice".to_string(),
+            justification: "suspected key compromise".to_string(),
+            created_at: Utc::now(),
+            revoked: false,
+            origin_node_id: None,
+            conflicted: false,
+        }
+    }
+
+    fn open_db() -> (Arc<Database>, TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Arc::new(Database::builder(dir.path()).open().expect("open db"));
+        (db, dir)
+    }
+
+    #[tokio::test]
+    async fn put_then_get_roundtrips_through_fjall() {
+        let (db, _dir) = open_db();
+        let store = FjallLocalEmergencyStore::new(&db).unwrap();
+        let c = candidate(Subsystem::Dek, "cluster", "rot-1");
+
+        store.put_candidate(c.clone()).await.unwrap();
+        let fetched = store
+            .get_candidate(Subsystem::Dek, "cluster", "rot-1")
+            .await
+            .unwrap();
+        assert_eq!(fetched, Some(c));
+    }
+
+    #[tokio::test]
+    async fn direct_fjall_read_sees_the_local_prefix() {
+        let (db, _dir) = open_db();
+        let store = FjallLocalEmergencyStore::new(&db).unwrap();
+        store
+            .put_candidate(candidate(Subsystem::Oauth2SigningKey, "default", "rot-1"))
+            .await
+            .unwrap();
+
+        // Read the raw Fjall keyspace directly (bypassing the trait) to
+        // confirm the write actually lands at the documented `_local:...`
+        // key, not merely somewhere the trait's own getter can find it.
+        let ks = db
+            .keyspace(KEYSPACE_NAME, KeyspaceCreateOptions::default)
+            .unwrap();
+        let raw = ks
+            .get(key::candidate_key(Subsystem::Oauth2SigningKey, "default", "rot-1").as_bytes())
+            .unwrap();
+        assert!(raw.is_some());
+    }
+
+    #[tokio::test]
+    async fn put_duplicate_fails() {
+        let (db, _dir) = open_db();
+        let store = FjallLocalEmergencyStore::new(&db).unwrap();
+        let c = candidate(Subsystem::Dek, "cluster", "rot-1");
+        store.put_candidate(c.clone()).await.unwrap();
+
+        let err = store.put_candidate(c).await.unwrap_err();
+        assert!(matches!(err, LocalEmergencyStoreError::AlreadyExists(_)));
+    }
+
+    #[tokio::test]
+    async fn list_candidates_scans_by_prefix() {
+        let (db, _dir) = open_db();
+        let store = FjallLocalEmergencyStore::new(&db).unwrap();
+        store
+            .put_candidate(candidate(Subsystem::Dek, "cluster", "rot-1"))
+            .await
+            .unwrap();
+        store
+            .put_candidate(candidate(Subsystem::Dek, "cluster", "rot-2"))
+            .await
+            .unwrap();
+        store
+            .put_candidate(candidate(Subsystem::Oauth2SigningKey, "cluster", "rot-3"))
+            .await
+            .unwrap();
+
+        let found = store
+            .list_candidates(Subsystem::Dek, "cluster")
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn revoke_persists_across_reopen() {
+        let (db, _dir) = open_db();
+        {
+            let store = FjallLocalEmergencyStore::new(&db).unwrap();
+            store
+                .put_candidate(candidate(Subsystem::Dek, "cluster", "rot-1"))
+                .await
+                .unwrap();
+            store
+                .revoke_candidate(Subsystem::Dek, "cluster", "rot-1")
+                .await
+                .unwrap();
+        }
+        // Re-open the store on the same db handle (simulating a fresh
+        // `FjallLocalEmergencyStore` after restart) to confirm the revoked
+        // flag survived the round trip through Fjall, not just in-process.
+        let store = FjallLocalEmergencyStore::new(&db).unwrap();
+        let fetched = store
+            .get_candidate(Subsystem::Dek, "cluster", "rot-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(fetched.revoked);
+    }
+
+    #[tokio::test]
+    async fn clear_removes_from_fjall() {
+        let (db, _dir) = open_db();
+        let store = FjallLocalEmergencyStore::new(&db).unwrap();
+        store
+            .put_candidate(candidate(Subsystem::Dek, "cluster", "rot-1"))
+            .await
+            .unwrap();
+
+        store
+            .clear_candidate(Subsystem::Dek, "cluster", "rot-1")
+            .await
+            .unwrap();
+
+        let fetched = store
+            .get_candidate(Subsystem::Dek, "cluster", "rot-1")
+            .await
+            .unwrap();
+        assert_eq!(fetched, None);
+    }
+
+    #[tokio::test]
+    async fn audit_pointer_survives_reopen() {
+        let (db, _dir) = open_db();
+        {
+            let store = FjallLocalEmergencyStore::new(&db).unwrap();
+            store
+                .put_audit_pointer("rot-1", "node-1:event-uuid")
+                .await
+                .unwrap();
+        }
+        let store = FjallLocalEmergencyStore::new(&db).unwrap();
+        let fetched = store.get_audit_pointer("rot-1").await.unwrap();
+        assert_eq!(fetched, Some("node-1:event-uuid".to_string()));
+    }
+
+    #[tokio::test]
+    async fn audit_pointer_missing_returns_none() {
+        let (db, _dir) = open_db();
+        let store = FjallLocalEmergencyStore::new(&db).unwrap();
+        let fetched = store.get_audit_pointer("rot-missing").await.unwrap();
+        assert_eq!(fetched, None);
+    }
+}

--- a/doc/src/admin.md
+++ b/doc/src/admin.md
@@ -106,6 +106,26 @@ cluster_salt = "fbb27433d07ab307cc1fc899d0e174cf197fd398fbcff7285a63fe2f94eec2fe
 spool_dir = /var/spool/keystone/audit
 ```
 
+**`[local_emergency]`** - Node-local quorum-bypass emergency rotation (ADR 0028)
+
+```ini
+[local_emergency]
+# Disabled by default. Must be explicitly opted in per-node.
+enabled = false
+
+# How long the Raft leader must be unknown before the guardrail unlocks
+# local-only writes (avoids tripping on a transient election blip).
+leaderless_grace_period_seconds = 30
+
+# Interval between best-effort gossip fan-out attempts to reachable peers
+# while partitioned.
+gossip_interval_seconds = 10
+```
+
+See "Quorum-Bypass Emergency Rotation" below and
+[OAuth2 admin guide](oauth2/admin.md#emergency-signing-key-rotation-during-quorum-loss)
+for the operational procedure.
+
 ### Dynamic Auth Plugins
 
 Register custom authentication plugins via `[auth_plugins]` and per-plugin
@@ -181,8 +201,7 @@ Key metrics to alert on:
 
 - Verify the method is listed in `[auth] methods`
 - For OIDC/K8s: check provider configuration and connectivity
-- For auth plugins: check logs for `keystone_auth_plugin_load_failure`
-  alerts
+- For auth plugins: check logs for `keystone_auth_plugin_load_failure` alerts
 
 **OPA policy failures**
 
@@ -267,6 +286,64 @@ keystone-manage cluster status
 keystone-manage cluster list
 ```
 
+### Quorum-Bypass Emergency Rotation (ADR 0028)
+
+When Raft has lost quorum, the ordinary emergency rotation paths (OAuth2
+signing-key emergency rotation, DEK emergency rotation) cannot commit -- they're
+themselves Raft proposals. `[local_emergency]` provides a node-local fallback:
+an operator writes a rotation candidate straight to that node's local Fjall
+keyspace (never touched by Raft's `apply()`), bypassing quorum entirely.
+Guardrail: refused unless `[local_emergency] enabled = true` on that node
+**and** the Raft leader has been unknown for at least
+`leaderless_grace_period_seconds` -- this is not a general-purpose quorum-skip,
+only a last resort while genuinely partitioned.
+
+**Two subsystems use this path**: OAuth2 domain signing keys (see
+[OAuth2 admin guide](oauth2/admin.md#emergency-signing-key-rotation-during-quorum-loss))
+and the cluster DEK (below).
+
+**Gossip.** A background sweep (every `gossip_interval_seconds`) best-effort
+pushes each locally-originated candidate to every other reachable Raft peer over
+the same inter-node mTLS channel Raft itself uses. This only makes candidates
+_visible_ cluster-wide (`conflicted: true` if a peer reports a different active
+candidate for the same subsystem/scope) -- it does not reconcile or auto-resolve
+anything.
+
+**Reconciliation.** Once quorum returns, an operator lists candidates on each
+node that may have been reached during the outage and explicitly picks one
+`rotation_id` to promote into Raft-replicated state. Reconciliation is strictly
+per-node (run against the specific node holding the candidate, not cluster-wide)
+and dual-control (confirming operator must differ from the one who staged it).
+
+**DEK local-quorum-bypass rotation and reconciliation** (via
+`ClusterAdminService` gRPC, same mTLS/operator-role boundary as `rotate-dek`):
+
+```bash
+# During quorum loss, on a guardrail-enabled node:
+keystone-manage storage rotate-dek \
+  --local-quorum-bypass --justification "suspected KEK compromise, quorum lost"
+
+# After quorum returns, on every node possibly reached during the outage:
+keystone-manage storage list-dek-local-emergency-candidates
+
+# A different operator promotes the chosen candidate on the node that holds it:
+keystone-manage storage reconcile-dek-local-emergency --rotation-id <id>
+```
+
+Reconciliation installs the DEK via the normal Raft transaction path and refuses
+(`FailedPrecondition`) if the DEK version has advanced past what the candidate
+expected -- i.e. another rotation already committed while this candidate sat
+staged.
+
+**Known scope limits** (deliberate, see ADR 0028 "Implementation Status"):
+
+- No cross-node broadcast to clear a candidate once superseded elsewhere --
+  gossip gives visibility, not cleanup.
+- No automatic/unattended reconciliation sweep; an operator must pick a
+  `rotation_id` explicitly, per node.
+- Up to one `gossip_interval_seconds` of propagation delay after staging (no
+  immediate post-stage push).
+
 ---
 
 ## Dynamic Auth Plugins
@@ -281,13 +358,13 @@ developer guide.
 `[distributed_storage]`, decoupled from whichever `IdentityBackend` is
 configured. There is currently no SQL driver alternative - `full_auth`-mode
 plugins using `provision_user`/`find_user` are not available in a deployment
-without distributed storage configured. `mapping`- and `route`-mode plugins
-have no such requirement, since they never call those host functions.
+without distributed storage configured. `mapping`- and `route`-mode plugins have
+no such requirement, since they never call those host functions.
 
 ### Plugin Configuration
 
-Plugins are configured in `keystone.conf` under `[auth_plugins]` and
-per-plugin sections.
+Plugins are configured in `keystone.conf` under `[auth_plugins]` and per-plugin
+sections.
 
 **Minimal example** (full_auth mode - plugin authenticates users):
 
@@ -357,28 +434,28 @@ Audit logging is always enabled; it cannot be disabled.
 
 ### Configuration Reference
 
-| Key                                           | Mode        | Default                        | Description                                                                                                                                        |
-| --------------------------------------------- | ----------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path`                                        | All         | Required                       | Filesystem path to `.wasm` plugin binary                                                                                                           |
-| `sha256`                                      | All         | Required                       | SHA-256 checksum of plugin file (verified at startup)                                                                                              |
-| `mode`                                        | All         | `full_auth`                    | Operating mode: `full_auth`, `mapping`, or `route`                                                                                                 |
-| `capabilities`                                | All         | Empty                          | Comma-separated host functions: `http_fetch`, `provision_user`, `find_user`, `assign_role`                                                         |
-| `exposed_headers`                             | All         | Empty                          | HTTP headers plugin may access (comma-separated); hard-denied: `Authorization`, `Cookie`, `X-Auth-Token`, `X-Subject-Token`, `Proxy-Authorization` |
-| `allowed_hosts`                               | All         | Required if `http_fetch` used  | Hostname allowlist for `http_fetch` calls (comma-separated)                                                                                        |
-| `http_fetch_auth_header`                      | All         | Optional                       | Header name to attach auth secret (e.g., `Authorization`)                                                                                          |
-| `http_fetch_auth_secret_env`                  | All         | Optional                       | Environment variable containing auth secret (never enters guest memory)                                                                            |
-| `http_fetch_follow_redirects`                 | All         | `false`                        | Allow HTTP redirects (each hop re-validated against allowlist)                                                                                     |
-| `provision_domain_id`                         | `full_auth` | Required if provisioning       | Single domain where plugin may create users; `find_user` revalidates on every call                                                                 |
-| `allowed_provision_domains`                   | `full_auth` | Alternative                    | Comma-separated list of domains; use if plugin must span multiple domains                                                                          |
-| `assign_role_allowed`                         | `full_auth` | Required if `assign_role` used | Comma-separated role names plugin may grant (e.g., `member,reader`)                                                                                |
-| `inspect_methods`                             | `route`     | Required                       | Comma-separated identity methods that trigger this plugin (e.g., `application_credential`)                                                         |
-| `route_targets`                               | `route`     | Required                       | Comma-separated allowlist of methods this plugin may route to; `admin` and `trust` forbidden                                                       |
-| `timeout_ms`                                  | All         | 1000                           | Wall-clock timeout for plugin invocation, including any `http_fetch` calls (the whole redirect chain shares this one budget, not one per hop)      |
-| `fuel_limit`                                  | All         | 10000000                       | Instruction budget (protects against infinite loops)                                                                                               |
-| `memory_limit_mb`                             | All         | 16                             | Linear-memory limit for plugin heap                                                                                                                |
-| `invocation_rate_limit_per_source_per_minute` | All         | 20                             | Per-source-IP rate limit (sliding window)                                                                                                          |
-| `invocation_rate_limit_per_minute`            | All         | 300                            | Per-plugin global rate limit                                                                                                                       |
-| `max_concurrent_invocations`                  | All         | 16                             | Maximum simultaneous invocations                                                                                                                   |
+| Key                                           | Mode        | Default                        | Description                                                                                                                                                                                                                        |
+| --------------------------------------------- | ----------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`                                        | All         | Required                       | Filesystem path to `.wasm` plugin binary                                                                                                                                                                                           |
+| `sha256`                                      | All         | Required                       | SHA-256 checksum of plugin file (verified at startup)                                                                                                                                                                              |
+| `mode`                                        | All         | `full_auth`                    | Operating mode: `full_auth`, `mapping`, or `route`                                                                                                                                                                                 |
+| `capabilities`                                | All         | Empty                          | Comma-separated host functions: `http_fetch`, `provision_user`, `find_user`, `assign_role`                                                                                                                                         |
+| `exposed_headers`                             | All         | Empty                          | HTTP headers plugin may access (comma-separated); hard-denied: `Authorization`, `Cookie`, `X-Auth-Token`, `X-Subject-Token`, `Proxy-Authorization`                                                                                 |
+| `allowed_hosts`                               | All         | Required if `http_fetch` used  | Hostname allowlist for `http_fetch` calls (comma-separated)                                                                                                                                                                        |
+| `http_fetch_auth_header`                      | All         | Optional                       | Header name to attach auth secret (e.g., `Authorization`)                                                                                                                                                                          |
+| `http_fetch_auth_secret_env`                  | All         | Optional                       | Environment variable containing auth secret (never enters guest memory)                                                                                                                                                            |
+| `http_fetch_follow_redirects`                 | All         | `false`                        | Allow HTTP redirects (each hop re-validated against allowlist)                                                                                                                                                                     |
+| `provision_domain_id`                         | `full_auth` | Required if provisioning       | Single domain where plugin may create users; `find_user` revalidates on every call                                                                                                                                                 |
+| `allowed_provision_domains`                   | `full_auth` | Alternative                    | Comma-separated list of domains; use if plugin must span multiple domains                                                                                                                                                          |
+| `assign_role_allowed`                         | `full_auth` | Required if `assign_role` used | Comma-separated role names plugin may grant (e.g., `member,reader`)                                                                                                                                                                |
+| `inspect_methods`                             | `route`     | Required                       | Comma-separated identity methods that trigger this plugin (e.g., `application_credential`)                                                                                                                                         |
+| `route_targets`                               | `route`     | Required                       | Comma-separated allowlist of methods this plugin may route to; `admin` and `trust` forbidden                                                                                                                                       |
+| `timeout_ms`                                  | All         | 1000                           | Wall-clock timeout for plugin invocation, including any `http_fetch` calls (the whole redirect chain shares this one budget, not one per hop)                                                                                      |
+| `fuel_limit`                                  | All         | 10000000                       | Instruction budget (protects against infinite loops)                                                                                                                                                                               |
+| `memory_limit_mb`                             | All         | 16                             | Linear-memory limit for plugin heap                                                                                                                                                                                                |
+| `invocation_rate_limit_per_source_per_minute` | All         | 20                             | Per-source-IP rate limit (sliding window)                                                                                                                                                                                          |
+| `invocation_rate_limit_per_minute`            | All         | 300                            | Per-plugin global rate limit                                                                                                                                                                                                       |
+| `max_concurrent_invocations`                  | All         | 16                             | Maximum simultaneous invocations                                                                                                                                                                                                   |
 | `valid_since`                                 | `full_auth` | None (never rejects)           | RFC 3339 timestamp; a token whose `issued_at` predates this is rejected (`PluginVersionMismatch`) on re-verification. Bump alongside `sha256` for a security fix. Not enforceable for `mapping`-mode tokens today (ADR 0025 §4/§8) |
 
 ### Plugin Loading & Errors
@@ -425,8 +502,8 @@ curl -X POST http://keystone:5000/v4/auth_plugins/{plugin_name}/identity_links \
 
 RBAC-tiered: system-scope `admin` may link any user; a domain-scoped
 `admin`/`manager` may link only a non-system user in their own domain.
-Re-linking an already-linked `external_id` returns `409 Conflict` - `DELETE`
-the existing link first.
+Re-linking an already-linked `external_id` returns `409 Conflict` - `DELETE` the
+existing link first.
 
 > **Note:** SCIM convenience fields (`scim_provider_id`, `scim_external_id`) are
 > documented in ADR 0025 §4 but not yet implemented. Track as follow-up work.
@@ -444,13 +521,13 @@ curl -X POST http://keystone:5000/v4/auth_plugins/{plugin_name}/revoke_all \
 # Response: { "revoke_all": { "users_disabled": N, "links_deleted": N } }
 ```
 
-**This does NOT revoke role assignments** the plugin granted via
-`assign_role` - attributing a stored grant to the plugin that created it
-would require per-record origin bookkeeping this ADR deliberately avoids.
-Disabling the account already denies all access; review a re-enabled user's
-remaining assignments against the CADF audit trail (`plugin_name` recorded on
-every `assign_role` event) and revoke any you deem compromised via the
-ordinary per-grant revocation API before re-enabling.
+**This does NOT revoke role assignments** the plugin granted via `assign_role` -
+attributing a stored grant to the plugin that created it would require
+per-record origin bookkeeping this ADR deliberately avoids. Disabling the
+account already denies all access; review a re-enabled user's remaining
+assignments against the CADF audit trail (`plugin_name` recorded on every
+`assign_role` event) and revoke any you deem compromised via the ordinary
+per-grant revocation API before re-enabling.
 
 ### Plugin Errors & Troubleshooting
 
@@ -478,8 +555,8 @@ ordinary per-grant revocation API before re-enabling.
 
 **Plugin behavior unexpectedly changes**
 
-- Plugin was patched and Keystone restarted with the new `sha256` - there is
-  no hot reload (ADR 0025 §5); a running process never picks up a changed
+- Plugin was patched and Keystone restarted with the new `sha256` - there is no
+  hot reload (ADR 0025 §5); a running process never picks up a changed
   `.wasm`/`sha256` without a restart
 - Mapping rules changed (for `mapping` mode) - verify `MappingRuleSet` config
 - Identity links modified - check audit trail for admin changes
@@ -514,16 +591,16 @@ When updating a plugin:
 2. **Update config** with new hash and new `path` if needed
 3. **If this update fixes a security issue, also bump `valid_since`** to the
    deployment instant. Updating `sha256` alone does **not** invalidate
-   outstanding tokens - version binding is a separate, explicit
-   `valid_since` cutoff compared against each token's `issued_at`
-   (`full_auth` mode only; see the Configuration Reference table below).
-   Forgetting this step leaves tokens minted by the previous (vulnerable)
-   plugin version valid until they expire naturally.
+   outstanding tokens - version binding is a separate, explicit `valid_since`
+   cutoff compared against each token's `issued_at` (`full_auth` mode only; see
+   the Configuration Reference table below). Forgetting this step leaves tokens
+   minted by the previous (vulnerable) plugin version valid until they expire
+   naturally.
 4. **Restart Keystone** (all nodes, one at a time)
-5. **Optional:** Run `POST .../revoke_all` if the plugin had a security fix,
-   to also disable/unlink/revoke everything the compromised version
-   provisioned or granted - `valid_since` alone only stops *new* uses of
-   already-issued tokens, not cleanup of persistent state
+5. **Optional:** Run `POST .../revoke_all` if the plugin had a security fix, to
+   also disable/unlink/revoke everything the compromised version provisioned or
+   granted - `valid_since` alone only stops _new_ uses of already-issued tokens,
+   not cleanup of persistent state
 
 ### Disaster Recovery
 

--- a/doc/src/adr/0028-oauth2-quorum-bypass-emergency-rotation.md
+++ b/doc/src/adr/0028-oauth2-quorum-bypass-emergency-rotation.md
@@ -4,7 +4,9 @@
 
 ## Status
 
-Proposed
+Implemented (2026-07-16) — see [Implementation Status](#implementation-status)
+below for the two resolved design gaps and the scope decisions made along the
+way.
 
 ## Reference
 
@@ -293,6 +295,79 @@ already established for their ordinary paths:
 - **Compound failure (admin UDS also unusable) is out of scope**, as noted in §0
   — this ADR closes the "Raft partitioned, admin UDS fine" gap, not "everything
   is down at once."
+
+## Implementation Status
+
+Implemented across both subsystems: the shared `local-emergency-store` crate
+(namespace, guardrail, gossip decision logic), a Fjall-backed store wired into
+`crates/storage`, OAuth2 signing-key and DEK local-write/gossip/reconciliation
+paths, and audit wiring. Two design gaps identified during implementation
+(not anticipated by the ADR as originally written) were resolved as follows;
+both diverge from a literal reading of this ADR and are recorded here rather
+than silently.
+
+**Design gap 1: DEK transport.** This ADR (and its originating planning
+document) assumed `keystone-manage storage rotate-dek` already shared the
+admin-UDS HTTP transport with the OAuth2 CLI commands. It doesn't --
+`crates/cli-manage/src/storage/rotate_dek.rs` talks gRPC directly to
+`ClusterAdminService` over the internal management network (mTLS/SPIFFE), not
+through `interface_admin`. Rather than moving DEK management onto a new HTTP
+surface with no precedent, the DEK local-write, gossip, and reconciliation
+operations were added as new `ClusterAdminService` RPCs
+(`RotateDekLocalEmergency`, `GossipLocalEmergencyCandidate`,
+`ListDekLocalEmergencyCandidates`, `ReconcileDekLocalEmergency`),
+authenticated the same way `RotateDek`/`ConfirmRotateDek` already are. This is
+a smaller, more consistent extension of an existing boundary than introducing
+a parallel HTTP admin surface for one operation.
+
+**Design gap 2: audit mechanism.** This ADR describes the local audit entry as
+"persisted in the node's local FjallDB partition... HMAC-chained the same way
+as ADR 0023's audit spool," but ADR 0023's actual mechanism
+(`crates/audit/src/spool.rs`, `dispatcher.rs`) is a filesystem JSONL spool with
+independent per-event HMAC (a `seq` field, not a hash chain), not a Fjall
+partition. Implemented instead as an ordinary `CadfEvent` through the existing
+`AuditDispatcher`/spool pipeline (`OAUTH2_LOCAL_EMERGENCY_KEY_RECONCILED` for
+OAuth2; `DEK_ROTATION_LOCAL_EMERGENCY_STAGED`/`_RECONCILED` for DEK, via the
+distributed-storage crate's own `AuditForwarder`/`AuditRecord` mechanism,
+which predates and is independent of `AuditDispatcher`). A compact
+`_local:emergency:audit:<rotation_id>` pointer record (the
+`_local:...` namespace convention this ADR specifies) is written in the local
+Fjall keyspace on OAuth2 reconciliation, mapping a rotation id to its CADF
+event id so reconciliation/audit tooling can find the spool entry without a
+full scan; DEK does not need this indirection because its simpler audit
+records already embed `rotation_id` directly.
+
+**Other scope decisions:**
+
+- **Staging is audited on the OAuth2 side only if and when reconciled**,
+  mirroring the pre-existing, unrelated-to-this-ADR convention that
+  `stage_emergency_rotation` (the ordinary Raft-backed emergency path) is
+  likewise unaudited until `confirm-rotate-signing-key` succeeds. DEK's own
+  audit convention differs (it already audits `RotateDek`'s emergency stage 1)
+  and the local-write path follows suit for consistency within that
+  subsystem.
+- **No admin-UDS-only SPIFFE extractor was built.** No existing HTTP handler
+  anywhere in the codebase reads the `Interface::Admin` connection extension;
+  every admin-UDS operation today is secured by the ordinary `Auth` extractor
+  plus an OPA policy requiring `SystemAdmin`. The OAuth2 local-write,
+  list-candidates, and reconcile endpoints reuse that same boundary rather
+  than introducing a new one with no precedent.
+- **Reconciliation is a per-node operation an operator drives explicitly**,
+  not an automatic sweep. An operator must run `list-local-emergency-candidates`
+  / `list-dek-local-emergency-candidates` against every node that may hold a
+  candidate, then `reconcile-local-emergency-key` /
+  `reconcile-dek-local-emergency` against the specific node holding the
+  chosen `rotation_id`. There is no cross-node broadcast to clear a candidate
+  once a sibling wins reconciliation elsewhere in the cluster -- only the
+  node reconciliation was run against clears its own candidates. Gossip (§3)
+  guarantees *visibility* of a conflict across nodes, not automatic cleanup
+  everywhere once it is resolved.
+- **DEK reconciliation additionally guards against a stale target version**:
+  if a different rotation already committed to Raft while a candidate sat
+  staged (e.g. an operator ran an ordinary `rotate-dek` in the meantime),
+  reconciliation refuses rather than installing a DEK at a version that
+  collides with or regresses past the live one, and the operator must re-stage
+  a fresh local-quorum-bypass candidate instead.
 
 ## Consequences
 

--- a/doc/src/oauth2/admin.md
+++ b/doc/src/oauth2/admin.md
@@ -150,12 +150,67 @@ What happens:
 Normal rotation cadence resumes afterward; the `signing_key_rotation_days` timer
 resets.
 
-**Current limitation:** both the stage and confirm steps go through the normal
-Raft-backed HTTP path (admin UDS + SPIFFE mTLS to
+**Note:** the stage and confirm steps above go through the normal Raft-backed
+HTTP path (admin UDS + SPIFFE mTLS to
 `/v4/oauth2/{domain_id}/rotate-signing-key`), which requires Raft quorum to
 commit. If the cluster has lost quorum at the same moment a key is compromised,
-there is currently no quorum-bypass fallback — see the companion ADR amendment
-for this gap.
+use the quorum-bypass path below instead.
+
+### Emergency signing key rotation during quorum loss
+
+See [ADR 0028](../adr/0028-oauth2-quorum-bypass-emergency-rotation.md) and the
+[admin guide's Quorum-Bypass Emergency Rotation section](../admin.md#quorum-bypass-emergency-rotation-adr-0028)
+for the full node-local mechanism (guardrail, gossip, scope limits) shared with
+DEK rotation. This section covers the OAuth2-specific commands.
+
+Requires `[local_emergency] enabled = true` on the responding node, and the Raft
+leader must have been unknown for at least `leaderless_grace_period_seconds`
+(guardrail refuses otherwise).
+
+**1. Stage** — during quorum loss, on a guardrail-enabled node:
+
+```bash
+keystone-manage oauth2 rotate-signing-key \
+  --domain <domain_id> --local-quorum-bypass \
+  --justification "suspected key compromise, quorum lost"
+```
+
+Writes a rotation candidate to that node's local Fjall keyspace only — never
+touches Raft. A background sweep gossips it (best-effort) to reachable peers
+every `gossip_interval_seconds`, marking it `conflicted: true` on any node where
+a different active candidate already exists for the same domain.
+
+**2. List candidates** — once quorum returns, on every node that may have been
+reached during the outage:
+
+```bash
+curl -X GET https://keystone:5000/v4/oauth2/<domain_id>/local-emergency-candidates \
+  -H "X-Auth-Token: $ADMIN_TOKEN"
+```
+
+CLI equivalent:
+`keystone-manage oauth2 list-local-emergency-candidates --domain <domain_id>`.
+Check `conflicted` before choosing a `rotation_id` — `true` means gossip saw a
+different candidate elsewhere and you must decide deliberately which one wins.
+
+**3. Reconcile** — a _different_ operator than the one who staged it, against
+the specific node holding the chosen candidate (reconciliation does not fan out
+cluster-wide):
+
+```bash
+keystone-manage oauth2 reconcile-local-emergency-key \
+  --domain <domain_id> --rotation-id <rotation_id>
+```
+
+Promotes the candidate's key to `Primary` via the same Raft transaction path
+normal rotation uses (requires quorum), demotes the prior `Primary` to
+`Previous`, clears the candidate on this node, and revokes any other active
+candidate for the domain on this node. Rejects if the confirming operator
+matches the initiator (dual-control) or if the candidate was already revoked.
+Emits `OAUTH2_LOCAL_EMERGENCY_KEY_RECONCILED` (CADF) with a
+`_local:emergency:audit:<rotation_id>` pointer recorded in the local emergency
+store back to the event — staging itself is **not** audited (consistent with the
+ordinary emergency path's stage/confirm asymmetry); only reconciliation is.
 
 ## Downstream control-plane enforcement (Nova/Neutron/etc.)
 
@@ -205,22 +260,24 @@ migration runbook.
 
 ## Known gaps
 
-Two items from ADR 0026 §3 remain intentionally unbuilt; see the follow-up ADR
-amendments for the design work required to close them:
-
-- **UDS/loopback quorum-bypass emergency rotation** — today's emergency rotation
-  still requires Raft quorum. There is no local-only fallback for the case where
-  quorum is lost at the same time a key is compromised.
 - **Audit-log-derived JTI backfill** — `--revoke-jti` is manual only.
   Auto-populating the revocation list from a time window against the audit trail
   needs a queryable audit-log store that does not exist yet.
+- Quorum-bypass local-emergency rotation
+  ([ADR 0028](../adr/0028-oauth2-quorum-bypass-emergency-rotation.md), gap noted
+  in ADR 0026 §3) is implemented — see "Emergency signing key rotation during
+  quorum loss" above. Deliberate scope limits: no cross-node broadcast to clear
+  a superseded candidate, no unattended reconciliation sweep, per-node (not
+  cluster-wide) reconciliation.
 
 ## Troubleshooting
 
-| Symptom                                                                       | Likely cause                                                                                                     |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `/jwks` or `/.well-known/openid-configuration` returns 404                    | Domain has no signing key — run `keystone-manage oauth2 ensure-signing-key --domain <id>`                        |
-| `429` on `/token`                                                             | Rate limit hit — see `token_rate_limit_*` config                                                                 |
-| `429` on `/authorize`, `/device`, `/device/login`, or `/device_authorization` | Global per-IP limiter hit — see `[rate_limit_global_ip]`                                                         |
-| `confirm-rotate-signing-key` fails with "rotation not found/expired"          | The 15-minute confirmation window elapsed and the rotation auto-aborted; re-run `rotate-signing-key --emergency` |
-| Downstream service rejects all OP tokens after Keystone/network blip          | Expected fail-closed behavior — check JWKS/revocation endpoint reachability from the service                     |
+| Symptom                                                                       | Likely cause                                                                                                                     |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `/jwks` or `/.well-known/openid-configuration` returns 404                    | Domain has no signing key — run `keystone-manage oauth2 ensure-signing-key --domain <id>`                                        |
+| `429` on `/token`                                                             | Rate limit hit — see `token_rate_limit_*` config                                                                                 |
+| `429` on `/authorize`, `/device`, `/device/login`, or `/device_authorization` | Global per-IP limiter hit — see `[rate_limit_global_ip]`                                                                         |
+| `confirm-rotate-signing-key` fails with "rotation not found/expired"          | The 15-minute confirmation window elapsed and the rotation auto-aborted; re-run `rotate-signing-key --emergency`                 |
+| Downstream service rejects all OP tokens after Keystone/network blip          | Expected fail-closed behavior — check JWKS/revocation endpoint reachability from the service                                     |
+| `rotate-signing-key --local-quorum-bypass` refused                            | `[local_emergency] enabled = false` on that node, or leader has not been unknown long enough (`leaderless_grace_period_seconds`) |
+| `reconcile-local-emergency-key` fails with dual-control error                 | Confirming operator matches the one who staged the candidate — use a different operator                                          |

--- a/policy/oauth2/key/list_local_emergency_candidates.rego
+++ b/policy/oauth2/key/list_local_emergency_candidates.rego
@@ -1,0 +1,24 @@
+# METADATA
+# description: Policy for listing node-local quorum-bypass emergency signing key candidates (ADR 0028 §6)
+package identity.oauth2.key.list_local_emergency_candidates
+
+# List local emergency candidates on the responding node (GET
+# .../local-emergency-candidates), so an operator can see any
+# LOCAL_EMERGENCY_CONFLICT before choosing which rotation_id to reconcile.
+# SystemAdmin only, same posture as rotate_signing_key.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "listing node-local emergency signing key candidates requires SystemAdmin."
+}

--- a/policy/oauth2/key/list_local_emergency_candidates_test.rego
+++ b/policy/oauth2/key/list_local_emergency_candidates_test.rego
@@ -1,0 +1,13 @@
+package test_oauth2_key_list_local_emergency_candidates
+
+import data.identity.oauth2.key.list_local_emergency_candidates
+
+test_allowed if {
+	list_local_emergency_candidates.allow with input as {"credentials": {"roles": ["admin"]}}
+	list_local_emergency_candidates.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+}
+
+test_forbidden if {
+	not list_local_emergency_candidates.allow with input as {"credentials": {"roles": []}}
+	not list_local_emergency_candidates.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/oauth2/key/reconcile_local_emergency_key.rego
+++ b/policy/oauth2/key/reconcile_local_emergency_key.rego
@@ -1,0 +1,26 @@
+# METADATA
+# description: Policy for reconciling a node-local quorum-bypass emergency signing key rotation (ADR 0028 §6)
+package identity.oauth2.key.reconcile_local_emergency_key
+
+# Reconcile a `--local-quorum-bypass` candidate into Raft-replicated state
+# (POST .../reconcile-local-emergency-key). SystemAdmin only, same posture as
+# rotate_signing_key/confirm_rotate_signing_key -- the dual-control
+# "confirmer != initiator" check itself is enforced by the provider layer
+# (it needs the stored initiator identity, which is not policy input), not
+# by this policy.
+
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+violation contains {"field": "role", "msg": msg} if {
+	not "admin" in input.credentials.roles
+	not input.credentials.is_admin
+	msg := "reconciling a node-local emergency signing key rotation requires SystemAdmin."
+}

--- a/policy/oauth2/key/reconcile_local_emergency_key_test.rego
+++ b/policy/oauth2/key/reconcile_local_emergency_key_test.rego
@@ -1,0 +1,13 @@
+package test_oauth2_key_reconcile_local_emergency_key
+
+import data.identity.oauth2.key.reconcile_local_emergency_key
+
+test_allowed if {
+	reconcile_local_emergency_key.allow with input as {"credentials": {"roles": ["admin"]}}
+	reconcile_local_emergency_key.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+}
+
+test_forbidden if {
+	not reconcile_local_emergency_key.allow with input as {"credentials": {"roles": []}}
+	not reconcile_local_emergency_key.allow with input as {"credentials": {"roles": ["manager"]}}
+}


### PR DESCRIPTION
Implements ADR 0028 end to end: node-local Fjall write path that
bypasses Raft quorum for OAuth2 signing-key and DEK emergency
rotation, guarded by config opt-in + sustained leaderless outage.

- local-emergency-store crate: shared trait, key namespace, guardrail
  predicate, gossip decision logic
- FjallLocalEmergencyStore: dedicated keyspace, never touched by
  Raft's apply()
- OAuth2 and DEK staging via --local-quorum-bypass (reuses existing
  HTTP/gRPC transports and SystemAdmin/operator auth boundaries
  instead of a new admin-UDS surface)
- periodic best-effort gossip fan-out to Raft peers, surfacing
  LOCAL_EMERGENCY_CONFLICT rather than silently dropping
- per-node, dual-control reconciliation promoting a chosen candidate
  back into Raft; DEK path refuses a stale target version
- CADF audit on reconciliation (OAuth2) / AuditForwarder (DEK), with
  an audit-pointer record for OAuth2 spool lookups
- fixes a real gap: keystone.rs never wired
  Service::set_local_emergency_store, so the OAuth2 bypass path was
  unreachable at runtime despite compiling clean
- marks ADR 0028 Implemented, records both design-gap resolutions
  (DEK transport, audit mechanism) and other scope decisions

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
