### PR TITLE
feat(tempest): Improve tempest testing

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -431,12 +431,13 @@ jobs:
             echo "### Tempest identity compatibility (advisory, non-blocking)"
             echo
             if [ "${{ steps.tempest_verify.outcome }}" = "success" ]; then
-              echo "All selected tempest identity tests passed against both keystone-py and keystone-rs."
+              echo "All selected tempest identity tests passed."
             else
               echo "Some tempest identity tests failed - see failed test IDs below."
               echo
               echo '```'
-              grep -A 200 "FAILED TESTS (target=" tempest-results.log || echo "(unable to parse failures from log)"
+              awk '/FAILED TESTS \(target=/{show=1} show{print} /END FAILED TESTS \(target=/{show=0}' tempest-results.log \
+                | sed -E 's/^\[tempest-identity-[a-z]+\] ?//' || echo "(unable to parse failures from log)"
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -471,3 +472,54 @@ jobs:
       - name: Dump events
         if: failure()
         run: kubectl get events
+
+  tempest-track:
+    if: "success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'openstack-experimental-release-plz'"
+    runs-on: ubuntu-latest
+    needs:
+      - k3s-test
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Fetch tempest results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5.0.0
+        with:
+          name: tempest-identity-results
+
+      - name: Extract tempest summary
+        id: summary
+        run: |
+          {
+            echo "body<<TEMPEST_COMMENT_EOF"
+            for target in rust python; do
+              if grep -q "^\[tempest-identity-${target}\]" tempest-results.log; then
+                echo "**${target}**"
+                echo
+                echo '```'
+                grep "^\[tempest-identity-${target}\]" tempest-results.log \
+                  | sed -E "s/^\[tempest-identity-${target}\] ?//" \
+                  | awk '/^Totals$/{f=1} f{print} /^Sum of execute time/{f=0}'
+                echo '```'
+                echo
+              fi
+            done
+            echo "<details><summary>Failed test IDs</summary>"
+            echo
+            echo '```'
+            awk '/FAILED TESTS \(target=/{show=1} show{print} /END FAILED TESTS \(target=/{show=0}' tempest-results.log \
+              | sed -E 's/^\[tempest-identity-[a-z]+\] ?//'
+            echo '```'
+            echo "</details>"
+            echo "TEMPEST_COMMENT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post tempest results to PR
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: tempest
+          message: |
+            🧪 **Tempest Identity Compatibility Results** (advisory, non-blocking)
+
+            ${{ steps.summary.outputs.body }}
+
+            [View full run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,10 +137,10 @@ The skaffold config splits into `keystone` and `infra` modules to avoid
 redeploying all tracking labels on every change.
 
 **Tempest identity compatibility tests** (advisory, non-blocking): a third
-`tempest` module runs the OpenStack tempest identity v3 suite against both
-`keystone-rs` and `keystone-py` to track v3 API compatibility gaps. Since
-not every v3 operation is implemented by keystone-rs yet, this is run and
-reported separately from the main verify suite and never blocks CI:
+`tempest` module runs the OpenStack tempest identity v3 suite against
+`keystone-rs` to track v3 API compatibility gaps. Since not every v3
+operation is implemented by keystone-rs yet, this is run and reported
+separately from the main verify suite and never blocks CI:
 
 ```console
 skaffold verify -m tempest -a build.artifacts -v debug
@@ -148,7 +148,17 @@ skaffold verify -m tempest -a build.artifacts -v debug
 
 Failing test IDs are printed in each container's log
 (`===== FAILED TESTS (target=...) =====`); in CI these are also collected
-into a job summary and an uploaded `tempest-identity-results` log artifact.
+into a job summary, posted as a PR comment, and an uploaded
+`tempest-identity-results` log artifact.
+
+`keystone-py` is not run by default (it's the reference implementation the
+suite is written against, so its results add little day-to-day signal).
+Opt in with the `python-identity` profile, e.g. to sanity-check the
+tempest config itself after an upgrade:
+
+```console
+skaffold verify -m tempest -a build.artifacts -p python-identity -v debug
+```
 
 ### OpenStackClient (OSC)
 

--- a/crates/core/src/policy.rs
+++ b/crates/core/src/policy.rs
@@ -94,13 +94,25 @@ pub enum PolicyError {
 impl From<PolicyError> for openstack_keystone_api_types::error::KeystoneApiError {
     /// Convert a policy error into a Keystone API error.
     ///
+    /// Only a genuine OPA decision (`Forbidden`, meaning the policy engine
+    /// ran and denied the request) maps to 403. Every other variant
+    /// (transport/serialization failures talking to OPA, an unresolved
+    /// security context, a scope-drift invariant violation, ...) is an
+    /// internal/plumbing failure, not a policy decision, and must surface
+    /// as a 500 -- mapping it to `forbidden` would silently disguise a bug
+    /// as an intentional access denial with no server-side error log.
+    ///
     /// # Parameters
     /// - `error`: The policy error to convert.
     ///
     /// # Returns
     /// - `Self` - The converted `KeystoneApiError`.
     fn from(error: PolicyError) -> Self {
-        Self::forbidden(error)
+        if matches!(error, PolicyError::Forbidden(_)) {
+            Self::forbidden(error)
+        } else {
+            Self::internal(error)
+        }
     }
 }
 
@@ -209,6 +221,17 @@ pub struct Credentials {
     #[builder(default)]
     #[serde(default)]
     pub domain_id: Option<String>,
+
+    /// The domain of the currently-scoped project, when the caller holds a
+    /// project (or trust-project) scoped token. Distinct from `domain_id`
+    /// (which is only set for a genuinely *domain*-scoped token) so that
+    /// policies gating on domain-scope membership (e.g. the `manager` role
+    /// checks in `domain_matches_domain_scope`) cannot be satisfied merely
+    /// by holding a role on a project that happens to live in that domain.
+    /// `None` for domain/system/unscoped tokens.
+    #[builder(default)]
+    #[serde(default)]
+    pub project_domain_id: Option<String>,
 
     /// System scope information.
     #[builder(default)]
@@ -337,8 +360,12 @@ impl TryFrom<&ValidatedSecurityContext> for Credentials {
                 ScopeInfo::Domain(domain) => {
                     builder.domain_id(domain.id.clone());
                 }
-                ScopeInfo::Project { project, .. } => {
+                ScopeInfo::Project {
+                    project,
+                    project_domain,
+                } => {
                     builder.project_id(project.id.clone());
+                    builder.project_domain_id(project_domain.id.clone());
                 }
                 ScopeInfo::System(system) => {
                     if system == "system" {
@@ -349,6 +376,7 @@ impl TryFrom<&ValidatedSecurityContext> for Credentials {
                 }
                 ScopeInfo::TrustProject(tpi) => {
                     builder.project_id(tpi.project.id.clone());
+                    builder.project_domain_id(tpi.project_domain.id.clone());
                     builder.trust(tpi.trust.clone());
                 }
                 ScopeInfo::Unscoped => {}
@@ -494,5 +522,81 @@ impl PolicyEvaluationResult {
             can_see_other_domain_resources: Some(false),
             violations: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::tests::test_fixture_scoped;
+    use openstack_keystone_core_types::role::RoleRef;
+
+    /// A project-scoped token must carry the domain of the scoped project
+    /// as `project_domain_id`, distinct from `domain_id` (which stays
+    /// unset for project scope) so policies like
+    /// `identity/resource/domain/show` can grant a project-scoped caller
+    /// read access to their own domain without conflating it with genuine
+    /// domain-scope membership (`domain_matches_domain_scope`).
+    #[test]
+    fn credentials_from_project_scope_carries_project_domain_id() {
+        let vsc = test_fixture_scoped();
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.project_id.as_deref(), Some("project_id"));
+        assert_eq!(creds.project_domain_id.as_deref(), Some("domain_id"));
+        assert_eq!(creds.domain_id, None);
+    }
+
+    #[test]
+    fn credentials_from_domain_scope_leaves_project_domain_id_unset() {
+        let authz = AuthzInfoBuilder::default()
+            .roles(vec![RoleRef {
+                id: "admin".to_string(),
+                name: Some("admin".to_string()),
+                domain_id: None,
+            }])
+            .scope(ScopeInfo::Domain(
+                openstack_keystone_core_types::resource::Domain {
+                    id: "domain_id".to_string(),
+                    name: "domain_name".to_string(),
+                    enabled: true,
+                    ..Default::default()
+                },
+            ))
+            .build()
+            .unwrap();
+
+        let user = openstack_keystone_core_types::identity::UserResponseBuilder::default()
+            .id("uid")
+            .domain_id("domain_id")
+            .enabled(true)
+            .name("testuser")
+            .build()
+            .unwrap();
+
+        let sc = SecurityContext::test_build()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    UserIdentityInfoBuilder::default()
+                        .user_id("uid")
+                        .user(user)
+                        .user_domain(openstack_keystone_core_types::resource::Domain {
+                            id: "domain_id".to_string(),
+                            name: "domain_name".to_string(),
+                            enabled: true,
+                            ..Default::default()
+                        })
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .authorization(authz)
+            .build();
+
+        let vsc = ValidatedSecurityContext::test_new(sc);
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.domain_id.as_deref(), Some("domain_id"));
+        assert_eq!(creds.project_domain_id, None);
+        assert_eq!(creds.project_id, None);
     }
 }

--- a/doc/src/developer.md
+++ b/doc/src/developer.md
@@ -78,11 +78,10 @@ files).
 ### Tempest identity compatibility tests
 
 The `tempest` module runs the OpenStack tempest identity v3 test suite
-against both `keystone-rs` and `keystone-py`, deployed side by side by the
-`keystone` module. Since not every v3 operation is implemented by
-keystone-rs yet, these results are advisory rather than a merge gate: the
-module is run and reported on separately from the main verify suite so it
-never blocks CI.
+against `keystone-rs`, deployed by the `keystone` module. Since not every
+v3 operation is implemented by keystone-rs yet, these results are advisory
+rather than a merge gate: the module is run and reported on separately
+from the main verify suite so it never blocks CI.
 
 ```console
 skaffold verify -m tempest -a build.artifacts -v debug
@@ -91,8 +90,17 @@ skaffold verify -m tempest -a build.artifacts -v debug
 Failing test IDs are printed per target in the pod logs
 (`===== FAILED TESTS (target=...) =====`), and are used to track API
 compatibility gaps and catch breaking changes over time. In CI these are
-also collected into a job summary and an uploaded `tempest-identity-results`
-log artifact.
+also collected into a job summary, posted as a PR comment, and an uploaded
+`tempest-identity-results` log artifact.
+
+`keystone-py` isn't run by default since it's the reference implementation
+the suite is written against. Add the `python-identity` profile to also
+run against it, e.g. to confirm the tempest config itself after an
+upgrade:
+
+```console
+skaffold verify -m tempest -a build.artifacts -p python-identity -v debug
+```
 
 ## OpenStackClient (OSC)
 

--- a/policy/resource/domain/show.rego
+++ b/policy/resource/domain/show.rego
@@ -33,6 +33,12 @@ allow if {
 	identity.domain_matches_domain_scope
 }
 
-violation contains {"field": "id", "msg": "showing a domain requires system admin, `reader` role with system scope, or `manager` role with matching domain scope."} if {
+# METADATA
+# description: A project-scoped caller can view the domain their project belongs to
+allow if {
+	input.credentials.project_domain_id == input.existing.domain.id
+}
+
+violation contains {"field": "id", "msg": "showing a domain requires system admin, `reader` role with system scope, `manager` role with matching domain scope, or a project scoped to the domain."} if {
 	not input.credentials.is_admin
 }

--- a/policy/resource/domain/show_test.rego
+++ b/policy/resource/domain/show_test.rego
@@ -14,3 +14,11 @@ test_not_allowed if {
 	not show.allow with input as {"credentials": {"roles": ["manager"]}}
 	not show.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}}
 }
+
+# A project-scoped caller (no admin/reader/manager role) can view the domain
+# their own project belongs to, but not an unrelated one.
+test_own_project_domain if {
+	show.allow with input as {"credentials": {"roles": [], "project_domain_id": "foo"}, "existing": {"domain": {"id": "foo"}}}
+	not show.allow with input as {"credentials": {"roles": [], "project_domain_id": "foo"}, "existing": {"domain": {"id": "bar"}}}
+	not show.allow with input as {"credentials": {"roles": []}, "existing": {"domain": {"id": "foo"}}}
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -345,6 +345,13 @@ build:
   local:
     concurrency: 0
 
+# Only the rust target runs by default (see the `python-identity` profile
+# below to opt in to also running against keystone-py): keystone-py is
+# already the reference implementation the suite is written against, so its
+# results add little signal day-to-day and doubling the run time isn't
+# worth it for routine CI/local runs. It stays available on demand to
+# confirm the test suite/config themselves are sound whenever tempest is
+# upgraded or the config template changes.
 verify:
   - &tempest_identity_rust
     name: "tempest-identity-rust"
@@ -411,7 +418,6 @@ profiles:
             buildArgs: {}
     verify:
       - *tempest_identity_rust
-      - *tempest_identity_python
 
   - name: local
     build:
@@ -421,3 +427,14 @@ profiles:
         useDockerCLI: true
         concurrency: 0
         push: true
+
+  # Opt-in: also run against keystone-py, e.g. `skaffold verify -m tempest
+  # -a build.artifacts -p python-identity` (or `-p github-ci,python-identity`
+  # in CI). Uses a JSON patch instead of its own `verify:` list so it adds
+  # to whichever other profile's verify list is already active rather than
+  # replacing it.
+  - name: python-identity
+    patches:
+      - op: add
+        path: /verify/-
+        value: *tempest_identity_python


### PR DESCRIPTION
Post tempest identity compatibility results as a sticky PR comment
(mirroring loadtest-track) so gaps are visible without opening the
job summary or log artifact.

Skip keystone-py by default: it's the reference implementation the
suite is written against, so its results add little day-to-day
signal and doubling the run time isn't worth it for routine runs.
Add it back with the new python-identity skaffold profile when
needed (e.g. after a tempest upgrade, to sanity-check the config).

Also tighten the failed-test extraction to use the FAILED TESTS /
END FAILED TESTS markers instead of a fixed line count, so it can't
bleed into unrelated log output.

Add project_domain_id to Credentials, populated from the scoped
project's domain (ScopeInfo::Project/TrustProject), distinct from
domain_id (set only for a genuinely domain-scoped token) so it can't
be conflated with domain-scope membership used by the `manager` role
check.

identity/resource/domain/show.rego grants read access when it
matches the target domain, matching upstream Keystone's default
policy where a project-scoped caller can see the domain their own
project lives in (tempest test_default_domain_exists was getting a
403 for this).

Also stop PolicyError::From<KeystoneApiError> mapping every policy
error to 403. Only a genuine OPA Forbidden decision should; internal
failures (unresolved security context, OPA transport/JSON errors,
scope-drift) now surface as 500s instead of masquerading as access
denials with no server-side log.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
