### PR TITLE
fix: Use system field in OPA policies

### DIFF
--- a/policy/assignment/list.rego
+++ b/policy/assignment/list.rego
@@ -31,8 +31,8 @@ allow if {
 # description: "'reader' in the system scope can list any role assignments."
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }
 
 # METADATA

--- a/policy/assignment/list_test.rego
+++ b/policy/assignment/list_test.rego
@@ -4,7 +4,7 @@ import data.identity.assignment.list
 
 test_allowed if {
 	list.allow with input as {"credentials": {"roles": ["admin"]}}
-	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 	list.allow with input as {
 		"credentials": {"roles": ["admin"], "domain_id": "domain_a"},
 		"target": {"assignment": {"domain_id": "domain_b"}},

--- a/policy/auth/project/list.rego
+++ b/policy/auth/project/list.rego
@@ -19,6 +19,6 @@ allow if {
 
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }

--- a/policy/auth/project/list_test.rego
+++ b/policy/auth/project/list_test.rego
@@ -4,7 +4,7 @@ import data.identity.auth.project.list
 
 test_allowed if {
 	list.allow with input as {"credentials": {"roles": ["admin"]}}
-	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 	list.allow with input as {"credentials": {"roles": []}}
 	list.allow with input as {"credentials": {"roles": ["reader"]}}
 }

--- a/policy/auth/token/show.rego
+++ b/policy/auth/token/show.rego
@@ -37,8 +37,8 @@ allow if {
 # description: "'reader' in the system scope can inspect tokens"
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }
 
 # METADATA

--- a/policy/auth/token/show_test.rego
+++ b/policy/auth/token/show_test.rego
@@ -5,13 +5,13 @@ import data.identity.auth.token.show
 test_allowed if {
 	show.allow with input as {"credentials": {"roles": ["admin"]}}
 	show.allow with input as {"credentials": {"roles": ["service"]}}
-	show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	show.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 	show.allow with input as {"credentials": {"user_id": "foo"}, "existing": {"token": {"user": {"id": "foo"}}}}
 	show.allow with input as {"credentials": {"roles": ["admin"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
 }
 
 test_forbidden if {
-	not show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "not_all"}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "system": "not_all"}}
 	not show.allow with input as {"credentials": {"roles": ["manager"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
 	not show.allow with input as {"credentials": {"roles": ["member"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
 	not show.allow with input as {"credentials": {"roles": ["reader"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}

--- a/policy/endpoint/list.rego
+++ b/policy/endpoint/list.rego
@@ -30,6 +30,6 @@ allow if {
 # description: "'reader' in the system scope can list any endpoints."
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }

--- a/policy/endpoint/list_test.rego
+++ b/policy/endpoint/list_test.rego
@@ -5,12 +5,12 @@ import data.identity.endpoint.list
 test_allowed if {
 	list.allow with input as {"credentials": {"roles": ["admin"]}}
 	list.allow with input as {"credentials": {"is_admin": true}}
-	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 }
 
 test_forbidden if {
 	not list.allow with input as {"credentials": {"roles": []}}
 	not list.allow with input as {"credentials": {"roles": ["reader"]}}
-	not list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not list.allow with input as {"credentials": {"roles": ["reader"], "system": "domain"}}
 	not list.allow with input as {"credentials": {"roles": ["manager"]}}
 }

--- a/policy/endpoint/show.rego
+++ b/policy/endpoint/show.rego
@@ -33,6 +33,6 @@ allow if {
 # description: "'reader' in the system scope can show any endpoint."
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }

--- a/policy/endpoint/show_test.rego
+++ b/policy/endpoint/show_test.rego
@@ -5,12 +5,12 @@ import data.identity.endpoint.show
 test_allowed if {
 	show.allow with input as {"credentials": {"roles": ["admin"]}}
 	show.allow with input as {"credentials": {"is_admin": true}}
-	show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	show.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 }
 
 test_forbidden if {
 	not show.allow with input as {"credentials": {"roles": []}}
 	not show.allow with input as {"credentials": {"roles": ["reader"]}}
-	not show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "system": "domain"}}
 	not show.allow with input as {"credentials": {"roles": ["manager"]}}
 }

--- a/policy/identity/group/list.rego
+++ b/policy/identity/group/list.rego
@@ -24,6 +24,7 @@ allow if {
 
 allow if {
 	"reader" in input.credentials.roles
+	input.credentials.system != null
 	input.credentials.system == "all"
 }
 

--- a/policy/region/list.rego
+++ b/policy/region/list.rego
@@ -28,6 +28,6 @@ allow if {
 # description: "'reader' in the system scope can list any regions."
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }

--- a/policy/region/list_test.rego
+++ b/policy/region/list_test.rego
@@ -5,12 +5,12 @@ import data.identity.region.list
 test_allowed if {
 	list.allow with input as {"credentials": {"roles": ["admin"]}}
 	list.allow with input as {"credentials": {"is_admin": true}}
-	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 }
 
 test_forbidden if {
 	not list.allow with input as {"credentials": {"roles": []}}
 	not list.allow with input as {"credentials": {"roles": ["reader"]}}
-	not list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not list.allow with input as {"credentials": {"roles": ["reader"], "system": "domain"}}
 	not list.allow with input as {"credentials": {"roles": ["manager"]}}
 }

--- a/policy/region/show.rego
+++ b/policy/region/show.rego
@@ -30,6 +30,6 @@ allow if {
 # description: "'reader' in the system scope can show any region."
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }

--- a/policy/region/show_test.rego
+++ b/policy/region/show_test.rego
@@ -5,12 +5,12 @@ import data.identity.region.show
 test_allowed if {
 	show.allow with input as {"credentials": {"roles": ["admin"]}}
 	show.allow with input as {"credentials": {"is_admin": true}}
-	show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	show.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 }
 
 test_forbidden if {
 	not show.allow with input as {"credentials": {"roles": []}}
 	not show.allow with input as {"credentials": {"roles": ["reader"]}}
-	not show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "system": "domain"}}
 	not show.allow with input as {"credentials": {"roles": ["manager"]}}
 }

--- a/policy/service/list.rego
+++ b/policy/service/list.rego
@@ -29,6 +29,6 @@ allow if {
 # description: "'reader' in the system scope can list any services."
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }

--- a/policy/service/list_test.rego
+++ b/policy/service/list_test.rego
@@ -5,12 +5,12 @@ import data.identity.service.list
 test_allowed if {
 	list.allow with input as {"credentials": {"roles": ["admin"]}}
 	list.allow with input as {"credentials": {"is_admin": true}}
-	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 }
 
 test_forbidden if {
 	not list.allow with input as {"credentials": {"roles": []}}
 	not list.allow with input as {"credentials": {"roles": ["reader"]}}
-	not list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not list.allow with input as {"credentials": {"roles": ["reader"], "system": "domain"}}
 	not list.allow with input as {"credentials": {"roles": ["manager"]}}
 }

--- a/policy/service/show.rego
+++ b/policy/service/show.rego
@@ -31,6 +31,6 @@ allow if {
 # description: "'reader' in the system scope can show any service."
 allow if {
 	"reader" in input.credentials.roles
-	input.credentials.system_scope != null
-	"all" == input.credentials.system_scope
+	input.credentials.system != null
+	"all" == input.credentials.system
 }

--- a/policy/service/show_test.rego
+++ b/policy/service/show_test.rego
@@ -5,12 +5,12 @@ import data.identity.service.show
 test_allowed if {
 	show.allow with input as {"credentials": {"roles": ["admin"]}}
 	show.allow with input as {"credentials": {"is_admin": true}}
-	show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+	show.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
 }
 
 test_forbidden if {
 	not show.allow with input as {"credentials": {"roles": []}}
 	not show.allow with input as {"credentials": {"roles": ["reader"]}}
-	not show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "system": "domain"}}
 	not show.allow with input as {"credentials": {"roles": ["manager"]}}
 }


### PR DESCRIPTION
Update system-scoped reader policies to useinput.credentials.system, matching the field serialized by the RustCredentials type.

Update the corresponding Rego test inputs to use the same system field.

This restores policy rules that were previously checking the nonexistentcredentials.system_scope field.

Closes #1045.

Testing

Ran OPA formatting validation with OPA 1.16.2 in Docker

Ran OPA policy tests with OPA 1.16.2 in Docker

Ran git diff --check

Note: was made with assistance of CodeX.