### PR TITLE
fix: use PATCH for v3 update operations

### DIFF
--- a/crates/keystone/src/api/v3/endpoint/update.rs
+++ b/crates/keystone/src/api/v3/endpoint/update.rs
@@ -29,7 +29,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 
 /// Update existing endpoint
 #[utoipa::path(
-    put,
+    patch,
     path = "/{endpoint_id}",
     description = "Update endpoint by ID",
     params(),
@@ -180,7 +180,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .extension(vsc)
                     .header("Content-Type", "application/json")
@@ -254,7 +254,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .extension(vsc)
                     .header("Content-Type", "application/json")
@@ -298,7 +298,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .extension(vsc)
                     .header("Content-Type", "application/json")
@@ -353,7 +353,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .extension(vsc)
                     .header("Content-Type", "application/json")
@@ -385,7 +385,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .header("Content-Type", "application/json")
                     .body(Body::from(serde_json::to_string(&req).unwrap()))
@@ -395,5 +395,29 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_put() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"endpoint":{"enabled":false}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 }

--- a/crates/keystone/src/api/v3/service/update.rs
+++ b/crates/keystone/src/api/v3/service/update.rs
@@ -29,7 +29,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 
 /// Update existing service
 #[utoipa::path(
-    put,
+    patch,
     path = "/{service_id}",
     description = "Update service by ID",
     params(),
@@ -167,7 +167,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .extension(vsc)
                     .header("Content-Type", "application/json")
@@ -224,7 +224,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .extension(vsc)
                     .header("Content-Type", "application/json")
@@ -277,7 +277,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .extension(vsc)
                     .header("Content-Type", "application/json")
@@ -309,7 +309,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .uri("/foo")
                     .header("Content-Type", "application/json")
                     .body(Body::from(serde_json::to_string(&req).unwrap()))
@@ -319,5 +319,29 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_put() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"service":{"description":"updated"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 }

--- a/crates/keystone/src/api/v3/user/update.rs
+++ b/crates/keystone/src/api/v3/user/update.rs
@@ -29,7 +29,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 
 /// Update existing user
 #[utoipa::path(
-    put,
+    patch,
     path = "/{user_id}",
     description = "Update user by ID",
     params(),
@@ -172,7 +172,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .header(http::header::CONTENT_TYPE, "application/json")
                     .uri("/bar")
                     .extension(vsc)
@@ -220,7 +220,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .header(http::header::CONTENT_TYPE, "application/json")
                     .uri("/missing")
                     .extension(vsc)
@@ -273,7 +273,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .header(http::header::CONTENT_TYPE, "application/json")
                     .uri("/bar")
                     .extension(vsc)
@@ -302,7 +302,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .method("PUT")
+                    .method("PATCH")
                     .header(http::header::CONTENT_TYPE, "application/json")
                     .uri("/bar")
                     .body(Body::from(serde_json::to_string(&update_req).unwrap()))
@@ -312,5 +312,29 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_put() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/bar")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"user":{"enabled":false}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 }

--- a/tests/api/src/endpoint.rs
+++ b/tests/api/src/endpoint.rs
@@ -115,7 +115,7 @@ struct EndpointUpdateRequestInternal<'a> {
 
 impl RestEndpoint for EndpointUpdateRequestInternal<'_> {
     fn method(&self) -> http::Method {
-        http::Method::PUT
+        http::Method::PATCH
     }
 
     fn endpoint(&self) -> Cow<'static, str> {

--- a/tests/api/src/identity/user.rs
+++ b/tests/api/src/identity/user.rs
@@ -138,7 +138,7 @@ struct UserUpdateRequest {
 
 impl RestEndpoint for UserUpdateRequest {
     fn method(&self) -> http::Method {
-        http::Method::PUT
+        http::Method::PATCH
     }
 
     fn endpoint(&self) -> Cow<'static, str> {

--- a/tests/api/src/service.rs
+++ b/tests/api/src/service.rs
@@ -115,7 +115,7 @@ struct ServiceUpdateRequestInternal<'a> {
 
 impl RestEndpoint for ServiceUpdateRequestInternal<'_> {
     fn method(&self) -> http::Method {
-        http::Method::PUT
+        http::Method::PATCH
     }
 
     fn endpoint(&self) -> Cow<'static, str> {


### PR DESCRIPTION
Summary

Updates the Identity v3 user, service, and endpoint update APIs to use PATCH instead of PUT, matching the OpenStack Identity v3 API specification.

Changes

Changed PUT to PATCH for:

PATCH /v3/users/{user_id}

PATCH /v3/services/{service_id}

PATCH /v3/endpoints/{endpoint_id}

Updated the related handler tests to send PATCH

Updated the API test client helpers to use PATCH

Left credential updates unchanged because they already use PATCH

Left v3 role grants and role implication operations as PUT because they create associations rather than update resources

Left v4 update routes unchanged; v4 support for both PUT and PATCH can be handled separately

Testing

Verified there are no remaining PUT methods in the affected v3 update handlers

Ran git diff --check

Ran formatting checks

Ran the relevant update tests

Note: used CodeX for assistance