### PR TITLE
feat(ldap): Add LDAP identity driver

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,6 +20,9 @@ command = { command-line = [ "tools/raft-env.sh" ] }
 [scripts.setup.start-api]
 command = { command-line = [ "tools/start-api.sh" ] }
 
+[scripts.setup.start-ldap-test]
+command = { command-line = [ "tools/start-ldap-test.sh" ] }
+
 
 [profile.ci]
 inherits = "default"
@@ -98,6 +101,29 @@ inherits = "api"
 filter = "binary(integration_api_v3) + binary(integration_api_v4) + binary(scim_v2)"
 setup = "start-api"
 [profile.ci-api.junit]
+path = "junit.xml"
+store-success-output = false
+store-failure-output = true
+
+# --- LDAP driver functional tests ---
+# Spins up a throwaway local `slapd` (no Docker daemon required; see
+# tools/start-ldap-test.sh), seeds it from
+# crates/identity-driver-ldap/tests/fixtures/base.ldif, and runs the
+# `live_tests` module's functional tests against it. Those tests skip
+# themselves (rather than fail) under any other profile, since
+# KEYSTONE_LDAP_TEST_URL is only set here.
+[profile.ldap]
+
+[[profile.ldap.scripts]]
+filter = "package(openstack-keystone-identity-driver-ldap)"
+setup = "start-ldap-test"
+
+[profile.ci-ldap]
+inherits = "ldap"
+[[profile.ci-ldap.scripts]]
+filter = "package(openstack-keystone-identity-driver-ldap)"
+setup = "start-ldap-test"
+[profile.ci-ldap.junit]
 path = "junit.xml"
 store-success-output = false
 store-failure-output = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,24 @@ jobs:
       - name: Run tests (unit)
         run: cargo nextest run --all-features --profile ci
 
+      - name: Install slapd for LDAP tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y slapd ldap-utils
+          # Debian/Ubuntu's stock AppArmor profile for /usr/sbin/slapd only
+          # grants rwk on /var/lib/ldap and rw (no lock) on /var/tmp, so the
+          # mdb backend's throwaway test database under /var/tmp fails to
+          # open (mdb_db_open: Permission denied) when the profile is
+          # enforced. Unload it for this disposable local test instance.
+          if command -v apparmor_parser >/dev/null 2>&1 && [ -e /etc/apparmor.d/usr.sbin.slapd ]; then
+            sudo mkdir -p /etc/apparmor.d/disable
+            sudo ln -sf /etc/apparmor.d/usr.sbin.slapd /etc/apparmor.d/disable/
+            sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.slapd
+          fi
+
+      - name: Run LDAP tests
+        run: cargo nextest run -p openstack-keystone-identity-driver-ldap --profile ci-ldap
+
       # Compile-only: catches rot in the TPM sample without requiring a
       # real/virtual TPM in CI (ADR 0016-v2 §2.5.2 test/sample scope decision
       # — real/virtual TPM availability in CI runners isn't reliable enough

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,6 +3825,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "lber"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbcf559624bfd9fe8d488329a8959766335a43a9b8b2cdd6a2c379fca02909a5"
+dependencies = [
+ "bytes",
+ "nom",
+]
+
+[[package]]
+name = "ldap3"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fe89f5e7cfb7e4701e3a38ff9f00358e026a9aee940355d88ee9d81e5c7503"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "futures-util",
+ "lber",
+ "log",
+ "nom",
+ "percent-encoding",
+ "rustls",
+ "rustls-native-certs",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "x509-parser 0.18.1",
+]
+
+[[package]]
 name = "leb128"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,6 +4615,7 @@ dependencies = [
  "openstack-keystone-credential-driver-sql",
  "openstack-keystone-distributed-storage",
  "openstack-keystone-federation-driver-sql",
+ "openstack-keystone-identity-driver-ldap",
  "openstack-keystone-identity-driver-sql",
  "openstack-keystone-idmapping-driver-sql",
  "openstack-keystone-k8s-auth-driver-raft",
@@ -5005,6 +5041,25 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "openstack-keystone-identity-driver-ldap"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "eyre",
+ "ldap3",
+ "openstack-keystone-config",
+ "openstack-keystone-core",
+ "openstack-keystone-core-types",
+ "rand 0.10.1",
+ "secrecy",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/auth-plugin-identity-driver-raft",
   "crates/auth-plugin-runtime",
   "crates/federation-driver-sql",
+  "crates/identity-driver-ldap",
   "crates/identity-driver-sql",
   "crates/idmapping-driver-sql",
   "crates/k8s-auth-driver-raft",
@@ -106,6 +107,7 @@ inventory = { version = "0.3" }
 ipnet = { version = "2" }
 itertools = { version = "0.15" }
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
+ldap3 = { version = "0.12", default-features = false, features = ["tls-rustls-aws-lc-rs"] }
 mockall = { version = "0.15" }
 mockall_double = { version = "0.3" }
 nix = { version = "0.31", default-features = false }
@@ -137,6 +139,7 @@ openstack-keystone-mapping-driver-raft = { version = "0.1", path = "crates/mappi
 openstack-keystone-oauth2-client-driver-raft = { version = "0.1", path = "crates/oauth2-client-driver-raft/" }
 openstack-keystone-oauth2-key-driver-raft = { version = "0.1", path = "crates/oauth2-key-driver-raft/" }
 openstack-keystone-oauth2-session-driver-raft = { version = "0.1", path = "crates/oauth2-session-driver-raft/" }
+openstack-keystone-identity-driver-ldap = { version = "0.1", path = "crates/identity-driver-ldap" }
 openstack-keystone-identity-driver-sql = { version = "0.1", path = "crates/identity-driver-sql" }
 openstack-keystone-idmapping-driver-sql = { version = "0.1", path = "crates/idmapping-driver-sql/" }
 openstack-keystone-resource-driver-sql = { version = "0.1", path = "crates/resource-driver-sql/" }

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -291,6 +291,10 @@ impl From<IdentityProviderError> for KeystoneApiError {
             IdentityProviderError::TooManyRequests { retry_after_secs } => Self::TooManyRequests {
                 retry_after: retry_after_secs,
             },
+            // A write attempt against a read-only backend (e.g. the LDAP
+            // identity driver, ADR-0027) is a permissions statement, not a
+            // server fault.
+            err @ IdentityProviderError::Readonly(..) => Self::forbidden(err),
             other => Self::InternalError(other.to_string()),
         }
     }
@@ -756,6 +760,31 @@ mod tests {
             <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
             StatusCode::CONFLICT
         );
+    }
+
+    #[test]
+    fn identity_provider_readonly_returns_403() {
+        let err = IdentityProviderError::Readonly("ldap identity driver is read-only".to_string());
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::Forbidden { .. }));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn identity_provider_not_implemented_falls_through_to_internal_error() {
+        let err = IdentityProviderError::NotImplemented("expiring group membership".to_string());
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::InternalError(..)));
+    }
+
+    #[test]
+    fn identity_provider_ldap_connection_falls_through_to_internal_error() {
+        let err = IdentityProviderError::LdapConnection("bind failed".to_string());
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::InternalError(..)));
     }
 
     #[test]

--- a/crates/config/src/ldap.rs
+++ b/crates/config/src/ldap.rs
@@ -1,0 +1,527 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # LDAP identity backend configuration (ADR-0027)
+//!
+//! Maps 1:1 with Python Keystone's `[ldap]` config section (`conf.ldap.*`) so
+//! a config file written for Python Keystone works unmodified here.
+use std::collections::{HashMap, HashSet};
+
+use secrecy::SecretString;
+use serde::Deserialize;
+
+/// LDAP identity backend configuration.
+#[derive(Debug, Deserialize, Clone)]
+pub struct LdapProvider {
+    // --- Connection ---
+    /// LDAP server URL.
+    #[serde(default = "default_url")]
+    pub url: String,
+    /// Service bind DN used for all directory queries.
+    pub user: Option<String>,
+    /// Service bind password.
+    pub password: Option<SecretString>,
+    /// Enable TLS for the connection.
+    #[serde(default)]
+    pub use_tls: bool,
+    /// Path to a CA certificate file used to validate the LDAP server.
+    ///
+    /// Parsed for config-file compatibility with Python Keystone, but not
+    /// currently applied: TLS verification uses the platform/`rustls`
+    /// default trust store regardless of this setting (tracked as a
+    /// follow-up; see ADR-0027 implementation notes). Set
+    /// `tls_req_cert = never` for a self-signed test directory in the
+    /// meantime, or install the CA into the system trust store.
+    pub tls_cacertfile: Option<String>,
+    /// Path to a directory of CA certificates used to validate the LDAP
+    /// server. Same not-yet-applied caveat as `tls_cacertfile`.
+    pub tls_cacertdir: Option<String>,
+    /// Certificate validation strictness for TLS connections.
+    #[serde(default)]
+    pub tls_req_cert: TlsReqCert,
+    /// Connection timeout, in seconds.
+    #[serde(default = "default_connection_timeout")]
+    pub connection_timeout: f64,
+    /// Randomize the order in which multiple LDAP URLs are tried.
+    #[serde(default)]
+    pub randomize_urls: bool,
+    /// Enable the service connection pool.
+    #[serde(default = "default_true_bool")]
+    pub pool: bool,
+    /// Service connection pool size.
+    #[serde(default = "default_pool_size")]
+    pub pool_size: i32,
+    /// Maximum number of connection retries for the service pool.
+    #[serde(default = "default_pool_retry_max")]
+    pub pool_retry_max: i32,
+    /// Delay, in seconds, between service pool connection retries.
+    #[serde(default = "default_pool_retry_delay")]
+    pub pool_retry_delay: f64,
+    /// Service pool connection acquisition timeout, in seconds.
+    #[serde(default = "default_pool_connection_timeout")]
+    pub pool_connection_timeout: f64,
+    /// Maximum lifetime of a pooled service connection, in seconds.
+    #[serde(default = "default_pool_connection_lifetime")]
+    pub pool_connection_lifetime: f64,
+    /// Enable the dedicated authentication connection pool, isolating
+    /// end-user bind storms from the service query pool.
+    #[serde(default = "default_true_bool")]
+    pub auth_pool: bool,
+    /// Authentication connection pool size.
+    #[serde(default = "default_auth_pool_size")]
+    pub auth_pool_size: i32,
+    /// Maximum lifetime of a pooled authentication connection, in seconds.
+    #[serde(default = "default_auth_pool_connection_lifetime")]
+    pub auth_pool_connection_lifetime: f64,
+
+    // --- Query ---
+    /// Default search scope for subtree operations.
+    #[serde(default)]
+    pub query_scope: QueryScope,
+    /// Number of entries requested per page (RFC 2696).
+    #[serde(default = "default_page_size")]
+    pub page_size: i32,
+    /// Alias dereferencing policy applied to searches.
+    #[serde(default)]
+    pub alias_dereferencing: AliasDereferencing,
+    /// Chase LDAP referrals.
+    #[serde(default)]
+    pub chase_referrals: Option<bool>,
+    /// LDAP client library debug level.
+    #[serde(default)]
+    pub debug_level: i32,
+
+    // --- User mapping ---
+    /// Base DN for user entries.
+    #[serde(default)]
+    pub user_tree_dn: String,
+    /// LDAP `objectClass` identifying user entries.
+    #[serde(default = "default_user_objectclass")]
+    pub user_objectclass: String,
+    /// Attribute used as the public user ID.
+    #[serde(default = "default_user_id_attribute")]
+    pub user_id_attribute: String,
+    /// Attribute used as the user name.
+    #[serde(default = "default_user_name_attribute")]
+    pub user_name_attribute: String,
+    /// Attribute used as the user's mail address.
+    #[serde(default = "default_user_mail_attribute")]
+    pub user_mail_attribute: String,
+    /// Attribute used as the user's description.
+    #[serde(default = "default_user_description_attribute")]
+    pub user_description_attribute: String,
+    /// Attribute used as the user's password (read-only backend: only used
+    /// to keep the attribute out of `extra` regardless of the
+    /// `user_additional_attribute_mapping` configuration).
+    #[serde(default = "default_user_pass_attribute")]
+    pub user_pass_attribute: String,
+    /// Attribute mapped to a user's `default_project_id`. Unused by this
+    /// read-only backend (Python only consults it on write), kept for config
+    /// parity.
+    pub user_default_project_id_attribute: Option<String>,
+    /// Attribute used to determine whether a user is enabled.
+    #[serde(default = "default_user_enabled_attribute")]
+    pub user_enabled_attribute: String,
+    /// Bitmask applied to `user_enabled_attribute` to determine enabled
+    /// state, when the attribute stores a bitmask rather than a boolean
+    /// (e.g. Active Directory's `userAccountControl`). Ignores
+    /// `user_enabled_invert` when set, matching Python Keystone.
+    pub user_enabled_mask: Option<i32>,
+    /// Invert the interpretation of `user_enabled_attribute`. Has no effect
+    /// when `user_enabled_mask` or `user_enabled_emulation` is in use.
+    #[serde(default)]
+    pub user_enabled_invert: bool,
+    /// Enabled state to assume when `user_enabled_attribute` is absent.
+    /// A free-form string (matching Python's `StrOpt`) since it doubles as
+    /// a boolean literal (`"True"`/`"False"`) in the plain-boolean case and
+    /// as an integer literal (e.g. `"512"`) in the `user_enabled_mask` case.
+    #[serde(default = "default_user_enabled_default")]
+    pub user_enabled_default: String,
+    /// Extra LDAP attributes exposed under `extra` in the API response,
+    /// mapped as `ldap_attribute -> extra_key`.
+    #[serde(default)]
+    pub user_additional_attribute_mapping: HashMap<String, String>,
+    /// Additional LDAP filter clause AND-ed into every user search.
+    pub user_filter: Option<String>,
+    /// Attributes never surfaced as `extra`, even if mapped.
+    #[serde(default = "default_user_attribute_ignore")]
+    pub user_attribute_ignore: HashSet<String>,
+    /// Emulate the enabled attribute via group membership.
+    #[serde(default)]
+    pub user_enabled_emulation: bool,
+    /// DN of the group used for enabled-emulation membership checks.
+    pub user_enabled_emulation_dn: Option<String>,
+    /// Use the group configuration options for the enabled-emulation group.
+    #[serde(default)]
+    pub user_enabled_emulation_use_group_config: bool,
+
+    // --- Group mapping ---
+    /// Base DN for group entries.
+    #[serde(default)]
+    pub group_tree_dn: String,
+    /// LDAP `objectClass` identifying group entries.
+    #[serde(default = "default_group_objectclass")]
+    pub group_objectclass: String,
+    /// Attribute used as the public group ID.
+    #[serde(default = "default_group_id_attribute")]
+    pub group_id_attribute: String,
+    /// Attribute used as the group name.
+    #[serde(default = "default_group_name_attribute")]
+    pub group_name_attribute: String,
+    /// Attribute used as the group description.
+    #[serde(default = "default_group_desc_attribute")]
+    pub group_desc_attribute: String,
+    /// Attribute on a group entry listing member DNs (or member IDs, when
+    /// `group_members_are_ids` is set).
+    #[serde(default = "default_group_member_attribute")]
+    pub group_member_attribute: String,
+    /// Members of `group_member_attribute` are keystone user IDs rather than
+    /// LDAP DNs (e.g. `posixGroup`'s `memberUid`).
+    #[serde(default)]
+    pub group_members_are_ids: bool,
+    /// Attributes never surfaced as `extra`, even if mapped.
+    #[serde(default)]
+    pub group_attribute_ignore: HashSet<String>,
+    /// Extra LDAP attributes exposed under `extra` in the API response,
+    /// mapped as `ldap_attribute -> extra_key`.
+    #[serde(default)]
+    pub group_additional_attribute_mapping: HashMap<String, String>,
+    /// Additional LDAP filter clause AND-ed into every group search.
+    pub group_filter: Option<String>,
+    /// Use `LDAP_MATCHING_RULE_IN_CHAIN` for Active Directory nested group
+    /// resolution.
+    #[serde(default)]
+    pub group_ad_nesting: bool,
+
+    // --- General ---
+    /// Base DN suffix of the directory.
+    #[serde(default = "default_suffix")]
+    pub suffix: String,
+}
+
+impl Default for LdapProvider {
+    fn default() -> Self {
+        Self {
+            url: default_url(),
+            user: None,
+            password: None,
+            use_tls: false,
+            tls_cacertfile: None,
+            tls_cacertdir: None,
+            tls_req_cert: TlsReqCert::default(),
+            connection_timeout: default_connection_timeout(),
+            randomize_urls: false,
+            pool: default_true_bool(),
+            pool_size: default_pool_size(),
+            pool_retry_max: default_pool_retry_max(),
+            pool_retry_delay: default_pool_retry_delay(),
+            pool_connection_timeout: default_pool_connection_timeout(),
+            pool_connection_lifetime: default_pool_connection_lifetime(),
+            auth_pool: default_true_bool(),
+            auth_pool_size: default_auth_pool_size(),
+            auth_pool_connection_lifetime: default_auth_pool_connection_lifetime(),
+            query_scope: QueryScope::default(),
+            page_size: default_page_size(),
+            alias_dereferencing: AliasDereferencing::default(),
+            chase_referrals: None,
+            debug_level: 0,
+            user_tree_dn: String::new(),
+            user_objectclass: default_user_objectclass(),
+            user_id_attribute: default_user_id_attribute(),
+            user_name_attribute: default_user_name_attribute(),
+            user_mail_attribute: default_user_mail_attribute(),
+            user_description_attribute: default_user_description_attribute(),
+            user_pass_attribute: default_user_pass_attribute(),
+            user_default_project_id_attribute: None,
+            user_enabled_attribute: default_user_enabled_attribute(),
+            user_enabled_mask: None,
+            user_enabled_invert: false,
+            user_enabled_default: default_user_enabled_default(),
+            user_additional_attribute_mapping: HashMap::new(),
+            user_filter: None,
+            user_attribute_ignore: default_user_attribute_ignore(),
+            user_enabled_emulation: false,
+            user_enabled_emulation_dn: None,
+            user_enabled_emulation_use_group_config: false,
+            group_tree_dn: String::new(),
+            group_objectclass: default_group_objectclass(),
+            group_id_attribute: default_group_id_attribute(),
+            group_name_attribute: default_group_name_attribute(),
+            group_desc_attribute: default_group_desc_attribute(),
+            group_member_attribute: default_group_member_attribute(),
+            group_members_are_ids: false,
+            group_attribute_ignore: HashSet::new(),
+            group_additional_attribute_mapping: HashMap::new(),
+            group_filter: None,
+            group_ad_nesting: false,
+            suffix: default_suffix(),
+        }
+    }
+}
+
+/// TLS certificate validation strictness (`[ldap] tls_req_cert`).
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum TlsReqCert {
+    /// Reject the connection if no certificate is provided or verification
+    /// fails.
+    #[default]
+    #[serde(rename = "demand")]
+    Demand,
+    /// Accept the connection whether or not a certificate is provided.
+    #[serde(rename = "allow")]
+    Allow,
+    /// Attempt verification, but do not reject the connection on failure.
+    #[serde(rename = "try")]
+    Try,
+    /// Skip certificate verification entirely.
+    #[serde(rename = "never")]
+    Never,
+}
+
+/// Default search scope for subtree LDAP operations (`[ldap] query_scope`).
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum QueryScope {
+    /// Single-level search relative to the tree DN.
+    #[default]
+    #[serde(rename = "one")]
+    One,
+    /// Whole-subtree search relative to the tree DN.
+    #[serde(rename = "sub")]
+    Sub,
+}
+
+/// Alias dereferencing policy (`[ldap] alias_dereferencing`).
+///
+/// Parsed for config-file compatibility with Python Keystone, but not
+/// currently applied to searches: the `ldap3` crate (v0.11) has no
+/// per-search or per-connection alias-dereferencing control. Every search
+/// therefore uses the `ldap3`/OpenLDAP client library default regardless of
+/// this setting (tracked as a follow-up; see ADR-0027 implementation notes).
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum AliasDereferencing {
+    /// Fall back to the default dereferencing behavior configured by the
+    /// underlying LDAP client library.
+    #[default]
+    #[serde(rename = "default")]
+    Default,
+    /// Never dereference aliases.
+    #[serde(rename = "never")]
+    Never,
+    /// Dereference aliases only while searching.
+    #[serde(rename = "searching")]
+    Searching,
+    /// Always dereference aliases.
+    #[serde(rename = "always")]
+    Always,
+    /// Dereference aliases only when locating the search base.
+    #[serde(rename = "finding")]
+    Finding,
+}
+
+fn default_url() -> String {
+    "ldap://localhost".into()
+}
+
+fn default_true_bool() -> bool {
+    true
+}
+
+fn default_connection_timeout() -> f64 {
+    -1.0
+}
+
+fn default_pool_size() -> i32 {
+    10
+}
+
+fn default_pool_retry_max() -> i32 {
+    3
+}
+
+fn default_pool_retry_delay() -> f64 {
+    0.1
+}
+
+fn default_pool_connection_timeout() -> f64 {
+    -1.0
+}
+
+fn default_pool_connection_lifetime() -> f64 {
+    600.0
+}
+
+fn default_auth_pool_size() -> i32 {
+    100
+}
+
+fn default_auth_pool_connection_lifetime() -> f64 {
+    60.0
+}
+
+fn default_page_size() -> i32 {
+    0
+}
+
+fn default_user_objectclass() -> String {
+    "inetOrgPerson".into()
+}
+
+fn default_user_id_attribute() -> String {
+    "cn".into()
+}
+
+fn default_user_name_attribute() -> String {
+    "sn".into()
+}
+
+fn default_user_mail_attribute() -> String {
+    "mail".into()
+}
+
+fn default_user_description_attribute() -> String {
+    "description".into()
+}
+
+fn default_user_pass_attribute() -> String {
+    "userPassword".into()
+}
+
+fn default_user_enabled_attribute() -> String {
+    "enabled".into()
+}
+
+fn default_user_enabled_default() -> String {
+    "True".into()
+}
+
+fn default_user_attribute_ignore() -> HashSet<String> {
+    HashSet::from(["default_project_id".into()])
+}
+
+fn default_group_objectclass() -> String {
+    "groupOfNames".into()
+}
+
+fn default_group_id_attribute() -> String {
+    "cn".into()
+}
+
+fn default_group_name_attribute() -> String {
+    "ou".into()
+}
+
+fn default_group_desc_attribute() -> String {
+    "description".into()
+}
+
+fn default_group_member_attribute() -> String {
+    "member".into()
+}
+
+fn default_suffix() -> String {
+    "cn=example,cn=com".into()
+}
+
+#[cfg(test)]
+mod tests {
+    use config::{Config, File, FileFormat};
+    use secrecy::ExposeSecret;
+
+    use super::*;
+
+    #[test]
+    fn test_defaults() {
+        let cfg = LdapProvider::default();
+        assert_eq!(cfg.url, "ldap://localhost");
+        assert_eq!(cfg.query_scope, QueryScope::One);
+        assert_eq!(cfg.tls_req_cert, TlsReqCert::Demand);
+        assert_eq!(cfg.alias_dereferencing, AliasDereferencing::Default);
+        assert_eq!(cfg.user_objectclass, "inetOrgPerson");
+        assert_eq!(cfg.user_id_attribute, "cn");
+        assert_eq!(cfg.user_name_attribute, "sn");
+        assert_eq!(cfg.user_enabled_default, "True");
+        assert_eq!(cfg.group_objectclass, "groupOfNames");
+        assert!(!cfg.group_members_are_ids);
+        assert!(cfg.pool);
+        assert!(cfg.auth_pool);
+    }
+
+    #[test]
+    fn test_parse_minimal_section() {
+        let c = Config::builder()
+            .add_source(File::from_str(
+                r#"
+[ldap]
+"#,
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let parsed: LdapProvider = c.get("ldap").unwrap();
+        assert_eq!(parsed.url, "ldap://localhost");
+        assert_eq!(parsed.user_objectclass, "inetOrgPerson");
+    }
+
+    #[test]
+    fn test_parse_full_section() {
+        let c = Config::builder()
+            .add_source(File::from_str(
+                r#"
+[ldap]
+url = ldaps://ldap.example.com
+user = cn=service,dc=example,dc=com
+password = secret
+use_tls = true
+tls_req_cert = never
+query_scope = one
+alias_dereferencing = always
+user_tree_dn = ou=Users,dc=example,dc=com
+user_objectclass = person
+user_id_attribute = uid
+group_tree_dn = ou=Groups,dc=example,dc=com
+group_ad_nesting = true
+suffix = dc=example,dc=com
+"#,
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let parsed: LdapProvider = c.get("ldap").unwrap();
+        assert_eq!(parsed.url, "ldaps://ldap.example.com");
+        assert_eq!(parsed.password.unwrap().expose_secret(), "secret");
+        assert!(parsed.use_tls);
+        assert_eq!(parsed.tls_req_cert, TlsReqCert::Never);
+        assert_eq!(parsed.query_scope, QueryScope::One);
+        assert_eq!(parsed.alias_dereferencing, AliasDereferencing::Always);
+        assert_eq!(parsed.user_id_attribute, "uid");
+        assert!(parsed.group_ad_nesting);
+        assert_eq!(parsed.suffix, "dc=example,dc=com");
+    }
+
+    #[test]
+    fn test_env_override() {
+        temp_env::with_var("OS_LDAP__PASSWORD", Some("envsecret"), || {
+            let c = Config::builder()
+                .add_source(File::from_str("[ldap]\n", FileFormat::Ini))
+                .add_source(
+                    config::Environment::with_prefix("OS")
+                        .prefix_separator("_")
+                        .separator("__"),
+                )
+                .build()
+                .unwrap();
+            let parsed: LdapProvider = c.get("ldap").unwrap();
+            assert_eq!(parsed.password.unwrap().expose_secret(), "envsecret");
+        });
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -77,6 +77,7 @@ mod idmapping;
 mod interface;
 mod jws_token;
 mod k8s_auth;
+mod ldap;
 mod listener;
 mod local_emergency;
 mod mapping;
@@ -116,6 +117,7 @@ pub use idmapping::*;
 pub use interface::*;
 pub use jws_token::*;
 pub use k8s_auth::*;
+pub use ldap::*;
 pub use listener::*;
 pub use local_emergency::*;
 pub use mapping::*;
@@ -221,6 +223,10 @@ pub struct Config {
     /// K8s Auth provider configuration.
     #[serde(default)]
     pub k8s_auth: K8sAuthProvider,
+
+    /// LDAP identity backend configuration (ADR-0027).
+    #[serde(default)]
+    pub ldap: LdapProvider,
 
     /// Node-local, quorum-bypass emergency write path configuration
     /// (ADR 0028).

--- a/crates/core-types/src/identity/error.rs
+++ b/crates/core-types/src/identity/error.rs
@@ -60,6 +60,16 @@ pub enum IdentityProviderError {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
+    /// LDAP connection, bind, TLS, or pool acquisition failure (ADR-0027
+    /// §12).
+    #[error("LDAP connection error: {0}")]
+    LdapConnection(String),
+
+    /// LDAP filter construction failure; should not occur with correct
+    /// escaping (ADR-0027 §12).
+    #[error("LDAP filter build error: {0}")]
+    LdapFilterBuild(String),
+
     #[error("corrupted database entries for user {0}")]
     MalformedUser(String),
 
@@ -75,12 +85,23 @@ pub enum IdentityProviderError {
     #[error("no entry in the `user` table found for user_id: {0}")]
     NoMainUserEntry(String),
 
+    /// The operation has no equivalent in the configured backend, e.g.
+    /// expiring group membership or service accounts against an LDAP
+    /// identity backend (ADR-0027 §12).
+    #[error("operation not implemented by backend: {0}")]
+    NotImplemented(String),
+
     /// Password hashing error.
     #[error("{}", source)]
     PasswordHash {
         #[source]
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
+
+    /// Operation rejected because the configured backend is read-only, e.g.
+    /// any mutation against the LDAP identity backend (ADR-0027 §12).
+    #[error("operation not permitted: backend is read-only ({0})")]
+    Readonly(String),
 
     /// Resource provider error.
     #[error(transparent)]

--- a/crates/identity-driver-ldap/Cargo.toml
+++ b/crates/identity-driver-ldap/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "openstack-keystone-identity-driver-ldap"
+description = "OpenStack Keystone LDAP driver for the identity provider"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+exclude.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+chrono = { workspace = true, features = ["now"] }
+eyre.workspace = true
+ldap3.workspace = true
+openstack-keystone-config.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
+rand.workspace = true
+secrecy.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync", "macros"] }
+tracing.workspace = true
+
+[dev-dependencies]
+openstack-keystone-core = { workspace = true, features = ["mock"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-test = { workspace = true, features = ["no-env-filter"] }
+
+[lints]
+workspace = true

--- a/crates/identity-driver-ldap/src/authenticate.rs
+++ b/crates/identity-driver-ldap/src/authenticate.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # LDAP bind authentication (ADR-0027 §3)
+//!
+//! Two-step flow: resolve the caller's user DN via the service pool, bind
+//! as that DN with the supplied password via the dedicated auth pool, then
+//! re-fetch the user's attributes via the service pool to build the
+//! [`AuthenticationResult`].
+use openstack_keystone_config::LdapProvider;
+use openstack_keystone_core::auth::{
+    AuthenticationContext, AuthenticationError, AuthenticationResult, AuthenticationResultBuilder,
+    IdentityInfo, PrincipalInfo, UserIdentityInfoBuilder,
+};
+use openstack_keystone_core_types::identity::{IdentityProviderError, UserPasswordAuthRequest};
+
+use crate::connection::{AuthPool, ServicePool};
+use crate::user;
+
+/// Authenticate a user by password against the directory.
+///
+/// `auth.id` selects the user directly; `auth.name` (with `auth.domain`)
+/// resolves by name first. A domain other than the configured default can
+/// never match an LDAP user (ADR-0027 §11), and is rejected the same way an
+/// unknown user is, to avoid distinguishing "wrong domain" from "wrong
+/// user" in the response.
+pub async fn authenticate_by_password(
+    service_pool: &ServicePool,
+    auth_pool: &AuthPool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    auth: &UserPasswordAuthRequest,
+) -> Result<AuthenticationResult, IdentityProviderError> {
+    if let Some(domain_id) = auth.domain.as_ref().and_then(|d| d.id.as_deref())
+        && domain_id != default_domain_id
+    {
+        return Err(AuthenticationError::UserNameOrPasswordWrong.into());
+    }
+
+    let user_dn = user::resolve_dn(service_pool, cfg, auth.id.as_deref(), auth.name.as_deref())
+        .await?
+        .ok_or(AuthenticationError::UserNameOrPasswordWrong)?;
+
+    auth_pool
+        .try_bind(&user_dn, &auth.password)
+        .await
+        .map_err(|_| AuthenticationError::UserNameOrPasswordWrong)?;
+
+    let user_response = user::get_by_dn(service_pool, cfg, default_domain_id, &user_dn)
+        .await?
+        .ok_or(AuthenticationError::UserNameOrPasswordWrong)?;
+
+    if !user_response.enabled {
+        return Err(AuthenticationError::UserDisabled(user_response.id).into());
+    }
+
+    Ok(AuthenticationResultBuilder::default()
+        .context(AuthenticationContext::Password)
+        .principal(PrincipalInfo {
+            identity: IdentityInfo::User(
+                UserIdentityInfoBuilder::default()
+                    .user_id(user_response.id.clone())
+                    .user(user_response)
+                    .build()?,
+            ),
+        })
+        .build()?)
+}

--- a/crates/identity-driver-ldap/src/connection.rs
+++ b/crates/identity-driver-ldap/src/connection.rs
@@ -1,0 +1,404 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # LDAP connection pools (ADR-0027 §8)
+//!
+//! Two independent pools are maintained:
+//!
+//! - [`ServicePool`]: bound as the service account, used for every directory
+//!   read (attribute lookups, subtree searches, DN resolution ahead of a
+//!   bind).
+//! - [`AuthPool`]: never reuses a connection across users. Each end-user
+//!   authentication attempt opens (or reuses a just-vacated) connection,
+//!   binds as the resolved user DN with the caller-supplied password, and
+//!   the connection is dropped immediately after the check. Bounding it
+//!   separately from the service pool keeps an authentication storm from
+//!   starving directory queries needed for unrelated requests.
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ldap3::{Ldap, LdapConnAsync, LdapConnSettings, LdapError, Scope, SearchEntry};
+use secrecy::{ExposeSecret, SecretString};
+use tokio::sync::{Mutex, Semaphore};
+
+use openstack_keystone_config::{LdapProvider, TlsReqCert};
+use openstack_keystone_core_types::identity::IdentityProviderError;
+
+fn ldap_error(context: &str, err: LdapError) -> IdentityProviderError {
+    IdentityProviderError::LdapConnection(format!("{context}: {err}"))
+}
+
+fn conn_timeout(seconds: f64) -> Option<Duration> {
+    if seconds > 0.0 {
+        Some(Duration::from_secs_f64(seconds))
+    } else {
+        None
+    }
+}
+
+/// Build the [`LdapConnSettings`] implied by the `[ldap]` TLS/timeout
+/// configuration for one candidate `url`.
+fn conn_settings(cfg: &LdapProvider, url: &str) -> LdapConnSettings {
+    let mut settings = LdapConnSettings::new();
+    if let Some(timeout) = conn_timeout(cfg.connection_timeout) {
+        settings = settings.set_conn_timeout(timeout);
+    }
+    if cfg.use_tls {
+        // `ldaps://` URLs negotiate TLS at the transport level; a plain
+        // `ldap://` URL relies on StartTLS instead.
+        settings = settings.set_starttls(!url.starts_with("ldaps://"));
+        if cfg.tls_req_cert == TlsReqCert::Never {
+            tracing::warn!(
+                "[ldap] tls_req_cert = never: LDAP server certificate verification is disabled"
+            );
+            settings = settings.set_no_tls_verify(true);
+        }
+    }
+    settings
+}
+
+/// Split `[ldap] url` into individual candidate URLs (comma/whitespace
+/// separated, matching Python's `re.split(r'[\s,]+', conf.ldap.url)`), for
+/// HA failover across multiple directory servers, optionally shuffled per
+/// `randomize_urls` so a downed first server doesn't serialize every
+/// process/thread behind the same connection-timeout wait.
+fn candidate_urls(cfg: &LdapProvider) -> Vec<String> {
+    let mut urls: Vec<String> = cfg
+        .url
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect();
+    if cfg.randomize_urls {
+        use rand::seq::SliceRandom;
+        urls.shuffle(&mut rand::rng());
+    }
+    urls
+}
+
+/// Open a connection to the directory — trying each of `[ldap] url`'s
+/// comma/whitespace-separated candidates in turn, using the first that
+/// connects — and bind as `bind_dn`/`bind_pw` (anonymous bind when
+/// `bind_dn` is `None`).
+async fn connect_and_bind(
+    cfg: &LdapProvider,
+    bind_dn: Option<&str>,
+    bind_pw: Option<&str>,
+) -> Result<Ldap, IdentityProviderError> {
+    let urls = candidate_urls(cfg);
+    let mut last_err = None;
+    for url in &urls {
+        match LdapConnAsync::with_settings(conn_settings(cfg, url), url).await {
+            Ok((conn, mut ldap)) => {
+                ldap3::drive!(conn);
+                let bind_result = match (bind_dn, bind_pw) {
+                    (Some(dn), Some(pw)) => ldap.simple_bind(dn, pw).await,
+                    _ => ldap.simple_bind("", "").await,
+                };
+                match bind_result.and_then(|r| r.success()) {
+                    Ok(_) => return Ok(ldap),
+                    Err(e) => {
+                        last_err = Some(ldap_error("binding to LDAP server", e));
+                        // A bind failure (bad credentials) is authoritative,
+                        // not a per-server connectivity fluke — don't try
+                        // the next URL as if this one were merely down.
+                        break;
+                    }
+                }
+            }
+            Err(e) => last_err = Some(ldap_error("connecting to LDAP server", e)),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| {
+        IdentityProviderError::LdapConnection("no [ldap] url configured".into())
+    }))
+}
+
+struct PooledConnection {
+    ldap: Ldap,
+    created_at: Instant,
+}
+
+/// Connection pool bound as the service account, used for all directory
+/// reads.
+pub struct ServicePool {
+    cfg: Arc<LdapProvider>,
+    idle: Mutex<Vec<PooledConnection>>,
+    permits: Semaphore,
+    max_lifetime: Duration,
+}
+
+impl ServicePool {
+    pub fn new(cfg: Arc<LdapProvider>) -> Self {
+        let size = if cfg.pool {
+            cfg.pool_size.max(1) as usize
+        } else {
+            1
+        };
+        let max_lifetime = if cfg.pool_connection_lifetime > 0.0 {
+            Duration::from_secs_f64(cfg.pool_connection_lifetime)
+        } else {
+            Duration::MAX
+        };
+        Self {
+            cfg,
+            idle: Mutex::new(Vec::new()),
+            permits: Semaphore::new(size),
+            max_lifetime,
+        }
+    }
+
+    async fn acquire(&self) -> Result<Ldap, IdentityProviderError> {
+        // The permit bounds concurrent connections at `pool_size`; it is
+        // released implicitly once this function returns, since we hand
+        // back an owned `Ldap` handle rather than holding the permit for
+        // the caller's whole request. Concurrency is still capped because
+        // `acquire()` blocks until a permit is available.
+        let _permit = self
+            .permits
+            .acquire()
+            .await
+            .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+
+        if let Some(conn) = self.idle.lock().await.pop()
+            && conn.created_at.elapsed() < self.max_lifetime
+        {
+            return Ok(conn.ldap);
+        }
+
+        let mut retries_left = self.cfg.pool_retry_max.max(0);
+        let retry_delay = Duration::from_secs_f64(self.cfg.pool_retry_delay.max(0.0));
+        loop {
+            match connect_and_bind(
+                &self.cfg,
+                self.cfg.user.as_deref(),
+                self.cfg.password.as_ref().map(|s| s.expose_secret()),
+            )
+            .await
+            {
+                Ok(ldap) => return Ok(ldap),
+                Err(_) if retries_left > 0 => {
+                    retries_left -= 1;
+                    tokio::time::sleep(retry_delay).await;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    async fn release(&self, ldap: Ldap) {
+        self.idle.lock().await.push(PooledConnection {
+            ldap,
+            created_at: Instant::now(),
+        });
+    }
+
+    /// Verify the directory is reachable and the service bind credentials
+    /// are valid. Used at backend construction time to fail fast rather
+    /// than register a backend that can never serve a request.
+    pub async fn health_check(&self) -> Result<(), IdentityProviderError> {
+        let ldap = self.acquire().await?;
+        self.release(ldap).await;
+        Ok(())
+    }
+
+    /// Non-paged search, suitable for BASE-scoped lookups and small result
+    /// sets (single-entry `get`/`dn_to_id` resolution).
+    pub async fn search(
+        &self,
+        base: &str,
+        scope: Scope,
+        filter: &str,
+        attrs: &[&str],
+    ) -> Result<Vec<SearchEntry>, IdentityProviderError> {
+        let mut ldap = self.acquire().await?;
+        let raw = ldap.search(base, scope, filter, attrs).await;
+        self.release(ldap).await;
+        let search_result = raw.map_err(|e| ldap_error("searching LDAP directory", e))?;
+        match search_result.success() {
+            Ok((entries, _res)) => Ok(entries.into_iter().map(SearchEntry::construct).collect()),
+            // The search base itself doesn't exist (e.g. a constructed DN
+            // for a nonexistent object, or a misconfigured tree DN) — treat
+            // as "no results" rather than a hard error.
+            Err(LdapError::LdapResult { result }) if result.rc == 32 => Ok(vec![]),
+            Err(e) => Err(ldap_error("searching LDAP directory", e)),
+        }
+    }
+
+    /// Paged subtree search (RFC 2696), looping until the server returns an
+    /// empty cookie. Used by every unbounded subtree operation
+    /// (`list_users`, `list_groups`, membership reverse-searches) so large
+    /// directories don't exceed the server's configured `sizelimit`.
+    pub async fn paged_search(
+        &self,
+        base: &str,
+        scope: Scope,
+        filter: &str,
+        attrs: &[&str],
+    ) -> Result<Vec<SearchEntry>, IdentityProviderError> {
+        let page_size = self.cfg.page_size;
+        if page_size <= 0 {
+            return self.search(base, scope, filter, attrs).await;
+        }
+
+        let mut ldap = self.acquire().await?;
+        let mut entries = Vec::new();
+        let adapter = ldap3::adapters::PagedResults::new(page_size);
+        let mut stream = match ldap
+            .streaming_search_with(adapter, base, scope, filter, attrs)
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                self.release(ldap).await;
+                return Err(ldap_error("starting paged LDAP search", e));
+            }
+        };
+        loop {
+            match stream.next().await {
+                Ok(Some(entry)) => entries.push(SearchEntry::construct(entry)),
+                Ok(None) => break,
+                Err(e) => {
+                    return Err(ldap_error("reading paged LDAP search results", e));
+                }
+            }
+        }
+        if let Err(e) = stream.finish().await.success()
+            && !matches!(&e, LdapError::LdapResult { result } if result.rc == 32)
+        {
+            return Err(ldap_error("finishing paged LDAP search", e));
+        }
+        self.release(ldap).await;
+        Ok(entries)
+    }
+}
+
+/// Connection pool used exclusively for the second step of
+/// `authenticate_by_password`: binding as the resolved end-user DN with the
+/// caller-supplied password. Connections are never reused across users or
+/// requests.
+pub struct AuthPool {
+    cfg: Arc<LdapProvider>,
+    permits: Semaphore,
+}
+
+impl AuthPool {
+    pub fn new(cfg: Arc<LdapProvider>) -> Self {
+        let size = if cfg.auth_pool {
+            cfg.auth_pool_size.max(1) as usize
+        } else {
+            cfg.pool_size.max(1) as usize
+        };
+        Self {
+            cfg,
+            permits: Semaphore::new(size),
+        }
+    }
+
+    /// Attempt a simple bind as `user_dn` with `password`. Returns `Ok(())`
+    /// on a successful bind, or an authentication/connection error
+    /// otherwise. The connection is unbound and dropped immediately after
+    /// the check, regardless of outcome.
+    pub async fn try_bind(
+        &self,
+        user_dn: &str,
+        password: &SecretString,
+    ) -> Result<(), IdentityProviderError> {
+        let _permit = self
+            .permits
+            .acquire()
+            .await
+            .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+
+        let mut ldap = connect_and_bind(&self.cfg, None, None).await?;
+        let bind_result = ldap
+            .simple_bind(user_dn, password.expose_secret())
+            .await
+            .map_err(|e| ldap_error("binding as user", e))
+            .and_then(|res| res.success().map_err(|e| ldap_error("binding as user", e)));
+        let _ = ldap.unbind().await;
+        bind_result.map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_conn_timeout_positive_seconds() {
+        assert_eq!(conn_timeout(5.0), Some(Duration::from_secs_f64(5.0)));
+    }
+
+    #[test]
+    fn test_conn_timeout_non_positive_means_infinite() {
+        assert_eq!(conn_timeout(0.0), None);
+        assert_eq!(conn_timeout(-1.0), None);
+    }
+
+    #[test]
+    fn test_conn_settings_starttls_for_plain_ldap_url() {
+        let cfg = LdapProvider {
+            use_tls: true,
+            url: "ldap://directory.example.com".into(),
+            ..Default::default()
+        };
+        assert!(conn_settings(&cfg, &cfg.url).starttls());
+    }
+
+    #[test]
+    fn test_conn_settings_no_starttls_for_ldaps_url() {
+        let cfg = LdapProvider {
+            use_tls: true,
+            url: "ldaps://directory.example.com".into(),
+            ..Default::default()
+        };
+        assert!(!conn_settings(&cfg, &cfg.url).starttls());
+    }
+
+    #[test]
+    fn test_conn_settings_no_tls_when_disabled() {
+        let cfg = LdapProvider {
+            use_tls: false,
+            url: "ldap://directory.example.com".into(),
+            ..Default::default()
+        };
+        assert!(!conn_settings(&cfg, &cfg.url).starttls());
+    }
+
+    #[test]
+    fn test_candidate_urls_splits_comma_and_whitespace() {
+        let cfg = LdapProvider {
+            url: "ldap://s1.example.com, ldap://s2.example.com  ldap://s3.example.com".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            candidate_urls(&cfg),
+            vec![
+                "ldap://s1.example.com",
+                "ldap://s2.example.com",
+                "ldap://s3.example.com",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_candidate_urls_single_url_passthrough() {
+        let cfg = LdapProvider {
+            url: "ldap://directory.example.com".into(),
+            ..Default::default()
+        };
+        assert_eq!(candidate_urls(&cfg), vec!["ldap://directory.example.com"]);
+    }
+}

--- a/crates/identity-driver-ldap/src/enabled.rs
+++ b/crates/identity-driver-ldap/src/enabled.rs
@@ -1,0 +1,151 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Enabled-attribute emulation (ADR-0027 §7)
+//!
+//! Mirrors Python's `EnabledEmuMixIn`. Bitmask and invert/default are pure
+//! functions of the raw attribute value; group-membership emulation needs a
+//! directory round trip and so is a separate, async entry point.
+use ldap3::Scope;
+
+use openstack_keystone_config::LdapProvider;
+use openstack_keystone_core_types::identity::IdentityProviderError;
+
+use crate::connection::ServicePool;
+use crate::filter::escape_filter_value;
+
+fn truthy(v: &str) -> bool {
+    matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "y")
+}
+
+/// Determine whether a user/group is enabled from the raw
+/// `user_enabled_attribute` value, applying the bitmask and/or invert
+/// strategies, falling back to `user_enabled_default` when the attribute is
+/// absent.
+///
+/// Does not perform the group-membership emulation strategy; call
+/// [`enabled_via_group_membership`] separately when
+/// `user_enabled_emulation` is set.
+///
+/// Mirrors Python's `UserApi._ldap_res_to_model`:
+/// `enabled = (raw_value & mask) != mask` when `user_enabled_mask` is set —
+/// i.e. the account is enabled unless *all* masked bits are set (the
+/// Active Directory `userAccountControl` convention, where bit `2` marks
+/// `ACCOUNTDISABLE`) — and this ignores `user_enabled_invert` entirely, as
+/// documented on `[ldap] user_enabled_mask`.
+pub fn enabled_from_attribute(cfg: &LdapProvider, raw_value: Option<&str>) -> bool {
+    if let Some(mask) = cfg.user_enabled_mask {
+        let value: i32 = raw_value
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| cfg.user_enabled_default.parse().unwrap_or(0));
+        return (value & mask) != mask;
+    }
+    match raw_value {
+        Some(v) => {
+            let t = truthy(v);
+            if cfg.user_enabled_invert { !t } else { t }
+        }
+        None => truthy(&cfg.user_enabled_default),
+    }
+}
+
+/// Determine whether `user_dn` is enabled via membership in the
+/// enabled-emulation group (`user_enabled_emulation_dn`).
+///
+/// A BASE-scoped search on the emulation group's DN, filtered by whether
+/// its member attribute contains `user_dn`, returns the entry if the user
+/// is a member and nothing otherwise.
+pub async fn enabled_via_group_membership(
+    pool: &ServicePool,
+    group_dn: &str,
+    member_attribute: &str,
+    user_dn: &str,
+) -> Result<bool, IdentityProviderError> {
+    let filter = format!("({member_attribute}={})", escape_filter_value(user_dn));
+    let entries = pool
+        .search(group_dn, Scope::Base, &filter, &["objectClass"])
+        .await?;
+    Ok(!entries.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> LdapProvider {
+        LdapProvider::default()
+    }
+
+    #[test]
+    fn test_default_when_attribute_absent() {
+        let mut c = cfg();
+        c.user_enabled_default = "True".into();
+        assert!(enabled_from_attribute(&c, None));
+        c.user_enabled_default = "False".into();
+        assert!(!enabled_from_attribute(&c, None));
+    }
+
+    #[test]
+    fn test_truthy_string_values() {
+        let c = cfg();
+        assert!(enabled_from_attribute(&c, Some("true")));
+        assert!(enabled_from_attribute(&c, Some("TRUE")));
+        assert!(enabled_from_attribute(&c, Some("1")));
+        assert!(!enabled_from_attribute(&c, Some("false")));
+        assert!(!enabled_from_attribute(&c, Some("0")));
+    }
+
+    #[test]
+    fn test_invert_flips_string_interpretation() {
+        let mut c = cfg();
+        c.user_enabled_invert = true;
+        assert!(!enabled_from_attribute(&c, Some("true")));
+        assert!(enabled_from_attribute(&c, Some("false")));
+    }
+
+    /// `mask = 2` mirrors Active Directory's `userAccountControl` bit 2
+    /// (`ACCOUNTDISABLE`): enabled unless that bit is set, i.e.
+    /// `(value & mask) != mask` — not `!= 0`.
+    #[test]
+    fn test_bitmask_strategy() {
+        let mut c = cfg();
+        c.user_enabled_mask = Some(2);
+        assert!(!enabled_from_attribute(&c, Some("2")));
+        assert!(!enabled_from_attribute(&c, Some("3")));
+        assert!(enabled_from_attribute(&c, Some("1")));
+    }
+
+    /// The attribute-absent fallback uses `user_enabled_default` parsed as
+    /// an integer (e.g. AD's typical `512` "normal account" value), not a
+    /// hardcoded `0`.
+    #[test]
+    fn test_bitmask_strategy_falls_back_to_enabled_default_when_absent() {
+        let mut c = cfg();
+        c.user_enabled_mask = Some(2);
+        c.user_enabled_default = "512".into();
+        assert!(enabled_from_attribute(&c, None));
+        c.user_enabled_default = "2".into();
+        assert!(!enabled_from_attribute(&c, None));
+    }
+
+    /// `user_enabled_invert` has no effect once `user_enabled_mask` is set
+    /// (documented on the config option, matches Python).
+    #[test]
+    fn test_bitmask_strategy_ignores_invert() {
+        let mut c = cfg();
+        c.user_enabled_mask = Some(2);
+        c.user_enabled_invert = true;
+        assert!(!enabled_from_attribute(&c, Some("2")));
+        assert!(enabled_from_attribute(&c, Some("1")));
+    }
+}

--- a/crates/identity-driver-ldap/src/filter.rs
+++ b/crates/identity-driver-ldap/src/filter.rs
@@ -1,0 +1,292 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # `UserListParameters`/`GroupListParameters` to LDAP filter translation (ADR-0027 §5).
+//!
+//! There is no generic Hints/comparator abstraction in this codebase (unlike
+//! Python Keystone's LDAP driver): `UserListParameters` and
+//! `GroupListParameters` each carry a small, fixed set of `Option` fields, so
+//! translation is a direct, total function of those fields rather than a
+//! general filter-comparator engine.
+use openstack_keystone_config::LdapProvider;
+use openstack_keystone_core_types::identity::{GroupListParameters, UserListParameters, UserType};
+
+/// Outcome of translating list parameters into an LDAP query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ListDecision {
+    /// Run a subtree search with this filter string.
+    Query(String),
+    /// The parameters can never match anything in this backend (e.g. a
+    /// `domain_id` other than the configured default, or a `user_type` that
+    /// LDAP never produces) — skip the directory round trip entirely.
+    EmptyResult,
+}
+
+/// Escape an LDAP filter value per RFC 4515, preventing filter injection.
+pub fn escape_filter_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'*' => out.push_str("\\2a"),
+            b'(' => out.push_str("\\28"),
+            b')' => out.push_str("\\29"),
+            b'\\' => out.push_str("\\5c"),
+            0 => out.push_str("\\00"),
+            _ => out.push(byte as char),
+        }
+    }
+    out
+}
+
+/// `domain_id` short-circuit shared by user and group listing: LDAP is not
+/// domain-aware, so a request scoped to any domain other than the
+/// configured default can never match.
+fn domain_matches(domain_id: &Option<String>, default_domain_id: &str) -> bool {
+    match domain_id {
+        Some(id) => id == default_domain_id,
+        None => true,
+    }
+}
+
+/// Translate [`UserListParameters`] into an LDAP filter, or a short-circuit
+/// decision when the parameters can never match an LDAP user.
+pub fn user_list_filter(
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    params: &UserListParameters,
+) -> ListDecision {
+    if !domain_matches(&params.domain_id, default_domain_id) {
+        return ListDecision::EmptyResult;
+    }
+    // LDAP users are always non-local, non-federated, non-service-account:
+    // a single flat directory namespace with no local password/federation
+    // tables (ADR-0027 §11).
+    if matches!(
+        params.user_type,
+        Some(UserType::Local) | Some(UserType::Federated) | Some(UserType::ServiceAccount)
+    ) {
+        return ListDecision::EmptyResult;
+    }
+
+    let mut clauses = vec![
+        format!("(objectClass={})", cfg.user_objectclass),
+        format!("({}=*)", cfg.user_id_attribute),
+    ];
+    if let Some(filter) = &cfg.user_filter {
+        clauses.push(filter.clone());
+    }
+    if let Some(name) = &params.name {
+        clauses.push(format!(
+            "({}={})",
+            cfg.user_name_attribute,
+            escape_filter_value(name)
+        ));
+    }
+    if let Some(unique_id) = &params.unique_id {
+        clauses.push(format!(
+            "({}={})",
+            cfg.user_id_attribute,
+            escape_filter_value(unique_id)
+        ));
+    }
+    ListDecision::Query(format!("(&{})", clauses.join("")))
+}
+
+/// Translate [`GroupListParameters`] into an LDAP filter, or a short-circuit
+/// decision when the parameters can never match an LDAP group.
+pub fn group_list_filter(
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    params: &GroupListParameters,
+) -> ListDecision {
+    if !domain_matches(&params.domain_id, default_domain_id) {
+        return ListDecision::EmptyResult;
+    }
+
+    let mut clauses = vec![
+        format!("(objectClass={})", cfg.group_objectclass),
+        format!("({}=*)", cfg.group_id_attribute),
+    ];
+    if let Some(filter) = &cfg.group_filter {
+        clauses.push(filter.clone());
+    }
+    if let Some(name) = &params.name {
+        clauses.push(format!(
+            "({}={})",
+            cfg.group_name_attribute,
+            escape_filter_value(name)
+        ));
+    }
+    ListDecision::Query(format!("(&{})", clauses.join("")))
+}
+
+#[cfg(test)]
+mod tests {
+    use openstack_keystone_core_types::identity::{
+        GroupListParametersBuilder, UserListParametersBuilder,
+    };
+
+    use super::*;
+
+    fn cfg() -> LdapProvider {
+        LdapProvider::default()
+    }
+
+    #[test]
+    fn test_escape_filter_value_escapes_all_metacharacters() {
+        assert_eq!(
+            escape_filter_value("a*b(c)d\\e\0f"),
+            "a\\2ab\\28c\\29d\\5ce\\00f"
+        );
+    }
+
+    #[test]
+    fn test_escape_filter_value_passthrough_for_plain_values() {
+        assert_eq!(escape_filter_value("jdoe"), "jdoe");
+    }
+
+    #[test]
+    fn test_user_list_filter_defaults_to_objectclass_only() {
+        let params = UserListParametersBuilder::default().build().unwrap();
+        match user_list_filter(&cfg(), "default", &params) {
+            ListDecision::Query(f) => assert_eq!(f, "(&(objectClass=inetOrgPerson)(cn=*))"),
+            ListDecision::EmptyResult => panic!("expected a query"),
+        }
+    }
+
+    #[test]
+    fn test_user_list_filter_by_name_and_unique_id() {
+        let params = UserListParametersBuilder::default()
+            .name(Some("j*doe".to_string()))
+            .unique_id(Some("uid-1".to_string()))
+            .build()
+            .unwrap();
+        match user_list_filter(&cfg(), "default", &params) {
+            ListDecision::Query(f) => {
+                assert_eq!(
+                    f,
+                    "(&(objectClass=inetOrgPerson)(cn=*)(sn=j\\2adoe)(cn=uid-1))"
+                )
+            }
+            ListDecision::EmptyResult => panic!("expected a query"),
+        }
+    }
+
+    #[test]
+    fn test_user_list_filter_includes_configured_user_filter() {
+        let mut c = cfg();
+        c.user_filter = Some("(mail=*@example.com)".into());
+        let params = UserListParametersBuilder::default().build().unwrap();
+        match user_list_filter(&c, "default", &params) {
+            ListDecision::Query(f) => {
+                assert_eq!(
+                    f,
+                    "(&(objectClass=inetOrgPerson)(cn=*)(mail=*@example.com))"
+                )
+            }
+            ListDecision::EmptyResult => panic!("expected a query"),
+        }
+    }
+
+    #[test]
+    fn test_user_list_filter_domain_mismatch_short_circuits() {
+        let params = UserListParametersBuilder::default()
+            .domain_id(Some("other-domain".to_string()))
+            .build()
+            .unwrap();
+        assert_eq!(
+            user_list_filter(&cfg(), "default", &params),
+            ListDecision::EmptyResult
+        );
+    }
+
+    #[test]
+    fn test_user_list_filter_matching_domain_still_queries() {
+        let params = UserListParametersBuilder::default()
+            .domain_id(Some("default".to_string()))
+            .build()
+            .unwrap();
+        assert!(matches!(
+            user_list_filter(&cfg(), "default", &params),
+            ListDecision::Query(_)
+        ));
+    }
+
+    #[test]
+    fn test_user_list_filter_local_federated_service_account_short_circuit() {
+        for user_type in [
+            UserType::Local,
+            UserType::Federated,
+            UserType::ServiceAccount,
+        ] {
+            let params = UserListParametersBuilder::default()
+                .user_type(Some(user_type))
+                .build()
+                .unwrap();
+            assert_eq!(
+                user_list_filter(&cfg(), "default", &params),
+                ListDecision::EmptyResult,
+                "user_type {user_type:?} should short-circuit"
+            );
+        }
+    }
+
+    #[test]
+    fn test_user_list_filter_all_and_nonlocal_still_query() {
+        for user_type in [UserType::All, UserType::NonLocal] {
+            let params = UserListParametersBuilder::default()
+                .user_type(Some(user_type))
+                .build()
+                .unwrap();
+            assert!(matches!(
+                user_list_filter(&cfg(), "default", &params),
+                ListDecision::Query(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_group_list_filter_defaults_to_objectclass_only() {
+        let params = GroupListParametersBuilder::default().build().unwrap();
+        match group_list_filter(&cfg(), "default", &params) {
+            ListDecision::Query(f) => assert_eq!(f, "(&(objectClass=groupOfNames)(cn=*))"),
+            ListDecision::EmptyResult => panic!("expected a query"),
+        }
+    }
+
+    #[test]
+    fn test_group_list_filter_by_name() {
+        let params = GroupListParametersBuilder::default()
+            .name("admins")
+            .build()
+            .unwrap();
+        match group_list_filter(&cfg(), "default", &params) {
+            ListDecision::Query(f) => {
+                assert_eq!(f, "(&(objectClass=groupOfNames)(cn=*)(ou=admins))")
+            }
+            ListDecision::EmptyResult => panic!("expected a query"),
+        }
+    }
+
+    #[test]
+    fn test_group_list_filter_domain_mismatch_short_circuits() {
+        let params = GroupListParametersBuilder::default()
+            .domain_id("other-domain")
+            .build()
+            .unwrap();
+        assert_eq!(
+            group_list_filter(&cfg(), "default", &params),
+            ListDecision::EmptyResult
+        );
+    }
+}

--- a/crates/identity-driver-ldap/src/group.rs
+++ b/crates/identity-driver-ldap/src/group.rs
@@ -1,0 +1,206 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # LDAP group read and membership operations (ADR-0027 §3, §9)
+use ldap3::SearchEntry;
+
+use openstack_keystone_config::LdapProvider;
+use openstack_keystone_core_types::identity::{Group, GroupListParameters, IdentityProviderError};
+
+use crate::connection::ServicePool;
+use crate::filter::{ListDecision, escape_filter_value, group_list_filter};
+use crate::id_dn::{self, ldap_scope};
+use crate::models;
+
+const ALL_ATTRS: [&str; 1] = ["*"];
+
+/// The `LDAP_MATCHING_RULE_IN_CHAIN` OID used to resolve Active Directory
+/// nested group membership in a single query (ADR-0027 §9).
+const AD_MATCHING_RULE_IN_CHAIN: &str = "1.2.840.113556.1.4.1941";
+
+fn member_dns(entry: &SearchEntry, member_attribute: &str) -> Vec<String> {
+    entry
+        .attrs
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(member_attribute))
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default()
+}
+
+/// Look up a single group entry by `group_id_attribute` under
+/// `group_tree_dn`, scoped by `[ldap] query_scope`, mirroring Python's
+/// `_ldap_get` (see `user::get_entry_by_id` for why this never constructs a
+/// DN directly).
+async fn get_entry_by_id(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    group_id: &str,
+) -> Result<Option<SearchEntry>, IdentityProviderError> {
+    let mut filter = format!(
+        "(&({}={})(objectClass={}))",
+        cfg.group_id_attribute,
+        escape_filter_value(group_id),
+        cfg.group_objectclass
+    );
+    if let Some(extra) = &cfg.group_filter {
+        filter = format!("(&{filter}{extra})");
+    }
+    let entries = pool
+        .search(
+            &cfg.group_tree_dn,
+            ldap_scope(cfg.query_scope),
+            &filter,
+            &ALL_ATTRS,
+        )
+        .await?;
+    Ok(entries.into_iter().next())
+}
+
+/// Get a single group by ID.
+pub async fn get(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    group_id: &str,
+) -> Result<Option<Group>, IdentityProviderError> {
+    match get_entry_by_id(pool, cfg, group_id).await? {
+        Some(entry) => Ok(Some(models::to_group(cfg, default_domain_id, &entry)?)),
+        None => Ok(None),
+    }
+}
+
+/// List groups matching the given parameters.
+pub async fn list(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    params: &GroupListParameters,
+) -> Result<Vec<Group>, IdentityProviderError> {
+    let filter = match group_list_filter(cfg, default_domain_id, params) {
+        ListDecision::Query(f) => f,
+        ListDecision::EmptyResult => return Ok(vec![]),
+    };
+    let entries = pool
+        .paged_search(
+            &cfg.group_tree_dn,
+            ldap_scope(cfg.query_scope),
+            &filter,
+            &ALL_ATTRS,
+        )
+        .await?;
+    entries
+        .iter()
+        .map(|entry| models::to_group(cfg, default_domain_id, entry))
+        .collect()
+}
+
+/// Find the ID of any group in `domain_id` whose name matches `name`
+/// case-insensitively. A non-default domain never matches (ADR-0027 §11).
+pub async fn find_by_name_ci(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    domain_id: &str,
+    name: &str,
+) -> Result<Option<String>, IdentityProviderError> {
+    if domain_id != default_domain_id {
+        return Ok(None);
+    }
+    let filter = format!(
+        "(&(objectClass={})({}={}))",
+        cfg.group_objectclass,
+        cfg.group_name_attribute,
+        escape_filter_value(name)
+    );
+    let entries = pool
+        .search(
+            &cfg.group_tree_dn,
+            ldap_scope(cfg.query_scope),
+            &filter,
+            &[cfg.group_id_attribute.as_str()],
+        )
+        .await?;
+    match entries.into_iter().next() {
+        Some(entry) => Ok(Some(
+            id_dn::dn_to_id(pool, &cfg.group_id_attribute, &entry.dn).await?,
+        )),
+        None => Ok(None),
+    }
+}
+
+/// List the groups a user is a member of, identified by `member_value` — the
+/// user's DN, or its `user_id_attribute` value when `group_members_are_ids`
+/// is set (mirrors Python's `list_groups_for_user`, which switches between
+/// `user_ref['dn']` and `user_ref['id']` the same way).
+///
+/// When `group_ad_nesting` is set, uses `LDAP_MATCHING_RULE_IN_CHAIN` to
+/// resolve nested Active Directory group membership in a single query.
+pub async fn list_groups_of_user_dn(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    member_value: &str,
+) -> Result<Vec<Group>, IdentityProviderError> {
+    let member_clause = if cfg.group_ad_nesting {
+        format!(
+            "({}:{AD_MATCHING_RULE_IN_CHAIN}:={})",
+            cfg.group_member_attribute,
+            escape_filter_value(member_value)
+        )
+    } else {
+        format!(
+            "({}={})",
+            cfg.group_member_attribute,
+            escape_filter_value(member_value)
+        )
+    };
+    let filter = format!("(&(objectClass={}){member_clause})", cfg.group_objectclass);
+    let entries = pool
+        .paged_search(
+            &cfg.group_tree_dn,
+            ldap_scope(cfg.query_scope),
+            &filter,
+            &ALL_ATTRS,
+        )
+        .await?;
+    entries
+        .iter()
+        .map(|entry| models::to_group(cfg, default_domain_id, entry))
+        .collect()
+}
+
+/// List the user IDs that are members of `group_id`, read directly off the
+/// group entry's member attribute.
+///
+/// When `group_members_are_ids` is set, member values are keystone user IDs
+/// already and are returned as-is; otherwise they are member DNs and are
+/// resolved to IDs via [`id_dn::dn_to_id`] (mirrors Python's
+/// `_transform_group_member_ids`).
+pub async fn list_users_of_group(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    group_id: &str,
+) -> Result<Vec<String>, IdentityProviderError> {
+    let Some(entry) = get_entry_by_id(pool, cfg, group_id).await? else {
+        return Ok(vec![]);
+    };
+    let members = member_dns(&entry, &cfg.group_member_attribute);
+    if cfg.group_members_are_ids {
+        return Ok(members);
+    }
+    let mut ids = Vec::with_capacity(members.len());
+    for member_dn in members {
+        ids.push(id_dn::dn_to_id(pool, &cfg.user_id_attribute, &member_dn).await?);
+    }
+    Ok(ids)
+}

--- a/crates/identity-driver-ldap/src/id_dn.rs
+++ b/crates/identity-driver-ldap/src/id_dn.rs
@@ -1,0 +1,120 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Query scope and DN-to-ID mapping (ADR-0027 §4)
+//!
+//! Python's `_id_to_dn` (constructing a DN directly from an ID, without a
+//! directory round trip) is only ever used on the LDAP *write* path
+//! (`create`/`update`/`delete`, via `_ldap_add`/`_ldap_delete`); every read
+//! path (`get`, `get_by_name`, `get_all`) instead runs a single filtered
+//! search under `tree_dn`, scoped by `[ldap] query_scope`, and reads the
+//! resulting entry's real DN off the search result. Since this backend is
+//! permanently read-only, there is no DN-construction path to reproduce here
+//! — only [`ldap_scope`], mapping `query_scope` to the ldap3 [`Scope`] used
+//! by every read search, and [`dn_to_id`], mirroring `_dn_to_id` for turning
+//! a group's raw member DN back into a user ID.
+use ldap3::Scope;
+
+use openstack_keystone_config::QueryScope;
+use openstack_keystone_core_types::identity::IdentityProviderError;
+
+use crate::connection::ServicePool;
+
+/// Map `[ldap] query_scope` to the ldap3 search scope used for every read
+/// operation (`get`, `get_by_name`, `get_all`) — mirrors Python's
+/// `LDAP_SCOPES = {'one': ldap.SCOPE_ONELEVEL, 'sub': ldap.SCOPE_SUBTREE}`.
+pub fn ldap_scope(query_scope: QueryScope) -> Scope {
+    match query_scope {
+        QueryScope::One => Scope::OneLevel,
+        QueryScope::Sub => Scope::Subtree,
+    }
+}
+
+/// Extract the value of `id_attribute` from `dn`'s leading RDN, if the RDN's
+/// attribute name matches (case-insensitively).
+fn rdn_value_if_attribute(dn: &str, id_attribute: &str) -> Option<String> {
+    let rdn = dn.split(',').next()?;
+    let (attr, value) = rdn.split_once('=')?;
+    if attr.trim().eq_ignore_ascii_case(id_attribute) {
+        Some(value.trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Resolve `dn` to the value of `id_attribute` on that entry.
+///
+/// If `id_attribute` matches the DN's leading RDN attribute, the value is
+/// parsed out of the DN directly with no directory round trip. Otherwise a
+/// BASE-scoped search reads the attribute off the entry (mirrors Python's
+/// `_dn_to_id`, which always uses `SCOPE_BASE` for this fallback regardless
+/// of `query_scope`).
+pub async fn dn_to_id(
+    pool: &ServicePool,
+    id_attribute: &str,
+    dn: &str,
+) -> Result<String, IdentityProviderError> {
+    if let Some(value) = rdn_value_if_attribute(dn, id_attribute) {
+        return Ok(value);
+    }
+    let entries = pool
+        .search(dn, Scope::Base, "(objectClass=*)", &[id_attribute])
+        .await?;
+    let entry = entries
+        .into_iter()
+        .next()
+        .ok_or_else(|| IdentityProviderError::Driver(format!("no LDAP entry found at dn {dn}")))?;
+    entry
+        .attrs
+        .get(id_attribute)
+        .and_then(|values| values.first())
+        .cloned()
+        .ok_or_else(|| {
+            IdentityProviderError::Driver(format!("attribute {id_attribute} missing on dn {dn}"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ldap_scope_one_is_onelevel() {
+        assert_eq!(ldap_scope(QueryScope::One), Scope::OneLevel);
+    }
+
+    #[test]
+    fn test_ldap_scope_sub_is_subtree() {
+        assert_eq!(ldap_scope(QueryScope::Sub), Scope::Subtree);
+    }
+
+    #[test]
+    fn test_rdn_value_if_attribute_matches() {
+        assert_eq!(
+            rdn_value_if_attribute("cn=jdoe,ou=Users,dc=example,dc=com", "cn"),
+            Some("jdoe".to_string())
+        );
+        assert_eq!(
+            rdn_value_if_attribute("CN=jdoe,ou=Users,dc=example,dc=com", "cn"),
+            Some("jdoe".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rdn_value_if_attribute_mismatch() {
+        assert_eq!(
+            rdn_value_if_attribute("uid=jdoe,ou=Users,dc=example,dc=com", "cn"),
+            None
+        );
+    }
+}

--- a/crates/identity-driver-ldap/src/lib.rs
+++ b/crates/identity-driver-ldap/src/lib.rs
@@ -1,0 +1,468 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OpenStack Keystone LDAP driver for the identity provider (ADR-0027)
+//!
+//! Read-only identity backend backed by an external LDAP directory
+//! (FreeIPA, Active Directory, OpenLDAP, ...), configuration-compatible
+//! with Python Keystone's `[ldap]` section. See `doc/src/adr/0027-ldap-identity-driver.md`.
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use secrecy::SecretString;
+
+use openstack_keystone_config::LdapProvider;
+use openstack_keystone_core::auth::AuthenticationResult;
+use openstack_keystone_core::identity::IdentityProviderError;
+use openstack_keystone_core::identity::backend::IdentityBackend;
+use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core_types::identity::*;
+
+mod authenticate;
+mod connection;
+mod enabled;
+mod filter;
+mod group;
+mod id_dn;
+#[cfg(test)]
+mod live_tests;
+mod models;
+mod user;
+
+use connection::{AuthPool, ServicePool};
+
+fn readonly(operation: &str) -> IdentityProviderError {
+    IdentityProviderError::Readonly(format!(
+        "ldap identity driver is read-only: {operation} is not permitted"
+    ))
+}
+
+fn not_implemented(operation: &str) -> IdentityProviderError {
+    IdentityProviderError::NotImplemented(format!(
+        "ldap identity driver does not support {operation}"
+    ))
+}
+
+/// The read-only LDAP identity backend.
+pub struct LdapBackend {
+    config: Arc<LdapProvider>,
+    service_pool: ServicePool,
+    auth_pool: AuthPool,
+}
+
+impl LdapBackend {
+    /// Construct the backend and verify the directory is reachable with the
+    /// configured service bind credentials. Fails fast rather than
+    /// registering a backend that can never serve a request (mirrors the
+    /// JWS token provider's `load_keys().await?` precedent in
+    /// `crates/keystone/src/plugin_manager.rs`).
+    pub async fn new(cfg: &LdapProvider) -> eyre::Result<Self> {
+        if cfg.tls_cacertfile.is_some() || cfg.tls_cacertdir.is_some() {
+            tracing::warn!(
+                "[ldap] tls_cacertfile/tls_cacertdir are configured but not yet applied by this \
+                 driver; TLS verification uses the platform/rustls default trust store instead. \
+                 Install the CA into the system trust store, or set tls_req_cert = never for a \
+                 test directory."
+            );
+        }
+        let config = Arc::new(cfg.clone());
+        let service_pool = ServicePool::new(config.clone());
+        let auth_pool = AuthPool::new(config.clone());
+        service_pool
+            .health_check()
+            .await
+            .map_err(|e| eyre::eyre!("{e}"))?;
+        Ok(Self {
+            config,
+            service_pool,
+            auth_pool,
+        })
+    }
+
+    async fn default_domain_id(&self, state: &ServiceState) -> String {
+        state
+            .config_manager
+            .config
+            .read()
+            .await
+            .identity
+            .default_domain_id
+            .clone()
+    }
+}
+
+/// Linkage anchor — see ADR-0018. Referenced by the `keystone` crate's
+/// `build.rs`-generated `_ANCHORS` static so the linker extracts `.rlib`
+/// members, keeping this crate visible even before it is registered with the
+/// `PluginManager`.
+#[allow(dead_code)]
+pub fn anchor() {}
+
+#[async_trait]
+impl IdentityBackend for LdapBackend {
+    async fn add_user_to_group<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _group_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        Err(readonly("add_user_to_group"))
+    }
+
+    async fn add_user_to_group_expiring<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _group_id: &'a str,
+        _idp_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        Err(not_implemented("expiring group membership"))
+    }
+
+    async fn add_users_to_groups<'a>(
+        &self,
+        _state: &ServiceState,
+        _memberships: Vec<(&'a str, &'a str)>,
+    ) -> Result<(), IdentityProviderError> {
+        Err(readonly("add_users_to_groups"))
+    }
+
+    async fn add_users_to_groups_expiring<'a>(
+        &self,
+        _state: &ServiceState,
+        _memberships: Vec<(&'a str, &'a str)>,
+        _idp_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        Err(not_implemented("expiring group membership"))
+    }
+
+    #[tracing::instrument(skip(self, state, auth))]
+    async fn authenticate_by_password(
+        &self,
+        state: &ServiceState,
+        auth: &UserPasswordAuthRequest,
+    ) -> Result<AuthenticationResult, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        authenticate::authenticate_by_password(
+            &self.service_pool,
+            &self.auth_pool,
+            &self.config,
+            &default_domain_id,
+            auth,
+        )
+        .await
+    }
+
+    #[tracing::instrument(skip(self, state))]
+    async fn check_user_exist<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: Option<&'a str>,
+        name: Option<&'a str>,
+        domain_id: Option<&'a str>,
+    ) -> Result<String, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        user::check_user_exist(
+            &self.service_pool,
+            &self.config,
+            &default_domain_id,
+            user_id,
+            name,
+            domain_id,
+        )
+        .await
+    }
+
+    async fn create_group(
+        &self,
+        _state: &ServiceState,
+        _group: GroupCreate,
+    ) -> Result<Group, IdentityProviderError> {
+        Err(readonly("create_group"))
+    }
+
+    async fn create_service_account(
+        &self,
+        _state: &ServiceState,
+        _sa: ServiceAccountCreate,
+    ) -> Result<ServiceAccount, IdentityProviderError> {
+        Err(not_implemented("service accounts"))
+    }
+
+    async fn create_user(
+        &self,
+        _state: &ServiceState,
+        _user: UserCreate,
+    ) -> Result<UserResponse, IdentityProviderError> {
+        Err(readonly("create_user"))
+    }
+
+    async fn delete_group<'a>(
+        &self,
+        _state: &ServiceState,
+        _group_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        Err(readonly("delete_group"))
+    }
+
+    async fn delete_user<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        Err(readonly("delete_user"))
+    }
+
+    #[tracing::instrument(skip(self, state))]
+    async fn get_group<'a>(
+        &self,
+        state: &ServiceState,
+        group_id: &'a str,
+    ) -> Result<Option<Group>, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        group::get(
+            &self.service_pool,
+            &self.config,
+            &default_domain_id,
+            group_id,
+        )
+        .await
+    }
+
+    async fn get_service_account<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+    ) -> Result<Option<ServiceAccount>, IdentityProviderError> {
+        Ok(None)
+    }
+
+    #[tracing::instrument(skip(self, state))]
+    async fn get_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Option<UserResponse>, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        user::get(
+            &self.service_pool,
+            &self.config,
+            &default_domain_id,
+            user_id,
+        )
+        .await
+    }
+
+    async fn get_user_domain_id<'a>(
+        &self,
+        state: &ServiceState,
+        _user_id: &'a str,
+    ) -> Result<String, IdentityProviderError> {
+        Ok(self.default_domain_id(state).await)
+    }
+
+    #[tracing::instrument(skip(self, state))]
+    async fn find_user_by_name_ci<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        name: &'a str,
+    ) -> Result<Option<String>, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        user::find_by_name_ci(
+            &self.service_pool,
+            &self.config,
+            &default_domain_id,
+            domain_id,
+            name,
+        )
+        .await
+    }
+
+    async fn find_federated_user<'a>(
+        &self,
+        _state: &ServiceState,
+        _idp_id: &'a str,
+        _unique_id: &'a str,
+    ) -> Result<Option<UserResponse>, IdentityProviderError> {
+        // LDAP users bypass the SQL identity/federation tables entirely
+        // (ADR-0027 §11): there is no `idmapping`/`nonlocal_user` concept to
+        // resolve a federated identity against.
+        Err(not_implemented("federated users"))
+    }
+
+    #[tracing::instrument(skip(self, state))]
+    async fn list_groups(
+        &self,
+        state: &ServiceState,
+        params: &GroupListParameters,
+    ) -> Result<Vec<Group>, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        group::list(&self.service_pool, &self.config, &default_domain_id, params).await
+    }
+
+    #[tracing::instrument(skip(self, state))]
+    async fn list_users(
+        &self,
+        state: &ServiceState,
+        params: &UserListParameters,
+    ) -> Result<Vec<UserResponse>, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        user::list(&self.service_pool, &self.config, &default_domain_id, params).await
+    }
+
+    #[tracing::instrument(skip(self, state))]
+    async fn list_groups_of_user<'a>(
+        &self,
+        state: &ServiceState,
+        user_id: &'a str,
+    ) -> Result<Vec<Group>, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        // Mirrors Python's `list_groups_for_user`: membership is keyed on
+        // the user's DN, unless `group_members_are_ids` is set, in which
+        // case group member attributes hold the user's ID directly.
+        let member_value = if self.config.group_members_are_ids {
+            user_id.to_string()
+        } else {
+            match user::resolve_dn(&self.service_pool, &self.config, Some(user_id), None).await? {
+                Some(dn) => dn,
+                None => return Ok(vec![]),
+            }
+        };
+        group::list_groups_of_user_dn(
+            &self.service_pool,
+            &self.config,
+            &default_domain_id,
+            &member_value,
+        )
+        .await
+    }
+
+    #[tracing::instrument(skip(self, _state))]
+    async fn list_users_of_group<'a>(
+        &self,
+        _state: &ServiceState,
+        group_id: &'a str,
+    ) -> Result<Vec<String>, IdentityProviderError> {
+        group::list_users_of_group(&self.service_pool, &self.config, group_id).await
+    }
+
+    #[tracing::instrument(skip(self, state))]
+    async fn find_group_by_name_ci<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        name: &'a str,
+    ) -> Result<Option<String>, IdentityProviderError> {
+        let default_domain_id = self.default_domain_id(state).await;
+        group::find_by_name_ci(
+            &self.service_pool,
+            &self.config,
+            &default_domain_id,
+            domain_id,
+            name,
+        )
+        .await
+    }
+
+    async fn update_group<'a>(
+        &self,
+        _state: &ServiceState,
+        _group_id: &'a str,
+        _group: GroupUpdate,
+    ) -> Result<Group, IdentityProviderError> {
+        Err(readonly("update_group"))
+    }
+
+    async fn remove_user_from_group<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _group_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        Err(readonly("remove_user_from_group"))
+    }
+
+    async fn remove_user_from_group_expiring<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _group_id: &'a str,
+        _idp_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        Err(not_implemented("expiring group membership"))
+    }
+
+    async fn remove_user_from_groups<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _group_ids: HashSet<&'a str>,
+    ) -> Result<(), IdentityProviderError> {
+        Err(readonly("remove_user_from_groups"))
+    }
+
+    async fn remove_user_from_groups_expiring<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _group_ids: HashSet<&'a str>,
+        _idp_id: &'a str,
+    ) -> Result<(), IdentityProviderError> {
+        Err(not_implemented("expiring group membership"))
+    }
+
+    async fn set_user_groups<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _group_ids: HashSet<&'a str>,
+    ) -> Result<(), IdentityProviderError> {
+        Err(readonly("set_user_groups"))
+    }
+
+    async fn update_user<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _user: UserUpdate,
+    ) -> Result<UserResponse, IdentityProviderError> {
+        Err(readonly("update_user"))
+    }
+
+    async fn update_user_password<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _original_password: SecretString,
+        _new_password: SecretString,
+    ) -> Result<(), IdentityProviderError> {
+        Err(readonly("update_user_password"))
+    }
+
+    async fn set_user_groups_expiring<'a>(
+        &self,
+        _state: &ServiceState,
+        _user_id: &'a str,
+        _group_ids: HashSet<&'a str>,
+        _idp_id: &'a str,
+        _last_verified: Option<&'a DateTime<Utc>>,
+    ) -> Result<(), IdentityProviderError> {
+        Err(not_implemented("expiring group membership"))
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/crates/identity-driver-ldap/src/live_tests.rs
+++ b/crates/identity-driver-ldap/src/live_tests.rs
@@ -1,0 +1,425 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Functional tests against a real OpenLDAP (`slapd`) instance
+//!
+//! Exercises the LDAP driver's query, ID/DN, filter, and bind-auth logic
+//! against an actual directory, seeded from
+//! `tests/fixtures/base.ldif` (`tests/fixtures/keystone-test.schema` adds
+//! the non-standard `enabled` attribute used by `disableduser`).
+//!
+//! Opt-in: skipped unless `KEYSTONE_LDAP_TEST_URL` is set. The `ldap`
+//! nextest profile (`.config/nextest.toml`) sets it via
+//! `tools/start-ldap-test.sh`, which starts and seeds a throwaway local
+//! `slapd` (no Docker daemon required). Run manually with:
+//! `tools/start-ldap-test.sh && cargo test -p openstack-keystone-identity-driver-ldap --lib live_tests`.
+use secrecy::SecretString;
+
+use openstack_keystone_config::LdapProvider;
+use openstack_keystone_core_types::identity::{
+    GroupListParametersBuilder, IdentityProviderError, UserListParametersBuilder,
+    UserPasswordAuthRequestBuilder,
+};
+
+use crate::{LdapBackend, authenticate, group, user};
+
+const DEFAULT_DOMAIN_ID: &str = "default";
+
+/// Test fixture connection details, or `None` to skip (no live directory
+/// configured for this test run).
+fn test_url() -> Option<String> {
+    std::env::var("KEYSTONE_LDAP_TEST_URL").ok()
+}
+
+fn base_dn() -> String {
+    std::env::var("KEYSTONE_LDAP_TEST_BASE_DN").unwrap_or_else(|_| "dc=example,dc=com".into())
+}
+
+fn admin_dn() -> String {
+    std::env::var("KEYSTONE_LDAP_TEST_ADMIN_DN")
+        .unwrap_or_else(|_| format!("cn=admin,{}", base_dn()))
+}
+
+fn admin_pw() -> String {
+    std::env::var("KEYSTONE_LDAP_TEST_ADMIN_PW").unwrap_or_else(|_| "adminpw".into())
+}
+
+fn test_config(url: &str) -> LdapProvider {
+    LdapProvider {
+        url: url.to_string(),
+        user: Some(admin_dn()),
+        password: Some(SecretString::from(admin_pw())),
+        user_tree_dn: format!("ou=Users,{}", base_dn()),
+        group_tree_dn: format!("ou=Groups,{}", base_dn()),
+        suffix: base_dn(),
+        ..Default::default()
+    }
+}
+
+/// Skips (returns `Ok(None)`, letting the caller `return Ok(())`) rather
+/// than failing when no live directory is configured for this run.
+macro_rules! skip_unless_configured {
+    () => {
+        match test_url() {
+            Some(url) => url,
+            None => {
+                eprintln!(
+                    "skipping live LDAP test: KEYSTONE_LDAP_TEST_URL not set \
+                     (run tools/start-ldap-test.sh first, or use the `ldap` nextest profile)"
+                );
+                return Ok(());
+            }
+        }
+    };
+}
+
+#[tokio::test]
+async fn test_get_user_by_id() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(format!("failed to connect: {e}")))?;
+    let found = user::get(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        "jdoe",
+    )
+    .await?
+    .expect("jdoe must exist in the seeded fixture");
+    assert_eq!(found.id, "jdoe");
+    assert_eq!(found.name, "Doe");
+    assert_eq!(found.domain_id, DEFAULT_DOMAIN_ID);
+    assert!(
+        found.enabled,
+        "jdoe has no `enabled` attribute; must default to enabled"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_user_not_found_returns_none() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let found = user::get(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        "nobody-such-user",
+    )
+    .await?;
+    assert!(found.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disabled_user_reports_disabled() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let found = user::get(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        "disableduser",
+    )
+    .await?
+    .expect("disableduser must exist in the seeded fixture");
+    assert!(!found.enabled);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_users_by_name() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let params = UserListParametersBuilder::default()
+        .name(Some("Doe".to_string()))
+        .build()
+        .expect("valid params");
+    let users = user::list(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        &params,
+    )
+    .await?;
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].id, "jdoe");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_users_all_finds_seeded_entries() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let params = UserListParametersBuilder::default()
+        .build()
+        .expect("valid params");
+    let users = user::list(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        &params,
+    )
+    .await?;
+    let ids: Vec<&str> = users.iter().map(|u| u.id.as_str()).collect();
+    assert!(ids.contains(&"jdoe"));
+    assert!(ids.contains(&"bsmith"));
+    assert!(ids.contains(&"disableduser"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_user_by_name_ci() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let id = user::find_by_name_ci(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        DEFAULT_DOMAIN_ID,
+        "doe",
+    )
+    .await?;
+    assert_eq!(id, Some("jdoe".to_string()));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_group_and_members() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let found = group::get(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        "users",
+    )
+    .await?
+    .expect("`users` group must exist in the seeded fixture");
+    assert_eq!(found.id, "users");
+
+    let members =
+        group::list_users_of_group(&backend.service_pool, &backend.config, "users").await?;
+    let mut members = members;
+    members.sort();
+    assert_eq!(members, vec!["bsmith".to_string(), "jdoe".to_string()]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_groups_by_name() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let params = GroupListParametersBuilder::default()
+        .name("admins")
+        .build()
+        .expect("valid params");
+    let groups = group::list(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        &params,
+    )
+    .await?;
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].id, "admins");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_groups_of_user() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let jdoe_dn = user::resolve_dn(&backend.service_pool, &backend.config, Some("jdoe"), None)
+        .await?
+        .expect("jdoe must resolve to a DN");
+    let groups = group::list_groups_of_user_dn(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        &jdoe_dn,
+    )
+    .await?;
+    let mut ids: Vec<&str> = groups.iter().map(|g| g.id.as_str()).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec!["admins", "users"]);
+    Ok(())
+}
+
+/// `group_members_are_ids` support (`posixGroup`'s `memberUid`): member
+/// values are keystone user IDs already, with no DN round trip.
+#[tokio::test]
+async fn test_list_users_of_group_members_are_ids() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let mut cfg = test_config(&url);
+    cfg.group_objectclass = "posixGroup".into();
+    cfg.group_member_attribute = "memberUid".into();
+    cfg.group_members_are_ids = true;
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let mut members =
+        group::list_users_of_group(&backend.service_pool, &backend.config, "posixadmins").await?;
+    members.sort();
+    assert_eq!(members, vec!["bsmith".to_string(), "jdoe".to_string()]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_authenticate_by_password_success() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let auth = UserPasswordAuthRequestBuilder::default()
+        .id("jdoe")
+        .password(SecretString::from("jdoepass"))
+        .build()
+        .expect("valid auth request");
+    let result = authenticate::authenticate_by_password(
+        &backend.service_pool,
+        &backend.auth_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        &auth,
+    )
+    .await?;
+    match result.principal.identity {
+        openstack_keystone_core::auth::IdentityInfo::User(u) => {
+            assert_eq!(u.user_id, "jdoe");
+        }
+        other => panic!("expected IdentityInfo::User, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_authenticate_by_password_wrong_password_rejected() -> Result<(), IdentityProviderError>
+{
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let auth = UserPasswordAuthRequestBuilder::default()
+        .id("jdoe")
+        .password(SecretString::from("not-the-password"))
+        .build()
+        .expect("valid auth request");
+    let result = authenticate::authenticate_by_password(
+        &backend.service_pool,
+        &backend.auth_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        &auth,
+    )
+    .await;
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_authenticate_by_password_disabled_user_rejected() -> Result<(), IdentityProviderError>
+{
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let auth = UserPasswordAuthRequestBuilder::default()
+        .id("disableduser")
+        .password(SecretString::from("disabledpass"))
+        .build()
+        .expect("valid auth request");
+    let result = authenticate::authenticate_by_password(
+        &backend.service_pool,
+        &backend.auth_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        &auth,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "a disabled user must be rejected even with the correct password"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_check_user_exist_rejects_disabled_user() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let cfg = test_config(&url);
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let result = user::check_user_exist(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        Some("disableduser"),
+        None,
+        None,
+    )
+    .await;
+    assert!(result.is_err());
+    Ok(())
+}
+
+/// `[ldap] query_scope = "one"` must still find entries directly under the
+/// tree DN (a one-level-deep, flat OU, as in the fixture).
+#[tokio::test]
+async fn test_query_scope_one_still_finds_flat_entries() -> Result<(), IdentityProviderError> {
+    let url = skip_unless_configured!();
+    let mut cfg = test_config(&url);
+    cfg.query_scope = openstack_keystone_config::QueryScope::One;
+    let backend = LdapBackend::new(&cfg)
+        .await
+        .map_err(|e| IdentityProviderError::LdapConnection(e.to_string()))?;
+    let found = user::get(
+        &backend.service_pool,
+        &backend.config,
+        DEFAULT_DOMAIN_ID,
+        "jdoe",
+    )
+    .await?;
+    assert!(found.is_some());
+    Ok(())
+}

--- a/crates/identity-driver-ldap/src/models.rs
+++ b/crates/identity-driver-ldap/src/models.rs
@@ -1,0 +1,274 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # LDAP entry to core-types conversion (ADR-0027 §6)
+use std::collections::HashMap;
+
+use ldap3::SearchEntry;
+use serde_json::Value;
+
+use openstack_keystone_config::LdapProvider;
+use openstack_keystone_core_types::identity::{
+    Group, IdentityProviderError, UserOptions, UserResponse,
+};
+
+use crate::enabled::enabled_from_attribute;
+
+/// Attributes that must never be surfaced under `extra`, even if an
+/// operator misconfigures the additional-attribute mapping to include them
+/// (ADR-0027 §6 point 5).
+const NEVER_EXPOSED_ATTRIBUTES: &[&str] = &["dn", "userpassword", "unicodepwd", "password"];
+
+/// Case-insensitive view over an entry's attributes (Python's
+/// `_ldap_res_to_model` lowercases attribute names before matching
+/// `attribute_mapping`).
+fn lowercase_attrs(attrs: &HashMap<String, Vec<String>>) -> HashMap<String, &Vec<String>> {
+    attrs
+        .iter()
+        .map(|(k, v)| (k.to_ascii_lowercase(), v))
+        .collect()
+}
+
+fn single_value(lower_attrs: &HashMap<String, &Vec<String>>, attribute: &str) -> Option<String> {
+    lower_attrs
+        .get(&attribute.to_ascii_lowercase())
+        .and_then(|values| values.first())
+        .cloned()
+}
+
+fn build_extra(
+    lower_attrs: &HashMap<String, &Vec<String>>,
+    mapping: &HashMap<String, String>,
+    extra_disallowed: &str,
+) -> HashMap<String, Value> {
+    let extra_disallowed = extra_disallowed.to_ascii_lowercase();
+    let mut extra = HashMap::new();
+    for (ldap_attr, extra_key) in mapping {
+        let ldap_attr_lower = ldap_attr.to_ascii_lowercase();
+        if NEVER_EXPOSED_ATTRIBUTES.contains(&ldap_attr_lower.as_str())
+            || NEVER_EXPOSED_ATTRIBUTES.contains(&extra_key.to_ascii_lowercase().as_str())
+            || ldap_attr_lower == extra_disallowed
+        {
+            continue;
+        }
+        if let Some(values) = lower_attrs.get(&ldap_attr.to_ascii_lowercase()) {
+            let value = if values.len() > 1 {
+                Value::Array(values.iter().map(|v| Value::String(v.clone())).collect())
+            } else {
+                match values.first() {
+                    Some(v) => Value::String(v.clone()),
+                    None => continue,
+                }
+            };
+            extra.insert(extra_key.clone(), value);
+        }
+    }
+    extra
+}
+
+/// Convert an LDAP user entry into a [`UserResponse`].
+///
+/// `domain_id` is always the configured `default_domain_id`: LDAP is not
+/// domain-aware (ADR-0027 §11). `id` falls back to the entry's DN when
+/// `user_id_attribute` is absent or multi-valued.
+pub fn to_user_response(
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    entry: &SearchEntry,
+) -> Result<UserResponse, IdentityProviderError> {
+    let lower_attrs = lowercase_attrs(&entry.attrs);
+
+    let id = match lower_attrs.get(&cfg.user_id_attribute.to_ascii_lowercase()) {
+        Some(values) if values.len() == 1 => values[0].clone(),
+        _ => {
+            tracing::warn!(
+                dn = %entry.dn,
+                attribute = %cfg.user_id_attribute,
+                "user_id_attribute missing or multi-valued; falling back to DN as user id"
+            );
+            entry.dn.clone()
+        }
+    };
+    let name = single_value(&lower_attrs, &cfg.user_name_attribute).unwrap_or_else(|| id.clone());
+    let enabled_raw = single_value(&lower_attrs, &cfg.user_enabled_attribute);
+    let enabled = enabled_from_attribute(cfg, enabled_raw.as_deref());
+    let extra = build_extra(
+        &lower_attrs,
+        &cfg.user_additional_attribute_mapping,
+        &cfg.user_pass_attribute,
+    );
+
+    Ok(UserResponse {
+        default_project_id: None,
+        domain_id: default_domain_id.to_string(),
+        enabled,
+        extra,
+        federated: None,
+        id,
+        name,
+        options: UserOptions::default(),
+        password_expires_at: None,
+    })
+}
+
+/// Convert an LDAP group entry into a [`Group`].
+///
+/// `domain_id` is always the configured `default_domain_id`. `id` falls back
+/// to the entry's DN when `group_id_attribute` is absent or multi-valued.
+pub fn to_group(
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    entry: &SearchEntry,
+) -> Result<Group, IdentityProviderError> {
+    let lower_attrs = lowercase_attrs(&entry.attrs);
+
+    let id = match lower_attrs.get(&cfg.group_id_attribute.to_ascii_lowercase()) {
+        Some(values) if values.len() == 1 => values[0].clone(),
+        _ => {
+            tracing::warn!(
+                dn = %entry.dn,
+                attribute = %cfg.group_id_attribute,
+                "group_id_attribute missing or multi-valued; falling back to DN as group id"
+            );
+            entry.dn.clone()
+        }
+    };
+    let name = single_value(&lower_attrs, &cfg.group_name_attribute).unwrap_or_else(|| id.clone());
+    let description = single_value(&lower_attrs, &cfg.group_desc_attribute);
+    let extra = build_extra(&lower_attrs, &cfg.group_additional_attribute_mapping, "");
+
+    Ok(Group {
+        description,
+        domain_id: default_domain_id.to_string(),
+        extra,
+        id,
+        name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn entry(dn: &str, attrs: &[(&str, &[&str])]) -> SearchEntry {
+        let mut map = HashMap::new();
+        for (k, values) in attrs {
+            map.insert(
+                k.to_string(),
+                values.iter().map(|v| v.to_string()).collect(),
+            );
+        }
+        SearchEntry {
+            dn: dn.to_string(),
+            attrs: map,
+            bin_attrs: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_to_user_response_basic_mapping() {
+        let cfg = LdapProvider::default();
+        let e = entry(
+            "cn=jdoe,ou=Users,dc=example,dc=com",
+            &[("cn", &["jdoe"]), ("sn", &["Doe"]), ("enabled", &["TRUE"])],
+        );
+        let user = to_user_response(&cfg, "default", &e).unwrap();
+        assert_eq!(user.id, "jdoe");
+        assert_eq!(user.name, "Doe");
+        assert_eq!(user.domain_id, "default");
+        assert!(user.enabled);
+    }
+
+    #[test]
+    fn test_to_user_response_case_insensitive_attribute_matching() {
+        let cfg = LdapProvider::default();
+        let e = entry(
+            "cn=jdoe,ou=Users,dc=example,dc=com",
+            &[("CN", &["jdoe"]), ("SN", &["Doe"])],
+        );
+        let user = to_user_response(&cfg, "default", &e).unwrap();
+        assert_eq!(user.id, "jdoe");
+        assert_eq!(user.name, "Doe");
+    }
+
+    #[test]
+    fn test_to_user_response_falls_back_to_dn_when_id_attribute_missing() {
+        let cfg = LdapProvider::default();
+        let e = entry("cn=jdoe,ou=Users,dc=example,dc=com", &[("sn", &["Doe"])]);
+        let user = to_user_response(&cfg, "default", &e).unwrap();
+        assert_eq!(user.id, "cn=jdoe,ou=Users,dc=example,dc=com");
+    }
+
+    #[test]
+    fn test_to_user_response_falls_back_to_dn_when_id_attribute_multivalued() {
+        let cfg = LdapProvider::default();
+        let e = entry(
+            "cn=jdoe,ou=Users,dc=example,dc=com",
+            &[("cn", &["jdoe", "john"])],
+        );
+        let user = to_user_response(&cfg, "default", &e).unwrap();
+        assert_eq!(user.id, "cn=jdoe,ou=Users,dc=example,dc=com");
+    }
+
+    #[test]
+    fn test_to_user_response_additional_attribute_mapping() {
+        let mut cfg = LdapProvider::default();
+        cfg.user_additional_attribute_mapping
+            .insert("mail".into(), "email".into());
+        let e = entry(
+            "cn=jdoe,ou=Users,dc=example,dc=com",
+            &[("cn", &["jdoe"]), ("mail", &["jdoe@example.com"])],
+        );
+        let user = to_user_response(&cfg, "default", &e).unwrap();
+        assert_eq!(
+            user.extra.get("email"),
+            Some(&Value::String("jdoe@example.com".into()))
+        );
+    }
+
+    #[test]
+    fn test_to_user_response_never_exposes_dn_or_password_even_if_mapped() {
+        let mut cfg = LdapProvider::default();
+        cfg.user_additional_attribute_mapping
+            .insert("userpassword".into(), "password".into());
+        cfg.user_additional_attribute_mapping
+            .insert("dn".into(), "distinguished_name".into());
+        let e = entry(
+            "cn=jdoe,ou=Users,dc=example,dc=com",
+            &[("cn", &["jdoe"]), ("userpassword", &["{SSHA}notarealhash"])],
+        );
+        let user = to_user_response(&cfg, "default", &e).unwrap();
+        assert!(!user.extra.contains_key("password"));
+        assert!(!user.extra.contains_key("distinguished_name"));
+    }
+
+    #[test]
+    fn test_to_group_basic_mapping() {
+        let cfg = LdapProvider::default();
+        let e = entry(
+            "cn=admins,ou=Groups,dc=example,dc=com",
+            &[
+                ("cn", &["admins"]),
+                ("ou", &["Admins"]),
+                ("description", &["Admin group"]),
+            ],
+        );
+        let group = to_group(&cfg, "default", &e).unwrap();
+        assert_eq!(group.id, "admins");
+        assert_eq!(group.name, "Admins");
+        assert_eq!(group.domain_id, "default");
+        assert_eq!(group.description, Some("Admin group".to_string()));
+    }
+}

--- a/crates/identity-driver-ldap/src/user.rs
+++ b/crates/identity-driver-ldap/src/user.rs
@@ -1,0 +1,229 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # LDAP user read operations (ADR-0027 §3)
+use ldap3::Scope;
+
+use openstack_keystone_config::LdapProvider;
+use openstack_keystone_core::auth::AuthenticationError;
+use openstack_keystone_core_types::identity::{
+    IdentityProviderError, UserListParameters, UserResponse,
+};
+
+use crate::connection::ServicePool;
+use crate::enabled::enabled_via_group_membership;
+use crate::filter::{ListDecision, escape_filter_value, user_list_filter};
+use crate::id_dn::{self, ldap_scope};
+use crate::models;
+
+const ALL_ATTRS: [&str; 1] = ["*"];
+
+/// Look up a single user entry by `id_attribute` under `user_tree_dn`,
+/// scoped by `[ldap] query_scope`, mirroring Python's `_ldap_get` (the read
+/// path never constructs a DN directly — that's write-only in Python and
+/// this backend is permanently read-only).
+async fn get_entry_by_id(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    user_id: &str,
+) -> Result<Option<ldap3::SearchEntry>, IdentityProviderError> {
+    let mut filter = format!(
+        "(&({}={})(objectClass={}))",
+        cfg.user_id_attribute,
+        escape_filter_value(user_id),
+        cfg.user_objectclass
+    );
+    if let Some(extra) = &cfg.user_filter {
+        filter = format!("(&{filter}{extra})");
+    }
+    let entries = pool
+        .search(
+            &cfg.user_tree_dn,
+            ldap_scope(cfg.query_scope),
+            &filter,
+            &ALL_ATTRS,
+        )
+        .await?;
+    Ok(entries.into_iter().next())
+}
+
+/// Apply the group-membership enabled-emulation strategy on top of the
+/// attribute-derived `enabled` value, when configured (ADR-0027 §7).
+async fn apply_enabled_emulation(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    base_enabled: bool,
+    user_dn: &str,
+) -> Result<bool, IdentityProviderError> {
+    if !cfg.user_enabled_emulation {
+        return Ok(base_enabled);
+    }
+    let Some(group_dn) = &cfg.user_enabled_emulation_dn else {
+        return Ok(base_enabled);
+    };
+    enabled_via_group_membership(pool, group_dn, &cfg.group_member_attribute, user_dn).await
+}
+
+/// Resolve `user_id`/`name` to the entry's DN, without fetching attributes.
+/// Used ahead of the second bind step in `authenticate_by_password`.
+pub async fn resolve_dn(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    id: Option<&str>,
+    name: Option<&str>,
+) -> Result<Option<String>, IdentityProviderError> {
+    if let Some(id) = id {
+        return Ok(get_entry_by_id(pool, cfg, id).await?.map(|e| e.dn));
+    }
+    if let Some(name) = name {
+        return find_dn_by_attribute(pool, cfg, &cfg.user_name_attribute, name).await;
+    }
+    Ok(None)
+}
+
+async fn find_dn_by_attribute(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    attribute: &str,
+    value: &str,
+) -> Result<Option<String>, IdentityProviderError> {
+    let filter = format!(
+        "(&(objectClass={})({attribute}={}))",
+        cfg.user_objectclass,
+        escape_filter_value(value)
+    );
+    let entries = pool
+        .search(
+            &cfg.user_tree_dn,
+            ldap_scope(cfg.query_scope),
+            &filter,
+            &[attribute],
+        )
+        .await?;
+    Ok(entries.into_iter().next().map(|e| e.dn))
+}
+
+/// Get a single user by ID.
+pub async fn get(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    user_id: &str,
+) -> Result<Option<UserResponse>, IdentityProviderError> {
+    let Some(entry) = get_entry_by_id(pool, cfg, user_id).await? else {
+        return Ok(None);
+    };
+    let mut user = models::to_user_response(cfg, default_domain_id, &entry)?;
+    user.enabled = apply_enabled_emulation(pool, cfg, user.enabled, &entry.dn).await?;
+    Ok(Some(user))
+}
+
+/// Get a single user by DN. Used by the second step of
+/// `authenticate_by_password`, after the bind succeeds against the same DN.
+pub async fn get_by_dn(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    dn: &str,
+) -> Result<Option<UserResponse>, IdentityProviderError> {
+    let filter = format!("(objectClass={})", cfg.user_objectclass);
+    let entries = pool.search(dn, Scope::Base, &filter, &ALL_ATTRS).await?;
+    let Some(entry) = entries.first() else {
+        return Ok(None);
+    };
+    let mut user = models::to_user_response(cfg, default_domain_id, entry)?;
+    user.enabled = apply_enabled_emulation(pool, cfg, user.enabled, &entry.dn).await?;
+    Ok(Some(user))
+}
+
+/// List users matching the given parameters.
+pub async fn list(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    params: &UserListParameters,
+) -> Result<Vec<UserResponse>, IdentityProviderError> {
+    let filter = match user_list_filter(cfg, default_domain_id, params) {
+        ListDecision::Query(f) => f,
+        ListDecision::EmptyResult => return Ok(vec![]),
+    };
+    let entries = pool
+        .paged_search(
+            &cfg.user_tree_dn,
+            ldap_scope(cfg.query_scope),
+            &filter,
+            &ALL_ATTRS,
+        )
+        .await?;
+    let mut users = Vec::with_capacity(entries.len());
+    for entry in &entries {
+        let mut user = models::to_user_response(cfg, default_domain_id, entry)?;
+        user.enabled = apply_enabled_emulation(pool, cfg, user.enabled, &entry.dn).await?;
+        users.push(user);
+    }
+    Ok(users)
+}
+
+/// Find the ID of any user in `domain_id` whose name matches `name`
+/// case-insensitively. A non-default domain never matches (ADR-0027 §11).
+pub async fn find_by_name_ci(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    domain_id: &str,
+    name: &str,
+) -> Result<Option<String>, IdentityProviderError> {
+    if domain_id != default_domain_id {
+        return Ok(None);
+    }
+    let dn = find_dn_by_attribute(pool, cfg, &cfg.user_name_attribute, name).await?;
+    match dn {
+        Some(dn) => Ok(Some(
+            id_dn::dn_to_id(pool, &cfg.user_id_attribute, &dn).await?,
+        )),
+        None => Ok(None),
+    }
+}
+
+/// Cheaply resolve a user reference to the canonical user ID, verifying the
+/// account exists and is enabled (ADR-0022 Invariant 8 rate-limiting probe).
+pub async fn check_user_exist(
+    pool: &ServicePool,
+    cfg: &LdapProvider,
+    default_domain_id: &str,
+    user_id: Option<&str>,
+    name: Option<&str>,
+    domain_id: Option<&str>,
+) -> Result<String, IdentityProviderError> {
+    let dn = if let Some(user_id) = user_id {
+        resolve_dn(pool, cfg, Some(user_id), None).await?
+    } else {
+        let name = name.ok_or(IdentityProviderError::UserIdOrNameWithDomain)?;
+        let domain_id = domain_id.ok_or(IdentityProviderError::UserIdOrNameWithDomain)?;
+        if domain_id != default_domain_id {
+            None
+        } else {
+            find_dn_by_attribute(pool, cfg, &cfg.user_name_attribute, name).await?
+        }
+    };
+    let dn = dn.ok_or_else(|| {
+        IdentityProviderError::UserNotFound(user_id.or(name).unwrap_or_default().to_string())
+    })?;
+    let user = get_by_dn(pool, cfg, default_domain_id, &dn)
+        .await?
+        .ok_or_else(|| IdentityProviderError::UserNotFound(dn.clone()))?;
+    if !user.enabled {
+        return Err(AuthenticationError::UserDisabled(user.id).into());
+    }
+    Ok(user.id)
+}

--- a/crates/identity-driver-ldap/tests/fixtures/base.ldif
+++ b/crates/identity-driver-ldap/tests/fixtures/base.ldif
@@ -1,0 +1,59 @@
+dn: dc=example,dc=com
+objectClass: dcObject
+objectClass: organization
+dc: example
+o: Example Org
+
+dn: ou=Users,dc=example,dc=com
+objectClass: organizationalUnit
+ou: Users
+
+dn: ou=Groups,dc=example,dc=com
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=jdoe,ou=Users,dc=example,dc=com
+objectClass: inetOrgPerson
+cn: jdoe
+sn: Doe
+givenName: Jane
+mail: jdoe@example.com
+userPassword: jdoepass
+description: Jane Doe functional test account
+
+dn: cn=bsmith,ou=Users,dc=example,dc=com
+objectClass: inetOrgPerson
+cn: bsmith
+sn: Smith
+mail: bsmith@example.com
+userPassword: bsmithpass
+
+dn: cn=disableduser,ou=Users,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: extensibleObject
+cn: disableduser
+sn: Disabled
+userPassword: disabledpass
+enabled: FALSE
+
+dn: cn=admins,ou=Groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: extensibleObject
+cn: admins
+ou: admins
+member: cn=jdoe,ou=Users,dc=example,dc=com
+
+dn: cn=users,ou=Groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: extensibleObject
+cn: users
+ou: users
+member: cn=jdoe,ou=Users,dc=example,dc=com
+member: cn=bsmith,ou=Users,dc=example,dc=com
+
+dn: cn=posixadmins,ou=Groups,dc=example,dc=com
+objectClass: posixGroup
+cn: posixadmins
+gidNumber: 5000
+memberUid: jdoe
+memberUid: bsmith

--- a/crates/identity-driver-ldap/tests/fixtures/keystone-test.schema
+++ b/crates/identity-driver-ldap/tests/fixtures/keystone-test.schema
@@ -1,0 +1,5 @@
+attributetype ( 1.3.6.1.4.1.99999.1.1 NAME 'enabled'
+	DESC 'Keystone functional test: account enabled flag (userAccountControl-style deployments use their own schema; this is a stand-in for the plain-boolean case)'
+	EQUALITY caseIgnoreMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	SINGLE-VALUE )

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -58,6 +58,7 @@ openstack-keystone-oauth2-client-driver-raft.workspace = true
 openstack-keystone-oauth2-key-driver-raft.workspace = true
 openstack-keystone-oauth2-session-driver-raft.workspace = true
 openstack-keystone-key-repository.workspace = true
+openstack-keystone-identity-driver-ldap.workspace = true
 openstack-keystone-identity-driver-sql.workspace = true
 openstack-keystone-idmapping-driver-sql.workspace = true
 openstack-keystone-resource-driver-sql.workspace = true

--- a/crates/keystone/src/plugin_manager.rs
+++ b/crates/keystone/src/plugin_manager.rs
@@ -941,6 +941,18 @@ impl PluginManager {
             jws_token_provider.load_keys().await?;
             slf.register_token_backend("jws", Arc::new(jws_token_provider));
         }
+        // Only construct the LDAP identity backend when actually selected:
+        // unlike the SQL backend (always eagerly registered above), this
+        // opens a real connection to an external directory server, which
+        // must not be attempted for a `driver = sql` deployment that never
+        // configured `[ldap]`. When `driver = "ldap"` *is* selected, fail
+        // loudly here (ADR-0027) rather than registering a backend that can
+        // never serve a request.
+        if config.identity.driver == "ldap" {
+            let ldap_backend =
+                openstack_keystone_identity_driver_ldap::LdapBackend::new(&config.ldap).await?;
+            slf.register_identity_backend("ldap", Arc::new(ldap_backend));
+        }
         slf.register_k8s_auth_backend(
             "raft",
             Arc::new(openstack_keystone_k8s_auth_driver_raft::RaftBackend::default()),

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -64,6 +64,7 @@
   - [RFC 7644 Compatibility](scim/compatibility.md)
 - [Kubernetes TokenReview Auth](k8s_auth.md)
 - [Mapping Engine](mapping.md)
+- [LDAP Identity Backend](ldap.md)
 
 ---
 

--- a/doc/src/adr/0027-ldap-identity-driver.md
+++ b/doc/src/adr/0027-ldap-identity-driver.md
@@ -4,7 +4,79 @@
 
 ## Status
 
-Proposed
+Accepted. Implemented in `crates/identity-driver-ldap`, selectable via
+`[identity] driver = "ldap"` plus a `[ldap]` config section
+(`crates/config/src/ldap.rs`). A few implementation notes refine this ADR's
+original text:
+
+- Backend selection is not `inventory`-based; it is a hand-written
+  `HashMap<String, Arc<dyn IdentityBackend>>` registry in
+  `crates/keystone/src/plugin_manager.rs`, conditionally populated only when
+  `driver = "ldap"` is configured (mirroring the JWS token provider's
+  fail-fast-on-select precedent). The linker-anchor mechanism in §1 is
+  unrelated to this selection; it only keeps the crate linked.
+- There is no generic Hints/comparator abstraction in this codebase. §5's
+  filter translation is a direct function of `UserListParameters`/
+  `GroupListParameters`' concrete fields, not a general comparator engine.
+- `is_domain_aware()`/`generates_uuids()` capability-flag methods were not
+  added to `IdentityBackend`; the backend simply always reports
+  `config.identity.default_domain_id` and uses the directory's
+  `user_id_attribute` value as `id`.
+- Write operations return a dedicated `IdentityProviderError::Readonly`
+  (mapped to HTTP 403); operations with no LDAP equivalent (expiring group
+  membership, service accounts, federated users) return
+  `IdentityProviderError::NotImplemented` instead, since these are a
+  different condition than a read-only rejection.
+
+A subsequent review against upstream Python Keystone
+(`keystone/identity/backends/ldap/{core,common}.py`,
+`keystone/conf/ldap.py`) found and fixed several compatibility bugs:
+
+- `query_scope` defaulted to `sub`; Python defaults to `one`.
+- `user_enabled_mask` used `(value & mask) != 0`; Python's actual semantics
+  are `(value & mask) != mask` (enabled unless *all* masked bits are set —
+  the Active Directory `userAccountControl` `ACCOUNTDISABLE` convention),
+  and `user_enabled_mask` ignores `user_enabled_invert` entirely. The
+  previous formula was exactly inverted for the common `mask = 2` case.
+- `user_enabled_default` was typed as a Rust `bool`, which cannot represent
+  Python's dual usage as a boolean literal (`"True"`) in the plain case and
+  an integer literal (e.g. `"512"`) in the `user_enabled_mask` case; it is
+  now a `String`, parsed contextually, matching Python's `StrOpt`.
+- `get`/`get_by_name`/`get_all` (single lookups and listing) previously
+  resolved a DN via ID construction/search first, then did a second
+  BASE-scoped fetch. Python's read path never constructs a DN this way
+  (`_id_to_dn` is write-only, used only by `create`/`update`/`delete`, which
+  don't exist on this permanently-read-only backend) — every read is a
+  single filtered search under `tree_dn`, scoped by `query_scope`
+  (`one`/`sub`), reading the resulting entry's real DN off the result. The
+  driver was changed to do the same, which also means `query_scope = "one"`
+  now actually restricts listing/lookup to one level below the tree DN, as
+  in Python, rather than always searching the whole subtree.
+- `group_members_are_ids` (members of `group_member_attribute` are user IDs,
+  not DNs — e.g. `posixGroup`'s `memberUid`) was missing entirely; group
+  membership resolution always assumed DNs.
+- Several missing `[ldap]` options were added for config-file parity:
+  `user_description_attribute`, `user_pass_attribute`,
+  `user_default_project_id_attribute`, `group_members_are_ids`,
+  `group_attribute_ignore`, and an `alias_dereferencing = default` choice.
+- `[ldap] url` now supports Python's comma/whitespace-separated multi-URL
+  HA syntax, trying each candidate in turn (optionally shuffled via
+  `randomize_urls`) until one connects and binds.
+
+Two Python options are parsed for config-file compatibility but not
+functionally applied, since the `ldap3` crate (v0.11) has no equivalent
+hook: `alias_dereferencing` (no per-search deref control) and
+`tls_cacertfile`/`tls_cacertdir` (TLS verification uses the platform/
+`rustls` default trust store). Both are documented inline and log a
+startup warning when set. Custom CA loading is a reasonable follow-up if
+needed; operators can install the CA into the system trust store or use
+`tls_req_cert = never` for self-signed test directories in the meantime.
+
+Live-directory functional tests against a real OpenLDAP `slapd` instance
+now exist (`crates/identity-driver-ldap/tests/`), run as a `cargo nextest`
+setup-script pattern (installing/seeding a local `slapd`, no Docker daemon
+required) analogous to `tools/start-api.sh`. A side-by-side Python/Rust
+smoke comparison remains follow-up work, not implemented in this change.
 
 ## Context
 

--- a/doc/src/ldap.md
+++ b/doc/src/ldap.md
@@ -1,0 +1,208 @@
+# LDAP Identity Backend
+
+The LDAP identity backend (`crates/identity-driver-ldap`) is a read-only
+`IdentityBackend` implementation that reads users and groups directly from an
+LDAP directory (OpenLDAP, FreeIPA, Active Directory, etc.). Its `[ldap]`
+config section is field-for-field compatible with Python Keystone's
+`keystone.conf.ldap` options, so a config file already in use with Python
+Keystone works against `keystone-rs` largely unmodified — enabling a
+config-only `driver = sql` → `driver = ldap` switch during a rolling upgrade.
+See [ADR-0027](adr/0027-ldap-identity-driver.md) for the full design
+rationale and the Python-compatibility findings from its implementation
+review.
+
+## Enabling the backend
+
+```ini
+[identity]
+driver = ldap
+default_domain_id = default
+
+[ldap]
+url = ldaps://ldap.example.com
+user = cn=service,dc=example,dc=com
+password = servicepassword
+suffix = dc=example,dc=com
+user_tree_dn = ou=Users,dc=example,dc=com
+group_tree_dn = ou=Groups,dc=example,dc=com
+```
+
+`[identity] driver` is a single, deployment-wide setting — there is no
+per-domain driver selection yet, so a `keystone-rs` deployment runs either
+fully against LDAP or fully against SQL, not a mix. All LDAP users and groups
+are exposed under the single `default_domain_id` domain, since the LDAP
+directory itself has no concept of Keystone domains.
+
+`LdapBackend::new()` performs one real bind against `url`/`user`/`password`
+at startup and fails fast if it cannot reach the directory — a misconfigured
+`[ldap]` section prevents the server from starting rather than surfacing as
+runtime errors on the first request.
+
+## Read-only
+
+Every mutating `IdentityBackend` method (`create_user`, `update_user`,
+`delete_user`, `create_group`, `add_user_to_group`, `update_user_password`,
+etc.) returns `IdentityProviderError::Readonly`, mapped to an HTTP `403`.
+Manage users and groups directly in the directory (or via whatever tool your
+organization already uses for that) — Keystone only reads from it.
+
+A few capabilities that don't exist in an LDAP directory at all return
+`IdentityProviderError::NotImplemented` (mapped to `500`) rather than
+`Readonly`, since there's no LDAP concept to even be read-only about:
+`create_service_account`, `find_federated_user`, and the expiring-group-
+membership methods. `get_service_account` returns `Ok(None)` unconditionally.
+
+## Configuration reference
+
+### Connection
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `url` | `ldap://localhost` | One or more server URLs, comma/whitespace-separated (matches Python's `re.split(r'[\s,]+', ...)`). Each candidate is tried in turn on connect/bind failure. |
+| `user` | unset | Service bind DN, used for all read queries. |
+| `password` | unset | Service bind password. |
+| `use_tls` | `false` | Use StartTLS on the plain `ldap://` connection. Use `ldaps://` in `url` for implicit TLS instead. |
+| `tls_cacertfile` / `tls_cacertdir` | unset | Parsed for config compatibility but **not applied** — see [Known limitations](#known-limitations). |
+| `tls_req_cert` | `demand` | `demand` \| `allow` \| `try` \| `never`. |
+| `connection_timeout` | `-1` (no timeout) | Seconds. |
+| `randomize_urls` | `false` | Shuffle the candidate list from `url` before trying servers (matches Python's `random.shuffle`). |
+| `pool` / `pool_size` / `pool_retry_max` / `pool_retry_delay` / `pool_connection_timeout` / `pool_connection_lifetime` | `true` / `10` / `3` / `0.1` / `-1` / `600` | Service (read) connection pool. |
+| `auth_pool` / `auth_pool_size` / `auth_pool_connection_lifetime` | `true` / `100` / `60` | Dedicated pool for end-user password-auth binds, isolated from the service pool so a burst of failed logins can't starve directory reads. |
+
+### Query
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `query_scope` | `one` | `one` (single-level under the tree DN) or `sub` (whole subtree). Governs the scope of **every** read search — `get`, `get_by_name`, and `list` — not just id/DN resolution. |
+| `page_size` | `0` (disabled) | Entries per page (RFC 2696) for `list_users`/`list_groups`. |
+| `alias_dereferencing` | `default` | Parsed but **not applied** — see [Known limitations](#known-limitations). |
+| `chase_referrals` | unset | |
+| `debug_level` | `0` | |
+
+### User mapping
+
+| Option | Default |
+| --- | --- |
+| `user_tree_dn` | `""` (must be set) |
+| `user_objectclass` | `inetOrgPerson` |
+| `user_id_attribute` | `cn` |
+| `user_name_attribute` | `sn` |
+| `user_mail_attribute` | `mail` |
+| `user_description_attribute` | `description` |
+| `user_pass_attribute` | `userPassword` |
+| `user_enabled_attribute` | `enabled` |
+| `user_enabled_mask` | unset |
+| `user_enabled_invert` | `false` |
+| `user_enabled_default` | `"True"` |
+| `user_additional_attribute_mapping` | `{}` |
+| `user_filter` | unset |
+| `user_attribute_ignore` | `{default_project_id}` |
+| `user_enabled_emulation` | `false` |
+| `user_enabled_emulation_dn` | unset |
+| `user_enabled_emulation_use_group_config` | `false` |
+
+`user_id_attribute` falls back to the entry's DN (with a logged warning) when
+the configured attribute is absent or multi-valued on a given entry, rather
+than failing the whole request.
+
+#### Enabled-attribute strategies
+
+`user_enabled_attribute` is interpreted by one of four strategies, evaluated
+in the same precedence order as Python Keystone:
+
+1. **Group-membership emulation** (`user_enabled_emulation = true`): a user is
+   enabled iff they're a member of `user_enabled_emulation_dn`.
+2. **Bitmask** (`user_enabled_mask` set): `enabled = (raw_value & mask) !=
+   mask` — the user is enabled unless *all* masked bits are set. This is the
+   Active Directory `userAccountControl` convention, where `mask = 2`
+   corresponds to the `ACCOUNTDISABLE` bit. `user_enabled_invert` is ignored
+   entirely once a mask is configured, matching Python.
+3. **Invert** (`user_enabled_invert = true`, no mask): the raw boolean value
+   is negated.
+4. **Plain boolean**: the raw attribute value is parsed directly.
+
+When `user_enabled_attribute` is absent from an entry, the backend falls back
+to parsing `user_enabled_default`, which is why that option is a string
+rather than a boolean — under the bitmask strategy it's expected to hold an
+integer literal (e.g. `"512"`) instead of `"True"`/`"False"`.
+
+### Group mapping
+
+| Option | Default |
+| --- | --- |
+| `group_tree_dn` | `""` (must be set) |
+| `group_objectclass` | `groupOfNames` |
+| `group_id_attribute` | `cn` |
+| `group_name_attribute` | `ou` |
+| `group_desc_attribute` | `description` |
+| `group_member_attribute` | `member` |
+| `group_members_are_ids` | `false` |
+| `group_attribute_ignore` | `{}` |
+| `group_additional_attribute_mapping` | `{}` |
+| `group_filter` | unset |
+| `group_ad_nesting` | `false` |
+
+`group_members_are_ids` supports directories where `group_member_attribute`
+holds Keystone user IDs directly instead of member DNs — most commonly
+`posixGroup`'s `memberUid`, which stores POSIX usernames rather than
+distinguished names. Leave it `false` for the default `groupOfNames` +
+`member` (DN-valued) convention.
+
+`group_ad_nesting` resolves nested Active Directory group membership using
+the `LDAP_MATCHING_RULE_IN_CHAIN` (`1.2.840.113556.1.4.1941`) matching rule
+in `list_groups_of_user`.
+
+### General
+
+| Option | Default |
+| --- | --- |
+| `suffix` | `cn=example,cn=com` |
+
+## Known limitations
+
+- **`tls_cacertfile` / `tls_cacertdir` are parsed but not applied.** The
+  `ldap3` crate has no ready-made hook for a custom CA trust root short of
+  manually constructing a `rustls::ClientConfig`; TLS verification always
+  uses the platform/`rustls` default trust store instead. A startup warning
+  is logged when either option is set. Work around this by installing the
+  directory's CA into the system trust store, or by setting `tls_req_cert =
+  never` for a test/lab directory.
+- **`alias_dereferencing` is parsed but not applied.** The `ldap3` crate
+  (v0.11) has no per-search or per-connection alias-dereferencing control;
+  every search uses the underlying client library's default behavior
+  regardless of this setting.
+- **No per-domain driver selection.** `[identity] driver` is global; running
+  some domains against LDAP and others against SQL simultaneously isn't
+  supported yet.
+
+## Testing
+
+Beyond crate-level unit tests (`cargo test -p
+openstack-keystone-identity-driver-ldap`), the crate ships a `live_tests`
+module that exercises the driver's read and authentication paths against a
+real OpenLDAP (`slapd`) instance — real network round trips, real schema
+validation, real bind/search behavior, not mocks.
+
+Run it via the dedicated nextest profile:
+
+```sh
+cargo nextest run -p openstack-keystone-identity-driver-ldap --profile ldap
+```
+
+This uses a nextest setup script (`tools/start-ldap-test.sh`) to start a
+throwaway local `slapd` on port 3890, seed it from
+`crates/identity-driver-ldap/tests/fixtures/base.ldif`, and export
+`KEYSTONE_LDAP_TEST_URL`/`_BASE_DN`/`_ADMIN_DN`/`_ADMIN_PW` for the test
+binary to pick up. `tools/teardown-ldap-test.sh` stops it afterwards (nextest
+does not run teardown scripts automatically, so run it by hand after a manual
+`cargo nextest run --profile ldap`).
+
+Under any other profile, `live_tests`' functions skip themselves gracefully
+(printing a skip message) rather than failing, since
+`KEYSTONE_LDAP_TEST_URL` is only set by the `ldap`/`ci-ldap` profiles — plain
+`cargo test` for the crate never requires a live directory.
+
+The fixture directory (`base.ldif`) seeds users and groups covering the
+enabled/disabled cases, `groupOfNames` membership, and a `posixGroup` for
+exercising `group_members_are_ids`; see the file itself for the full seed
+data.

--- a/tools/start-ldap-test.sh
+++ b/tools/start-ldap-test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Starts a throwaway local `slapd` (OpenLDAP) instance for the LDAP identity
+# driver's functional tests (crates/identity-driver-ldap), seeded from
+# tests/fixtures/base.ldif. Runs as a plain local process, not a container --
+# no Docker daemon is required or used, matching tools/start-api.sh's
+# pattern of spawning real daemons directly for nextest setup scripts.
+#
+# Requires the `slapd`/`ldap-utils` Debian/Ubuntu packages (or equivalent):
+#   apt-get install -y slapd ldap-utils
+
+STATE_DIR="/var/tmp/nextest/keystone-ldap"
+FIXTURES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/crates/identity-driver-ldap/tests/fixtures"
+LDAP_HOST="127.0.0.1"
+LDAP_PORT="3890"
+LDAP_URL="ldap://${LDAP_HOST}:${LDAP_PORT}"
+BASE_DN="dc=example,dc=com"
+ADMIN_DN="cn=admin,${BASE_DN}"
+ADMIN_PW="adminpw"
+
+tools/teardown-ldap-test.sh || true
+rm -rf "$STATE_DIR"
+mkdir -p "$STATE_DIR/data" "$STATE_DIR/run" "$STATE_DIR/fixtures"
+
+# slapd runs under an AppArmor profile (usr.sbin.slapd) on Debian/Ubuntu that
+# only grants read/write access to /etc/ldap, /var/lib/ldap and /var/tmp --
+# it cannot read files from an arbitrary repo checkout path. Copy the
+# fixtures it needs to open directly (schema, ldif) into STATE_DIR, which
+# lives under /var/tmp and is therefore covered by the profile.
+cp "${FIXTURES_DIR}/keystone-test.schema" "${FIXTURES_DIR}/base.ldif" "$STATE_DIR/fixtures/"
+
+cat > "$STATE_DIR/slapd.conf" <<EOF
+include /etc/ldap/schema/core.schema
+include /etc/ldap/schema/cosine.schema
+include /etc/ldap/schema/inetorgperson.schema
+include /etc/ldap/schema/nis.schema
+include ${STATE_DIR}/fixtures/keystone-test.schema
+
+modulepath /usr/lib/ldap
+moduleload back_mdb.so
+
+pidfile ${STATE_DIR}/run/slapd.pid
+argsfile ${STATE_DIR}/run/slapd.args
+
+database mdb
+maxsize 1073741824
+suffix "${BASE_DN}"
+rootdn "${ADMIN_DN}"
+rootpw "${ADMIN_PW}"
+directory ${STATE_DIR}/data
+EOF
+
+> "$STATE_DIR/slapd.log" 2>&1 /usr/sbin/slapd -f "$STATE_DIR/slapd.conf" -h "${LDAP_URL}/" -d config,acl,trace &
+SLAPD_BG_PID=$!
+disown
+
+# slapd forks into the background and (re)writes its own pidfile; wait for
+# that rather than trusting $! or a fixed sleep.
+for _ in $(seq 1 50); do
+  [ -s "$STATE_DIR/run/slapd.pid" ] && break
+  sleep 0.1
+done
+if [ ! -s "$STATE_DIR/run/slapd.pid" ]; then
+  echo "slapd did not start (no pidfile written)" >&2
+  echo "--- $STATE_DIR/slapd.log ---" >&2
+  cat "$STATE_DIR/slapd.log" >&2 || true
+  echo "--- dmesg | grep -i apparmor (last 20) ---" >&2
+  (sudo -n dmesg 2>/dev/null || dmesg 2>/dev/null) | grep -i apparmor | tail -20 >&2 || true
+  echo "--- aa-status (slapd) ---" >&2
+  (command -v aa-status >/dev/null 2>&1 && (sudo -n aa-status 2>&1 || aa-status 2>&1) | grep -A1 slapd) >&2 || true
+  kill "$SLAPD_BG_PID" 2>/dev/null || true
+  exit 1
+fi
+
+for _ in $(seq 1 50); do
+  if ldapsearch -x -H "$LDAP_URL" -b "" -s base "(objectclass=*)" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
+ldapadd -x -H "$LDAP_URL" -D "$ADMIN_DN" -w "$ADMIN_PW" -f "${STATE_DIR}/fixtures/base.ldif"
+
+if [ -n "${NEXTEST_ENV:-}" ]; then
+  {
+    echo "KEYSTONE_LDAP_TEST_URL=${LDAP_URL}"
+    echo "KEYSTONE_LDAP_TEST_BASE_DN=${BASE_DN}"
+    echo "KEYSTONE_LDAP_TEST_ADMIN_DN=${ADMIN_DN}"
+    echo "KEYSTONE_LDAP_TEST_ADMIN_PW=${ADMIN_PW}"
+  } >> "$NEXTEST_ENV"
+fi
+
+echo "Test slapd instance ready at ${LDAP_URL} (base ${BASE_DN})"

--- a/tools/teardown-ldap-test.sh
+++ b/tools/teardown-ldap-test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+STATE_DIR="/var/tmp/nextest/keystone-ldap"
+PID_FILE="${STATE_DIR}/run/slapd.pid"
+
+if [ -f "$PID_FILE" ]; then
+  echo "Killing test slapd process $(cat "$PID_FILE")"
+  kill "$(cat "$PID_FILE")" 2>/dev/null || true
+fi


### PR DESCRIPTION
Also adds functional tests against a real OpenLDAP (slapd) instance,
run via a new `ldap` nextest profile that starts and seeds a throwaway
local slapd (no Docker daemon required, following the existing
start-api.sh pattern) and exercises get/list/find/authenticate/group
membership end to end.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
