### PR TITLE
fix(security): Address security review findings

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,13 @@
+# Gate G (security review, issue #983): mutation testing scoped to the
+# core auth/policy invariant modules, to prove the negative tests in
+# these files actually fail when the invariant they check is broken --
+# a negative test that still passes after the check is deleted is worse
+# than no test at all. Full-workspace mutation testing is far too slow
+# to run per-PR, so this stays scoped and runs on a schedule/manually
+# (see .github/workflows/mutants.yml), not as a required CI gate.
+examine_globs = [
+    "crates/core-types/src/auth.rs",
+    "crates/core/src/auth.rs",
+    "crates/core/src/policy.rs",
+]
+test_package = ["openstack-keystone-core", "openstack-keystone-core-types"]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -11,3 +11,15 @@ examine_globs = [
     "crates/core/src/policy.rs",
 ]
 test_package = ["openstack-keystone-core", "openstack-keystone-core-types"]
+
+# auth_plugin_auth::acceptance_tests spawns a nested `cargo build --release
+# --target wasm32-unknown-unknown` to produce its reference-plugin wasm
+# fixture. That nested cargo invocation isn't sandbox-safe under
+# cargo-mutants' isolated per-mutant tree copies (missing target/network
+# there) and fails independently of any mutation, so it's excluded from
+# this test run rather than treated as a caught/missed mutant signal.
+additional_cargo_test_args = [
+    "--",
+    "--skip",
+    "auth_plugin_auth::acceptance_tests",
+]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+<!--
+Thanks for the contribution! Fill in the sections below.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Test plan
+
+<!-- How was this verified? cargo test output, manual steps, screenshots, etc. -->
+
+## Security review checklist
+
+**Required if this diff touches authentication, scope, delegation, tokens,
+credentials, EC2, trusts, application credentials, or OPA policy input.**
+Delete this section entirely if it doesn't apply. See
+[`doc/src/security.md`](../doc/src/security.md) §7 for the full context
+behind each item.
+
+- [ ] Does any delegation/authorization decision read the **scope**
+      (`project_id`, `ScopeInfo`) where it should read the **chain**
+      (`authentication_context()`, delegation object)? (I1/I2)
+- [ ] New delegation-sensitive policy rule? Is the fact it needs projected
+      onto `Credentials` from the chain, and does the rule anchor on
+      `delegated_project_id` + carry the scope-drift tripwire? (I2/I3)
+- [ ] New scope shape or redemption path for a delegated auth? Are effective
+      roles still bounded by the delegation? Added a test that a restricted
+      delegation cannot exceed its roles via the new path? (I4)
+- [ ] New `ScopeInfo` variant or auth method? Updated
+      `validate_scope_boundaries()`, `calculate_effective_roles()`,
+      `fully_resolved()`, and `Credentials::try_from` — all without adding a
+      wildcard `_ =>` arm? (I5, Gate J)
+- [ ] New lookup by a client-derivable key (like `sha256(access)`)? Does it
+      re-assert `type`/shape after fetch? (I6)
+- [ ] Does any new data reaching OPA include secrets/decrypted blobs? (I7,
+      Gate I)
+- [ ] New list/collection endpoint? Does it re-check each item with the
+      per-item read policy? (I8)
+- [ ] Does the change let a narrow auth method be broadened by a
+      request-supplied scope? (I5)
+- [ ] Are there negative tests proving the escape is blocked, not just
+      positive tests proving the happy path works?
+- [ ] Does the test drive `ValidatedSecurityContext::new_for_scope()`
+      end-to-end, not just the inner helper (`calculate_effective_roles`,
+      `validate_scope_boundaries`) in isolation?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,11 @@ jobs:
       - name: Check Rego undefined-argument footgun (Gate E)
         run: python3 tools/check_rego_undefined_argument_footgun.py
 
+      # Gate J (security review V1/V2 / issue #986): the mechanically
+      # checkable subset of the security.md §7 reviewer checklist.
+      - name: Check security.md §7 checklist SAST (Gate J)
+        run: python3 tools/check_security_checklist_sast.py
+
   openapi:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,24 @@ jobs:
           path: target/nextest/*/junit.xml
           reporter: java-junit
 
+  # Gate B1 (security review V3 / issue #977): runs unconditionally, not
+  # gated on path filters, so it catches a Rust change that renames/drops an
+  # enforce() call, or a policy change that leaves a handler's enforce()
+  # target dangling, no matter which side of the split it touches.
+  policy-handler-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check policy<->handler existence (Gate B1)
+        run: python3 tools/check_policy_handler_coverage.py
+
   openapi:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,14 @@ jobs:
         with:
           version: latest
 
+      # Runs here unconditionally (not only in policy-container.yml, which is
+      # gated on `paths: policy/**`) so a Rust-only PR that changes which
+      # policy_name a handler enforces, or reshapes the Credentials
+      # projection, is also gated by the Rego test suite. See security review
+      # V3 / Gate A (doc/src/security-architecture-review.md).
+      - name: Test OPA policies
+        run: opa test policy
+
       - name: Rust Cache
         uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,12 @@ jobs:
       - name: Check EventPayload has no secret fields (Gate I)
         run: python3 tools/check_event_payload_no_secret_fields.py
 
+      # Gate C (security review V1/V2 / issue #982): every
+      # delegation-sensitive policy's test suite must carry a scope-drift
+      # negative case (security.md I3), not just a wrong-project case.
+      - name: Check delegated-policy scope-drift test presence (Gate C)
+        run: python3 tools/check_delegated_policy_scope_drift_tests.py
+
   openapi:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,14 @@ jobs:
       - name: Check security.md §7 checklist SAST (Gate J)
         run: python3 tools/check_security_checklist_sast.py
 
+      # Gate I companion (security review V9 / issue #987): EventPayload
+      # (the ADR 0023 audit-trail projection) must never grow a
+      # secret-shaped field; crates/core/src/policy.rs and the
+      # credential/os_ec2 policy-input helpers carry the equivalent
+      # assertion as Rust unit tests (cargo test already gates those).
+      - name: Check EventPayload has no secret fields (Gate I)
+        run: python3 tools/check_event_payload_no_secret_fields.py
+
   openapi:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,12 @@ jobs:
       - name: Check policy<->handler existence (Gate B1)
         run: python3 tools/check_policy_handler_coverage.py
 
+      # Gate E (security review V3 / issue #985): security.md I2's
+      # undefined-argument footgun -- a delegation-boundary helper called
+      # with a bare dotted path instead of object.get(..., null).
+      - name: Check Rego undefined-argument footgun (Gate E)
+        run: python3 tools/check_rego_undefined_argument_footgun.py
+
   openapi:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,62 @@
+name: Mutation testing
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # weekly, Sunday 03:00 UTC
+  workflow_dispatch: # allow manual triggering
+  pull_request:
+    paths:
+      - '.github/workflows/mutants.yml'
+      - '.cargo/mutants.toml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mutants:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install protobuf-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libtss2-dev pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust Cache
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        with:
+          tool: cargo-mutants
+
+      # Gate G (security review, issue #983): scoped to the core auth/policy
+      # invariant modules via .cargo/mutants.toml -- proves the negative
+      # tests there actually fail when the invariant they check is broken.
+      # Full-workspace mutation testing is far too slow to run per-PR, so
+      # this is a scheduled/manual job, not a required check; a PR that
+      # only touches this workflow or its config still runs it once to
+      # validate the change.
+      - name: Run cargo-mutants
+        run: cargo mutants --in-place --no-shuffle --timeout 120
+
+      - name: Upload mutants report
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: mutants-report
+          path: mutants.out

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -35,6 +35,7 @@ jobs:
         uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921 # stable
         with:
           toolchain: stable
+          targets: "${{ matrix.target }},wasm32-unknown-unknown"
 
       - name: Rust Cache
         uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0

--- a/.github/workflows/policy-container.yml
+++ b/.github/workflows/policy-container.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           version: ${{ env.ORAS_VERSION }}
 
+      - name: Setup cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Build policy container
         run: opa build policy --bundle
 
@@ -73,3 +76,29 @@ jobs:
 
       - name: Push policy
         run: oras push ghcr.io/${{ github.repository }}/opa-bundle:${{ github.ref_name }},latest --config config.json:application/vnd.oci.image.config.v1+json bundle.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
+
+      # Gate H (security review V4, issue #984): the running policy is as
+      # security-critical as the binary and should carry the same
+      # provenance bar. Sign by digest (not the mutable `latest`/branch
+      # tags) with cosign keyless signing, reusing the `id-token: write`
+      # permission already granted to this job for OIDC.
+      - name: Resolve pushed bundle digest
+        id: digest
+        run: |
+          digest=$(oras resolve "ghcr.io/${{ github.repository }}/opa-bundle:${{ github.ref_name }}")
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign policy bundle (cosign keyless)
+        run: |
+          cosign sign --yes "ghcr.io/${{ github.repository }}/opa-bundle@${{ steps.digest.outputs.digest }}"
+
+      # Prove the signature verifies before the workflow reports success,
+      # so a broken signing setup fails CI instead of silently shipping an
+      # unverifiable bundle. A deployment's OPA loader should run the same
+      # `cosign verify` (pinned to this digest) before serving the bundle.
+      - name: Verify policy bundle signature
+        run: |
+          cosign verify \
+            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "ghcr.io/${{ github.repository }}/opa-bundle@${{ steps.digest.outputs.digest }}"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ doc/html
 # cargo-mutants output (Gate G, issue #983)
 /mutants.out/
 /mutants.out.old/
+
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ policy.wasm
 build.artifacts
 
 doc/html
+
+# cargo-mutants output (Gate G, issue #983)
+/mutants.out/
+/mutants.out.old/

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -265,6 +265,9 @@ impl From<ApplicationCredentialProviderError> for KeystoneApiError {
             err @ ApplicationCredentialProviderError::ApplicationCredentialExpired => {
                 Self::unauthorized(err, None::<String>)
             }
+            err @ ApplicationCredentialProviderError::AccessRulesUnenforced => {
+                Self::BadRequest(err.to_string())
+            }
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/config/src/application_credentials.rs
+++ b/crates/config/src/application_credentials.rs
@@ -21,12 +21,27 @@ pub struct ApplicationCredentialProvider {
     /// Application credentials provider driver.
     #[serde(default = "default_sql_driver")]
     pub driver: String,
+
+    /// When `true`, refuse to create an application credential carrying a
+    /// non-empty `access_rules` list instead of silently accepting it.
+    ///
+    /// `access_rules` (per-endpoint restrictions) are stored and CRUD'd but
+    /// **not enforced at request time** -- no middleware matches the
+    /// incoming (service, method, path) against them yet (security review
+    /// V5, `doc/src/security.md` §5/§9). Until that enforcement lands, a
+    /// non-empty `access_rules` list is a restriction the operator believes
+    /// is active but is actually a no-op. Defaults to `false` to preserve
+    /// existing behavior (a warning is logged either way); set `true` to
+    /// fail loud instead.
+    #[serde(default)]
+    pub reject_unenforced_access_rules: bool,
 }
 
 impl Default for ApplicationCredentialProvider {
     fn default() -> Self {
         Self {
             driver: default_sql_driver(),
+            reject_unenforced_access_rules: false,
         }
     }
 }

--- a/crates/core-types/src/application_credential/error.rs
+++ b/crates/core-types/src/application_credential/error.rs
@@ -25,6 +25,17 @@ pub enum ApplicationCredentialProviderError {
     #[error("more than one access rule matching the ID and parameters found")]
     AccessRuleConflict,
 
+    /// `access_rules` were provided but request-time enforcement doesn't
+    /// exist yet (security review V5, `doc/src/security.md` §9): accepting
+    /// them would silently promise a restriction the server cannot honor.
+    /// Only returned when
+    /// `application_credential.reject_unenforced_access_rules` is enabled.
+    #[error(
+        "access_rules are not enforced at request time yet (see doc/src/security.md §9); \
+         refusing to create an application credential with a non-empty access_rules list"
+    )]
+    AccessRulesUnenforced,
+
     /// AccessRule is still referenced by an application credential and can not
     /// be deleted.
     #[error("access rule with id: {0} is still in use by an application credential")]

--- a/crates/core-types/src/auth.rs
+++ b/crates/core-types/src/auth.rs
@@ -3149,4 +3149,245 @@ mod tests {
         let has_auth = ctx.audit_ids().iter().any(|s| s == "parent2");
         assert!(has_auth);
     }
+
+    // --- AuthenticationContext::is_delegated (OSSA-2026-015 / ADR 0019 §2) ---
+
+    fn make_token_with_methods(methods: Vec<&str>) -> AuthenticationContext {
+        let payload = UnscopedPayloadBuilder::default()
+            .user_id("uid")
+            .audit_ids(std::iter::empty::<String>())
+            .methods(methods.into_iter().map(str::to_string))
+            .expires_at(Utc::now())
+            .build()
+            .unwrap();
+        AuthenticationContext::Token(FernetToken::Unscoped(payload))
+    }
+
+    #[test]
+    fn test_is_delegated_direct_application_credential() {
+        let ctx = AuthenticationContext::ApplicationCredential {
+            application_credential: make_app_cred("uid"),
+            token: None,
+        };
+        assert!(ctx.is_delegated());
+    }
+
+    #[test]
+    fn test_is_delegated_direct_trust() {
+        let ctx = AuthenticationContext::Trust {
+            trust: make_trust("uid"),
+            token: None,
+        };
+        assert!(ctx.is_delegated());
+    }
+
+    #[test]
+    fn test_is_delegated_rescoped_token_carries_trust_method() {
+        // matches!(..) is false here (this is a Token variant), so only the
+        // methods()-based OR branch can make this true. Catches `||` -> `&&`
+        // and matches!-branch deletion mutants.
+        let ctx = make_token_with_methods(vec!["trust"]);
+        assert!(ctx.is_delegated());
+    }
+
+    #[test]
+    fn test_is_delegated_rescoped_token_carries_app_cred_method() {
+        let ctx = make_token_with_methods(vec!["application_credential"]);
+        assert!(ctx.is_delegated());
+    }
+
+    #[test]
+    fn test_is_delegated_rescoped_token_non_delegated_methods() {
+        let ctx = make_token_with_methods(vec!["password", "token"]);
+        assert!(!ctx.is_delegated());
+    }
+
+    #[test]
+    fn test_is_delegated_password_is_false() {
+        assert!(!AuthenticationContext::Password.is_delegated());
+    }
+
+    #[test]
+    fn test_is_delegated_webauthn_is_false() {
+        assert!(!AuthenticationContext::WebauthN.is_delegated());
+    }
+
+    // --- ScopeInfo / TrustProjectInfo PartialEq (scope-drift comparisons) ---
+
+    fn make_trust_project_info(trust_id: &str, project_id: &str) -> TrustProjectInfo {
+        TrustProjectInfo {
+            trust: TrustBuilder::default()
+                .id(trust_id)
+                .trustor_user_id("trustor")
+                .trustee_user_id("trustee")
+                .impersonation(false)
+                .build()
+                .unwrap(),
+            project: Project {
+                id: project_id.into(),
+                ..make_project()
+            },
+            project_domain: make_domain(),
+        }
+    }
+
+    #[test]
+    fn test_scope_info_domain_eq_same_id_and_enabled() {
+        assert_eq!(
+            ScopeInfo::Domain(make_domain()),
+            ScopeInfo::Domain(make_domain())
+        );
+    }
+
+    #[test]
+    fn test_scope_info_domain_eq_different_id_is_false() {
+        let other = Domain {
+            id: "other_did".into(),
+            ..make_domain()
+        };
+        assert_ne!(ScopeInfo::Domain(make_domain()), ScopeInfo::Domain(other));
+    }
+
+    #[test]
+    fn test_scope_info_domain_eq_different_enabled_is_false() {
+        assert_ne!(
+            ScopeInfo::Domain(make_domain()),
+            ScopeInfo::Domain(make_disabled_domain())
+        );
+    }
+
+    #[test]
+    fn test_scope_info_project_eq_same_fields() {
+        let a = ScopeInfo::Project {
+            project: make_project(),
+            project_domain: make_domain(),
+        };
+        let b = ScopeInfo::Project {
+            project: make_project(),
+            project_domain: make_domain(),
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_scope_info_project_eq_different_project_id_is_false() {
+        let a = ScopeInfo::Project {
+            project: make_project(),
+            project_domain: make_domain(),
+        };
+        let b = ScopeInfo::Project {
+            project: make_project2(),
+            project_domain: make_domain(),
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_scope_info_project_eq_different_domain_id_is_false() {
+        let a = ScopeInfo::Project {
+            project: make_project(),
+            project_domain: make_domain(),
+        };
+        let b = ScopeInfo::Project {
+            project: Project {
+                domain_id: "other_did".into(),
+                ..make_project()
+            },
+            project_domain: make_domain(),
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_scope_info_project_eq_different_project_enabled_is_false() {
+        let a = ScopeInfo::Project {
+            project: make_project(),
+            project_domain: make_domain(),
+        };
+        let b = ScopeInfo::Project {
+            project: make_disabled_project(),
+            project_domain: make_domain(),
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_scope_info_project_eq_different_project_domain_enabled_is_false() {
+        let a = ScopeInfo::Project {
+            project: make_project(),
+            project_domain: make_domain(),
+        };
+        let b = ScopeInfo::Project {
+            project: make_project(),
+            project_domain: make_disabled_domain(),
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_scope_info_system_eq() {
+        assert_eq!(
+            ScopeInfo::System("system".into()),
+            ScopeInfo::System("system".into())
+        );
+        assert_ne!(
+            ScopeInfo::System("system".into()),
+            ScopeInfo::System("other".into())
+        );
+    }
+
+    #[test]
+    fn test_scope_info_trust_project_eq_delegates_to_trust_project_info() {
+        let a = ScopeInfo::TrustProject(Box::new(make_trust_project_info("t1", "p1")));
+        let b = ScopeInfo::TrustProject(Box::new(make_trust_project_info("t1", "p1")));
+        assert_eq!(a, b);
+
+        let c = ScopeInfo::TrustProject(Box::new(make_trust_project_info("t2", "p1")));
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_scope_info_unscoped_eq() {
+        assert_eq!(ScopeInfo::Unscoped, ScopeInfo::Unscoped);
+    }
+
+    #[test]
+    fn test_scope_info_cross_variant_never_equal() {
+        assert_ne!(ScopeInfo::Domain(make_domain()), ScopeInfo::Unscoped);
+        assert_ne!(
+            ScopeInfo::System("system".into()),
+            ScopeInfo::Domain(make_domain())
+        );
+        assert_ne!(
+            ScopeInfo::Project {
+                project: make_project(),
+                project_domain: make_domain(),
+            },
+            ScopeInfo::Unscoped
+        );
+    }
+
+    #[test]
+    fn test_trust_project_info_eq_same_ids() {
+        assert_eq!(
+            make_trust_project_info("t1", "p1"),
+            make_trust_project_info("t1", "p1")
+        );
+    }
+
+    #[test]
+    fn test_trust_project_info_eq_different_trust_id_is_false() {
+        assert_ne!(
+            make_trust_project_info("t1", "p1"),
+            make_trust_project_info("t2", "p1")
+        );
+    }
+
+    #[test]
+    fn test_trust_project_info_eq_different_project_id_is_false() {
+        assert_ne!(
+            make_trust_project_info("t1", "p1"),
+            make_trust_project_info("t1", "p2")
+        );
+    }
 }

--- a/crates/core-types/src/token.rs
+++ b/crates/core-types/src/token.rs
@@ -169,7 +169,22 @@ impl FernetToken {
                         expires_at,
                     )?))
                 }
-                _ => Ok(Self::ProjectScope(
+                // Every other auth method gets the plain project-scope
+                // payload. Named explicitly, not a wildcard, so a new
+                // AuthenticationContext variant is a compile error here
+                // until a human decides whether it needs its own payload
+                // (security.md V2 / Gate J, issue #986) -- exactly the
+                // class of bug this arm's own history (see the doc comment
+                // above, OSSA-2026-015) demonstrates a wildcard can hide.
+                AuthenticationContext::K8s(_)
+                | AuthenticationContext::Password
+                | AuthenticationContext::Admin
+                | AuthenticationContext::Token(_)
+                | AuthenticationContext::WebauthN
+                | AuthenticationContext::Mapping(_)
+                | AuthenticationContext::Ec2Credential
+                | AuthenticationContext::Totp
+                | AuthenticationContext::WasmPlugin { .. } => Ok(Self::ProjectScope(
                     ProjectScopePayload::from_security_context(ctx, project, expires_at)?,
                 )),
             },
@@ -186,9 +201,25 @@ impl FernetToken {
                 AuthenticationContext::Oidc { oidc, .. } => Ok(Self::FederationUnscoped(
                     FederationUnscopedPayload::from_security_context(ctx, oidc, expires_at)?,
                 )),
-                _ => Ok(Self::Unscoped(UnscopedPayload::from_security_context(
-                    ctx, expires_at,
-                )?)),
+                // Every other auth method gets the plain unscoped payload
+                // (ApplicationCredential/Trust cannot actually reach
+                // Unscoped -- validate_scope_boundaries rejects both --
+                // but the match must still be exhaustive). Named
+                // explicitly, not a wildcard (security.md V2 / Gate J,
+                // issue #986).
+                AuthenticationContext::ApplicationCredential { .. }
+                | AuthenticationContext::K8s(_)
+                | AuthenticationContext::Password
+                | AuthenticationContext::Admin
+                | AuthenticationContext::Token(_)
+                | AuthenticationContext::Trust { .. }
+                | AuthenticationContext::WebauthN
+                | AuthenticationContext::Mapping(_)
+                | AuthenticationContext::Ec2Credential
+                | AuthenticationContext::Totp
+                | AuthenticationContext::WasmPlugin { .. } => Ok(Self::Unscoped(
+                    UnscopedPayload::from_security_context(ctx, expires_at)?,
+                )),
             },
         }
     }

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -15,6 +15,8 @@
 pub mod api_key_auth;
 pub mod auth;
 pub mod common;
+#[cfg(any(test, feature = "mock"))]
+pub mod policy_contract;
 pub mod v3;
 pub mod v4;
 
@@ -150,5 +152,83 @@ pub mod tests {
             .await
             .unwrap(),
         )
+    }
+
+    /// One recorded `enforce()` call, as observed by [`CapturingPolicy`].
+    ///
+    /// This is Gate B2 (security review V3a, issue #978): the shared,
+    /// non-opt-in capture point every handler-under-test's `(policy_name,
+    /// target, existing)` triple flows through, so the input-contract
+    /// assertions in [`super::policy_contract`] apply uniformly instead of
+    /// being re-derived (or skipped) per test.
+    #[derive(Clone, Debug)]
+    pub struct PolicyCall {
+        pub policy_name: &'static str,
+        pub target: serde_json::Value,
+        pub existing: Option<serde_json::Value>,
+    }
+
+    /// A [`crate::policy::PolicyEnforcer`] test double that records every
+    /// call instead of judging it, and always allows -- decision-making is
+    /// `opa test policy`'s job (Gate A) and, once built, Gate B3's; this
+    /// harness exists solely to assert what the handler *fed* the policy.
+    #[derive(Clone, Default)]
+    pub struct CapturingPolicy {
+        calls: std::sync::Arc<std::sync::Mutex<Vec<PolicyCall>>>,
+    }
+
+    impl CapturingPolicy {
+        /// Every call recorded so far, in order.
+        #[allow(clippy::unwrap_used)]
+        pub fn calls(&self) -> Vec<PolicyCall> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::policy::PolicyEnforcer for CapturingPolicy {
+        async fn enforce(
+            &self,
+            policy_name: &'static str,
+            _credentials: &ValidatedSecurityContext,
+            target: serde_json::Value,
+            existing: Option<serde_json::Value>,
+        ) -> Result<PolicyEvaluationResult, PolicyError> {
+            #[allow(clippy::unwrap_used)]
+            self.calls.lock().unwrap().push(PolicyCall {
+                policy_name,
+                target: target.clone(),
+                existing: existing.clone(),
+            });
+            Ok(PolicyEvaluationResult::allowed_admin())
+        }
+
+        async fn health_check(&self) -> Result<(), PolicyError> {
+            Ok(())
+        }
+    }
+
+    /// Like [`get_mocked_state`], but wired to a [`CapturingPolicy`] instead
+    /// of an allow/deny-only mock, so the test can inspect exactly what
+    /// `(policy_name, target, existing)` the handler under test sent.
+    pub async fn get_capturing_state(
+        provider_builder: ProviderBuilder,
+    ) -> (ServiceState, CapturingPolicy) {
+        let provider = provider_builder.build().unwrap();
+        let policy = CapturingPolicy::default();
+
+        let state = Arc::new(
+            Service::new(
+                ConfigManager::not_watched(Config::default()),
+                DatabaseConnection::Disconnected,
+                provider,
+                Arc::new(policy.clone()),
+                AuditDispatcher::noop(),
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        (state, policy)
     }
 }

--- a/crates/core/src/api/policy_contract.rs
+++ b/crates/core/src/api/policy_contract.rs
@@ -1,0 +1,175 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Gate B2 (security review V3a, issue #978): shared assertions for the
+//! handler -> policy input contract.
+//!
+//! `opa test policy` (Gate A) proves the Rego is right on *hand-authored*
+//! input. It says nothing about whether a handler actually builds that
+//! input correctly -- the wrong `policy_name`, a mis-keyed `target`, a
+//! `target`/`existing` swap on update, or a leaked secret field all produce
+//! a well-formed request to a correct policy that decides on the wrong
+//! document. These helpers are the uniform, non-opt-in assertion set applied
+//! to [`super::tests::CapturingPolicy`]'s recorded calls.
+
+use serde_json::Value;
+
+/// Field names that must never appear anywhere in a `target`/`existing`
+/// policy-input document (`security.md` I7, generalized). Decrypted secret
+/// material (a credential's `blob`, a user's `password`, an OAuth2 client's
+/// `client_secret`, ...) has no `.rego` rule that reads it, so its presence
+/// here would only ever feed an OPA decision log or a future careless rule.
+const SECRET_FIELD_NAMES: &[&str] = &[
+    "access_token",
+    "blob",
+    "client_secret",
+    "encrypted_blob",
+    "key_hash",
+    "password",
+    "refresh_token",
+    "secret",
+    "seed",
+    "totp_seed",
+    "token",
+];
+
+/// Assert that `value` is a JSON object whose top-level keys are *exactly*
+/// `expected` (order-independent). This is the mechanical form of ADR 0002's
+/// `{"target": {"<resource>": obj}}` contract: a mis-keyed resource name
+/// makes every `input.target.<resource>.*` lookup `undefined` at runtime,
+/// which an `undefined`-driven Rego rule can silently treat as allow.
+///
+/// Some endpoints legitimately carry more than one top-level key (e.g. the
+/// OS-EC2 legacy API's `{"user_id": ..., "credential": ...}`, documented in
+/// `policy/os_ec2/*.rego`) -- pass the endpoint's full, actual key set, not
+/// just the resource name, for those.
+///
+/// # Panics
+/// Panics with a descriptive message if `value` is not an object, or its key
+/// set doesn't match `expected`.
+pub fn assert_object_keys(value: &Value, expected: &[&str]) {
+    let obj = value
+        .as_object()
+        .unwrap_or_else(|| panic!("expected a JSON object, got {value:?}"));
+    let mut actual: Vec<&str> = obj.keys().map(String::as_str).collect();
+    actual.sort_unstable();
+    let mut expected: Vec<&str> = expected.to_vec();
+    expected.sort_unstable();
+    assert_eq!(
+        actual, expected,
+        "policy-input object has keys {actual:?}, expected {expected:?} (value: {value})"
+    );
+}
+
+/// Assert that `value` (and everything nested under it) carries no field
+/// named in [`SECRET_FIELD_NAMES`]. Run over both `target` and `existing`.
+///
+/// # Panics
+/// Panics naming the first offending field path found.
+pub fn assert_no_secrets(value: &Value) {
+    if let Some(path) = find_secret_field(value, "$") {
+        panic!("policy input leaks secret field at {path}: {value}");
+    }
+}
+
+fn find_secret_field(value: &Value, path: &str) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for (key, v) in map {
+                if SECRET_FIELD_NAMES
+                    .iter()
+                    .any(|denied| denied.eq_ignore_ascii_case(key))
+                {
+                    return Some(format!("{path}.{key}"));
+                }
+                if let Some(found) = find_secret_field(v, &format!("{path}.{key}")) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(items) => items
+            .iter()
+            .enumerate()
+            .find_map(|(i, v)| find_secret_field(v, &format!("{path}[{i}]"))),
+        _ => None,
+    }
+}
+
+/// Assert `existing` matches the expected create/show/update/delete/list
+/// slotting (ADR 0002): create/list pass `None`; show/delete/update pass
+/// `Some(..)` (the codebase's actual, `opa test`-covered convention keys the
+/// stored object under `existing` for show/delete too, not only update --
+/// see e.g. `policy/credential/show.rego`'s documented `input.existing`).
+///
+/// # Panics
+/// Panics if presence doesn't match `expected_present`.
+pub fn assert_existing_presence(existing: &Option<Value>, expected_present: bool) {
+    assert_eq!(
+        existing.is_some(),
+        expected_present,
+        "existing presence was {}, expected {}",
+        existing.is_some(),
+        expected_present
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_assert_object_keys_ok() {
+        assert_object_keys(&json!({"credential": {}}), &["credential"]);
+        assert_object_keys(
+            &json!({"user_id": "u", "credential": null}),
+            &["credential", "user_id"],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected [\"user_id\"]")]
+    fn test_assert_object_keys_wrong_key() {
+        assert_object_keys(&json!({"credentials": {}}), &["user_id"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected a JSON object")]
+    fn test_assert_object_keys_not_object() {
+        assert_object_keys(&Value::Null, &["credential"]);
+    }
+
+    #[test]
+    fn test_assert_no_secrets_ok() {
+        assert_no_secrets(&json!({"credential": {"id": "1", "type": "totp"}}));
+    }
+
+    #[test]
+    #[should_panic(expected = "leaks secret field at $.credential.blob")]
+    fn test_assert_no_secrets_catches_blob() {
+        assert_no_secrets(&json!({"credential": {"id": "1", "blob": "{\"seed\":\"AAAA\"}"}}));
+    }
+
+    #[test]
+    #[should_panic(expected = "leaks secret field at $.user.password")]
+    fn test_assert_no_secrets_catches_nested() {
+        assert_no_secrets(&json!({"user": {"name": "a", "password": "hunter2"}}));
+    }
+
+    #[test]
+    fn test_assert_existing_presence() {
+        assert_existing_presence(&None, false);
+        assert_existing_presence(&Some(json!({})), true);
+    }
+}

--- a/crates/core/src/application_credential/service.rs
+++ b/crates/core/src/application_credential/service.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose};
 use rand::{RngExt, rng};
 use secrecy::SecretString;
+use tracing::warn;
 use uuid::Uuid;
 use validator::Validate;
 
@@ -156,6 +157,23 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
                     role.id.clone(),
                 ));
             }
+        }
+        // V5 (security review, `doc/src/security.md` §9): `access_rules`
+        // are stored and CRUD'd but not enforced at request time yet -- no
+        // middleware matches the incoming (service, method, path) against
+        // them. Warn unconditionally so the gap is visible in logs, and
+        // fail loud instead when the operator has opted in, rather than
+        // silently accepting a restriction the server cannot honor.
+        if rec.access_rules.as_ref().is_some_and(|rules| !rules.is_empty()) {
+            let cfg = ctx.state().config_manager.config.read().await;
+            if cfg.application_credential.reject_unenforced_access_rules {
+                return Err(ApplicationCredentialProviderError::AccessRulesUnenforced);
+            }
+            warn!(
+                "creating application credential with a non-empty access_rules list; \
+                 access_rules are NOT enforced at request time yet (see doc/src/security.md §9) \
+                 -- the restriction is currently a no-op"
+            );
         }
         let mut new_rec = rec;
         if new_rec.id.is_none() {
@@ -413,4 +431,160 @@ pub fn generate_secret() -> SecretString {
     let encoded_secret = general_purpose::URL_SAFE_NO_PAD.encode(secret_bytes);
 
     SecretString::new(encoded_secret.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::application_credential::backend::MockApplicationCredentialBackend;
+    use crate::provider::Provider;
+    use crate::role::MockRoleProvider;
+    use crate::tests::get_mocked_state;
+
+    fn make_service(mock_backend: MockApplicationCredentialBackend) -> ApplicationCredentialService {
+        ApplicationCredentialService {
+            backend_driver: Arc::new(mock_backend),
+        }
+    }
+
+    fn no_op_role_mock() -> MockRoleProvider {
+        let mut role_mock = MockRoleProvider::default();
+        role_mock.expect_list_roles().returning(|_, _| Ok(vec![]));
+        role_mock
+    }
+
+    fn rule() -> AccessRuleCreate {
+        AccessRuleCreateBuilder::default()
+            .user_id("uid")
+            .service("compute")
+            .method("GET")
+            .path("/v2.1/servers")
+            .build()
+            .unwrap()
+    }
+
+    /// V5 (security review, issue #980): a non-empty `access_rules` list is
+    /// accepted by default (existing behavior preserved) -- the warning is
+    /// only observable via logs, not the return value.
+    #[tokio::test]
+    async fn test_create_with_access_rules_warns_by_default() {
+        let mut mock_backend = MockApplicationCredentialBackend::new();
+        mock_backend
+            .expect_create_application_credential()
+            .returning(|_, rec| {
+                Ok(ApplicationCredentialCreateResponseBuilder::default()
+                    .id(rec.id.clone().unwrap_or_default())
+                    .name(rec.name.clone())
+                    .project_id(rec.project_id.clone())
+                    .roles(rec.roles.clone())
+                    .secret(SecretString::from("s3cr3t"))
+                    .unrestricted(false)
+                    .user_id(rec.user_id.clone())
+                    .build()
+                    .unwrap())
+            });
+
+        let state = get_mocked_state(
+            Some(Config::default()),
+            Some(Provider::mocked_builder().mock_role(no_op_role_mock())),
+        )
+        .await;
+
+        let rec = ApplicationCredentialCreateBuilder::default()
+            .name("cred")
+            .project_id("pid")
+            .user_id("uid")
+            .roles(vec![])
+            .access_rules(vec![rule()])
+            .build()
+            .unwrap();
+
+        let result = make_service(mock_backend)
+            .create_application_credential(&ExecutionContext::internal(&state), rec)
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    /// V5: with `reject_unenforced_access_rules` enabled, creation with a
+    /// non-empty `access_rules` list fails loud -- and never reaches the
+    /// backend driver at all (no `expect_create_application_credential` is
+    /// configured on the mock, so a call would panic the test).
+    #[tokio::test]
+    async fn test_create_with_access_rules_rejected_when_configured() {
+        let mock_backend = MockApplicationCredentialBackend::new();
+
+        let mut cfg = Config::default();
+        cfg.application_credential.reject_unenforced_access_rules = true;
+
+        let state = get_mocked_state(
+            Some(cfg),
+            Some(Provider::mocked_builder().mock_role(no_op_role_mock())),
+        )
+        .await;
+
+        let rec = ApplicationCredentialCreateBuilder::default()
+            .name("cred")
+            .project_id("pid")
+            .user_id("uid")
+            .roles(vec![])
+            .access_rules(vec![rule()])
+            .build()
+            .unwrap();
+
+        let result = make_service(mock_backend)
+            .create_application_credential(&ExecutionContext::internal(&state), rec)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ApplicationCredentialProviderError::AccessRulesUnenforced)
+        ));
+    }
+
+    /// V5: an empty/absent `access_rules` list is never rejected, even with
+    /// `reject_unenforced_access_rules` enabled -- there is nothing
+    /// unenforceable to fail loud about.
+    #[tokio::test]
+    async fn test_create_without_access_rules_never_rejected() {
+        let mut mock_backend = MockApplicationCredentialBackend::new();
+        mock_backend
+            .expect_create_application_credential()
+            .returning(|_, rec| {
+                Ok(ApplicationCredentialCreateResponseBuilder::default()
+                    .id(rec.id.clone().unwrap_or_default())
+                    .name(rec.name.clone())
+                    .project_id(rec.project_id.clone())
+                    .roles(rec.roles.clone())
+                    .secret(SecretString::from("s3cr3t"))
+                    .unrestricted(false)
+                    .user_id(rec.user_id.clone())
+                    .build()
+                    .unwrap())
+            });
+
+        let mut cfg = Config::default();
+        cfg.application_credential.reject_unenforced_access_rules = true;
+
+        let state = get_mocked_state(
+            Some(cfg),
+            Some(Provider::mocked_builder().mock_role(no_op_role_mock())),
+        )
+        .await;
+
+        let rec = ApplicationCredentialCreateBuilder::default()
+            .name("cred")
+            .project_id("pid")
+            .user_id("uid")
+            .roles(vec![])
+            .build()
+            .unwrap();
+
+        let result = make_service(mock_backend)
+            .create_application_credential(&ExecutionContext::internal(&state), rec)
+            .await;
+
+        assert!(result.is_ok());
+    }
 }

--- a/crates/core/src/application_credential/service.rs
+++ b/crates/core/src/application_credential/service.rs
@@ -164,7 +164,11 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
         // them. Warn unconditionally so the gap is visible in logs, and
         // fail loud instead when the operator has opted in, rather than
         // silently accepting a restriction the server cannot honor.
-        if rec.access_rules.as_ref().is_some_and(|rules| !rules.is_empty()) {
+        if rec
+            .access_rules
+            .as_ref()
+            .is_some_and(|rules| !rules.is_empty())
+        {
             let cfg = ctx.state().config_manager.config.read().await;
             if cfg.application_credential.reject_unenforced_access_rules {
                 return Err(ApplicationCredentialProviderError::AccessRulesUnenforced);
@@ -442,7 +446,9 @@ mod tests {
     use crate::role::MockRoleProvider;
     use crate::tests::get_mocked_state;
 
-    fn make_service(mock_backend: MockApplicationCredentialBackend) -> ApplicationCredentialService {
+    fn make_service(
+        mock_backend: MockApplicationCredentialBackend,
+    ) -> ApplicationCredentialService {
         ApplicationCredentialService {
             backend_driver: Arc::new(mock_backend),
         }

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -3464,6 +3464,228 @@ mod tests {
         assert_eq!(roles[0].id, allowed_rid);
     }
 
+    /// Gate D compile-time exhaustiveness anchor (security review V1/V2,
+    /// issue #981): unlike [`AuthenticationContext::is_delegated`] (a
+    /// `matches!` over an explicit allow-list, which silently keeps
+    /// compiling if a variant is added), this match has **no wildcard
+    /// arm** -- every current variant is named, so adding a new
+    /// `AuthenticationContext` variant anywhere in the codebase without
+    /// also classifying it here is a compile error, not a silently-passing
+    /// test. `test_delegation_scope_kind_matrix_roles_never_exceed_delegation`
+    /// below is driven from this classification, not from `is_delegated()`.
+    fn is_delegating_auth_context(ctx: &AuthenticationContext) -> bool {
+        match ctx {
+            AuthenticationContext::ApplicationCredential { .. } => true,
+            AuthenticationContext::Trust { .. } => true,
+            AuthenticationContext::Oidc { .. }
+            | AuthenticationContext::K8s(_)
+            | AuthenticationContext::Password
+            | AuthenticationContext::Admin
+            | AuthenticationContext::Token(_)
+            | AuthenticationContext::WebauthN
+            | AuthenticationContext::Mapping(_)
+            | AuthenticationContext::Ec2Credential
+            | AuthenticationContext::Totp
+            | AuthenticationContext::WasmPlugin { .. } => false,
+        }
+    }
+
+    /// Gate D's companion anchor for `ScopeInfo`: same no-wildcard
+    /// requirement. The classification itself is unused by the matrix
+    /// below (which sweeps every variant unconditionally and only asserts
+    /// on whichever cells `new_for_scope` happens to accept) -- this
+    /// function exists purely so a new `ScopeInfo` variant fails to
+    /// compile here until a human decides how it fits the matrix.
+    fn classify_scope_kind(scope: &ScopeInfo) -> &'static str {
+        match scope {
+            ScopeInfo::Domain(_) => "domain",
+            ScopeInfo::Project { .. } => "project",
+            ScopeInfo::System(_) => "system",
+            ScopeInfo::TrustProject(_) => "trust_project",
+            ScopeInfo::Unscoped => "unscoped",
+        }
+    }
+
+    /// Gate D (security review V1/V2, issue #981): generated matrix over
+    /// every (delegating `AuthenticationContext` kind) x (`ScopeInfo`
+    /// variant) cell, driven end-to-end through `new_for_scope()`.
+    ///
+    /// Unlike the hand-written seed test above, this does not predict
+    /// allow/deny per cell -- that table already exists and is exhaustively
+    /// matched in `SecurityContext::validate_scope_boundaries`
+    /// (`crates/core-types/src/auth.rs`). Instead it asserts the
+    /// *invariant* mechanically, for every cell: whenever `new_for_scope`
+    /// accepts a delegated context on some scope, the resulting effective
+    /// roles never exceed the delegation's own role set, regardless of
+    /// which scope was requested or whether the delegation is restricted
+    /// or unrestricted. A cell that returns `Err` is not a failure here --
+    /// reachability is `validate_scope_boundaries`'s concern, not this
+    /// test's; this loop only ever asserts on cells that succeed, which is
+    /// exactly the shape the I4 near-miss (`from_security_context` falling
+    /// through to `ProjectScopePayload`) would have broken.
+    #[tokio::test]
+    async fn test_delegation_scope_kind_matrix_roles_never_exceed_delegation() {
+        let pid = "pid";
+        let allowed_rid = "reader";
+        let escalated_rid = "admin";
+
+        // The delegating principal holds BOTH roles on the project; every
+        // delegation kind below restricts to just `allowed_rid`. A
+        // regression that lets the wider personal assignment leak through
+        // on any cell is exactly what this matrix exists to catch.
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .returning(move |_e, q: &RoleAssignmentListParameters| {
+                let actor = q.user_id.clone().unwrap_or_default();
+                Ok(vec![
+                    assignment_with_role_actor(allowed_rid, &actor),
+                    assignment_with_role_actor(escalated_rid, &actor),
+                ])
+            });
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(|_e, _roles| Ok(()));
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_validate_trust_delegation_chain()
+            .returning(|_e, _trust| Ok(true));
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock.expect_get_user().returning(|_e, id| {
+            Ok(Some(
+                UserResponseBuilder::default()
+                    .id(id)
+                    .domain_id("d1")
+                    .enabled(true)
+                    .name(id)
+                    .build()
+                    .unwrap(),
+            ))
+        });
+        let state = get_mocked_state(
+            None,
+            Some(
+                Provider::mocked_builder()
+                    .mock_assignment(assignment_mock)
+                    .mock_role(role_mock)
+                    .mock_trust(trust_mock)
+                    .mock_identity(identity_mock),
+            ),
+        )
+        .await;
+
+        let trust = Trust {
+            id: "t1".to_string(),
+            trustor_user_id: "trustor".to_string(),
+            trustee_user_id: "trustee".to_string(),
+            impersonation: false,
+            project_id: Some(pid.to_string()),
+            expires_at: None,
+            deleted_at: None,
+            extra: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: Some(vec![role_ref(allowed_rid, "reader")]),
+        };
+        let ac_restricted = openstack_keystone_core_types::application_credential::ApplicationCredential {
+            id: "ac1".to_string(),
+            user_id: "appcred_owner".to_string(),
+            project_id: pid.to_string(),
+            name: "cred".to_string(),
+            description: None,
+            roles: vec![role_ref(allowed_rid, "reader")],
+            unrestricted: false,
+            expires_at: None,
+            access_rules: None,
+        };
+        let ac_unrestricted = openstack_keystone_core_types::application_credential::ApplicationCredential {
+            unrestricted: true,
+            ..ac_restricted.clone()
+        };
+
+        // (label, principal user_id, delegation's own role ids, context builder)
+        let delegating_cases: Vec<(&str, &str, Vec<&str>, Box<dyn Fn() -> AuthenticationContext>)> = vec![
+            (
+                "trust",
+                "trustee",
+                vec![allowed_rid],
+                Box::new({
+                    let t = trust.clone();
+                    move || AuthenticationContext::Trust {
+                        trust: t.clone(),
+                        token: None,
+                    }
+                }),
+            ),
+            (
+                "app_cred_restricted",
+                "appcred_owner",
+                vec![allowed_rid],
+                Box::new({
+                    let ac = ac_restricted.clone();
+                    move || AuthenticationContext::ApplicationCredential {
+                        application_credential: ac.clone(),
+                        token: None,
+                    }
+                }),
+            ),
+            (
+                "app_cred_unrestricted",
+                "appcred_owner",
+                vec![allowed_rid],
+                Box::new({
+                    let ac = ac_unrestricted.clone();
+                    move || AuthenticationContext::ApplicationCredential {
+                        application_credential: ac.clone(),
+                        token: None,
+                    }
+                }),
+            ),
+        ];
+
+        let scope_kinds: Vec<ScopeInfo> = vec![
+            make_domain_scope("d1"),
+            make_project_scope(pid),
+            ScopeInfo::System("all".to_string()),
+            make_trust_scope("trustor", "trustee", pid, Some(vec![role_ref(allowed_rid, "reader")])),
+            ScopeInfo::Unscoped,
+        ];
+        // Exercise every ScopeInfo variant at least once, so a variant
+        // added without a row here is visibly under-covered rather than
+        // silently skipped (the classifier above still gates it at
+        // compile time regardless).
+        assert_eq!(scope_kinds.len(), 5);
+
+        for (label, principal_user_id, delegation_roles, ctx_fn) in &delegating_cases {
+            assert!(
+                is_delegating_auth_context(&ctx_fn()),
+                "case {label} must be classified as delegating for this matrix to mean anything"
+            );
+            for scope in &scope_kinds {
+                let scope_label = classify_scope_kind(scope);
+                let ctx = SecurityContextTestingBuilder::default()
+                    .authentication_context(ctx_fn())
+                    .principal(make_user_identity(*principal_user_id))
+                    .build();
+                let result =
+                    ValidatedSecurityContext::new_for_scope(ctx, scope.clone(), &state).await;
+                if let Ok(validated) = result
+                    && let Some(roles) = validated.0.authorization().unwrap().effective_roles()
+                {
+                    for role in roles {
+                        assert!(
+                            delegation_roles.contains(&role.id.as_str()),
+                            "cell ({label}, {scope_label}): effective role {role:?} exceeds \
+                             delegation role set {delegation_roles:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     // Companion negative case: a trust may reach a plain Project scope only
     // for its OWN bound project -- it must not be usable to reach a
     // different project by presenting the EC2-redemption shape.

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -2526,6 +2526,43 @@ mod tests {
         ));
     }
 
+    // Companion positive case: an admin principal with no roles on the
+    // target scope must NOT trip `ActorHasNoRolesOnTarget` — `is_admin`
+    // bypasses the check. Catches `delete !` on `!ctx.is_admin()`.
+    #[tokio::test]
+    async fn test_new_for_scope_admin_with_no_roles_on_target_is_allowed() {
+        let uid = "uid";
+        let pid = "pid";
+
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .returning(|_, _| Ok(Vec::<Assignment>::new()));
+
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_assignment(assignment_mock)),
+        )
+        .await;
+
+        let authz = AuthzInfoBuilder::default()
+            .scope(make_project_scope(pid))
+            .roles(Vec::new())
+            .build()
+            .unwrap();
+        let mut ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity(uid))
+            .authorization(authz)
+            .build();
+        ctx.set_is_admin();
+
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, make_project_scope(pid), &state).await;
+
+        assert!(result.is_ok());
+    }
+
     // --- Mapping: domain scope match returns pre-populated roles ---
     #[tokio::test]
     async fn test_new_for_scope_mapping_domain_scope_match() {
@@ -3166,6 +3203,56 @@ mod tests {
         assert_eq!(eff[0].id, rid);
     }
 
+    // Discriminates `is_system && matches!(scope_clone, ScopeInfo::Unscoped)`
+    // (the fast-path upgrade guard): `is_system` alone must never upgrade a
+    // non-Unscoped target scope to System. Catches `&&` -> `||`.
+    #[tokio::test]
+    async fn test_new_for_scope_mapping_fast_path_is_system_true_project_not_upgraded() {
+        let pid = "project-2";
+        let vir_id = "vu-fast-path-system-project-0000000000000000";
+        let rid = "member";
+        let roles = vec![role_ref(rid, "member")];
+
+        let authz = AuthzInfoBuilder::default()
+            .scope(make_project_scope(pid))
+            .roles(roles.clone())
+            .build()
+            .unwrap();
+
+        let mc = MappingContext {
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "rule-1".to_string(),
+            virtual_user_id: vir_id.to_string(),
+            is_system: true,
+        };
+
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Mapping(mc))
+            .principal(make_user_identity(vir_id))
+            .authorization(authz)
+            .build();
+
+        // No mock mapping provider — get_virtual_user must NOT be called
+        let state = get_mocked_state(None, None).await;
+
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, make_project_scope(pid), &state).await;
+
+        let validated = result.unwrap();
+        assert!(matches!(
+            validated.0.authorization().unwrap().scope,
+            ScopeInfo::Project { .. }
+        ));
+        let eff = validated
+            .0
+            .authorization()
+            .unwrap()
+            .effective_roles()
+            .unwrap();
+        assert_eq!(eff.len(), 1);
+        assert_eq!(eff[0].id, rid);
+    }
+
     // --- Mapping fast path: pre-set domain roles skip storage read ---
     #[tokio::test]
     async fn test_new_for_scope_mapping_fast_path_domain() {
@@ -3274,6 +3361,86 @@ mod tests {
         assert!(matches!(
             validated.0.authorization().unwrap().scope,
             ScopeInfo::System(ref s) if s == "all"
+        ));
+        let eff = validated
+            .0
+            .authorization()
+            .unwrap()
+            .effective_roles()
+            .unwrap();
+        assert_eq!(eff.len(), 1);
+        assert_eq!(eff[0].id, rid);
+    }
+
+    // Discriminates `is_system && matches!(scope_clone, ScopeInfo::Unscoped)`
+    // in the no-prepopulated-roles branch: `is_system` alone must not divert
+    // a Project-scoped request onto the system-upgrade/slow-read path.
+    // Catches `&&` -> `||`.
+    #[tokio::test]
+    async fn test_new_for_scope_mapping_slow_path_is_system_true_project_not_upgraded() {
+        let pid = "project-3";
+        let vir_id = "vu-slow-path-system-project-0000000000000000";
+        let rid = "member";
+        let roles = vec![role_ref(rid, "member")];
+
+        let vu = VirtualUser {
+            user_id: vir_id.to_string(),
+            unique_workload_id: "workload-sys-project-slow".to_string(),
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "rule-1".to_string(),
+            domain_id: None,
+            resolved_user_name: "system-user".to_string(),
+            is_system: true,
+            resolved_group_bindings: vec![],
+            authorizations: vec![Authorization::Project {
+                project_id: pid.to_string(),
+                project_domain_id: "d1".to_string(),
+                roles: roles.clone(),
+            }],
+            ruleset_version: 1,
+            enabled: true,
+            created_at: 0,
+            last_authenticated_at: 0,
+        };
+
+        let mut mapping_mock = MockMappingProvider::new();
+        mapping_mock
+            .expect_get_virtual_user()
+            .returning(move |_e, id: &str| {
+                if id == vir_id {
+                    Ok(Some(vu.clone()))
+                } else {
+                    Ok(None)
+                }
+            });
+
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_mapping(mapping_mock)),
+        )
+        .await;
+
+        let mc = MappingContext {
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "rule-1".to_string(),
+            virtual_user_id: vir_id.to_string(),
+            is_system: true,
+        };
+
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Mapping(mc))
+            .principal(make_user_identity(vir_id))
+            .build();
+
+        // No pre-set authorization, target scope is Project (not Unscoped):
+        // `is_system` alone must not upgrade this to System scope.
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, make_project_scope(pid), &state).await;
+
+        let validated = result.unwrap();
+        assert!(matches!(
+            validated.0.authorization().unwrap().scope,
+            ScopeInfo::Project { .. }
         ));
         let eff = validated
             .0
@@ -3698,6 +3865,149 @@ mod tests {
         }
     }
 
+    // When the trustee's own domain differs from the trustor's domain, the
+    // trustor's domain enabled-state must be checked, and a disabled
+    // trustor domain must reject the trust. Catches `delete !` on
+    // `!trustor_domain_enabled`.
+    #[tokio::test]
+    async fn test_new_for_scope_trust_rejected_when_trustor_domain_disabled() {
+        use crate::resource::MockResourceProvider;
+
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_validate_trust_delegation_chain()
+            .returning(|_e, _trust| Ok(true));
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock.expect_get_user().returning(|_e, id| {
+            Ok(Some(
+                UserResponseBuilder::default()
+                    .id(id)
+                    .domain_id("trustor_domain")
+                    .enabled(true)
+                    .name(id)
+                    .build()
+                    .unwrap(),
+            ))
+        });
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_domain_enabled()
+            .withf(|_e, domain_id: &str| domain_id == "trustor_domain")
+            .returning(|_e, _domain_id| Ok(false));
+
+        let state = get_mocked_state(
+            None,
+            Some(
+                Provider::mocked_builder()
+                    .mock_trust(trust_mock)
+                    .mock_identity(identity_mock)
+                    .mock_resource(resource_mock),
+            ),
+        )
+        .await;
+
+        // Trustee's own domain ("d1", per `make_user_identity`) differs
+        // from the trustor's domain ("trustor_domain"), so the
+        // trustor-domain-enabled branch is exercised.
+        let trust = Trust {
+            id: "t1".to_string(),
+            trustor_user_id: "trustor".to_string(),
+            trustee_user_id: "trustee".to_string(),
+            impersonation: false,
+            project_id: Some("pid".to_string()),
+            expires_at: None,
+            deleted_at: None,
+            extra: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: None,
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Trust { trust, token: None })
+            .principal(make_user_identity("trustee"))
+            .build();
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, make_project_scope("pid"), &state).await;
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::TrustorDomainDisabled)
+        ));
+    }
+
+    // Companion positive case: same cross-domain setup, but the trustor's
+    // domain is enabled, so the trust must succeed.
+    #[tokio::test]
+    async fn test_new_for_scope_trust_accepted_when_trustor_domain_enabled() {
+        use crate::resource::MockResourceProvider;
+
+        let rid = "reader";
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .returning(move |_e, _q| Ok(vec![assignment_with_role(rid)]));
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(|_e, _roles| Ok(()));
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_validate_trust_delegation_chain()
+            .returning(|_e, _trust| Ok(true));
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock.expect_get_user().returning(|_e, id| {
+            Ok(Some(
+                UserResponseBuilder::default()
+                    .id(id)
+                    .domain_id("trustor_domain")
+                    .enabled(true)
+                    .name(id)
+                    .build()
+                    .unwrap(),
+            ))
+        });
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_domain_enabled()
+            .withf(|_e, domain_id: &str| domain_id == "trustor_domain")
+            .returning(|_e, _domain_id| Ok(true));
+
+        let state = get_mocked_state(
+            None,
+            Some(
+                Provider::mocked_builder()
+                    .mock_assignment(assignment_mock)
+                    .mock_role(role_mock)
+                    .mock_trust(trust_mock)
+                    .mock_identity(identity_mock)
+                    .mock_resource(resource_mock),
+            ),
+        )
+        .await;
+
+        let trust = Trust {
+            id: "t1".to_string(),
+            trustor_user_id: "trustor".to_string(),
+            trustee_user_id: "trustee".to_string(),
+            impersonation: false,
+            project_id: Some("pid".to_string()),
+            expires_at: None,
+            deleted_at: None,
+            extra: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: Some(vec![role_ref(rid, "reader")]),
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Trust { trust, token: None })
+            .principal(make_user_identity("trustee"))
+            .build();
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, make_project_scope("pid"), &state).await;
+        assert!(result.is_ok());
+    }
+
     // Companion negative case: a trust may reach a plain Project scope only
     // for its OWN bound project -- it must not be usable to reach a
     // different project by presenting the EC2-redemption shape.
@@ -3819,6 +4129,29 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    // Boundary case: `issued_at == valid_since` must be accepted (the check
+    // is `issued_at < valid_since`, not `<=`). Catches `<` -> `<=`.
+    #[tokio::test]
+    async fn test_wasm_plugin_token_issued_exactly_at_cutoff_is_accepted() {
+        let valid_since = Utc::now();
+
+        let state = get_mocked_state(Some(wasm_plugin_config("p", Some(valid_since))), None).await;
+
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::WasmPlugin {
+                plugin_name: "p".to_string(),
+                claims: HashMap::new(),
+                token: None,
+            })
+            .principal(make_user_identity("uid"))
+            .token(wasm_plugin_token("p", valid_since))
+            .build();
+
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, ScopeInfo::Unscoped, &state).await;
+        assert!(result.is_ok());
+    }
+
     #[tokio::test]
     async fn test_wasm_plugin_fresh_mint_ignores_valid_since() {
         // No `.token(..)` set - mirrors a brand-new mint, where
@@ -3901,5 +4234,60 @@ mod tests {
             result,
             Err(AuthenticationError::PluginVersionMismatch(ref name)) if name == "p"
         ));
+    }
+
+    // Boundary case for the mapping-mode plugin-version-binding check:
+    // `issued_at == valid_since` must be accepted (the check is
+    // `issued_at < valid_since`, not `<=`). Catches `<` -> `<=`.
+    #[tokio::test]
+    async fn test_mapping_wasm_plugin_token_issued_exactly_at_cutoff_is_accepted() {
+        use openstack_keystone_core_types::mapping::ruleset::MappingRuleSet;
+        use openstack_keystone_core_types::mapping::{DomainResolutionMode, IdentitySource};
+
+        let valid_since = Utc::now();
+
+        let ruleset = MappingRuleSet {
+            mapping_id: "map-1".to_string(),
+            domain_id: Some("d".to_string()),
+            source: IdentitySource::WasmPlugin {
+                plugin_name: "p".to_string(),
+            },
+            domain_resolution_mode: DomainResolutionMode::Fixed,
+            enabled: true,
+            rules: vec![],
+            ruleset_version: 1,
+        };
+        let mut mapping_mock = MockMappingProvider::new();
+        mapping_mock
+            .expect_get_ruleset()
+            .returning(move |_e, id: &str| {
+                if id == "map-1" {
+                    Ok(Some(ruleset.clone()))
+                } else {
+                    Ok(None)
+                }
+            });
+
+        let state = get_mocked_state(
+            Some(wasm_plugin_config("p", Some(valid_since))),
+            Some(Provider::mocked_builder().mock_mapping(mapping_mock)),
+        )
+        .await;
+
+        let mc = MappingContext {
+            mapping_id: "map-1".to_string(),
+            matched_rule_name: "rule-1".to_string(),
+            virtual_user_id: "vu-1".to_string(),
+            is_system: false,
+        };
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Mapping(mc))
+            .principal(make_user_identity("vu-1"))
+            .token(wasm_plugin_token("p", valid_since))
+            .build();
+
+        let result =
+            ValidatedSecurityContext::new_for_scope(ctx, ScopeInfo::Unscoped, &state).await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -3534,15 +3534,15 @@ mod tests {
         // regression that lets the wider personal assignment leak through
         // on any cell is exactly what this matrix exists to catch.
         let mut assignment_mock = MockAssignmentProvider::default();
-        assignment_mock
-            .expect_list_role_assignments()
-            .returning(move |_e, q: &RoleAssignmentListParameters| {
+        assignment_mock.expect_list_role_assignments().returning(
+            move |_e, q: &RoleAssignmentListParameters| {
                 let actor = q.user_id.clone().unwrap_or_default();
                 Ok(vec![
                     assignment_with_role_actor(allowed_rid, &actor),
                     assignment_with_role_actor(escalated_rid, &actor),
                 ])
-            });
+            },
+        );
         let mut role_mock = MockRoleProvider::default();
         role_mock
             .expect_expand_implied_roles()
@@ -3589,24 +3589,31 @@ mod tests {
             redelegation_count: None,
             roles: Some(vec![role_ref(allowed_rid, "reader")]),
         };
-        let ac_restricted = openstack_keystone_core_types::application_credential::ApplicationCredential {
-            id: "ac1".to_string(),
-            user_id: "appcred_owner".to_string(),
-            project_id: pid.to_string(),
-            name: "cred".to_string(),
-            description: None,
-            roles: vec![role_ref(allowed_rid, "reader")],
-            unrestricted: false,
-            expires_at: None,
-            access_rules: None,
-        };
-        let ac_unrestricted = openstack_keystone_core_types::application_credential::ApplicationCredential {
-            unrestricted: true,
-            ..ac_restricted.clone()
-        };
+        let ac_restricted =
+            openstack_keystone_core_types::application_credential::ApplicationCredential {
+                id: "ac1".to_string(),
+                user_id: "appcred_owner".to_string(),
+                project_id: pid.to_string(),
+                name: "cred".to_string(),
+                description: None,
+                roles: vec![role_ref(allowed_rid, "reader")],
+                unrestricted: false,
+                expires_at: None,
+                access_rules: None,
+            };
+        let ac_unrestricted =
+            openstack_keystone_core_types::application_credential::ApplicationCredential {
+                unrestricted: true,
+                ..ac_restricted.clone()
+            };
 
         // (label, principal user_id, delegation's own role ids, context builder)
-        let delegating_cases: Vec<(&str, &str, Vec<&str>, Box<dyn Fn() -> AuthenticationContext>)> = vec![
+        let delegating_cases: Vec<(
+            &str,
+            &str,
+            Vec<&str>,
+            Box<dyn Fn() -> AuthenticationContext>,
+        )> = vec![
             (
                 "trust",
                 "trustee",
@@ -3649,7 +3656,12 @@ mod tests {
             make_domain_scope("d1"),
             make_project_scope(pid),
             ScopeInfo::System("all".to_string()),
-            make_trust_scope("trustor", "trustee", pid, Some(vec![role_ref(allowed_rid, "reader")])),
+            make_trust_scope(
+                "trustor",
+                "trustee",
+                pid,
+                Some(vec![role_ref(allowed_rid, "reader")]),
+            ),
             ScopeInfo::Unscoped,
         ];
         // Exercise every ScopeInfo variant at least once, so a variant

--- a/crates/core/src/policy.rs
+++ b/crates/core/src/policy.rs
@@ -353,7 +353,21 @@ impl TryFrom<&ValidatedSecurityContext> for Credentials {
                     claims.clone(),
                 )]));
             }
-            _ => {}
+            // Not delegated (or, for WasmPlugin, delegated but carrying no
+            // claims) -- nothing extra to project. Named explicitly, not a
+            // wildcard, so a new AuthenticationContext variant is a compile
+            // error here until a human decides how it fits (security.md
+            // V2 / Gate J, issue #986).
+            AuthenticationContext::WasmPlugin { .. }
+            | AuthenticationContext::Oidc { .. }
+            | AuthenticationContext::K8s(_)
+            | AuthenticationContext::Password
+            | AuthenticationContext::Admin
+            | AuthenticationContext::Token(_)
+            | AuthenticationContext::WebauthN
+            | AuthenticationContext::Mapping(_)
+            | AuthenticationContext::Ec2Credential
+            | AuthenticationContext::Totp => {}
         }
         if let Some(authz) = sc.authorization() {
             match &authz.scope {

--- a/crates/core/src/policy.rs
+++ b/crates/core/src/policy.rs
@@ -662,4 +662,303 @@ mod tests {
         let value = serde_json::to_value(&creds).unwrap();
         policy_contract::assert_no_secrets(&value);
     }
+
+    fn vsc_with_ctx_and_project(
+        auth_ctx: AuthenticationContext,
+        project_id: &str,
+    ) -> ValidatedSecurityContext {
+        let user = openstack_keystone_core_types::identity::UserResponseBuilder::default()
+            .id("uid")
+            .domain_id("domain_id")
+            .enabled(true)
+            .name("testuser")
+            .build()
+            .unwrap();
+        let authz = AuthzInfoBuilder::default()
+            .roles(vec![RoleRef {
+                id: "admin".to_string(),
+                name: Some("admin".to_string()),
+                domain_id: None,
+            }])
+            .scope(ScopeInfo::Project {
+                project: openstack_keystone_core_types::resource::Project {
+                    id: project_id.to_string(),
+                    domain_id: "domain_id".to_string(),
+                    enabled: true,
+                    name: "proj".to_string(),
+                    ..Default::default()
+                },
+                project_domain: openstack_keystone_core_types::resource::Domain {
+                    id: "domain_id".to_string(),
+                    name: "domain_name".to_string(),
+                    enabled: true,
+                    ..Default::default()
+                },
+            })
+            .build()
+            .unwrap();
+        let sc = SecurityContext::test_build()
+            .authentication_context(auth_ctx)
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    UserIdentityInfoBuilder::default()
+                        .user_id("uid")
+                        .user(user)
+                        .user_domain(openstack_keystone_core_types::resource::Domain {
+                            id: "domain_id".to_string(),
+                            name: "domain_name".to_string(),
+                            enabled: true,
+                            ..Default::default()
+                        })
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .authorization(authz)
+            .build();
+        ValidatedSecurityContext::test_new(sc)
+    }
+
+    fn make_ac(
+        project_id: &str,
+        unrestricted: bool,
+    ) -> openstack_keystone_core_types::application_credential::ApplicationCredential {
+        openstack_keystone_core_types::application_credential::ApplicationCredential {
+            id: "ac1".to_string(),
+            user_id: "uid".to_string(),
+            project_id: project_id.to_string(),
+            name: "cred".to_string(),
+            description: None,
+            roles: vec![],
+            unrestricted,
+            expires_at: None,
+            access_rules: None,
+        }
+    }
+
+    fn make_trust_ctx(project_id: Option<&str>) -> Trust {
+        Trust {
+            id: "t1".to_string(),
+            trustor_user_id: "trustor".to_string(),
+            trustee_user_id: "uid".to_string(),
+            impersonation: false,
+            project_id: project_id.map(|s| s.to_string()),
+            expires_at: None,
+            deleted_at: None,
+            extra: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: Some(vec![]),
+        }
+    }
+
+    /// Application-credential delegation facts (project + unrestricted flag)
+    /// must land on `Credentials` from the auth chain. Catches deletion of
+    /// the `ApplicationCredential` match arm in
+    /// `TryFrom<&ValidatedSecurityContext>`.
+    #[test]
+    fn credentials_from_application_credential_carries_delegation_facts() {
+        let vsc = vsc_with_ctx_and_project(
+            AuthenticationContext::ApplicationCredential {
+                application_credential: make_ac("project_id", true),
+                token: None,
+            },
+            "project_id",
+        );
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.delegated_project_id.as_deref(), Some("project_id"));
+        assert_eq!(creds.unrestricted, Some(true));
+        assert!(creds.is_delegated);
+    }
+
+    /// Trust delegation facts (project + trust object) must land on
+    /// `Credentials`. Catches deletion of the `Trust` match arm.
+    #[test]
+    fn credentials_from_trust_carries_delegation_facts() {
+        let vsc = vsc_with_ctx_and_project(
+            AuthenticationContext::Trust {
+                trust: make_trust_ctx(Some("project_id")),
+                token: None,
+            },
+            "project_id",
+        );
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.delegated_project_id.as_deref(), Some("project_id"));
+        assert!(creds.trust.is_some());
+        assert!(creds.is_delegated);
+    }
+
+    /// A trust with no bound project must not fabricate a
+    /// `delegated_project_id`.
+    #[test]
+    fn credentials_from_trust_without_project_leaves_delegated_project_id_unset() {
+        let vsc = vsc_with_ctx_and_project(
+            AuthenticationContext::Trust {
+                trust: make_trust_ctx(None),
+                token: None,
+            },
+            "project_id",
+        );
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.delegated_project_id, None);
+    }
+
+    /// Non-delegated auth methods must not populate `unrestricted` or
+    /// `delegated_project_id`.
+    #[test]
+    fn credentials_from_password_has_no_delegation_facts() {
+        let vsc = vsc_with_ctx_and_project(AuthenticationContext::Password, "project_id");
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.delegated_project_id, None);
+        assert_eq!(creds.unrestricted, None);
+        assert!(!creds.is_delegated);
+    }
+
+    /// The system-scope alias: the literal `"system"` scope value must map
+    /// to `"all"`, while any other named system scope passes through
+    /// unchanged. Catches `==` -> `!=` on the alias check.
+    #[test]
+    fn credentials_system_scope_all_alias() {
+        let authz = AuthzInfoBuilder::default()
+            .roles(vec![])
+            .scope(ScopeInfo::System("system".to_string()))
+            .build()
+            .unwrap();
+        let sc = SecurityContext::test_build()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    UserIdentityInfoBuilder::default()
+                        .user_id("uid")
+                        .user(
+                            openstack_keystone_core_types::identity::UserResponseBuilder::default()
+                                .id("uid")
+                                .domain_id("domain_id")
+                                .enabled(true)
+                                .name("testuser")
+                                .build()
+                                .unwrap(),
+                        )
+                        .user_domain(openstack_keystone_core_types::resource::Domain {
+                            id: "domain_id".to_string(),
+                            name: "domain_name".to_string(),
+                            enabled: true,
+                            ..Default::default()
+                        })
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .authorization(authz)
+            .build();
+        let vsc = ValidatedSecurityContext::test_new(sc);
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.system.as_deref(), Some("all"));
+    }
+
+    #[test]
+    fn credentials_system_scope_named_passes_through() {
+        let authz = AuthzInfoBuilder::default()
+            .roles(vec![])
+            .scope(ScopeInfo::System("other_system".to_string()))
+            .build()
+            .unwrap();
+        let sc = SecurityContext::test_build()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    UserIdentityInfoBuilder::default()
+                        .user_id("uid")
+                        .user(
+                            openstack_keystone_core_types::identity::UserResponseBuilder::default()
+                                .id("uid")
+                                .domain_id("domain_id")
+                                .enabled(true)
+                                .name("testuser")
+                                .build()
+                                .unwrap(),
+                        )
+                        .user_domain(openstack_keystone_core_types::resource::Domain {
+                            id: "domain_id".to_string(),
+                            name: "domain_name".to_string(),
+                            enabled: true,
+                            ..Default::default()
+                        })
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .authorization(authz)
+            .build();
+        let vsc = ValidatedSecurityContext::test_new(sc);
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.system.as_deref(), Some("other_system"));
+    }
+
+    /// A `WasmPlugin` context with claims must project them into
+    /// `plugin_claims`, keyed by plugin name. Catches the `!claims.is_empty()`
+    /// guard being flipped or deleted.
+    #[test]
+    fn credentials_from_wasm_plugin_with_claims_populates_plugin_claims() {
+        let mut claims = std::collections::HashMap::new();
+        claims.insert("department".to_string(), serde_json::json!("engineering"));
+        let vsc = vsc_with_ctx_and_project(
+            AuthenticationContext::WasmPlugin {
+                plugin_name: "acme_sso".to_string(),
+                claims,
+                token: None,
+            },
+            "project_id",
+        );
+        let creds = Credentials::try_from(&vsc).unwrap();
+        let plugin_claims = creds.plugin_claims.expect("plugin_claims must be set");
+        assert!(plugin_claims.contains_key("acme_sso"));
+    }
+
+    /// A `WasmPlugin` context with no claims must leave `plugin_claims`
+    /// unset (not an empty map keyed by plugin name).
+    #[test]
+    fn credentials_from_wasm_plugin_without_claims_leaves_plugin_claims_unset() {
+        let vsc = vsc_with_ctx_and_project(
+            AuthenticationContext::WasmPlugin {
+                plugin_name: "acme_sso".to_string(),
+                claims: std::collections::HashMap::new(),
+                token: None,
+            },
+            "project_id",
+        );
+        let creds = Credentials::try_from(&vsc).unwrap();
+        assert_eq!(creds.plugin_claims, None);
+    }
+
+    /// Scope-drift tripwire (I3): a delegated caller whose token scope no
+    /// longer matches its delegation project must fail closed with
+    /// `ScopeDrift`, never silently succeed. Catches `!=` -> `==` on the
+    /// drift comparison.
+    #[test]
+    fn credentials_scope_drift_between_token_and_delegation_project_is_rejected() {
+        let vsc = vsc_with_ctx_and_project(
+            AuthenticationContext::ApplicationCredential {
+                application_credential: make_ac("delegation_project", false),
+                token: None,
+            },
+            "other_project",
+        );
+        let err = Credentials::try_from(&vsc).unwrap_err();
+        assert!(matches!(err, PolicyError::ScopeDrift));
+    }
+
+    /// Same delegation and token project: no drift, succeeds normally.
+    #[test]
+    fn credentials_no_scope_drift_when_projects_match() {
+        let vsc = vsc_with_ctx_and_project(
+            AuthenticationContext::ApplicationCredential {
+                application_credential: make_ac("project_id", false),
+                token: None,
+            },
+            "project_id",
+        );
+        assert!(Credentials::try_from(&vsc).is_ok());
+    }
 }

--- a/crates/core/src/policy.rs
+++ b/crates/core/src/policy.rs
@@ -542,6 +542,7 @@ impl PolicyEvaluationResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::policy_contract;
     use crate::api::tests::test_fixture_scoped;
     use openstack_keystone_core_types::role::RoleRef;
 
@@ -612,5 +613,53 @@ mod tests {
         assert_eq!(creds.domain_id.as_deref(), Some("domain_id"));
         assert_eq!(creds.project_domain_id, None);
         assert_eq!(creds.project_id, None);
+    }
+
+    /// Gate I (security review V9, issue #987): a structural test that
+    /// `Credentials` -- the auth-chain projection sent to OPA on every
+    /// request -- never serializes a secret-bearing field, regardless of
+    /// which fields are populated. Currently vacuous (no field on
+    /// `Credentials` carries decrypted secret material today), but that is
+    /// exactly the point: it exists to catch a *future* field addition
+    /// that reintroduces one, the way `credential_policy_input`'s `blob`
+    /// stripping guards the sibling `target`/`existing` half of the
+    /// policy-input document (Gate B2).
+    #[test]
+    fn test_credentials_serialization_never_leaks_secrets() {
+        let creds = CredentialsBuilder::default()
+            .is_admin(false)
+            .user_id("uid")
+            .roles(vec!["member".to_string()])
+            .project_id("pid".to_string())
+            .auth_type("trust")
+            .is_delegated(true)
+            .unrestricted(false)
+            .delegated_project_id("pid".to_string())
+            .trust(Trust {
+                id: "t1".to_string(),
+                trustor_user_id: "trustor".to_string(),
+                trustee_user_id: "trustee".to_string(),
+                impersonation: false,
+                project_id: Some("pid".to_string()),
+                expires_at: None,
+                deleted_at: None,
+                extra: None,
+                remaining_uses: None,
+                redelegated_trust_id: None,
+                redelegation_count: None,
+                roles: Some(vec![]),
+            })
+            .plugin_claims(std::collections::HashMap::from([(
+                "acme_sso".to_string(),
+                std::collections::HashMap::from([(
+                    "department".to_string(),
+                    serde_json::json!("engineering"),
+                )]),
+            )]))
+            .build()
+            .unwrap();
+
+        let value = serde_json::to_value(&creds).unwrap();
+        policy_contract::assert_no_secrets(&value);
     }
 }

--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -131,7 +131,10 @@ async fn version(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    pub use openstack_keystone_core::api::tests::{get_mocked_state, test_fixture_scoped};
+    pub use openstack_keystone_core::api::policy_contract;
+    pub use openstack_keystone_core::api::tests::{
+        get_capturing_state, get_mocked_state, test_fixture_scoped,
+    };
 
     use std::net::SocketAddr;
 

--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -147,7 +147,260 @@ pub(crate) mod tests {
     use tower_http::normalize_path::NormalizePathLayer;
 
     use super::openapi_router;
-    use crate::provider::Provider;
+    use crate::policy::PolicyEnforcer;
+    use crate::provider::{Provider, ProviderBuilder};
+
+    /// A running `opa run -s` subprocess serving the repository's real
+    /// `policy/` tree over a private Unix socket. Must be kept alive for
+    /// the duration of the test that owns it -- dropping it kills the `opa`
+    /// process (`kill_on_drop`) and removes its socket's temp directory.
+    pub struct RealOpaGuard {
+        _child: tokio::process::Child,
+        _tmp_dir: tempfile::TempDir,
+    }
+
+    /// Like [`get_mocked_state`], but wired to the real, production
+    /// [`crate::policy::HttpPolicyEnforcer`] talking to a real `opa run -s`
+    /// subprocess evaluating the repository's actual `policy/` tree,
+    /// instead of `MockPolicy`'s canned allow/deny.
+    ///
+    /// Gate B3 (security review V3a, issue #979):
+    /// `get_mocked_state`/`get_capturing_state` prove a handler builds a
+    /// well-shaped policy input, but never run it against the real Rego
+    /// logic -- a handler could feed OPA a subtly wrong document that a
+    /// mock happily accepts but the real policy would decide differently
+    /// on. This closes that gap using the same production enforcer and
+    /// `opa` binary `tools/start-api.sh` orchestrates for `test_api`
+    /// (requires `opa` on `PATH`; already true in CI via
+    /// `open-policy-agent/setup-opa`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `opa` isn't on `PATH` or the server never becomes healthy
+    /// -- a broken real evaluator should fail the test loudly, not
+    /// silently degrade into a false result.
+    pub async fn get_state_with_real_policy(
+        provider_builder: ProviderBuilder,
+    ) -> (crate::keystone::ServiceState, RealOpaGuard) {
+        let tmp_dir = tempfile::tempdir().expect("failed to create a temp dir for the opa socket");
+        let socket_path = tmp_dir.path().join("opa.sock");
+        let policy_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../policy");
+        let addr = format!("unix://{}", socket_path.display());
+
+        let child = tokio::process::Command::new("opa")
+            .arg("run")
+            .arg("-s")
+            .arg(&policy_dir)
+            .arg("--addr")
+            .arg(&addr)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("failed to spawn `opa run` -- is `opa` installed and on PATH?");
+
+        let url: url::Url = addr.parse().expect("valid unix socket url");
+        let mut enforcer = None;
+        for _ in 0..200 {
+            if let Ok(candidate) = crate::policy::HttpPolicyEnforcer::new(url.clone()).await
+                && candidate.health_check().await.is_ok()
+            {
+                enforcer = Some(candidate);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        let enforcer = enforcer.expect("`opa run` never became healthy");
+
+        let provider = provider_builder.build().expect("provider builder failed");
+        let state = std::sync::Arc::new(
+            crate::keystone::Service::new(
+                openstack_keystone_config::ConfigManager::not_watched(
+                    openstack_keystone_config::Config::default(),
+                ),
+                sea_orm::DatabaseConnection::Disconnected,
+                provider,
+                std::sync::Arc::new(enforcer),
+                openstack_keystone_audit::AuditDispatcher::noop(),
+                None,
+            )
+            .await
+            .expect("service construction failed"),
+        );
+
+        (
+            state,
+            RealOpaGuard {
+                _child: child,
+                _tmp_dir: tmp_dir,
+            },
+        )
+    }
+
+    /// Shared real-policy VSC fixtures for handlers exercising the
+    /// delegation boundary (OSSA-2026-015) against a real `opa run`
+    /// subprocess via [`get_state_with_real_policy`] -- factored out of
+    /// `credential::create`'s original `real_policy_decision` module so
+    /// every delegation-sensitive handler test builds its
+    /// `ValidatedSecurityContext` fixtures the same way instead of
+    /// hand-copying them.
+    #[allow(clippy::unwrap_used)]
+    pub mod real_policy_fixtures {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+        use openstack_keystone_core_types::application_credential::ApplicationCredentialBuilder;
+        use openstack_keystone_core_types::auth::{
+            AuthenticationContext, AuthzInfoBuilder, IdentityInfo, PrincipalInfo, ScopeInfo,
+            SecurityContext, UserIdentityInfoBuilder,
+        };
+        use openstack_keystone_core_types::resource::{Domain, Project};
+        use openstack_keystone_core_types::role::RoleRef;
+
+        /// A resolved, enabled user identity in an enabled domain --
+        /// `UserIdentityInfo::validate()` (and thus `Auth`'s
+        /// `fully_resolved()` short-circuit for a test-injected VSC) fails
+        /// closed without both.
+        pub fn user_identity(user_id: &str) -> IdentityInfo {
+            IdentityInfo::User(
+                UserIdentityInfoBuilder::default()
+                    .user_id(user_id)
+                    .user(
+                        openstack_keystone_core_types::identity::UserResponseBuilder::default()
+                            .id(user_id)
+                            .domain_id("d1")
+                            .enabled(true)
+                            .name(user_id)
+                            .build()
+                            .unwrap(),
+                    )
+                    .user_domain(Domain {
+                        id: "d1".to_string(),
+                        name: "d1".to_string(),
+                        enabled: true,
+                        ..Default::default()
+                    })
+                    .build()
+                    .unwrap(),
+            )
+        }
+
+        /// A non-delegated, plain password-authenticated caller scoped to
+        /// `project_id` with `roles`.
+        pub fn member_vsc(
+            user_id: &str,
+            project_id: &str,
+            roles: &[&str],
+        ) -> ValidatedSecurityContext {
+            let authz = AuthzInfoBuilder::default()
+                .scope(ScopeInfo::Project {
+                    project: Project {
+                        id: project_id.to_string(),
+                        domain_id: "d1".to_string(),
+                        enabled: true,
+                        name: "project".to_string(),
+                        ..Default::default()
+                    },
+                    project_domain: Domain {
+                        id: "d1".to_string(),
+                        name: "d1".to_string(),
+                        enabled: true,
+                        ..Default::default()
+                    },
+                })
+                .roles(
+                    roles
+                        .iter()
+                        .enumerate()
+                        .map(|(i, name)| RoleRef {
+                            domain_id: None,
+                            id: format!("role-{i}"),
+                            name: Some((*name).to_string()),
+                        })
+                        .collect::<Vec<_>>(),
+                )
+                .build()
+                .unwrap();
+
+            let sc = SecurityContext::test_build()
+                .authentication_context(AuthenticationContext::Password)
+                .principal(PrincipalInfo {
+                    identity: user_identity(user_id),
+                })
+                .authorization(authz)
+                .build();
+            ValidatedSecurityContext::test_new(sc)
+        }
+
+        /// A restricted application credential authenticated context, scoped
+        /// to its own delegation project (no scope-drift), for the
+        /// delegated-allowed/delegated-escape cases.
+        pub fn restricted_app_cred_vsc(
+            user_id: &str,
+            delegation_project_id: &str,
+        ) -> ValidatedSecurityContext {
+            app_cred_vsc(user_id, delegation_project_id, false)
+        }
+
+        /// Like [`restricted_app_cred_vsc`], but `unrestricted`: `identity/
+        /// os_ec2/create_credential.rego`'s `is_restricted_app_cred` check
+        /// (OSSA-2026-005 / CVE-2026-33551) only fires on a *restricted*
+        /// application credential, so this is needed to exercise the
+        /// allowed path for that policy.
+        pub fn app_cred_vsc(
+            user_id: &str,
+            delegation_project_id: &str,
+            unrestricted: bool,
+        ) -> ValidatedSecurityContext {
+            let authz = AuthzInfoBuilder::default()
+                .scope(ScopeInfo::Project {
+                    project: Project {
+                        id: delegation_project_id.to_string(),
+                        domain_id: "d1".to_string(),
+                        enabled: true,
+                        name: "project".to_string(),
+                        ..Default::default()
+                    },
+                    project_domain: Domain {
+                        id: "d1".to_string(),
+                        name: "d1".to_string(),
+                        enabled: true,
+                        ..Default::default()
+                    },
+                })
+                .roles(vec![RoleRef {
+                    domain_id: None,
+                    id: "role-0".to_string(),
+                    name: Some("member".to_string()),
+                }])
+                .build()
+                .unwrap();
+
+            let app_cred = ApplicationCredentialBuilder::default()
+                .id("appcred1")
+                .name("appcred1")
+                .project_id(delegation_project_id)
+                .roles(vec![RoleRef {
+                    domain_id: None,
+                    id: "role-0".to_string(),
+                    name: Some("member".to_string()),
+                }])
+                .unrestricted(unrestricted)
+                .user_id(user_id)
+                .build()
+                .unwrap();
+
+            let sc = SecurityContext::test_build()
+                .authentication_context(AuthenticationContext::ApplicationCredential {
+                    application_credential: app_cred,
+                    token: None,
+                })
+                .principal(PrincipalInfo {
+                    identity: user_identity(user_id),
+                })
+                .authorization(authz)
+                .build();
+            ValidatedSecurityContext::test_new(sc)
+        }
+    }
 
     /// A request to a route with a trailing slash must be served by the same
     /// handler as the canonical (no-slash) path — no 404 and no redirect

--- a/crates/keystone/src/api/v3/auth/token/delete.rs
+++ b/crates/keystone/src/api/v3/auth/token/delete.rs
@@ -318,4 +318,119 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
+
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/auth/token/revoke.rego` decision (via a real `opa
+    /// run` subprocess instead of `MockPolicy`) through the
+    /// owner/non-owner matrix -- `identity.token_subject` is the rule that
+    /// actually decides who may revoke a token (besides admin), and a mock
+    /// can never catch a handler feeding it the wrong `user_id`. Requires
+    /// `opa` on `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+        use openstack_keystone_core_types::auth::{AuthzInfoBuilder, *};
+        use openstack_keystone_core_types::resource::Domain as CoreDomain;
+        use openstack_keystone_core_types::token::UnscopedPayload;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+        use crate::api::tests::real_policy_fixtures::member_vsc;
+        use crate::provider::ProviderBuilder;
+
+        fn subject_token_vsc(owner_user_id: &str) -> ValidatedSecurityContext {
+            let user_domain = CoreDomain {
+                id: "d1".into(),
+                enabled: true,
+                ..Default::default()
+            };
+            let authz = AuthzInfoBuilder::default()
+                .scope(ScopeInfo::Unscoped)
+                .build()
+                .unwrap();
+            ValidatedSecurityContext::test_new(
+                SecurityContext::test_build()
+                    .authentication_context(AuthenticationContext::Password)
+                    .principal(PrincipalInfo {
+                        identity: IdentityInfo::User(
+                            UserIdentityInfoBuilder::default()
+                                .user_id(owner_user_id)
+                                .user_domain(user_domain)
+                                .build()
+                                .unwrap(),
+                        ),
+                    })
+                    .token(ProviderToken::Unscoped(UnscopedPayload {
+                        user_id: owner_user_id.into(),
+                        ..Default::default()
+                    }))
+                    .authorization(authz)
+                    .build(),
+            )
+        }
+
+        fn provider_with_subject_token(owner_user_id: &'static str) -> ProviderBuilder {
+            let subject_vsc = subject_token_vsc(owner_user_id);
+            let fernet_for_revoke = subject_vsc.inner().token().unwrap().clone();
+
+            let mut token_mock = MockTokenProvider::default();
+            token_mock
+                .expect_validate_to_context()
+                .withf(|_, token: &'_ str, _, _| token == "subject")
+                .returning(move |_, _, _, _| Ok(subject_vsc.clone()));
+
+            let mut revoke_mock = MockRevokeProvider::default();
+            revoke_mock
+                .expect_revoke_token()
+                .withf(move |_, token: &ProviderToken| *token == fernet_for_revoke)
+                .returning(|_, _| Ok(()));
+
+            Provider::mocked_builder()
+                .mock_token(token_mock)
+                .mock_revoke(revoke_mock)
+        }
+
+        async fn revoke_request(
+            vsc: ValidatedSecurityContext,
+            provider_builder: ProviderBuilder,
+        ) -> StatusCode {
+            let (state, _opa_guard) = get_state_with_real_policy(provider_builder).await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .uri("/")
+                        .method("DELETE")
+                        .extension(vsc)
+                        .header("x-subject-token", "subject")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn owner_revoking_own_token_is_allowed() {
+            let status = revoke_request(
+                member_vsc("u1", "p1", &[]),
+                provider_with_subject_token("u1"),
+            )
+            .await;
+            assert_eq!(status, StatusCode::NO_CONTENT);
+        }
+
+        #[tokio::test]
+        async fn non_owner_revoking_someone_elses_token_is_denied() {
+            let status = revoke_request(
+                member_vsc("u2", "p1", &[]),
+                provider_with_subject_token("u1"),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/crates/keystone/src/api/v3/auth/token/show.rs
+++ b/crates/keystone/src/api/v3/auth/token/show.rs
@@ -256,6 +256,136 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/auth/token/show.rego` decision (via a real `opa
+    /// run` subprocess instead of `MockPolicy`) through the owner/non-owner
+    /// matrix -- `identity.token_subject` is the rule that actually decides
+    /// who may view a token (besides admin/service/system-reader), and a
+    /// mock can never catch a handler feeding it the wrong `user_id`
+    /// (issue #979 caught exactly this: `token_subject` compared against
+    /// `token.user_id`, but the real `Token` struct nests it as
+    /// `token.user.id`, so this branch was silently dead -- fixed in
+    /// `policy/identity.rego`). Requires `opa` on `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+        use openstack_keystone_core_types::auth::{AuthzInfoBuilder, *};
+        use openstack_keystone_core_types::resource::Domain as CoreDomain;
+        use openstack_keystone_core_types::token::UnscopedPayload;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+        use crate::api::tests::real_policy_fixtures::member_vsc;
+        use crate::provider::ProviderBuilder;
+
+        fn subject_token_vsc(owner_user_id: &str) -> ValidatedSecurityContext {
+            let user_domain = CoreDomain {
+                id: "d1".into(),
+                enabled: true,
+                ..Default::default()
+            };
+            let authz = AuthzInfoBuilder::default()
+                .scope(ScopeInfo::Domain(CoreDomain {
+                    id: "d1".into(),
+                    enabled: true,
+                    ..Default::default()
+                }))
+                .build()
+                .unwrap();
+            ValidatedSecurityContext::test_new(
+                SecurityContext::test_build()
+                    .authentication_context(AuthenticationContext::Password)
+                    .principal(PrincipalInfo {
+                        identity: IdentityInfo::User(
+                            UserIdentityInfoBuilder::default()
+                                .user_id(owner_user_id)
+                                .user_domain(user_domain)
+                                .build()
+                                .unwrap(),
+                        ),
+                    })
+                    .token(openstack_keystone_core_types::token::FernetToken::Unscoped(
+                        UnscopedPayload {
+                            user_id: owner_user_id.into(),
+                            ..Default::default()
+                        },
+                    ))
+                    .authorization(authz)
+                    .build(),
+            )
+        }
+
+        fn provider_with_subject_token(owner_user_id: &'static str) -> ProviderBuilder {
+            let subject_vsc = subject_token_vsc(owner_user_id);
+
+            let mut token_mock = MockTokenProvider::default();
+            token_mock
+                .expect_validate_to_context()
+                .returning(move |_, _, _, _| Ok(subject_vsc.clone()));
+
+            let mut catalog_mock = MockCatalogProvider::default();
+            catalog_mock
+                .expect_get_catalog()
+                .returning(|_, _| Ok(Vec::new()));
+
+            let mut resource_mock = MockResourceProvider::default();
+            resource_mock.expect_get_domain().returning(|_, _| {
+                Ok(Some(CoreDomain {
+                    id: "d1".into(),
+                    enabled: true,
+                    ..Default::default()
+                }))
+            });
+
+            Provider::mocked_builder()
+                .mock_token(token_mock)
+                .mock_catalog(catalog_mock)
+                .mock_resource(resource_mock)
+        }
+
+        async fn show_request(
+            vsc: ValidatedSecurityContext,
+            provider_builder: ProviderBuilder,
+        ) -> StatusCode {
+            let (state, _opa_guard) = get_state_with_real_policy(provider_builder).await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .uri("/")
+                        .extension(vsc)
+                        .header("x-subject-token", "subject")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn owner_viewing_own_token_is_allowed() {
+            let status = show_request(
+                member_vsc("u1", "p1", &[]),
+                provider_with_subject_token("u1"),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn non_owner_viewing_someone_elses_token_is_denied() {
+            let status = show_request(
+                member_vsc("u2", "p1", &[]),
+                provider_with_subject_token("u1"),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+    }
+
     #[tokio::test]
     async fn test_show_domain() {
         use openstack_keystone_core_types::auth::{AuthzInfoBuilder, *};

--- a/crates/keystone/src/api/v3/credential/create.rs
+++ b/crates/keystone/src/api/v3/credential/create.rs
@@ -208,4 +208,149 @@ mod tests {
         let res: CredentialResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(res.credential.id, "new_id");
     }
+
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/credential/create.rego` decision (via
+    /// `get_state_with_real_policy`'s real `opa run` subprocess + the
+    /// production `HttpPolicyEnforcer`, instead of a canned allow/deny)
+    /// through the authorized/unauthorized/delegated-allowed/
+    /// delegated-escape matrix. `test_create_policy_input_contract` above
+    /// proves the handler builds a well-shaped policy input; this proves
+    /// the real policy actually decides on it as expected -- closing the
+    /// gap a mock can never catch (a handler feeding OPA a subtly wrong
+    /// document that a mock accepts, but the real policy would not).
+    /// Requires `opa` on `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+        use crate::api::tests::real_policy_fixtures::{member_vsc, restricted_app_cred_vsc};
+        use crate::provider::ProviderBuilder;
+
+        /// A `MockCredentialProvider` whose `create_credential` always
+        /// succeeds -- only reached by the scenarios the real policy is
+        /// expected to allow; the denied scenarios never get this far.
+        fn allowing_provider() -> ProviderBuilder {
+            let mut credential_mock = crate::credential::MockCredentialProvider::default();
+            credential_mock
+                .expect_create_credential()
+                .returning(|_, rec| {
+                    let mut builder =
+                        openstack_keystone_core_types::credential::CredentialBuilder::default();
+                    builder
+                        .id("new_id")
+                        .blob(rec.blob.clone())
+                        .r#type(rec.r#type.clone())
+                        .user_id(rec.user_id.clone().unwrap_or_default());
+                    if let Some(project_id) = &rec.project_id {
+                        builder.project_id(project_id.clone());
+                    }
+                    Ok(builder.build().unwrap())
+                });
+            Provider::mocked_builder().mock_credential(credential_mock)
+        }
+
+        async fn create_request(
+            vsc: ValidatedSecurityContext,
+            credential: crate::api::v3::credential::types::CredentialCreate,
+            provider_builder: ProviderBuilder,
+        ) -> StatusCode {
+            let (state, _opa_guard) = get_state_with_real_policy(provider_builder).await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            let req = crate::api::v3::credential::types::CredentialCreateRequest { credential };
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .uri("/")
+                        .extension(vsc)
+                        .header("Content-Type", "application/json")
+                        .method("POST")
+                        .body(Body::from(serde_json::to_string(&req).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn authorized_member_creating_own_credential_is_allowed() {
+            let status = create_request(
+                member_vsc("u1", "p1", &["member"]),
+                CredentialCreateBuilder::default()
+                    .blob(r#"{"seed":"AAAA"}"#)
+                    .r#type("totp")
+                    .user_id("u1")
+                    .build()
+                    .unwrap(),
+                allowing_provider(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::CREATED);
+        }
+
+        #[tokio::test]
+        async fn unauthorized_caller_with_no_roles_is_denied() {
+            let status = create_request(
+                member_vsc("u1", "p1", &[]),
+                CredentialCreateBuilder::default()
+                    .blob(r#"{"seed":"AAAA"}"#)
+                    .r#type("totp")
+                    .user_id("u1")
+                    .build()
+                    .unwrap(),
+                Provider::mocked_builder(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        /// OSSA-2026-015: a restricted application credential creating a
+        /// non-ec2 credential bound to its own delegation project is
+        /// allowed.
+        #[tokio::test]
+        async fn delegated_credential_bound_to_own_project_is_allowed() {
+            let status = create_request(
+                restricted_app_cred_vsc("u1", "p1"),
+                CredentialCreateBuilder::default()
+                    .blob(r#"{"seed":"AAAA"}"#)
+                    .r#type("totp")
+                    .user_id("u1")
+                    .project_id("p1")
+                    .build()
+                    .unwrap(),
+                allowing_provider(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::CREATED);
+        }
+
+        /// OSSA-2026-015: a delegated caller whose token scope is pinned to
+        /// its own delegation project (no Rust-side scope-drift) must still
+        /// be denied by the real Rego policy from creating a credential
+        /// that escapes that project (here: no `project_id` on the target
+        /// at all, i.e. an unscoped credential) -- this is the
+        /// `credential_common.not_delegated_or_bound_to_own_project` check
+        /// itself, not the Rust-side tripwire in `Credentials::try_from`.
+        #[tokio::test]
+        async fn delegated_credential_escaping_own_project_is_denied() {
+            let status = create_request(
+                restricted_app_cred_vsc("u1", "p1"),
+                CredentialCreateBuilder::default()
+                    .blob(r#"{"seed":"AAAA"}"#)
+                    .r#type("totp")
+                    .user_id("u1")
+                    .build()
+                    .unwrap(),
+                Provider::mocked_builder(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/crates/keystone/src/api/v3/credential/create.rs
+++ b/crates/keystone/src/api/v3/credential/create.rs
@@ -86,10 +86,69 @@ mod tests {
     use openstack_keystone_core_types::credential::{CredentialBuilder, CredentialCreate};
 
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::api::v3::credential::types::{CredentialCreateBuilder, CredentialResponse};
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (security review V3a, issue #978): asserts the handler feeds
+    /// `enforce()` the contract `identity/credential/create.rego` expects --
+    /// single `credential` key, no `existing`, and no leaked `blob`.
+    #[tokio::test]
+    async fn test_create_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_create_credential()
+            .returning(|_, _| {
+                Ok(CredentialBuilder::default()
+                    .id("new_id")
+                    .blob(r#"{"seed":"AAAA"}"#)
+                    .r#type("totp")
+                    .user_id("uid")
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::credential::types::CredentialCreateRequest {
+            credential: CredentialCreateBuilder::default()
+                .blob(r#"{"seed":"AAAA"}"#)
+                .r#type("totp")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].policy_name, "identity/credential/create");
+        policy_contract::assert_object_keys(&calls[0].target, &["credential"]);
+        policy_contract::assert_existing_presence(&calls[0].existing, false);
+        policy_contract::assert_no_secrets(&calls[0].target);
+    }
 
     #[tokio::test]
     async fn test_create() {

--- a/crates/keystone/src/api/v3/credential/delete.rs
+++ b/crates/keystone/src/api/v3/credential/delete.rs
@@ -19,7 +19,6 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use serde_json::json;
 
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
@@ -59,7 +58,7 @@ pub(super) async fn delete(
             "identity/credential/delete",
             &user_auth,
             serde_json::Value::Null,
-            Some(json!({"credential": current})),
+            Some(super::credential_policy_input(&current)),
         )
         .await?;
 
@@ -95,9 +94,65 @@ mod tests {
     use openstack_keystone_core_types::credential::CredentialBuilder;
 
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (issue #978): mirrors `test_show_policy_input_contract` for
+    /// delete -- same documented shape in `identity/credential/delete.rego`.
+    #[tokio::test]
+    async fn test_delete_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_get_credential()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    CredentialBuilder::default()
+                        .id("foo")
+                        .blob(r#"{"seed":"AAAA"}"#)
+                        .r#type("totp")
+                        .user_id("uid")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        credential_mock
+            .expect_delete_credential()
+            .returning(|_, _| Ok(()));
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].policy_name, "identity/credential/delete");
+        assert_eq!(calls[0].target, serde_json::Value::Null);
+        policy_contract::assert_existing_presence(&calls[0].existing, true);
+        policy_contract::assert_object_keys(calls[0].existing.as_ref().unwrap(), &["credential"]);
+        policy_contract::assert_no_secrets(calls[0].existing.as_ref().unwrap());
+    }
 
     #[tokio::test]
     async fn test_delete_success() {

--- a/crates/keystone/src/api/v3/credential/delete.rs
+++ b/crates/keystone/src/api/v3/credential/delete.rs
@@ -239,4 +239,108 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
+
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/credential/delete.rego` decision through the
+    /// authorized/unauthorized/delegated-allowed/delegated-escape matrix,
+    /// exercising `credential_common.bound_to_own_delegation_project`
+    /// (OSSA-2026-015) via the real `opa run` subprocess instead of
+    /// `MockPolicy`. Requires `opa` on `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+        use crate::api::tests::real_policy_fixtures::{member_vsc, restricted_app_cred_vsc};
+        use crate::provider::ProviderBuilder;
+
+        fn provider_with_credential(existing_project_id: Option<&'static str>) -> ProviderBuilder {
+            let mut credential_mock = MockCredentialProvider::default();
+            credential_mock
+                .expect_get_credential()
+                .withf(|_, id: &'_ str| id == "cred1")
+                .returning(move |_, _| {
+                    let mut builder = CredentialBuilder::default();
+                    builder
+                        .id("cred1")
+                        .blob(r#"{"seed":"AAAA"}"#)
+                        .r#type("totp")
+                        .user_id("u1");
+                    if let Some(project_id) = existing_project_id {
+                        builder.project_id(project_id);
+                    }
+                    Ok(Some(builder.build().unwrap()))
+                });
+            credential_mock
+                .expect_delete_credential()
+                .returning(|_, _| Ok(()));
+            Provider::mocked_builder().mock_credential(credential_mock)
+        }
+
+        async fn delete_request(
+            vsc: ValidatedSecurityContext,
+            provider_builder: ProviderBuilder,
+        ) -> StatusCode {
+            let (state, _opa_guard) = get_state_with_real_policy(provider_builder).await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .method("DELETE")
+                        .uri("/cred1")
+                        .extension(vsc)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn owner_deleting_own_non_delegated_credential_is_allowed() {
+            let status = delete_request(
+                member_vsc("u1", "p1", &["member"]),
+                provider_with_credential(None),
+            )
+            .await;
+            assert_eq!(status, StatusCode::NO_CONTENT);
+        }
+
+        #[tokio::test]
+        async fn caller_with_no_roles_is_denied() {
+            let status =
+                delete_request(member_vsc("u1", "p1", &[]), provider_with_credential(None)).await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        /// OSSA-2026-015: a delegated caller deleting a credential bound to
+        /// its own delegation project is allowed.
+        #[tokio::test]
+        async fn delegated_caller_deleting_credential_bound_to_own_project_is_allowed() {
+            let status = delete_request(
+                restricted_app_cred_vsc("u1", "p1"),
+                provider_with_credential(Some("p1")),
+            )
+            .await;
+            assert_eq!(status, StatusCode::NO_CONTENT);
+        }
+
+        /// OSSA-2026-015: a delegated caller must not be able to delete an
+        /// unscoped credential (e.g. TOTP/MFA) it owns -- out-of-scope for
+        /// any delegated caller, since stealing a delegation token must not
+        /// be enough to destroy a user's MFA binding.
+        #[tokio::test]
+        async fn delegated_caller_deleting_unscoped_credential_is_denied() {
+            let status = delete_request(
+                restricted_app_cred_vsc("u1", "p1"),
+                provider_with_credential(None),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/crates/keystone/src/api/v3/credential/list.rs
+++ b/crates/keystone/src/api/v3/credential/list.rs
@@ -277,4 +277,79 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
+
+    /// Gate B3 (security review V3a, issue #979): the per-item re-check
+    /// (ADR 0019 §2, CVE-2019-19687) is where `list`'s delegation boundary
+    /// (OSSA-2026-015) actually lives -- `identity/credential/list.rego`
+    /// itself lets any member attempt to list, so this drives a delegated
+    /// caller's list through the real `identity/credential/show.rego`
+    /// decision (via a real `opa run` subprocess) over a mixed batch: one
+    /// record bound to the delegation's own project (must survive), one
+    /// bound to a different project, and one unscoped (both must be
+    /// silently dropped, never surfaced as an error). Requires `opa` on
+    /// `PATH`.
+    #[tokio::test]
+    async fn delegated_caller_list_is_filtered_to_own_project_by_real_policy() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock.expect_list_credentials().returning(|_, _| {
+            Ok(vec![
+                CredentialBuilder::default()
+                    .id("own-project")
+                    .blob(r#"{"seed":"AAAA"}"#)
+                    .r#type("totp")
+                    .user_id("u1")
+                    .project_id("p1")
+                    .build()
+                    .unwrap(),
+                CredentialBuilder::default()
+                    .id("other-project")
+                    .blob(r#"{"seed":"BBBB"}"#)
+                    .r#type("totp")
+                    .user_id("u1")
+                    .project_id("p2")
+                    .build()
+                    .unwrap(),
+                CredentialBuilder::default()
+                    .id("unscoped")
+                    .blob(r#"{"seed":"CCCC"}"#)
+                    .r#type("totp")
+                    .user_id("u1")
+                    .build()
+                    .unwrap(),
+            ])
+        });
+
+        let vsc = crate::api::tests::real_policy_fixtures::restricted_app_cred_vsc("u1", "p1");
+        let (state, _opa_guard) = crate::api::tests::get_state_with_real_policy(
+            Provider::mocked_builder().mock_credential(credential_mock),
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: CredentialList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            res.credentials
+                .iter()
+                .map(|c| c.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["own-project"]
+        );
+    }
 }

--- a/crates/keystone/src/api/v3/credential/list.rs
+++ b/crates/keystone/src/api/v3/credential/list.rs
@@ -104,10 +104,68 @@ mod tests {
     use openstack_keystone_core_types::credential::{CredentialBuilder, CredentialListParameters};
 
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::api::v3::credential::types::CredentialList;
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (issue #978): list performs a two-phase check (ADR 0019 §2,
+    /// CVE-2019-19687) -- assert *both* calls: the list-level filter-hint
+    /// check and the per-item `identity/credential/show` re-check, with the
+    /// per-item call keying the stripped stored record under `existing`.
+    #[tokio::test]
+    async fn test_list_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock.expect_list_credentials().returning(|_, _| {
+            Ok(vec![
+                CredentialBuilder::default()
+                    .id("1")
+                    .blob(r#"{"seed":"AAAA"}"#)
+                    .r#type("totp")
+                    .user_id("uid")
+                    .build()
+                    .unwrap(),
+            ])
+        });
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 2);
+
+        assert_eq!(calls[0].policy_name, "identity/credential/list");
+        policy_contract::assert_object_keys(&calls[0].target, &["credential"]);
+        policy_contract::assert_existing_presence(&calls[0].existing, false);
+        policy_contract::assert_no_secrets(&calls[0].target);
+
+        assert_eq!(calls[1].policy_name, "identity/credential/show");
+        assert_eq!(calls[1].target, serde_json::Value::Null);
+        policy_contract::assert_existing_presence(&calls[1].existing, true);
+        let existing = calls[1].existing.as_ref().unwrap();
+        policy_contract::assert_object_keys(existing, &["credential"]);
+        policy_contract::assert_no_secrets(existing);
+    }
 
     #[tokio::test]
     async fn test_list() {

--- a/crates/keystone/src/api/v3/credential/mod.rs
+++ b/crates/keystone/src/api/v3/credential/mod.rs
@@ -57,4 +57,43 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use openstack_keystone_core_types::credential::CredentialBuilder;
+
+    use super::credential_policy_input;
+    use crate::api::tests::policy_contract;
+
+    /// Gate I (security review V9, issue #987): a direct, structural test
+    /// on the stripping helper itself, not just through a handler's HTTP
+    /// round-trip (which Gate B2's per-handler tests already cover) -- a
+    /// future field addition to `Credential` that reintroduces a
+    /// secret-bearing field is caught here regardless of which handler
+    /// calls this helper.
+    #[test]
+    fn test_credential_policy_input_never_leaks_blob() {
+        let cred = CredentialBuilder::default()
+            .id("cred_id")
+            .blob(r#"{"access":"AKIA123","secret":"s3cr3t","seed":"TOTPSEED"}"#)
+            .r#type("ec2")
+            .user_id("uid")
+            .project_id("pid")
+            .build()
+            .unwrap();
+
+        let input = credential_policy_input(&cred);
+        policy_contract::assert_object_keys(&input, &["credential"]);
+        policy_contract::assert_no_secrets(&input);
+        assert!(
+            !input.to_string().contains("s3cr3t"),
+            "serialized policy input must not contain the decrypted secret bytes"
+        );
+    }
+
+    #[test]
+    fn test_credential_policy_input_none_is_null_credential() {
+        let input =
+            credential_policy_input(&None::<openstack_keystone_core_types::credential::Credential>);
+        policy_contract::assert_object_keys(&input, &["credential"]);
+        assert_eq!(input["credential"], serde_json::Value::Null);
+    }
+}

--- a/crates/keystone/src/api/v3/credential/show.rs
+++ b/crates/keystone/src/api/v3/credential/show.rs
@@ -182,4 +182,109 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
+
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/credential/show.rego` decision through the
+    /// authorized/unauthorized/delegated-allowed/delegated-escape matrix
+    /// via a real `opa run` subprocess, exercising
+    /// `credential_common.bound_to_own_delegation_project`
+    /// (OSSA-2026-015). Also underlies `credential::list`'s per-item
+    /// re-check (ADR 0019 §2, CVE-2019-19687). Requires `opa` on `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+        use crate::api::tests::real_policy_fixtures::{member_vsc, restricted_app_cred_vsc};
+        use crate::provider::ProviderBuilder;
+
+        fn provider_with_credential(
+            owner_user_id: &'static str,
+            existing_project_id: Option<&'static str>,
+        ) -> ProviderBuilder {
+            let mut credential_mock = MockCredentialProvider::default();
+            credential_mock
+                .expect_get_credential()
+                .withf(|_, id: &'_ str| id == "cred1")
+                .returning(move |_, _| {
+                    let mut builder = CredentialBuilder::default();
+                    builder
+                        .id("cred1")
+                        .blob(r#"{"seed":"AAAA"}"#)
+                        .r#type("totp")
+                        .user_id(owner_user_id);
+                    if let Some(project_id) = existing_project_id {
+                        builder.project_id(project_id);
+                    }
+                    Ok(Some(builder.build().unwrap()))
+                });
+            Provider::mocked_builder().mock_credential(credential_mock)
+        }
+
+        async fn show_request(
+            vsc: ValidatedSecurityContext,
+            provider_builder: ProviderBuilder,
+        ) -> StatusCode {
+            let (state, _opa_guard) = get_state_with_real_policy(provider_builder).await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .uri("/cred1")
+                        .extension(vsc)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn owner_reading_own_non_delegated_credential_is_allowed() {
+            let status = show_request(
+                member_vsc("u1", "p1", &["member"]),
+                provider_with_credential("u1", None),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn non_owner_reading_someone_elses_credential_is_denied() {
+            let status = show_request(
+                member_vsc("u2", "p1", &["member"]),
+                provider_with_credential("u1", None),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        /// OSSA-2026-015: a delegated caller reading a credential bound to
+        /// its own delegation project is allowed.
+        #[tokio::test]
+        async fn delegated_caller_reading_credential_bound_to_own_project_is_allowed() {
+            let status = show_request(
+                restricted_app_cred_vsc("u1", "p1"),
+                provider_with_credential("u1", Some("p1")),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        /// OSSA-2026-015: a delegated caller must not be able to read an
+        /// unscoped credential (e.g. TOTP/MFA seed) it owns.
+        #[tokio::test]
+        async fn delegated_caller_reading_unscoped_credential_is_denied() {
+            let status = show_request(
+                restricted_app_cred_vsc("u1", "p1"),
+                provider_with_credential("u1", None),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/crates/keystone/src/api/v3/credential/show.rs
+++ b/crates/keystone/src/api/v3/credential/show.rs
@@ -87,10 +87,66 @@ mod tests {
     use tower::ServiceExt;
     use tower_http::trace::TraceLayer;
 
+    use openstack_keystone_core_types::credential::CredentialBuilder;
+
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (issue #978): `identity/credential/show.rego` documents
+    /// `input.target = null`, `input.existing.credential = <stored>`. Assert
+    /// the handler actually feeds that shape, and that the stripped `blob`
+    /// never reaches the policy engine.
+    #[tokio::test]
+    async fn test_show_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_get_credential()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    CredentialBuilder::default()
+                        .id("foo")
+                        .blob(r#"{"seed":"AAAA"}"#)
+                        .r#type("totp")
+                        .user_id("uid")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].policy_name, "identity/credential/show");
+        assert_eq!(calls[0].target, serde_json::Value::Null);
+        policy_contract::assert_existing_presence(&calls[0].existing, true);
+        policy_contract::assert_object_keys(calls[0].existing.as_ref().unwrap(), &["credential"]);
+        policy_contract::assert_no_secrets(calls[0].existing.as_ref().unwrap());
+    }
 
     #[tokio::test]
     async fn test_get_not_found_not_allowed() {

--- a/crates/keystone/src/api/v3/credential/update.rs
+++ b/crates/keystone/src/api/v3/credential/update.rs
@@ -111,13 +111,96 @@ mod tests {
     use openstack_keystone_core_types::credential::CredentialBuilder;
 
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::api::v3::credential::types::{
         CredentialResponse as ApiCredentialResponse, CredentialUpdateBuilder,
         CredentialUpdateRequest,
     };
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (issue #978): update is the operation the review calls out
+    /// by name (V3a) for a `target`/`existing` swap -- assert `target` is
+    /// the patch and `existing` is the stored row, never the other way
+    /// round, and that neither carries the stripped `blob`.
+    #[tokio::test]
+    async fn test_update_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_get_credential()
+            .withf(|_, id: &'_ str| id == "bar")
+            .returning(|_, _| {
+                Ok(Some(
+                    CredentialBuilder::default()
+                        .id("bar")
+                        .blob(r#"{"seed":"OLD"}"#)
+                        .r#type("totp")
+                        .user_id("uid")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        credential_mock
+            .expect_update_credential()
+            .returning(|_, _, _| {
+                Ok(CredentialBuilder::default()
+                    .id("bar")
+                    .blob(r#"{"seed":"NEW"}"#)
+                    .r#type("totp")
+                    .user_id("uid")
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let update_req = CredentialUpdateRequest {
+            credential: CredentialUpdateBuilder::default()
+                .blob(r#"{"seed":"NEW"}"#)
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .uri("/bar")
+                    .extension(vsc)
+                    .body(Body::from(serde_json::to_string(&update_req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].policy_name, "identity/credential/update");
+        policy_contract::assert_object_keys(&calls[0].target, &["credential"]);
+        policy_contract::assert_existing_presence(&calls[0].existing, true);
+        policy_contract::assert_object_keys(calls[0].existing.as_ref().unwrap(), &["credential"]);
+        // The swap-detection itself: target (the patch) carries the new
+        // blob-derived data the client sent, existing carries the OLD
+        // stored seed -- confirms they were not passed in swapped order.
+        assert_eq!(
+            calls[0].target["credential"]["blob"],
+            serde_json::Value::Null,
+            "target must not carry the stripped blob field at all"
+        );
+        policy_contract::assert_no_secrets(&calls[0].target);
+        policy_contract::assert_no_secrets(calls[0].existing.as_ref().unwrap());
+    }
 
     #[tokio::test]
     async fn test_update() {

--- a/crates/keystone/src/api/v3/credential/update.rs
+++ b/crates/keystone/src/api/v3/credential/update.rs
@@ -324,4 +324,137 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
+
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/credential/update.rego` decision through the
+    /// authorized/unauthorized/delegated-allowed/delegated-escape matrix
+    /// via a real `opa run` subprocess, exercising both
+    /// `credential_common.bound_to_own_delegation_project` and
+    /// `moves_project_out_of_scope` (OSSA-2026-015). Requires `opa` on
+    /// `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+        use crate::api::tests::real_policy_fixtures::{member_vsc, restricted_app_cred_vsc};
+        use crate::provider::ProviderBuilder;
+
+        fn provider_with_credential(
+            owner_user_id: &'static str,
+            existing_project_id: Option<&'static str>,
+        ) -> ProviderBuilder {
+            let mut credential_mock = MockCredentialProvider::default();
+            credential_mock
+                .expect_get_credential()
+                .withf(|_, id: &'_ str| id == "bar")
+                .returning(move |_, _| {
+                    let mut builder = CredentialBuilder::default();
+                    builder
+                        .id("bar")
+                        .blob(r#"{"seed":"OLD"}"#)
+                        .r#type("totp")
+                        .user_id(owner_user_id);
+                    if let Some(project_id) = existing_project_id {
+                        builder.project_id(project_id);
+                    }
+                    Ok(Some(builder.build().unwrap()))
+                });
+            credential_mock
+                .expect_update_credential()
+                .returning(move |_, _, _| {
+                    let mut builder = CredentialBuilder::default();
+                    builder
+                        .id("bar")
+                        .blob(r#"{"seed":"NEW"}"#)
+                        .r#type("totp")
+                        .user_id(owner_user_id);
+                    if let Some(project_id) = existing_project_id {
+                        builder.project_id(project_id);
+                    }
+                    Ok(builder.build().unwrap())
+                });
+            Provider::mocked_builder().mock_credential(credential_mock)
+        }
+
+        async fn update_request(
+            vsc: ValidatedSecurityContext,
+            provider_builder: ProviderBuilder,
+        ) -> StatusCode {
+            let (state, _opa_guard) = get_state_with_real_policy(provider_builder).await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            let update_req = CredentialUpdateRequest {
+                credential: CredentialUpdateBuilder::default()
+                    .blob(r#"{"seed":"NEW"}"#)
+                    .build()
+                    .unwrap(),
+            };
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .method("PATCH")
+                        .header(http::header::CONTENT_TYPE, "application/json")
+                        .uri("/bar")
+                        .extension(vsc)
+                        .body(Body::from(serde_json::to_string(&update_req).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn owner_updating_own_non_delegated_credential_is_allowed() {
+            let status = update_request(
+                member_vsc("u1", "p1", &["member"]),
+                provider_with_credential("u1", None),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn caller_with_no_roles_is_denied() {
+            let status = update_request(
+                member_vsc("u1", "p1", &[]),
+                provider_with_credential("u1", None),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        /// OSSA-2026-015: a delegated caller updating a credential already
+        /// bound to its own delegation project is allowed. Note:
+        /// `moves_project_out_of_scope` in the policy is currently
+        /// unreachable via this handler -- `CredentialUpdate`
+        /// (`crates/api-types/src/v3/credential.rs`) has no `project_id`
+        /// field, so the update patch this handler builds can never carry
+        /// one for the policy to inspect.
+        #[tokio::test]
+        async fn delegated_caller_updating_credential_bound_to_own_project_is_allowed() {
+            let status = update_request(
+                restricted_app_cred_vsc("u1", "p1"),
+                provider_with_credential("u1", Some("p1")),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        /// OSSA-2026-015: a delegated caller must not be able to update an
+        /// unscoped credential (e.g. TOTP/MFA seed) it owns.
+        #[tokio::test]
+        async fn delegated_caller_updating_unscoped_credential_is_denied() {
+            let status = update_request(
+                restricted_app_cred_vsc("u1", "p1"),
+                provider_with_credential("u1", None),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/crates/keystone/src/api/v3/user/os_ec2/create.rs
+++ b/crates/keystone/src/api/v3/user/os_ec2/create.rs
@@ -296,4 +296,136 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
+
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/os_ec2/create_credential.rego` decision through
+    /// the authorized/unauthorized/delegated-allowed/delegated-escape/
+    /// restricted-app-cred matrix via a real `opa run` subprocess, covering
+    /// both the OSSA-2026-015 delegation boundary and the OSSA-2026-005 /
+    /// CVE-2026-33551 restricted-application-credential block. Requires
+    /// `opa` on `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+        use crate::api::tests::real_policy_fixtures::{app_cred_vsc, member_vsc};
+        use crate::provider::ProviderBuilder;
+
+        fn allowing_provider() -> ProviderBuilder {
+            let mut credential_mock = MockCredentialProvider::default();
+            credential_mock
+                .expect_create_credential()
+                .returning(|_, rec| {
+                    Ok(CredentialBuilder::default()
+                        .id("cred_id")
+                        .blob(rec.blob.clone())
+                        .r#type("ec2")
+                        .user_id(rec.user_id.clone().unwrap_or_default())
+                        .project_id(rec.project_id.clone().unwrap_or_default())
+                        .build()
+                        .unwrap())
+                });
+            Provider::mocked_builder().mock_credential(credential_mock)
+        }
+
+        async fn create_request(
+            vsc: ValidatedSecurityContext,
+            path_user_id: &str,
+            tenant_id: Option<&str>,
+            provider_builder: ProviderBuilder,
+        ) -> StatusCode {
+            let (state, _opa_guard) = get_state_with_real_policy(provider_builder).await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            let body = match tenant_id {
+                Some(tenant_id) => format!(r#"{{"tenant_id":"{tenant_id}"}}"#),
+                None => "{}".to_string(),
+            };
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .uri(format!("/{path_user_id}/credentials/OS-EC2"))
+                        .extension(vsc)
+                        .header("Content-Type", "application/json")
+                        .method("POST")
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn authorized_member_creating_own_ec2_credential_is_allowed() {
+            let status = create_request(
+                member_vsc("u1", "p1", &["member"]),
+                "u1",
+                Some("p1"),
+                allowing_provider(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::CREATED);
+        }
+
+        #[tokio::test]
+        async fn creating_ec2_credential_for_another_user_is_denied() {
+            let status = create_request(
+                member_vsc("u1", "p1", &["member"]),
+                "u2",
+                Some("p1"),
+                Provider::mocked_builder(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        /// OSSA-2026-005 / CVE-2026-33551: a restricted application
+        /// credential must never be usable to mint an EC2 credential, even
+        /// for itself bound to its own delegation project.
+        #[tokio::test]
+        async fn restricted_app_cred_creating_ec2_credential_is_denied() {
+            let status = create_request(
+                app_cred_vsc("u1", "p1", false),
+                "u1",
+                Some("p1"),
+                Provider::mocked_builder(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        /// An unrestricted application credential may mint an EC2 credential
+        /// bound to its own delegation project.
+        #[tokio::test]
+        async fn unrestricted_app_cred_creating_ec2_credential_bound_to_own_project_is_allowed() {
+            let status = create_request(
+                app_cred_vsc("u1", "p1", true),
+                "u1",
+                Some("p1"),
+                allowing_provider(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::CREATED);
+        }
+
+        /// OSSA-2026-015: an unrestricted application credential must still
+        /// be denied from minting an EC2 credential that escapes its own
+        /// delegation project.
+        #[tokio::test]
+        async fn unrestricted_app_cred_creating_ec2_credential_escaping_own_project_is_denied() {
+            let status = create_request(
+                app_cred_vsc("u1", "p1", true),
+                "u1",
+                Some("p2"),
+                Provider::mocked_builder(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/crates/keystone/src/api/v3/user/os_ec2/create.rs
+++ b/crates/keystone/src/api/v3/user/os_ec2/create.rs
@@ -105,10 +105,62 @@ mod tests {
     use openstack_keystone_core_types::credential::{CredentialBuilder, CredentialCreate};
 
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::api::v3::user::os_ec2::types::Ec2CredentialResponse;
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (issue #978): `identity/os_ec2/create_credential.rego`
+    /// documents `input.target = {"user_id": ..., "tenant_id": ...}`,
+    /// `input.existing = null`.
+    #[tokio::test]
+    async fn test_create_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_create_credential()
+            .returning(|_, rec| {
+                Ok(CredentialBuilder::default()
+                    .id("cred_id")
+                    .blob(rec.blob.clone())
+                    .r#type("ec2")
+                    .user_id("foo")
+                    .project_id("pid")
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo/credentials/OS-EC2")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(r#"{"tenant_id":"pid"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].policy_name, "identity/os_ec2/create_credential");
+        policy_contract::assert_object_keys(&calls[0].target, &["user_id", "tenant_id"]);
+        policy_contract::assert_existing_presence(&calls[0].existing, false);
+        policy_contract::assert_no_secrets(&calls[0].target);
+    }
 
     #[tokio::test]
     async fn test_create_auto_generates_access_and_secret() {

--- a/crates/keystone/src/api/v3/user/os_ec2/delete.rs
+++ b/crates/keystone/src/api/v3/user/os_ec2/delete.rs
@@ -51,7 +51,10 @@ pub(super) async fn delete(
             "identity/os_ec2/delete_credential",
             &user_auth,
             serde_json::Value::Null,
-            Some(json!({"user_id": &user_id, "credential": &current})),
+            Some(json!({
+                "user_id": &user_id,
+                "credential": current.as_ref().map(super::ec2_credential_policy_input),
+            })),
         )
         .await?;
 
@@ -86,9 +89,66 @@ mod tests {
     use openstack_keystone_core_types::credential::CredentialBuilder;
 
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (issue #978): mirrors `show`'s contract test for delete --
+    /// same documented multi-key shape, same blob-leak risk.
+    #[tokio::test]
+    async fn test_delete_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_get_credential_by_ec2_access()
+            .returning(|_, _| {
+                Ok(Some(
+                    CredentialBuilder::default()
+                        .id("cred_id")
+                        .blob(r#"{"access":"AKIA123","secret":"s3cr3t"}"#)
+                        .r#type("ec2")
+                        .user_id("foo")
+                        .project_id("pid")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        credential_mock
+            .expect_delete_credential()
+            .returning(|_, _| Ok(()));
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo/credentials/OS-EC2/AKIA123")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].policy_name, "identity/os_ec2/delete_credential");
+        assert_eq!(calls[0].target, serde_json::Value::Null);
+        policy_contract::assert_existing_presence(&calls[0].existing, true);
+        let existing = calls[0].existing.as_ref().unwrap();
+        policy_contract::assert_object_keys(existing, &["user_id", "credential"]);
+        policy_contract::assert_no_secrets(existing);
+    }
 
     #[tokio::test]
     async fn test_delete_found() {

--- a/crates/keystone/src/api/v3/user/os_ec2/list.rs
+++ b/crates/keystone/src/api/v3/user/os_ec2/list.rs
@@ -84,10 +84,51 @@ mod tests {
     use openstack_keystone_core_types::credential::CredentialBuilder;
 
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::api::v3::user::os_ec2::types::Ec2CredentialList;
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (issue #978): `identity/os_ec2/read_credential.rego`
+    /// documents `input.target = {"user_id": <path user_id>}`,
+    /// `input.existing = null` for a list request.
+    #[tokio::test]
+    async fn test_list_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_list_credentials_for_user()
+            .returning(|_, _, _| Ok(vec![]));
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo/credentials/OS-EC2")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].policy_name, "identity/os_ec2/read_credential");
+        policy_contract::assert_object_keys(&calls[0].target, &["user_id"]);
+        policy_contract::assert_existing_presence(&calls[0].existing, false);
+        policy_contract::assert_no_secrets(&calls[0].target);
+    }
 
     #[tokio::test]
     async fn test_list() {

--- a/crates/keystone/src/api/v3/user/os_ec2/mod.rs
+++ b/crates/keystone/src/api/v3/user/os_ec2/mod.rs
@@ -101,4 +101,31 @@ pub(super) fn ec2_credential_policy_input(cred: &CoreCredential) -> Value {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use openstack_keystone_core_types::credential::CredentialBuilder;
+
+    use super::ec2_credential_policy_input;
+    use crate::api::tests::policy_contract;
+
+    /// Gate I (security review V9, issue #987): direct, structural test on
+    /// the OS-EC2 stripping helper itself -- see the analogous test for
+    /// `credential_policy_input` in the sibling `/v3/credentials` module.
+    #[test]
+    fn test_ec2_credential_policy_input_never_leaks_blob() {
+        let cred = CredentialBuilder::default()
+            .id("cred_id")
+            .blob(r#"{"access":"AKIA123","secret":"s3cr3t"}"#)
+            .r#type("ec2")
+            .user_id("uid")
+            .project_id("pid")
+            .build()
+            .unwrap();
+
+        let input = ec2_credential_policy_input(&cred);
+        policy_contract::assert_no_secrets(&input);
+        assert!(
+            !input.to_string().contains("s3cr3t"),
+            "serialized policy input must not contain the decrypted secret bytes"
+        );
+    }
+}

--- a/crates/keystone/src/api/v3/user/os_ec2/mod.rs
+++ b/crates/keystone/src/api/v3/user/os_ec2/mod.rs
@@ -80,5 +80,25 @@ pub(super) fn to_ec2_credential(
     })
 }
 
+/// Build an OS-EC2 credential policy-input value with the decrypted `blob`
+/// stripped out.
+///
+/// # Security Note
+///
+/// `blob` holds the *decrypted* EC2 access/secret pair. No `os_ec2` `.rego`
+/// rule references it, so it must never reach the policy engine -- see the
+/// analogous `credential_policy_input` in the sibling `/v3/credentials`
+/// module (`crate::api::v3::credential`) and `doc/src/security.md` I7.
+pub(super) fn ec2_credential_policy_input(cred: &CoreCredential) -> Value {
+    serde_json::to_value(cred)
+        .map(|mut v| {
+            if let Some(obj) = v.as_object_mut() {
+                obj.remove("blob");
+            }
+            v
+        })
+        .unwrap_or(Value::Null)
+}
+
 #[cfg(test)]
 mod tests {}

--- a/crates/keystone/src/api/v3/user/os_ec2/show.rs
+++ b/crates/keystone/src/api/v3/user/os_ec2/show.rs
@@ -56,7 +56,10 @@ pub(super) async fn show(
             "identity/os_ec2/read_credential",
             &user_auth,
             serde_json::Value::Null,
-            Some(json!({"user_id": &user_id, "credential": &current})),
+            Some(json!({
+                "user_id": &user_id,
+                "credential": current.as_ref().map(super::ec2_credential_policy_input),
+            })),
         )
         .await?;
 
@@ -105,10 +108,66 @@ mod tests {
     use openstack_keystone_core_types::credential::CredentialBuilder;
 
     use super::super::openapi_router;
-    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::tests::{
+        get_capturing_state, get_mocked_state, policy_contract, test_fixture_scoped,
+    };
     use crate::api::v3::user::os_ec2::types::Ec2CredentialResponse;
     use crate::credential::MockCredentialProvider;
     use crate::provider::Provider;
+
+    /// Gate B2 (issue #978): `identity/os_ec2/read_credential.rego`
+    /// documents `input.existing = {"user_id": ..., "credential": ...}` for
+    /// a show request -- a legitimate multi-key exception to the single
+    /// resource-key convention (ADR 0002), but the raw stored `Credential`
+    /// (with its decrypted `blob`) must never be embedded directly.
+    #[tokio::test]
+    async fn test_show_policy_input_contract() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_get_credential_by_ec2_access()
+            .returning(|_, _| {
+                Ok(Some(
+                    CredentialBuilder::default()
+                        .id("cred_id")
+                        .blob(r#"{"access":"AKIA123","secret":"s3cr3t"}"#)
+                        .r#type("ec2")
+                        .user_id("foo")
+                        .project_id("pid")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let (state, policy) =
+            get_capturing_state(Provider::mocked_builder().mock_credential(credential_mock)).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo/credentials/OS-EC2/AKIA123")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let calls = policy.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].policy_name, "identity/os_ec2/read_credential");
+        assert_eq!(calls[0].target, serde_json::Value::Null);
+        policy_contract::assert_existing_presence(&calls[0].existing, true);
+        let existing = calls[0].existing.as_ref().unwrap();
+        policy_contract::assert_object_keys(existing, &["user_id", "credential"]);
+        policy_contract::assert_no_secrets(existing);
+    }
 
     #[tokio::test]
     async fn test_show_found() {

--- a/crates/keystone/src/api/v3/user/show.rs
+++ b/crates/keystone/src/api/v3/user/show.rs
@@ -228,4 +228,141 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
+
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/user/show.rego` decision (via
+    /// `get_state_with_real_policy`'s real `opa run` subprocess + the
+    /// production `HttpPolicyEnforcer`) through the
+    /// authorized(admin)/authorized(reader, same domain)/
+    /// unauthorized(no roles)/cross-domain(reader, different domain)
+    /// matrix -- the domain-scoped counterpart to
+    /// `credential::create`'s delegation-scoped Gate B3 matrix. Requires
+    /// `opa` on `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+        use openstack_keystone_core_types::auth::{
+            AuthenticationContext, AuthzInfoBuilder, IdentityInfo, PrincipalInfo, ScopeInfo,
+            SecurityContext, UserIdentityInfoBuilder,
+        };
+        use openstack_keystone_core_types::resource::Domain;
+        use openstack_keystone_core_types::role::RoleRef;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+
+        fn domain_scoped_vsc(caller_domain_id: &str, roles: &[&str]) -> ValidatedSecurityContext {
+            let authz = AuthzInfoBuilder::default()
+                .scope(ScopeInfo::Domain(Domain {
+                    id: caller_domain_id.to_string(),
+                    name: caller_domain_id.to_string(),
+                    enabled: true,
+                    ..Default::default()
+                }))
+                .roles(
+                    roles
+                        .iter()
+                        .enumerate()
+                        .map(|(i, name)| RoleRef {
+                            domain_id: None,
+                            id: format!("role-{i}"),
+                            name: Some((*name).to_string()),
+                        })
+                        .collect::<Vec<_>>(),
+                )
+                .build()
+                .unwrap();
+
+            let sc = SecurityContext::test_build()
+                .authentication_context(AuthenticationContext::Password)
+                .principal(PrincipalInfo {
+                    identity: IdentityInfo::User(
+                        UserIdentityInfoBuilder::default()
+                            .user_id("caller")
+                            .user(
+                                UserResponseBuilder::default()
+                                    .id("caller")
+                                    .domain_id(caller_domain_id)
+                                    .enabled(true)
+                                    .name("caller")
+                                    .build()
+                                    .unwrap(),
+                            )
+                            .user_domain(Domain {
+                                id: caller_domain_id.to_string(),
+                                name: caller_domain_id.to_string(),
+                                enabled: true,
+                                ..Default::default()
+                            })
+                            .build()
+                            .unwrap(),
+                    ),
+                })
+                .authorization(authz)
+                .build();
+            ValidatedSecurityContext::test_new(sc)
+        }
+
+        async fn show_request(vsc: ValidatedSecurityContext, target_domain_id: &str) -> StatusCode {
+            let mut identity_mock = MockIdentityProvider::default();
+            let target_domain_id = target_domain_id.to_string();
+            identity_mock.expect_get_user().returning(move |_, _| {
+                Ok(Some(
+                    UserResponseBuilder::default()
+                        .id("target")
+                        .domain_id(target_domain_id.clone())
+                        .enabled(true)
+                        .name("target")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+            let (state, _opa_guard) =
+                get_state_with_real_policy(Provider::mocked_builder().mock_identity(identity_mock))
+                    .await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .uri("/target")
+                        .extension(vsc)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn admin_can_show_user_in_any_domain() {
+            let status = show_request(domain_scoped_vsc("domain-a", &["admin"]), "domain-b").await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn reader_can_show_user_in_own_domain() {
+            let status = show_request(domain_scoped_vsc("domain-a", &["reader"]), "domain-a").await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn caller_with_no_roles_is_denied() {
+            let status = show_request(domain_scoped_vsc("domain-a", &[]), "domain-a").await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        /// Cross-domain: a reader scoped to `domain-a` must not be able to
+        /// view a user whose home domain is `domain-b` -- this is
+        /// `identity.domain_matches_domain_scope` itself, exercised through
+        /// the real handler and the real policy.
+        #[tokio::test]
+        async fn reader_cannot_show_user_in_different_domain() {
+            let status = show_request(domain_scoped_vsc("domain-a", &["reader"]), "domain-b").await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/crates/keystone/src/api/v4/mapping/ruleset/create.rs
+++ b/crates/keystone/src/api/v4/mapping/ruleset/create.rs
@@ -259,4 +259,158 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
+
+    /// Gate B3 (security review V3a, issue #979): drives this handler and
+    /// the real `identity/mapping/ruleset/create.rego` decision (via a real
+    /// `opa run` subprocess instead of `MockPolicy`) through the
+    /// own-domain-manager/foreign-domain/global-requires-admin matrix.
+    /// Requires `opa` on `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+        use openstack_keystone_core_types::auth::{
+            AuthenticationContext, AuthzInfoBuilder, IdentityInfo, PrincipalInfo, ScopeInfo,
+            SecurityContext, UserIdentityInfoBuilder,
+        };
+        use openstack_keystone_core_types::resource::Domain;
+        use openstack_keystone_core_types::role::RoleRef;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+        use crate::provider::ProviderBuilder;
+
+        fn domain_scoped_vsc(domain_id: &str, roles: &[&str]) -> ValidatedSecurityContext {
+            let domain = Domain {
+                id: domain_id.to_string(),
+                name: domain_id.to_string(),
+                enabled: true,
+                ..Default::default()
+            };
+
+            let authz = AuthzInfoBuilder::default()
+                .scope(ScopeInfo::Domain(domain.clone()))
+                .roles(
+                    roles
+                        .iter()
+                        .enumerate()
+                        .map(|(i, name)| RoleRef {
+                            domain_id: None,
+                            id: format!("role-{i}"),
+                            name: Some((*name).to_string()),
+                        })
+                        .collect::<Vec<_>>(),
+                )
+                .build()
+                .unwrap();
+
+            let sc = SecurityContext::test_build()
+                .authentication_context(AuthenticationContext::Password)
+                .principal(PrincipalInfo {
+                    identity: IdentityInfo::User(
+                        UserIdentityInfoBuilder::default()
+                            .user_id("u1")
+                            .user(
+                                openstack_keystone_core_types::identity::UserResponseBuilder::default()
+                                    .id("u1")
+                                    .domain_id(domain_id)
+                                    .enabled(true)
+                                    .name("u1")
+                                    .build()
+                                    .unwrap(),
+                            )
+                            .user_domain(domain)
+                            .build()
+                            .unwrap(),
+                    ),
+                })
+                .authorization(authz)
+                .build();
+            ValidatedSecurityContext::test_new(sc)
+        }
+
+        fn allowing_provider() -> ProviderBuilder {
+            let mut mock = MockMappingProvider::default();
+            mock.expect_create_ruleset()
+                .returning(|_, _| Ok(sample_ruleset_core()));
+            Provider::mocked_builder().mock_mapping(mock)
+        }
+
+        fn ruleset_for_domain(domain_id: Option<&str>) -> MappingRuleSetCreate {
+            let mut ruleset = sample_ruleset();
+            ruleset.domain_id = domain_id.map(String::from);
+            ruleset
+        }
+
+        async fn create_request(
+            vsc: ValidatedSecurityContext,
+            domain_id: Option<&str>,
+            provider_builder: ProviderBuilder,
+        ) -> StatusCode {
+            let (state, _opa_guard) = get_state_with_real_policy(provider_builder).await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            let req = MappingRuleSetCreateRequest {
+                mapping: ruleset_for_domain(domain_id),
+            };
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/")
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .extension(vsc)
+                        .body(Body::from(serde_json::to_string(&req).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn domain_manager_creating_ruleset_in_own_domain_is_allowed() {
+            let status = create_request(
+                domain_scoped_vsc("d1", &["manager"]),
+                Some("d1"),
+                allowing_provider(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::CREATED);
+        }
+
+        #[tokio::test]
+        async fn domain_manager_creating_ruleset_in_foreign_domain_is_denied() {
+            let status = create_request(
+                domain_scoped_vsc("d1", &["manager"]),
+                Some("d2"),
+                Provider::mocked_builder(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn domain_manager_creating_global_ruleset_is_denied() {
+            let status = create_request(
+                domain_scoped_vsc("d1", &["manager"]),
+                None,
+                Provider::mocked_builder(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn admin_creating_global_ruleset_is_allowed() {
+            let status = create_request(
+                domain_scoped_vsc("d1", &["admin"]),
+                None,
+                allowing_provider(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::CREATED);
+        }
+    }
 }

--- a/doc/src/security.md
+++ b/doc/src/security.md
@@ -65,6 +65,43 @@ Every invariant in §4 is a specialization of this rule.
 - **Secrets never reach OPA.** Decrypted credential `blob`s (EC2 secret keys,
   TOTP seeds) are stripped before policy input is built.
 
+### Additional trust boundaries (security review, issue #989)
+
+The diagram above draws the request → `Credentials` → OPA path. Three more
+boundaries carry the same weight and are named here explicitly:
+
+- **The OPA policy bundle itself.** Whatever a running `opa` instance loads
+  from `ghcr.io/<repo>/opa-bundle` *is* the authorization logic — a
+  tampered or rolled-back bundle is exactly as dangerous as a tampered
+  Keystone binary, without touching Keystone's own code or the `policy/`
+  tree at all. `policy-container.yml`'s publish job signs the bundle by
+  digest with cosign keyless signing and verifies that signature before
+  reporting success (Gate H, security review V4); a deployment that wants
+  load-time verification (OPA's own bundle downloader has no native
+  cosign/Sigstore hook) must run the equivalent `cosign verify` itself
+  before serving traffic, or pin `resource` to a verified digest instead of
+  `latest` — see `tools/opa_config.yaml`.
+- **The WASM plugin invocation path (ADR 0025).** A `mode = full_auth` or
+  `route` plugin is invoked *pre-authentication*, by definition — a remote,
+  unauthenticated party triggers plugin execution and its `http_fetch`
+  calls at will (security review V7). `AuthenticationContext::WasmPlugin`
+  and the `plugin_claims` projection already exist in the tree ahead of the
+  full mechanism; ADR 0025 is still Proposed, so the SSRF/claims-injection/
+  identity-binding/resource-exhaustion controls it specifies are deferred
+  until implementation starts, at which point each control needs a test
+  that exercises the failure, not just the intended path — tracked as part
+  of that feature's definition of done, not as a standalone gate now.
+- **The OAuth2/OIDC provider surface (ADR 0026).** Acting as an OAuth2/OIDC
+  *provider* is the classic web-authz surface Keystone did not previously
+  have — open-redirect via `redirect_uri`, authorization-code interception
+  without PKCE, refresh-token replay (security review V8). ADR 0026
+  commits to exact-match `redirect_uris`, mandatory PKCE for public
+  clients, and refresh-token rotation; V8a additionally verified (and
+  where needed, fixed — the device-flow endpoints now share the
+  `/authorize`/`/token` per-IP rate-limit posture) that the client-id/
+  grant-type oracle and username-enumeration classes don't apply here the
+  way they did in the public research that prompted the review.
+
 ## 4. Invariants
 
 Each invariant lists **what**, **why**, and **where enforced**. When you touch
@@ -304,7 +341,10 @@ since there is no delegation boundary to enforce.
 ## 7. Reviewer checklist
 
 Apply to any diff touching auth, scope, delegation, tokens, credentials, EC2, or
-policy input:
+policy input. This checklist is also the required "Security review checklist"
+section of [`.github/pull_request_template.md`](../../.github/pull_request_template.md)
+(security review design gate, issue #988) -- every PR touching these areas
+carries it, ticked by the reviewer, not just this prose reference.
 
 - [ ] Does any delegation/authorization decision read the **scope**
       (`project_id`, `ScopeInfo`) where it should read the **chain**

--- a/doc/src/security.md
+++ b/doc/src/security.md
@@ -266,7 +266,11 @@ the same scope (table above).
 > restrictions) are stored and CRUD'd but **not enforced at request time** — no
 > middleware matches the incoming (service, method, path) against them. A
 > rules-restricted app-cred can currently call any endpoint. Tracked separately;
-> see §7.
+> see §7. Interim mitigation (security review V5): `create_application_credential`
+> logs a `WARN` whenever a non-empty `access_rules` list is accepted, and
+> `application_credential.reject_unenforced_access_rules` (default `false`) lets
+> an operator fail loud — reject the create outright — instead of silently
+> accepting an unenforceable restriction. Neither replaces the middleware.
 
 ### EC2 credentials
 
@@ -342,4 +346,7 @@ policy input:
 
 - **App-cred `access_rules` unenforced at request time** (§5). Feature-sized;
   needs request-matching middleware and likely its own ADR. Until then, treat
-  `access_rules` as advisory, not a security control.
+  `access_rules` as advisory, not a security control. An interim gate exists
+  (security review V5): creation warns unconditionally on a non-empty
+  `access_rules` list, and `application_credential.reject_unenforced_access_rules`
+  (default `false`) can be set to fail loud instead.

--- a/policy/auth/token/revoke_test.rego
+++ b/policy/auth/token/revoke_test.rego
@@ -4,12 +4,12 @@ import data.identity.auth.token.revoke
 
 test_allowed if {
 	revoke.allow with input as {"credentials": {"roles": ["admin"]}}
-	revoke.allow with input as {"credentials": {"user_id": "foo"}, "existing": {"token": {"user_id": "foo"}}}
+	revoke.allow with input as {"credentials": {"user_id": "foo"}, "existing": {"token": {"user": {"id": "foo"}}}}
 }
 
 test_forbidden if {
 	not revoke.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "not_all"}}
-	not revoke.allow with input as {"credentials": {"roles": ["manager"], "user_id": "foo"}, "existing": {"token": {"user_id": "bar"}}}
-	not revoke.allow with input as {"credentials": {"roles": ["member"], "user_id": "foo"}, "existing": {"token": {"user_id": "bar"}}}
-	not revoke.allow with input as {"credentials": {"roles": ["reader"], "user_id": "foo"}, "existing": {"token": {"user_id": "bar"}}}
+	not revoke.allow with input as {"credentials": {"roles": ["manager"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
+	not revoke.allow with input as {"credentials": {"roles": ["member"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
+	not revoke.allow with input as {"credentials": {"roles": ["reader"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
 }

--- a/policy/auth/token/show_test.rego
+++ b/policy/auth/token/show_test.rego
@@ -6,13 +6,13 @@ test_allowed if {
 	show.allow with input as {"credentials": {"roles": ["admin"]}}
 	show.allow with input as {"credentials": {"roles": ["service"]}}
 	show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
-	show.allow with input as {"credentials": {"user_id": "foo"}, "existing": {"token": {"user_id": "foo"}}}
-	show.allow with input as {"credentials": {"roles": ["admin"], "user_id": "foo"}, "existing": {"token": {"user_id": "bar"}}}
+	show.allow with input as {"credentials": {"user_id": "foo"}, "existing": {"token": {"user": {"id": "foo"}}}}
+	show.allow with input as {"credentials": {"roles": ["admin"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
 }
 
 test_forbidden if {
 	not show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "not_all"}}
-	not show.allow with input as {"credentials": {"roles": ["manager"], "user_id": "foo"}, "existing": {"token": {"user_id": "bar"}}}
-	not show.allow with input as {"credentials": {"roles": ["member"], "user_id": "foo"}, "existing": {"token": {"user_id": "bar"}}}
-	not show.allow with input as {"credentials": {"roles": ["reader"], "user_id": "foo"}, "existing": {"token": {"user_id": "bar"}}}
+	not show.allow with input as {"credentials": {"roles": ["manager"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
+	not show.allow with input as {"credentials": {"roles": ["member"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "user_id": "foo"}, "existing": {"token": {"user": {"id": "bar"}}}}
 }

--- a/policy/credential/delete.rego
+++ b/policy/credential/delete.rego
@@ -43,5 +43,5 @@ allow if {
 	"member" in input.credentials.roles
 	input.credentials.is_delegated
 	input.existing.credential.user_id == input.credentials.user_id
-	credential_common.bound_to_own_delegation_project(input.existing.credential.project_id)
+	credential_common.bound_to_own_delegation_project(object.get(input.existing.credential, "project_id", null))
 }

--- a/policy/credential/show.rego
+++ b/policy/credential/show.rego
@@ -59,5 +59,5 @@ allow if {
 allow if {
 	input.credentials.is_delegated
 	input.existing.credential.user_id == input.credentials.user_id
-	credential_common.bound_to_own_delegation_project(input.existing.credential.project_id)
+	credential_common.bound_to_own_delegation_project(object.get(input.existing.credential, "project_id", null))
 }

--- a/policy/credential/update.rego
+++ b/policy/credential/update.rego
@@ -47,7 +47,7 @@ allow if {
 	"member" in input.credentials.roles
 	input.credentials.is_delegated
 	input.existing.credential.user_id == input.credentials.user_id
-	credential_common.bound_to_own_delegation_project(input.existing.credential.project_id)
+	credential_common.bound_to_own_delegation_project(object.get(input.existing.credential, "project_id", null))
 	not moves_project_out_of_scope
 }
 

--- a/policy/identity.rego
+++ b/policy/identity.rego
@@ -3,15 +3,11 @@
 package identity
 
 token_subject if {
-	input.credentials.user_id == input.target.token.user_id
+	input.credentials.user_id == input.target.token.user.id
 }
 
 token_subject if {
-	input.credentials.user_id == input.existing.token.user_id
-}
-
-token_subject if {
-	input.credentials.user_id == input.existing.token.user_id
+	input.credentials.user_id == input.existing.token.user.id
 }
 
 # A role without a domain_id (orphaned).

--- a/tools/check_delegated_policy_scope_drift_tests.py
+++ b/tools/check_delegated_policy_scope_drift_tests.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Gate C: invariant-test presence check for delegated policies (security
+review V1/V2, issue #982).
+
+security.md I3: a delegated caller's rules must assert
+`credentials.project_id == credentials.delegated_project_id`, failing closed
+on divergence (the scope-drift tripwire) -- and every delegated policy's
+test suite should carry a negative case proving that tripwire actually
+fires, not just the "delegation bound to the wrong project" case. This
+scans every decision-endpoint `.rego` file that is delegation-sensitive
+(imports `credential_common`, or references `is_delegated` directly) and
+requires its sibling `_test.rego` to contain a `not <alias>.allow` case
+whose `credentials` object sets `project_id` and `delegated_project_id` to
+different values with `is_delegated: true` -- the scope-drift shape itself,
+not just a same-value-mismatched-project case.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLICY_ROOT = REPO_ROOT / "policy"
+
+DELEGATION_MARKERS = ("credential_common", "is_delegated")
+
+
+def extract_braced_value(text: str, key_index: int) -> str | None:
+    """Given the index of a `"key":` match, return the `{...}` object that
+    follows it (the first `{` after the colon), or None if not an object.
+    """
+    brace = text.find("{", key_index)
+    if brace == -1:
+        return None
+    depth = 0
+    for i in range(brace, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace : i + 1]
+    return None
+
+
+def has_scope_drift_case(test_text: str) -> bool:
+    for m in re.finditer(r'"credentials"\s*:', test_text):
+        creds = extract_braced_value(test_text, m.end())
+        if creds is None:
+            continue
+        # The assertion must be a negative case (`not <alias>.allow`) --
+        # find the nearest `not ... allow` on the same source line.
+        line_start = test_text.rfind("\n", 0, m.start()) + 1
+        line_end = test_text.find("\n", m.start())
+        line = test_text[line_start : line_end if line_end != -1 else len(test_text)]
+        if not re.search(r"\bnot\s+\S+\.allow\b", line):
+            continue
+        if not re.search(r'"is_delegated"\s*:\s*true', creds):
+            continue
+        pid_m = re.search(r'"project_id"\s*:\s*"([^"]*)"', creds)
+        delegated_m = re.search(r'"delegated_project_id"\s*:\s*"([^"]*)"', creds)
+        if pid_m and delegated_m and pid_m.group(1) != delegated_m.group(1):
+            return True
+    return False
+
+
+def is_delegation_sensitive(text: str) -> bool:
+    return any(marker in text for marker in DELEGATION_MARKERS)
+
+
+def main():
+    violations = []
+    for path in sorted(POLICY_ROOT.rglob("*.rego")):
+        if path.stem.endswith("_test"):
+            continue
+        text = path.read_text()
+        if "default allow" not in text:
+            continue  # not a decision-endpoint policy (e.g. common.rego)
+        if not is_delegation_sensitive(text):
+            continue
+        test_path = path.with_name(path.stem + "_test.rego")
+        if not test_path.exists():
+            # Gate B1 already catches a missing test file outright.
+            continue
+        if not has_scope_drift_case(test_path.read_text()):
+            violations.append(
+                f"{test_path.relative_to(REPO_ROOT)}: {path.relative_to(REPO_ROOT)} is "
+                "delegation-sensitive but its test suite has no scope-drift negative "
+                "case (a `not <alias>.allow` with credentials.project_id != "
+                "delegated_project_id and is_delegated: true) -- security.md I3"
+            )
+    if violations:
+        print("Gate C (delegated-policy scope-drift test presence) failed:\n")
+        for v in violations:
+            print(f"  - {v}")
+        print(f"\n{len(violations)} issue(s) found.")
+        return 1
+    print("Gate C OK: every delegation-sensitive policy's test suite has a scope-drift negative case.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_event_payload_no_secret_fields.py
+++ b/tools/check_event_payload_no_secret_fields.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Gate I companion (security review V9, issue #987): structural check that
+`EventPayload` (`crates/core-types/src/events.rs`) never grows a
+secret-bearing field.
+
+`EventPayload` variants feed the ADR 0023 audit trail (via `EventDispatcher`
+/ `AuditHook`). Every variant today carries only ID-shaped fields, which is
+exactly what makes the audit trail safe -- there is no decrypted credential
+`blob`, password, or seed to leak. `EventPayload` deliberately does not
+derive `Serialize` (a dynamic serialization test analogous to the
+`Credentials` one in `crates/core/src/policy.rs` isn't possible without
+adding it, which would be a bigger, riskier change than this check
+warrants), so this is a source-level structural scan instead: it parses
+every variant's field declarations and rejects a denylisted field name,
+catching a future variant addition that reintroduces one.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EVENTS_RS = REPO_ROOT / "crates/core-types/src/events.rs"
+
+# Same secret-field denylist as crates/core/src/api/policy_contract.rs.
+SECRET_FIELD_NAMES = {
+    "blob",
+    "encrypted_blob",
+    "key_hash",
+    "password",
+    "secret",
+    "client_secret",
+    "totp_seed",
+    "seed",
+    "access_token",
+    "refresh_token",
+}
+
+FIELD_RE = re.compile(r"^\s*(\w+)\s*:\s*[^,{}]+,?\s*$")
+
+
+def extract_enum_body(text: str, enum_name: str) -> str:
+    marker = f"pub enum {enum_name} "
+    start = text.find(marker)
+    if start == -1:
+        raise SystemExit(f"could not find `{marker}` in {EVENTS_RS}")
+    brace = text.find("{", start)
+    depth = 0
+    for i in range(brace, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace : i + 1]
+    raise SystemExit(f"unbalanced braces parsing `{enum_name}` in {EVENTS_RS}")
+
+
+def find_field_violations(body: str):
+    violations = []
+    for line in body.splitlines():
+        m = FIELD_RE.match(line)
+        if not m:
+            continue
+        field_name = m.group(1)
+        if field_name.lower() in SECRET_FIELD_NAMES:
+            violations.append(field_name)
+    return violations
+
+
+def main():
+    text = EVENTS_RS.read_text()
+    body = extract_enum_body(text, "EventPayload")
+    violations = find_field_violations(body)
+    if violations:
+        print("Gate I (EventPayload secret-field check) failed:\n")
+        for v in violations:
+            print(
+                f"  - EventPayload has a field named `{v}`, which looks like it "
+                "carries secret material into the ADR 0023 audit trail "
+                "(security.md I7/V9)"
+            )
+        print(f"\n{len(violations)} issue(s) found.")
+        return 1
+    print("Gate I OK: no EventPayload variant has a secret-shaped field name.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_policy_handler_coverage.py
+++ b/tools/check_policy_handler_coverage.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Gate B1: policy <-> handler existence checker (security review V3, #977).
+
+`opa test policy` (Gate A) proves the Rego logic is internally consistent.
+It says nothing about whether a `policy_name` string a handler passes to
+`enforce()` actually resolves to a real policy package, whether that policy
+carries a test, or whether every CRUD handler calls `enforce()` at all.  This
+script closes that gap with three checks, failing the build on any orphan
+found in any direction:
+
+  1. missing policy  -- every `.enforce("<name>", ...)` call site's name must
+     resolve to a `.rego` file that declares a matching `package` (OPA
+     resolves `data.<package>` by package declaration, not by directory
+     layout, so this cannot be done with a naive path join).
+  2. missing test    -- that `.rego` file must have a sibling `<stem>_test.rego`
+     in the same directory.
+  3. orphan policy   -- every decision-endpoint policy (a package that
+     defines `default allow`, as opposed to a shared helper module such as
+     `credential/common.rego`) must be referenced by at least one `enforce()`
+     call somewhere in the Rust tree.
+  4. unenforced handler -- every CRUD handler module (`create.rs`, `show.rs`,
+     `update.rs`, `delete.rs`, `list.rs`) under a known handler tree must
+     contain at least one `enforce()` call, except a small, explicit,
+     reviewed allowlist of endpoints that intentionally run pre-authn.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLICY_ROOT = REPO_ROOT / "policy"
+CRATES_ROOT = REPO_ROOT / "crates"
+
+# Handler trees where OPA enforce() is expected to gate every CRUD verb.
+# Persistence-layer crates (*-driver-sql) and CLI tooling (cli-manage) also
+# have create/show/update/delete/list.rs modules, but enforcement happens
+# once at the HTTP handler layer before a request reaches the backend, so
+# they are intentionally not in this list.
+HANDLER_ROOTS = [
+    CRATES_ROOT / "keystone/src/api",
+    CRATES_ROOT / "keystone/src/scim",
+    CRATES_ROOT / "keystone/src/federation/api",
+    CRATES_ROOT / "keystone/src/k8s_auth/api",
+    CRATES_ROOT / "webauthn/src/api",
+]
+
+CRUD_FILENAMES = {"create.rs", "show.rs", "update.rs", "delete.rs", "list.rs"}
+
+# Handlers that intentionally do not call enforce(): they run before any
+# Credentials exist to key a policy decision on. Keep this list explicit and
+# reviewed -- anything else missing enforce() is a bug, not an exception.
+ALLOWLIST_NO_ENFORCE = {
+    CRATES_ROOT / "keystone/src/api/v3/auth/token/create.rs",
+}
+
+ENFORCE_CALL_RE = re.compile(r"\.enforce\(\s*\"([\w/]+)\"")
+PACKAGE_RE = re.compile(r"^package\s+([\w.]+)", re.MULTILINE)
+DEFAULT_ALLOW_RE = re.compile(r"^default\s+allow\b", re.MULTILINE)
+
+
+def extract_enforced_policy_names():
+    """Map enforce() policy_name -> set of Rust source files calling it."""
+    names = {}
+    for src_root in CRATES_ROOT.glob("*/src"):
+        for path in src_root.rglob("*.rs"):
+            text = path.read_text()
+            for m in ENFORCE_CALL_RE.finditer(text):
+                names.setdefault(m.group(1), set()).add(path.relative_to(REPO_ROOT))
+    return names
+
+
+def index_decision_policies():
+    """Map dotted package name -> .rego file, for non-test decision endpoints.
+
+    A decision-endpoint policy is one that declares `default allow`; shared
+    helper modules (e.g. `credential/common.rego`) import other policies'
+    package but don't define one themselves, and are not enforce() targets.
+    """
+    packages = {}
+    duplicates = []
+    for path in sorted(POLICY_ROOT.rglob("*.rego")):
+        if path.stem.endswith("_test"):
+            continue
+        text = path.read_text()
+        m = PACKAGE_RE.search(text)
+        if not m:
+            continue
+        if not DEFAULT_ALLOW_RE.search(text):
+            continue
+        pkg = m.group(1)
+        if pkg in packages:
+            duplicates.append((pkg, packages[pkg], path))
+            continue
+        packages[pkg] = path
+    return packages, duplicates
+
+
+def check_enforced_names_resolve(names, packages):
+    errors = []
+    for name, sites in sorted(names.items()):
+        sites_str = ", ".join(str(s) for s in sorted(sites))
+        pkg = name.replace("/", ".")
+        rego_path = packages.get(pkg)
+        if rego_path is None:
+            errors.append(
+                f'enforce("{name}") called from [{sites_str}] but no '
+                f".rego file declares `package {pkg}` with `default allow`"
+            )
+            continue
+        test_path = rego_path.with_name(rego_path.stem + "_test.rego")
+        if not test_path.exists():
+            errors.append(
+                f'enforce("{name}") resolves to {rego_path.relative_to(REPO_ROOT)} '
+                f"but its sibling test file {test_path.relative_to(REPO_ROOT)} "
+                "does not exist"
+            )
+    return errors
+
+
+def check_no_orphan_policies(names, packages):
+    errors = []
+    for pkg, path in sorted(packages.items()):
+        name = pkg.replace(".", "/")
+        if name not in names:
+            errors.append(
+                f"{path.relative_to(REPO_ROOT)} declares `package {pkg}` with "
+                f'`default allow` but no handler calls enforce("{name}")'
+            )
+    return errors
+
+
+def check_duplicate_packages(duplicates):
+    errors = []
+    for pkg, first, second in duplicates:
+        errors.append(
+            f"package `{pkg}` with `default allow` is declared in both "
+            f"{first.relative_to(REPO_ROOT)} and {second.relative_to(REPO_ROOT)}"
+        )
+    return errors
+
+
+def check_handler_coverage():
+    errors = []
+    for handler_root in HANDLER_ROOTS:
+        if not handler_root.exists():
+            continue
+        for path in sorted(handler_root.rglob("*.rs")):
+            if path.name not in CRUD_FILENAMES:
+                continue
+            if path in ALLOWLIST_NO_ENFORCE:
+                continue
+            text = path.read_text()
+            if not ENFORCE_CALL_RE.search(text):
+                errors.append(
+                    f"{path.relative_to(REPO_ROOT)} is a CRUD handler module "
+                    "but contains no .enforce(...) call"
+                )
+    return errors
+
+
+def main():
+    names = extract_enforced_policy_names()
+    packages, duplicates = index_decision_policies()
+
+    errors = []
+    errors.extend(check_duplicate_packages(duplicates))
+    errors.extend(check_enforced_names_resolve(names, packages))
+    errors.extend(check_no_orphan_policies(names, packages))
+    errors.extend(check_handler_coverage())
+
+    if errors:
+        print("Gate B1 (policy<->handler existence check) failed:\n")
+        for e in errors:
+            print(f"  - {e}")
+        print(f"\n{len(errors)} issue(s) found.")
+        return 1
+
+    print(
+        f"Gate B1 OK: {len(names)} enforce() call site(s) all resolve to a "
+        f"policy + test; all {len(packages)} decision-endpoint policies are "
+        "referenced; all CRUD handler modules call enforce()."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_rego_undefined_argument_footgun.py
+++ b/tools/check_rego_undefined_argument_footgun.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Gate E: Rego lint for the undefined-argument footgun (security review V3, #985).
+
+`doc/src/security.md` I2: a delegation-boundary helper function's argument
+must never be `undefined` -- Rego evaluates a function's argument before
+dispatching to either of its rule bodies, so an undefined argument makes
+even the "not delegated" fast path (which never reads it) undefined too.
+Callers must wrap the argument in `object.get(parent, "key", null)`, never
+pass a bare dotted path like `input.target.credential.project_id` (which is
+`undefined`, not `null`, whenever an intermediate key is absent or the
+object itself is `null`).
+
+This scans every non-test `.rego` file under `policy/` for call sites of the
+known delegation-boundary helper functions and flags any argument that is a
+bare dotted-path expression instead of an `object.get(...)` call.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLICY_ROOT = REPO_ROOT / "policy"
+
+# Delegation-boundary helper functions whose argument contract (security.md
+# I2) requires object.get(...)-wrapped access -- see the doc comment on
+# `not_delegated_or_bound_to_own_project` in policy/credential/common.rego.
+# Extend this list if a new helper with the same contract is added.
+GUARDED_FUNCTIONS = [
+    "bound_to_own_delegation_project",
+    "not_delegated_or_bound_to_own_project",
+]
+
+CALL_RE = re.compile(
+    r"(?:[\w.]+\.)?(" + "|".join(re.escape(f) for f in GUARDED_FUNCTIONS) + r")\(([^)]*)\)"
+)
+
+
+def find_violations():
+    violations = []
+    for path in sorted(POLICY_ROOT.rglob("*.rego")):
+        if path.stem.endswith("_test"):
+            continue
+        text = path.read_text()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for m in CALL_RE.finditer(line):
+                func_name, arg = m.group(1), m.group(2).strip()
+                # A bare identifier is either the function's own definition
+                # (`fn(project_id) if {`) or a call site passing a local
+                # variable that may already have been derived safely
+                # elsewhere -- neither is checkable by this regex-based
+                # scan, so only dotted-path expressions are flagged.
+                if "." not in arg:
+                    continue
+                if "object.get(" in arg:
+                    continue
+                violations.append(
+                    f"{path.relative_to(REPO_ROOT)}:{lineno}: {func_name}({arg}) is "
+                    "called with a bare path argument, not object.get(..., null) -- "
+                    "an undefined argument silently makes every rule using this "
+                    "function undefined too (security.md I2)"
+                )
+    return violations
+
+
+def main():
+    violations = find_violations()
+    if violations:
+        print("Gate E (Rego undefined-argument footgun) failed:\n")
+        for v in violations:
+            print(f"  - {v}")
+        print(f"\n{len(violations)} issue(s) found.")
+        return 1
+    print(f"Gate E OK: every {', '.join(GUARDED_FUNCTIONS)} call site uses object.get(...).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_security_checklist_sast.py
+++ b/tools/check_security_checklist_sast.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Gate J: grep-based SAST for the security.md Section 7 reviewer checklist
+(security review V1/V2, issue #986).
+
+Most of the Section 7 checklist needs a human reviewer's judgement. Two
+items are mechanically checkable and are exactly what this script encodes:
+
+1. A wildcard `_ =>` arm in a match over `AuthenticationContext` or
+   `ScopeInfo` inside one of the five security-critical projections
+   (`Credentials::try_from`, `from_security_context`,
+   `build_authz_info_from_fernet_token`, `validate_scope_boundaries`,
+   `calculate_effective_roles`) is exactly V2's "a contributor adds a new
+   auth method or scope shape and updates 6 of the 7 places that must
+   change; the missed one silently widens authority" -- a wildcard arm
+   compiles cleanly for a variant nobody has thought about yet, unlike an
+   explicit arm-per-variant match, which fails to compile.
+2. `input.credentials.project_id` used as a delegation boundary in a Rego
+   rule that also checks `is_delegated` -- security.md I1/I2 require
+   delegation boundaries to key on `delegated_project_id` (the chain), never
+   `project_id` (the attacker-influenceable token scope).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLICY_ROOT = REPO_ROOT / "policy"
+
+# The five security-critical projections (security review V2 / security.md
+# I1-I5) that must name every AuthenticationContext/ScopeInfo variant
+# explicitly, never fall back to a wildcard arm.
+CRITICAL_FUNCTIONS = [
+    (REPO_ROOT / "crates/core/src/policy.rs", "fn try_from("),
+    (REPO_ROOT / "crates/core-types/src/token.rs", "pub fn from_security_context("),
+    (
+        REPO_ROOT / "crates/core/src/token/service.rs",
+        "async fn build_authz_info_from_fernet_token(",
+    ),
+    (REPO_ROOT / "crates/core-types/src/auth.rs", "pub fn validate_scope_boundaries("),
+    (REPO_ROOT / "crates/core/src/auth.rs", "async fn calculate_effective_roles("),
+]
+
+TARGET_ENUMS = ("AuthenticationContext::", "ScopeInfo::")
+# A wildcard arm's pattern, capturing everything up to the next top-level
+# arm/closing-brace so its body can be inspected.
+WILDCARD_ARM_RE = re.compile(r"(?:^|\n)[ \t]*_[ \t]*(?:if[^=]*)?=>(?P<body>.*?)(?=\n[ \t]*\S.*=>|\n[ \t]*\})", re.DOTALL)
+
+
+def extract_braced_block(text: str, open_brace_index: int) -> str:
+    """Return the `{...}` block (inclusive) starting at `open_brace_index`."""
+    depth = 0
+    for i in range(open_brace_index, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_brace_index : i + 1]
+    return text[open_brace_index:]
+
+
+def find_function_body(text: str, signature: str) -> str | None:
+    sig_index = text.find(signature)
+    if sig_index == -1:
+        return None
+    brace_index = text.find("{", sig_index)
+    if brace_index == -1:
+        return None
+    return extract_braced_block(text, brace_index)
+
+
+def strip_line_comments(text: str) -> str:
+    """Blank out `//...` line comments so a stray "match"/"=>" in prose
+    (e.g. a doc comment discussing match arms) can't be mistaken for code.
+    Preserves line/character offsets by replacing with spaces, not deleting.
+    """
+    return re.sub(r"//[^\n]*", lambda m: " " * len(m.group(0)), text)
+
+
+def find_match_blocks(body: str):
+    """Yield (start_offset, block_text) for every `match ... { ... }` block
+    in `body`, where `start_offset` is the block's absolute position within
+    `body` -- used to dedupe a wildcard arm found via more than one
+    enclosing match (an outer match legitimately nests inner ones).
+    """
+    code = strip_line_comments(body)
+    for m in re.finditer(r"\bmatch\b[^{]*\{", code):
+        start = m.end() - 1
+        yield start, extract_braced_block(body, start)
+
+
+def check_wildcard_arms():
+    violations = []
+    for path, signature in CRITICAL_FUNCTIONS:
+        text = path.read_text()
+        body = find_function_body(text, signature)
+        if body is None:
+            violations.append(
+                f"{path.relative_to(REPO_ROOT)}: could not locate `{signature.strip()}` "
+                "-- update CRITICAL_FUNCTIONS in tools/check_security_checklist_sast.py "
+                "if it moved or was renamed"
+            )
+            continue
+        seen_offsets = set()
+        for block_start, block in find_match_blocks(body):
+            if not any(enum in block for enum in TARGET_ENUMS):
+                continue
+            for wm in WILDCARD_ARM_RE.finditer(strip_line_comments(block)):
+                arm_body = wm.group("body")
+                # A wildcard arm that fails closed (denies) is not the V2
+                # risk -- adding a variant still gets rejected by default,
+                # not silently granted. Only an arm that can succeed
+                # (Ok(...)/allow, or a no-op default) is a silent-widening
+                # risk worth flagging.
+                if re.search(r"\bErr\s*\(", arm_body) or "return Err" in arm_body:
+                    continue
+                # Absolute offset of the wildcard within `body`, so the same
+                # arm found through both an outer and an inner enclosing
+                # match (the outer one legitimately nests the inner one) is
+                # only reported once.
+                absolute_offset = block_start + wm.start()
+                key = (path, absolute_offset)
+                if key in seen_offsets:
+                    continue
+                seen_offsets.add(key)
+                violations.append(
+                    f"{path.relative_to(REPO_ROOT)}: `{signature.strip()}` contains a "
+                    "wildcard `_ =>` arm in a match over AuthenticationContext/ScopeInfo "
+                    "that does not fail closed -- name every variant explicitly so a new "
+                    "one is a compile error, not a silent default (security.md V2)"
+                )
+    return violations
+
+
+def check_rego_project_id_as_delegation_boundary():
+    violations = []
+    for path in sorted(POLICY_ROOT.rglob("*.rego")):
+        if path.stem.endswith("_test"):
+            continue
+        text = path.read_text()
+        if "is_delegated" not in text or "credentials.project_id" not in text:
+            continue
+        # Scope to each `... if { ... }` rule body so the co-occurrence is
+        # actually within one rule, not just somewhere else in the file.
+        for m in re.finditer(r"\bif\s*\{", text):
+            block = extract_braced_block(text, m.end() - 1)
+            if "is_delegated" not in block:
+                continue
+            for lineno_offset, line in enumerate(block.splitlines()):
+                if re.search(r"credentials\.project_id\b", line) and "delegated_project_id" not in line:
+                    line_no = text[: m.start()].count("\n") + 1 + lineno_offset
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}:{line_no}: `credentials.project_id` "
+                        "(token scope) used inside an is_delegated rule body -- delegation "
+                        "boundaries must key on `credentials.delegated_project_id` (the "
+                        "chain), not the attacker-influenceable scope (security.md I1/I2)"
+                    )
+    return violations
+
+
+def main():
+    violations = check_wildcard_arms() + check_rego_project_id_as_delegation_boundary()
+    if violations:
+        print("Gate J (security.md §7 checklist SAST) failed:\n")
+        for v in violations:
+            print(f"  - {v}")
+        print(f"\n{len(violations)} issue(s) found.")
+        return 1
+    print("Gate J OK: no wildcard arms in the 5 critical projections; no Rego rule "
+          "uses credentials.project_id as a delegation boundary.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/opa_config.yaml
+++ b/tools/opa_config.yaml
@@ -7,6 +7,20 @@ services:
     #    scheme: "Bearer"
     #    token: "<personal token>"
 
+# Gate H (security review V4): `policy-container.yml`'s publish job signs
+# the pushed bundle by digest with cosign keyless signing, reusing its
+# `id-token: write` OIDC permission, and verifies the signature itself
+# before the workflow reports success. OPA's own bundle downloader has no
+# native cosign/Sigstore verification hook, so that check cannot happen
+# inside this config -- a production deployment that wants load-time
+# verification (rather than trusting `latest` + polling, as this reference
+# config does for continuous policy rollout) must run its own
+# `cosign verify --certificate-identity-regexp
+# "^https://github.com/<owner>/<repo>/" --certificate-oidc-issuer
+# "https://token.actions.githubusercontent.com"` against the resolved
+# digest before OPA starts (an init container or admission check), or pin
+# `resource` below to a specific verified digest instead of `latest` and
+# update it through a controlled release process.
 bundles:
   authz:
     service: ghcr


### PR DESCRIPTION
- **ci(security): Run opa test policy unconditionally in ci.yml**
- **test(security): Add policy<->handler existence checker**
- **fix(security): Add policy input-contract harness**
- **fix(security): Warn or fail loud on unenforced access_rules**
- **test(security): Add auth scope delegation matrix**
- **chore(security): Add scoped mutation testing (Gate G)**
- **chore(security): Sign and verify the OPA policy bundle**
- **fix(security): Bare-path helper args, add Rego footgun**
- **fix(security): Remove wildcard arms in critical projections**
- **test(security): Assert no secret leakage into policy**
- **chore(security): Test delegated policies drift tripwire**
- **docs(security): Add PR template with security review**
- **docs(security): Document new trust boundaries**
- **test(security): Drive real OPA decisions through handlers**
