### PR TITLE
feat(config): Add Vault-backed configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -362,7 +362,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -4865,12 +4865,14 @@ dependencies = [
  "eyre",
  "http",
  "http-serde",
+ "httpmock",
  "ipnet",
  "notify",
  "regex",
  "secrecy",
  "serde",
  "serde_json",
+ "serial_test",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
@@ -4879,6 +4881,7 @@ dependencies = [
  "url",
  "url-macro",
  "validator",
+ "vaultrs",
 ]
 
 [[package]]
@@ -7305,6 +7308,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustify"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4800ce4c1cc2fec12c559dae2ddbf0e17fcee7569b796e6d75898efef443368b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "http",
+ "reqwest",
+ "rustify_derive",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "rustify_derive"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ea7fda74240f7410d0198b603a8a2f662acc7d76b6667a49f9b162cd8d9b4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_urlencoded",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8495,6 +8532,18 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -9637,6 +9686,25 @@ name = "varint-rs"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa6c38708f6257f1ec2ca7e5a11f9bbf58a27d7060078b6b333624968183d96"
+
+[[package]]
+name = "vaultrs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ffcc0e81025065dda612ec1e26a3d81bb16ef3062354873d17a35965d68522"
+dependencies = [
+ "async-trait",
+ "derive_builder",
+ "http",
+ "reqwest",
+ "rustify",
+ "rustify_derive",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "vcpkg"
@@ -10856,7 +10924,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -10897,7 +10965,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ utoipa-axum = { version = "0.2" }
 utoipa-swagger-ui = { version = "9.0", default-features = false }
 uuid = { version = "1.23", features = ["v4"] }
 validator = { version = "0.20" }
+vaultrs = { version = "0.8", default-features = false, features = ["rustls"] }
 x509-parser = { version = "0.18" }
 webauthn-authenticator-rs = { version = "0.5" }
 webauthn-rs = { version = "0.5" }

--- a/crates/cli-manage/src/main.rs
+++ b/crates/cli-manage/src/main.rs
@@ -92,7 +92,7 @@ pub trait PerformAction {
 #[tokio::main]
 async fn main() -> Result<(), Report> {
     let args = Args::parse();
-    let cfg = Config::load_all(args.config)?;
+    let cfg = Config::load_all(args.config).await?;
     match args.command {
         Command::Bootstrap(x) => x.take_action(&cfg).await?,
         Command::Catalog(x) => x.take_action(&cfg).await?,

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -22,15 +22,18 @@ notify = "8.2"
 regex.workspace = true
 secrecy = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["fs", "rt", "sync", "time"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["fs", "macros", "rt", "sync", "time"] }
 tracing.workspace = true
 url = { workspace = true, features = ["serde"] }
 url-macro.workspace = true
 validator = { workspace = true, features = ["derive"] }
+vaultrs.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true
+httpmock = "0.8"
+serial_test.workspace = true
 temp-env.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/config/src/distributed_storage.rs
+++ b/crates/config/src/distributed_storage.rs
@@ -444,6 +444,9 @@ allowed_peer_svids = ["spiffe://example.org/ns/default/sa/keystone"]
 
     #[test]
     fn test_env() {
+        // `Config::new` is async, but this test drives it from the synchronous
+        // `temp_env::with_vars` closure API, so run it to completion on a local
+        // current-thread runtime.
         temp_env::with_vars(
             [(
                 "OS_DISTRIBUTED_STORAGE__NODE_CLUSTER_ADDR",
@@ -465,7 +468,11 @@ path = /foo
                 )
                 .unwrap();
 
-                let cfg = crate::Config::new(cfg_file.path().to_path_buf()).unwrap();
+                let cfg = tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap()
+                    .block_on(crate::Config::new(cfg_file.path().to_path_buf()))
+                    .unwrap();
                 assert_eq!(
                     "http://test/",
                     cfg.distributed_storage

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -29,7 +29,12 @@
 //! ```no_run
 //! use openstack_keystone_config::Config;
 //!
-//! let cfg = Config::new("/etc/keystone/keystone.conf".into()).unwrap();
+//! # #[tokio::main]
+//! # async fn main() {
+//! let cfg = Config::new("/etc/keystone/keystone.conf".into())
+//!     .await
+//!     .unwrap();
+//! # }
 //! ```
 //!
 //! ```no_run
@@ -94,6 +99,7 @@ mod security_compliance;
 mod token;
 mod token_restriction;
 mod trust;
+mod vault;
 mod webauthn;
 
 pub use api_key::*;
@@ -134,6 +140,7 @@ pub use security_compliance::*;
 pub use token::*;
 pub use token_restriction::*;
 pub use trust::*;
+pub use vault::VaultSection;
 pub use webauthn::*;
 
 /// Keystone configuration.
@@ -322,20 +329,17 @@ pub struct Config {
     #[serde(default)]
     pub trust: TrustProvider,
 
+    /// Direct Vault bootstrap configuration.
+    #[serde(default)]
+    pub vault: Option<VaultSection>,
+
     /// Webauthn configuration.
     #[serde(default)]
     pub webauthn: WebauthnSection,
 }
 
 impl Config {
-    /// Load the config file.
-    ///
-    /// # Parameters
-    /// - `path`: Path to the config file
-    ///
-    /// # Returns
-    /// - `Ok(Self)` if the config was parsed successfully
-    pub fn new(path: PathBuf) -> Result<Self, Report> {
+    fn build_raw(path: PathBuf) -> Result<config::Config, Report> {
         let mut builder = config::Config::builder();
 
         if std::path::Path::new(&path).is_file() {
@@ -346,24 +350,81 @@ impl Config {
             builder = builder.add_source(File::with_name(&site_vars_file));
         }
 
-        builder = builder.add_source(
-            config::Environment::with_prefix("OS")
-                .prefix_separator("_")
-                .separator("__"),
-        );
-
-        builder.try_into()
+        builder
+            .add_source(
+                config::Environment::with_prefix("OS")
+                    .prefix_separator("_")
+                    .separator("__"),
+            )
+            .build()
+            .wrap_err("Failed to read configuration file")
     }
 
-    /// Load the config file and all certificates referred.
+    fn from_raw(raw: config::Config) -> Result<Self, Report> {
+        raw.try_deserialize()
+            .wrap_err("Failed to parse configuration file")
+    }
+
+    /// Load and parse the config file, resolving any Vault references.
     ///
     /// # Parameters
     /// - `path`: Path to the config file
     ///
     /// # Returns
     /// - `Ok(Self)` if the config was parsed successfully
-    pub fn load_all(path: PathBuf) -> Result<Self, Report> {
-        let mut cfg = Self::new(path)?;
+    pub async fn new(path: PathBuf) -> Result<Self, Report> {
+        let mut raw = Self::build_raw(path)?;
+        Self::resolve_vault_references(&mut raw).await?;
+        Self::from_raw(raw)
+    }
+
+    /// Load the config file, resolve Vault references and all certificates
+    /// referred, and validate the complete configuration.
+    ///
+    /// # Parameters
+    /// - `path`: Path to the config file
+    ///
+    /// # Returns
+    /// - `Ok(Self)` if the config was parsed successfully
+    pub async fn load_all(path: PathBuf) -> Result<Self, Report> {
+        Ok(Self::load_all_with_vault_state(&path).await?.config)
+    }
+
+    /// Resolve any Vault references in `raw` in place.
+    ///
+    /// Returns `Ok(None)` when the configuration contains no Vault references
+    /// (so a plain configuration pays no Vault cost), or `Ok(Some(runtime))`
+    /// with the live [`vault::VaultRuntime`] used to keep the resolved secrets
+    /// current.
+    async fn resolve_vault_references(
+        raw: &mut config::Config,
+    ) -> Result<Option<vault::VaultRuntime>, Report> {
+        if !vault::contains_vault_references(&raw.cache)? {
+            return Ok(None);
+        }
+        raw.get_table("vault")
+            .map_err(|_| vault::VaultConfigError::MissingConfiguration)?;
+        let vault_config: VaultSection = raw
+            .get("vault")
+            .map_err(|_| vault::VaultConfigError::InvalidConfiguration)?;
+        let resolved = vault::resolve(raw, &vault_config).await?;
+        Ok(Some(resolved.runtime))
+    }
+
+    async fn load_all_with_vault_state(path: &Path) -> Result<LoadedConfig, Report> {
+        let mut raw = Self::build_raw(path.to_path_buf())?;
+        let vault = Self::resolve_vault_references(&mut raw).await?;
+        let parsed = Self::from_raw(raw).and_then(Self::finish_load);
+        let config = match vault {
+            // A configuration that resolved Vault references but then failed to
+            // build is surfaced distinctly from a plain configuration error.
+            Some(_) => parsed.map_err(|_| vault::VaultConfigError::ResolvedConfigurationInvalid)?,
+            None => parsed?,
+        };
+        Ok(LoadedConfig { config, vault })
+    }
+
+    fn finish_load(mut cfg: Self) -> Result<Self, Report> {
         if let Some(ref mut ds) = cfg.distributed_storage {
             if let RaftTlsConfiguration::Tls(ref mut tls) = ds.tls_configuration {
                 tls.read_certs()
@@ -416,15 +477,27 @@ impl Config {
 
 impl TryFrom<config::ConfigBuilder<config::builder::DefaultState>> for Config {
     type Error = Report;
+
+    /// Build a [`Config`] directly from a prepared [`config::ConfigBuilder`].
+    ///
+    /// This is the synchronous construction path used by downstream crates
+    /// (and their tests) that assemble configuration in memory rather than
+    /// loading it from a file. It does not resolve Vault references, load
+    /// referred certificates, or run validation; use [`Config::load_all`] for
+    /// the full loading pipeline.
     fn try_from(
         builder: config::ConfigBuilder<config::builder::DefaultState>,
     ) -> Result<Self, Self::Error> {
-        builder
+        let raw = builder
             .build()
-            .wrap_err("Failed to read configuration file")?
-            .try_deserialize()
-            .wrap_err("Failed to parse configuration file")
+            .wrap_err("Failed to read configuration file")?;
+        Self::from_raw(raw)
     }
+}
+
+struct LoadedConfig {
+    config: Config,
+    vault: Option<vault::VaultRuntime>,
 }
 
 /// Config Manager supporting config file watch and reload.
@@ -452,31 +525,30 @@ impl ConfigManager {
         let (notify_tx, _) = tokio::sync::broadcast::channel(16);
 
         // Initial Load
-        let initial_cfg = Self::load_all(&config_path).await?;
+        let initial = Config::load_all_with_vault_state(&config_path).await?;
 
         let manager = Arc::new(Self {
-            config: Arc::new(RwLock::new(initial_cfg)),
+            config: Arc::new(RwLock::new(initial.config)),
             notify_tx,
         });
 
         // Spawn Background Watcher
         let manager_clone = Arc::clone(&manager);
         tokio::spawn(async move {
-            Self::watch_loop(manager_clone, config_path).await;
+            Self::watch_loop(manager_clone, config_path, initial.vault).await;
         });
 
         Ok(manager)
     }
 
-    /// Load the Config with the corresponding referred files.
-    async fn load_all(path: &Path) -> Result<Config, Report> {
-        Config::load_all(path.to_path_buf())
-    }
-
     /// Watch loop for constant watching for the configuration changes and
     /// corresponding notifications.
     #[allow(clippy::expect_used)]
-    async fn watch_loop(manager: Arc<Self>, config_path: PathBuf) {
+    async fn watch_loop(
+        manager: Arc<Self>,
+        config_path: PathBuf,
+        mut vault_runtime: Option<vault::VaultRuntime>,
+    ) {
         let (sync_tx, mut sync_rx) = tokio::sync::mpsc::channel(1);
 
         let mut watcher: RecommendedWatcher =
@@ -506,35 +578,90 @@ impl ConfigManager {
             let _ = watcher.watch(watch.as_path(), RecursiveMode::NonRecursive);
         }
 
-        while let Some(_event) = sync_rx.recv().await {
-            // 1. Drain the channel to ignore rapid-fire events
-            while sync_rx.try_recv().is_ok() {}
-
-            // Give the OS a moment to finish the file write
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-            match Self::load_all(&config_path).await {
-                Ok(new_cfg) => {
-                    // Ensure we are watching current cert files
-                    for watch_candidate in new_cfg.get_watch_files() {
-                        if !watched_paths.contains(&watch_candidate) {
-                            let _ = watcher
-                                .watch(watch_candidate.as_path(), RecursiveMode::NonRecursive);
-                            watched_paths.insert(watch_candidate.clone());
+        loop {
+            // Only arm the Vault maintenance timer when a Vault runtime is
+            // active; otherwise this branch never fires (rather than parking on
+            // a far-future sentinel deadline).
+            let vault_deadline = vault_runtime
+                .as_ref()
+                .map(vault::VaultRuntime::next_deadline);
+            let vault_tick = async {
+                match vault_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending::<()>().await,
+                }
+            };
+            tokio::select! {
+                event = sync_rx.recv() => {
+                    if event.is_none() {
+                        break;
+                    }
+                    while sync_rx.try_recv().is_ok() {}
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    match Config::load_all_with_vault_state(&config_path).await {
+                        Ok(loaded) => {
+                            Self::apply_loaded(
+                                &manager,
+                                loaded,
+                                &mut vault_runtime,
+                                &mut watcher,
+                                &mut watched_paths,
+                            ).await;
+                        }
+                        Err(_) => {
+                            error!("configuration reload failed; retaining last-known-good configuration");
                         }
                     }
-
-                    // Update the config itself
-                    let mut w = manager.config.write().await;
-                    *w = new_cfg;
-                    // Broadcast the change
-                    let _ = manager.notify_tx.send(());
                 }
-                Err(e) => {
-                    error!("config file watch error: {:?}", e);
+                () = vault_tick => {
+                    let Some(runtime) = &mut vault_runtime else {
+                        continue;
+                    };
+                    if runtime.renew_if_due().await.is_err() {
+                        error!("Vault token renewal failed; retrying while retaining current configuration");
+                    }
+                    match runtime.has_new_version().await {
+                        Ok(true) => match Config::load_all_with_vault_state(&config_path).await {
+                            Ok(loaded) => {
+                                Self::apply_loaded(
+                                    &manager,
+                                    loaded,
+                                    &mut vault_runtime,
+                                    &mut watcher,
+                                    &mut watched_paths,
+                                ).await;
+                            }
+                            Err(_) => {
+                                error!("Vault configuration refresh failed; retaining last-known-good configuration");
+                            }
+                        },
+                        Ok(false) => {}
+                        Err(_) => {
+                            error!("Vault metadata poll failed; retaining last-known-good configuration");
+                        }
+                    }
                 }
             }
         }
+    }
+
+    async fn apply_loaded(
+        manager: &Arc<Self>,
+        loaded: LoadedConfig,
+        vault_runtime: &mut Option<vault::VaultRuntime>,
+        watcher: &mut RecommendedWatcher,
+        watched_paths: &mut HashSet<PathBuf>,
+    ) {
+        for watch_candidate in loaded.config.get_watch_files() {
+            if !watched_paths.contains(&watch_candidate) {
+                let _ = watcher.watch(watch_candidate.as_path(), RecursiveMode::NonRecursive);
+                watched_paths.insert(watch_candidate);
+            }
+        }
+
+        *manager.config.write().await = loaded.config;
+        *vault_runtime = loaded.vault;
+        let _ = manager.notify_tx.send(());
     }
 }
 
@@ -543,13 +670,34 @@ mod tests {
     use std::fs;
     use std::io::Write;
 
+    use httpmock::MockServer;
     use secrecy::ExposeSecret;
+    use serde_json::json;
+    use serial_test::{parallel, serial};
     use tempfile::{NamedTempFile, tempdir};
-    use tokio::time::{Duration, sleep};
+    use tokio::time::{Duration, sleep, timeout};
 
     use super::*;
+    use crate::vault::tests::{mock_lookup, mock_metadata, mock_renew, mock_secret};
 
+    // `Config::new` is async, but these tests drive it from the synchronous
+    // `temp_env::with_var` closure API, so run it to completion on a local
+    // current-thread runtime.
+    fn block_on_config_new(path: PathBuf) -> Result<Config, Report> {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(Config::new(path))
+    }
+
+    // `build_raw` reads process-global environment (`OS_*` overrides and
+    // `KEYSTONE_SITE_VARS_FILE`). Tests that mutate that environment are marked
+    // `#[serial]` and every test that loads a config through `build_raw` is
+    // marked `#[parallel]`, so a mutated variable (e.g. a `KEYSTONE_SITE_VARS_FILE`
+    // pointing at a temp file that is about to be dropped) can never leak into a
+    // concurrently loading test.
     #[test]
+    #[serial]
     fn test_env() {
         temp_env::with_var("OS_API_POLICY__OPA_BASE_URL", Some("http://test/"), || {
             let mut cfg_file = NamedTempFile::new().unwrap();
@@ -564,12 +712,13 @@ mod tests {
             )
             .unwrap();
 
-            let cfg = Config::new(cfg_file.path().to_path_buf()).unwrap();
+            let cfg = block_on_config_new(cfg_file.path().to_path_buf()).unwrap();
             assert_eq!("http://test/", cfg.api_policy.opa_base_url.to_string());
         });
     }
 
     #[test]
+    #[serial]
     fn test_site_vars() {
         let mut site_vars_file = NamedTempFile::with_suffix(".toml").unwrap();
         write!(
@@ -602,7 +751,7 @@ mod tests {
                 )
                 .unwrap();
 
-                let cfg = Config::new(cfg_file.path().to_path_buf()).unwrap();
+                let cfg = block_on_config_new(cfg_file.path().to_path_buf()).unwrap();
                 let ds = cfg.distributed_storage.unwrap();
                 assert_eq!(1, ds.node_id);
                 assert_eq!("http://foo:8300/", ds.node_cluster_addr.to_string());
@@ -661,7 +810,226 @@ mod tests {
         config_path
     }
 
+    fn write_vault_config(
+        file: &mut NamedTempFile,
+        server: &MockServer,
+        refresh_interval_seconds: u64,
+    ) {
+        write!(
+            file,
+            r#"
+    [vault]
+    address = {}
+    token = test-token
+    refresh_interval_seconds = {}
+
+    [auth]
+    methods = []
+
+    [database]
+    connection = "vault://secret/keystone/database#password"
+            "#,
+            server.base_url(),
+            refresh_interval_seconds
+        )
+        .unwrap();
+        file.flush().unwrap();
+    }
+
     #[tokio::test]
+    #[parallel]
+    async fn test_async_loader_resolves_vault_reference() {
+        let server = MockServer::start();
+        let lookup = mock_lookup(&server, false, 60);
+        let metadata = mock_metadata(&server, 4);
+        let secret = mock_secret(
+            &server,
+            4,
+            json!({
+                "password": "environment-value"
+            }),
+        );
+        let mut config_file = NamedTempFile::with_suffix(".conf").unwrap();
+        write!(
+            config_file,
+            r#"
+    [vault]
+    address = {}
+    token = test-token
+
+    [auth]
+    methods = []
+
+    [database]
+    connection = "vault://secret/keystone/database#password"
+            "#,
+            server.base_url()
+        )
+        .unwrap();
+
+        let config = Config::load_all(config_file.path().to_path_buf())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            config.database.connection.expose_secret(),
+            "environment-value"
+        );
+        let vault = config.vault.unwrap();
+        assert_eq!(vault.token.expose_secret(), "test-token");
+        assert_eq!(vault.refresh_interval_seconds, 60);
+        lookup.assert_calls(1);
+        metadata.assert_calls(1);
+        secret.assert_calls(1);
+    }
+
+    #[tokio::test]
+    #[parallel]
+    async fn test_resolved_configuration_error_is_redacted() {
+        let server = MockServer::start();
+        let _lookup = mock_lookup(&server, false, 60);
+        let _metadata = mock_metadata(&server, 1);
+        let _secret = mock_secret(&server, 1, json!({"password": "SUPERSECRET"}));
+        let mut config_file = NamedTempFile::with_suffix(".conf").unwrap();
+        write!(
+            config_file,
+            r#"
+    [vault]
+    address = {}
+    token = test-token
+
+    [DEFAULT]
+    debug = "vault://secret/keystone/database#password"
+
+    [auth]
+    methods = []
+
+    [database]
+    connection = ordinary
+            "#,
+            server.base_url()
+        )
+        .unwrap();
+
+        let error = Config::load_all(config_file.path().to_path_buf())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_eq!(
+            error,
+            "configuration is invalid after resolving Vault references"
+        );
+        assert!(!error.contains("SUPERSECRET"));
+        assert!(!error.contains("test-token"));
+    }
+
+    #[tokio::test]
+    #[parallel]
+    async fn test_async_loader_fails_closed_without_vault_configuration() {
+        let mut config_file = NamedTempFile::with_suffix(".conf").unwrap();
+        write!(
+            config_file,
+            r#"
+    [auth]
+    methods = []
+    [database]
+    connection = "vault://secret/keystone/database#password"
+            "#
+        )
+        .unwrap();
+
+        let error = Config::load_all(config_file.path().to_path_buf())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_eq!(
+            error,
+            "Vault references require a [vault] configuration section"
+        );
+    }
+
+    #[tokio::test]
+    #[parallel]
+    async fn test_vault_version_reload_and_last_known_good_retention() {
+        let server = MockServer::start();
+        let _lookup = mock_lookup(&server, false, 60);
+        let mut metadata = mock_metadata(&server, 1);
+        let mut secret = mock_secret(&server, 1, json!({"password": "version-one"}));
+        let mut config_file = NamedTempFile::with_suffix(".conf").unwrap();
+        write_vault_config(&mut config_file, &server, 1);
+
+        let manager = ConfigManager::watched(config_file.path()).await.unwrap();
+        let mut reloads = manager.notify_tx.subscribe();
+        metadata.delete();
+        secret.delete();
+        let mut metadata = mock_metadata(&server, 2);
+        let mut secret = mock_secret(&server, 2, json!({"password": "version-two"}));
+
+        timeout(Duration::from_secs(4), reloads.recv())
+            .await
+            .expect("Vault version change should trigger a reload")
+            .unwrap();
+        assert_eq!(
+            manager
+                .config
+                .read()
+                .await
+                .database
+                .connection
+                .expose_secret(),
+            "version-two"
+        );
+
+        metadata.delete();
+        secret.delete();
+        let _metadata = mock_metadata(&server, 3);
+        let invalid_secret = mock_secret(&server, 3, json!({"password": 12345}));
+        timeout(Duration::from_secs(4), async {
+            while invalid_secret.calls() == 0 {
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("invalid Vault version should be attempted");
+        sleep(Duration::from_millis(100)).await;
+
+        assert!(reloads.try_recv().is_err());
+        assert_eq!(
+            manager
+                .config
+                .read()
+                .await
+                .database
+                .connection
+                .expose_secret(),
+            "version-two"
+        );
+    }
+
+    #[tokio::test]
+    #[parallel]
+    async fn test_renewable_vault_token_is_renewed_halfway_through_ttl() {
+        let server = MockServer::start();
+        let _lookup = mock_lookup(&server, true, 2);
+        let _metadata = mock_metadata(&server, 1);
+        let _secret = mock_secret(&server, 1, json!({"password": "value"}));
+        let renewal = mock_renew(&server, 2);
+        let mut config_file = NamedTempFile::with_suffix(".conf").unwrap();
+        write_vault_config(&mut config_file, &server, 60);
+
+        let _manager = ConfigManager::watched(config_file.path()).await.unwrap();
+        timeout(Duration::from_secs(4), async {
+            while renewal.calls() == 0 {
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("renewable token should be renewed");
+        assert!(renewal.calls() >= 1);
+    }
+
+    #[tokio::test]
+    #[parallel]
     async fn test_initial_load() {
         let dir = tempdir().unwrap();
         let config_path = setup_files(dir.path());
@@ -679,6 +1047,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel]
     async fn test_reload_on_config_change() {
         let dir = tempdir().unwrap();
         let config_path = setup_files(dir.path());
@@ -719,6 +1088,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel]
     async fn test_reload_on_cert_change() {
         let config_file = NamedTempFile::with_suffix(".conf").unwrap();
         let mut ca_file = NamedTempFile::new().unwrap();
@@ -788,6 +1158,7 @@ mod tests {
         assert!(success, "Config did not update after file change");
     }
     #[tokio::test]
+    #[parallel]
     async fn test_invalid_security_compliance_validation() {
         use std::io::Write;
         use tempfile::NamedTempFile;
@@ -819,7 +1190,7 @@ mod tests {
         f.sync_all().unwrap();
 
         // 1. Attempt to load the configuration
-        let result = Config::load_all(config_file.path().to_path_buf());
+        let result = Config::load_all(config_file.path().to_path_buf()).await;
 
         // 2. Assert that it completely fails and catches our error
         assert!(
@@ -870,8 +1241,9 @@ mod tests {
         assert!(cfg.trusted_proxies.is_empty());
     }
 
-    #[test]
-    fn test_api_key_trusted_proxies_and_validation() {
+    #[tokio::test]
+    #[parallel]
+    async fn test_api_key_trusted_proxies_and_validation() {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
@@ -899,7 +1271,9 @@ mod tests {
         .unwrap();
         f.sync_all().unwrap();
 
-        let cfg = Config::load_all(config_file.path().to_path_buf()).unwrap();
+        let cfg = Config::load_all(config_file.path().to_path_buf())
+            .await
+            .unwrap();
         assert_eq!(
             cfg.api_key.trusted_proxies,
             vec![
@@ -909,8 +1283,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_invalid_api_key_validation() {
+    #[tokio::test]
+    #[parallel]
+    async fn test_invalid_api_key_validation() {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
@@ -942,7 +1317,7 @@ mod tests {
         .unwrap();
         f.sync_all().unwrap();
 
-        let result = Config::load_all(config_file.path().to_path_buf());
+        let result = Config::load_all(config_file.path().to_path_buf()).await;
         assert!(result.is_err());
 
         let err_msg = format!("{:?}", result.unwrap_err());

--- a/crates/config/src/vault.rs
+++ b/crates/config/src/vault.rs
@@ -1,0 +1,611 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use config::{Value, ValueKind};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use thiserror::Error;
+use tokio::time::Instant;
+use url::Url;
+use vaultrs::client::{Client, VaultClient, VaultClientSettingsBuilder};
+use vaultrs::kv2;
+
+const DEFAULT_REFRESH_INTERVAL_SECONDS: u64 = 60;
+
+fn default_refresh_interval_seconds() -> u64 {
+    DEFAULT_REFRESH_INTERVAL_SECONDS
+}
+
+/// Bootstrap configuration for direct Vault access.
+#[derive(Clone, Debug, Deserialize)]
+pub struct VaultSection {
+    /// Vault server URL.
+    pub address: Url,
+    /// Vault token. Prefer setting this through `OS_VAULT__TOKEN`.
+    pub token: SecretString,
+    /// Optional Vault Enterprise namespace.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// How often KV v2 metadata is polled for a newer version.
+    #[serde(default = "default_refresh_interval_seconds")]
+    pub refresh_interval_seconds: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct SecretPath {
+    mount: String,
+    path: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct VaultReference {
+    secret: SecretPath,
+    key: String,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum VaultConfigError {
+    #[error("invalid Vault reference")]
+    InvalidReference,
+    #[error("Vault references require a [vault] configuration section")]
+    MissingConfiguration,
+    #[error("invalid [vault] configuration")]
+    InvalidConfiguration,
+    #[error("Vault token must not be empty")]
+    EmptyToken,
+    #[error("Vault refresh_interval_seconds must be greater than zero")]
+    InvalidRefreshInterval,
+    #[error("failed to initialize Vault client")]
+    ClientInitialization,
+    #[error("Vault token authentication failed")]
+    Authentication,
+    #[error("failed to read referenced Vault secret")]
+    SecretRead,
+    #[error("referenced Vault key was not found")]
+    MissingKey,
+    #[error("referenced Vault value must be a string")]
+    NonStringValue,
+    #[error("failed to poll Vault secret metadata")]
+    MetadataRead,
+    #[error("Vault token renewal failed")]
+    TokenRenewal,
+    #[error("configuration is invalid after resolving Vault references")]
+    ResolvedConfigurationInvalid,
+}
+
+#[derive(Debug)]
+struct RenewalState {
+    next: Instant,
+    ttl: Duration,
+}
+
+/// Runtime state retained by the configuration manager.
+pub(crate) struct VaultRuntime {
+    client: Arc<VaultClient>,
+    secret_versions: HashMap<SecretPath, u64>,
+    refresh_interval: Duration,
+    next_poll: Instant,
+    renewal: Option<RenewalState>,
+}
+
+impl VaultRuntime {
+    pub(crate) fn next_deadline(&self) -> Instant {
+        self.renewal
+            .as_ref()
+            .map(|renewal| renewal.next.min(self.next_poll))
+            .unwrap_or(self.next_poll)
+    }
+
+    pub(crate) async fn renew_if_due(&mut self) -> Result<(), VaultConfigError> {
+        let Some(renewal) = &self.renewal else {
+            return Ok(());
+        };
+        if Instant::now() < renewal.next {
+            return Ok(());
+        }
+
+        let previous_ttl = renewal.ttl;
+        match self.client.renew(None).await {
+            Ok(auth) => {
+                let ttl = Duration::from_secs(auth.lease_duration.max(1));
+                self.renewal = auth.renewable.then(|| RenewalState {
+                    next: Instant::now() + half_ttl(ttl),
+                    ttl,
+                });
+                Ok(())
+            }
+            Err(_) => {
+                let retry = half_ttl(previous_ttl).min(self.refresh_interval);
+                if let Some(renewal) = &mut self.renewal {
+                    renewal.next = Instant::now() + retry.max(Duration::from_secs(1));
+                }
+                Err(VaultConfigError::TokenRenewal)
+            }
+        }
+    }
+
+    pub(crate) async fn has_new_version(&mut self) -> Result<bool, VaultConfigError> {
+        if Instant::now() < self.next_poll {
+            return Ok(false);
+        }
+        self.next_poll = Instant::now() + self.refresh_interval;
+
+        for (secret, current_version) in &self.secret_versions {
+            let metadata = kv2::read_metadata(&*self.client, &secret.mount, &secret.path)
+                .await
+                .map_err(|_| VaultConfigError::MetadataRead)?;
+            if metadata.current_version > *current_version {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+pub(crate) struct ResolvedVault {
+    pub(crate) runtime: VaultRuntime,
+}
+
+fn half_ttl(ttl: Duration) -> Duration {
+    Duration::from_secs((ttl.as_secs() / 2).max(1))
+}
+
+fn parse_reference(value: &str) -> Result<VaultReference, VaultConfigError> {
+    let url = Url::parse(value).map_err(|_| VaultConfigError::InvalidReference)?;
+    if url.scheme() != "vault"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port().is_some()
+        || url.query().is_some()
+    {
+        return Err(VaultConfigError::InvalidReference);
+    }
+
+    let mount = url
+        .host_str()
+        .filter(|mount| !mount.is_empty())
+        .ok_or(VaultConfigError::InvalidReference)?;
+    let path = url.path().strip_prefix('/').unwrap_or(url.path());
+    let key = url
+        .fragment()
+        .filter(|key| !key.is_empty())
+        .ok_or(VaultConfigError::InvalidReference)?;
+    if path.is_empty() || path.ends_with('/') {
+        return Err(VaultConfigError::InvalidReference);
+    }
+
+    Ok(VaultReference {
+        secret: SecretPath {
+            mount: mount.to_string(),
+            path: path.to_string(),
+        },
+        key: key.to_string(),
+    })
+}
+
+fn visit_references(
+    value: &Value,
+    references: &mut HashSet<VaultReference>,
+    at_root: bool,
+) -> Result<(), VaultConfigError> {
+    match &value.kind {
+        ValueKind::String(value) if value.starts_with("vault://") => {
+            references.insert(parse_reference(value)?);
+        }
+        ValueKind::Table(table) => {
+            for (key, value) in table {
+                if at_root && key == "vault" {
+                    continue;
+                }
+                visit_references(value, references, false)?;
+            }
+        }
+        ValueKind::Array(values) => {
+            for value in values {
+                visit_references(value, references, false)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+pub(crate) fn contains_vault_references(value: &Value) -> Result<bool, VaultConfigError> {
+    let mut references = HashSet::new();
+    visit_references(value, &mut references, true)?;
+    Ok(!references.is_empty())
+}
+
+fn replace_references(
+    value: &mut Value,
+    secrets: &HashMap<SecretPath, HashMap<String, serde_json::Value>>,
+    at_root: bool,
+) -> Result<(), VaultConfigError> {
+    match &mut value.kind {
+        ValueKind::String(current) if current.starts_with("vault://") => {
+            let reference = parse_reference(current)?;
+            let resolved = secrets
+                .get(&reference.secret)
+                .and_then(|secret| secret.get(&reference.key))
+                .ok_or(VaultConfigError::MissingKey)?;
+            let resolved = resolved.as_str().ok_or(VaultConfigError::NonStringValue)?;
+            *current = resolved.to_string();
+        }
+        ValueKind::Table(table) => {
+            for (key, value) in table {
+                if at_root && key == "vault" {
+                    continue;
+                }
+                replace_references(value, secrets, false)?;
+            }
+        }
+        ValueKind::Array(values) => {
+            for value in values {
+                replace_references(value, secrets, false)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+pub(crate) async fn resolve(
+    raw: &mut config::Config,
+    vault: &VaultSection,
+) -> Result<ResolvedVault, VaultConfigError> {
+    if vault.token.expose_secret().is_empty() {
+        return Err(VaultConfigError::EmptyToken);
+    }
+    if vault.refresh_interval_seconds == 0 {
+        return Err(VaultConfigError::InvalidRefreshInterval);
+    }
+
+    let mut references = HashSet::new();
+    visit_references(&raw.cache, &mut references, true)?;
+
+    let mut settings = VaultClientSettingsBuilder::default();
+    settings
+        .address(vault.address.as_str())
+        .token(vault.token.expose_secret());
+    if let Some(namespace) = &vault.namespace {
+        settings.set_namespace(namespace.clone());
+    }
+    let settings = settings
+        .build()
+        .map_err(|_| VaultConfigError::ClientInitialization)?;
+    let client =
+        Arc::new(VaultClient::new(settings).map_err(|_| VaultConfigError::ClientInitialization)?);
+
+    let token = client
+        .lookup()
+        .await
+        .map_err(|_| VaultConfigError::Authentication)?;
+    let renewal = token
+        .renewable
+        .unwrap_or(false)
+        .then_some(token.ttl)
+        .filter(|ttl| *ttl > 0)
+        .map(|ttl| {
+            let ttl = Duration::from_secs(ttl);
+            RenewalState {
+                next: Instant::now() + half_ttl(ttl),
+                ttl,
+            }
+        });
+
+    let secret_paths: HashSet<_> = references
+        .iter()
+        .map(|reference| reference.secret.clone())
+        .collect();
+    let mut secrets = HashMap::new();
+    let mut secret_versions = HashMap::new();
+    for secret in secret_paths {
+        let metadata = kv2::read_metadata(&*client, &secret.mount, &secret.path)
+            .await
+            .map_err(|_| VaultConfigError::SecretRead)?;
+        let data = kv2::read_version::<HashMap<String, serde_json::Value>>(
+            &*client,
+            &secret.mount,
+            &secret.path,
+            metadata.current_version,
+        )
+        .await
+        .map_err(|_| VaultConfigError::SecretRead)?;
+        secret_versions.insert(secret.clone(), metadata.current_version);
+        secrets.insert(secret, data);
+    }
+
+    replace_references(&mut raw.cache, &secrets, true)?;
+    let refresh_interval = Duration::from_secs(vault.refresh_interval_seconds);
+    Ok(ResolvedVault {
+        runtime: VaultRuntime {
+            client,
+            secret_versions,
+            refresh_interval,
+            next_poll: Instant::now() + refresh_interval,
+            renewal,
+        },
+    })
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use config::{File, FileFormat};
+    use httpmock::{Method::GET, Method::POST, Mock, MockServer};
+    use serde_json::json;
+
+    use super::*;
+
+    pub(crate) fn mock_lookup(server: &MockServer, renewable: bool, ttl: u64) -> Mock<'_> {
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/auth/token/lookup-self");
+            then.status(200).json_body(json!({
+                "request_id": "request",
+                "lease_id": "",
+                "lease_duration": 0,
+                "renewable": false,
+                "data": {
+                    "accessor": "accessor",
+                    "creation_time": 1,
+                    "creation_ttl": ttl,
+                    "display_name": "token",
+                    "entity_id": "entity",
+                    "expire_time": null,
+                    "explicit_max_ttl": 0,
+                    "id": "redacted",
+                    "identity_policies": null,
+                    "issue_time": null,
+                    "meta": null,
+                    "num_uses": 0,
+                    "orphan": true,
+                    "path": "auth/token/create",
+                    "policies": ["default"],
+                    "renewable": renewable,
+                    "role": null,
+                    "ttl": ttl
+                },
+                "wrap_info": null,
+                "warnings": null,
+                "auth": null
+            }));
+        })
+    }
+
+    pub(crate) fn mock_metadata(server: &MockServer, version: u64) -> Mock<'_> {
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/secret/metadata/keystone/database");
+            then.status(200).json_body(json!({
+                "request_id": "request",
+                "lease_id": "",
+                "lease_duration": 0,
+                "renewable": false,
+                "data": {
+                    "cas_required": false,
+                    "created_time": "2026-01-01T00:00:00Z",
+                    "current_version": version,
+                    "delete_version_after": "0s",
+                    "max_versions": 0,
+                    "oldest_version": 0,
+                    "updated_time": "2026-01-01T00:00:00Z",
+                    "custom_metadata": null,
+                    "versions": {}
+                },
+                "wrap_info": null,
+                "warnings": null,
+                "auth": null
+            }));
+        })
+    }
+
+    pub(crate) fn mock_secret(
+        server: &MockServer,
+        version: u64,
+        data: serde_json::Value,
+    ) -> Mock<'_> {
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/secret/data/keystone/database")
+                .query_param("version", version.to_string());
+            then.status(200).json_body(json!({
+                "request_id": "request",
+                "lease_id": "",
+                "lease_duration": 0,
+                "renewable": false,
+                "data": {
+                    "data": data,
+                    "metadata": {
+                        "created_time": "2026-01-01T00:00:00Z",
+                        "deletion_time": "",
+                        "destroyed": false,
+                        "version": version
+                    }
+                },
+                "wrap_info": null,
+                "warnings": null,
+                "auth": null
+            }));
+        })
+    }
+
+    pub(crate) fn mock_renew(server: &MockServer, ttl: u64) -> Mock<'_> {
+        server.mock(|when, then| {
+            when.method(POST).path("/v1/auth/token/renew-self");
+            then.status(200).json_body(json!({
+                "request_id": "request",
+                "lease_id": "",
+                "lease_duration": 0,
+                "renewable": false,
+                "data": null,
+                "wrap_info": null,
+                "warnings": null,
+                "auth": {
+                    "client_token": "redacted",
+                    "accessor": "accessor",
+                    "policies": ["default"],
+                    "token_policies": ["default"],
+                    "metadata": null,
+                    "lease_duration": ttl,
+                    "renewable": true,
+                    "entity_id": "entity",
+                    "token_type": "service",
+                    "orphan": true
+                }
+            }));
+        })
+    }
+
+    fn test_vault(server: &MockServer, refresh_interval_seconds: u64) -> VaultSection {
+        VaultSection {
+            address: Url::parse(&server.base_url()).unwrap(),
+            token: SecretString::from("test-token"),
+            namespace: None,
+            refresh_interval_seconds,
+        }
+    }
+
+    #[test]
+    fn parses_complete_reference() {
+        let reference = parse_reference("vault://secret/keystone/database#password").unwrap();
+        assert_eq!(reference.secret.mount, "secret");
+        assert_eq!(reference.secret.path, "keystone/database");
+        assert_eq!(reference.key, "password");
+    }
+
+    #[test]
+    fn rejects_incomplete_or_ambiguous_references() {
+        for value in [
+            "vault:///path#key",
+            "vault://mount#key",
+            "vault://mount/path",
+            "vault://mount/path#",
+            "vault://user@mount/path#key",
+            "vault://mount:8200/path#key",
+            "vault://mount/path?version=1#key",
+            "vault://mount/path/#key",
+        ] {
+            assert!(parse_reference(value).is_err(), "accepted {value}");
+        }
+    }
+
+    #[tokio::test]
+    async fn recursively_resolves_and_deduplicates_secret_reads() {
+        let server = MockServer::start();
+        let lookup = mock_lookup(&server, false, 60);
+        let metadata = mock_metadata(&server, 3);
+        let secret = mock_secret(
+            &server,
+            3,
+            json!({"password": "db-secret", "username": "keystone"}),
+        );
+        let mut raw = config::Config::builder()
+            .add_source(File::from_str(
+                r#"
+                    [nested]
+                    connection = "main"
+                    values = ["ordinary", "vault://secret/keystone/database#username"]
+                "#,
+                FileFormat::Toml,
+            ))
+            .add_source(File::from_str(
+                r#"
+                    [nested]
+                    connection = "site"
+                "#,
+                FileFormat::Toml,
+            ))
+            .add_source(File::from_str(
+                r#"
+                    [nested]
+                    connection = "vault://secret/keystone/database#password"
+                "#,
+                FileFormat::Toml,
+            ))
+            .build()
+            .unwrap();
+
+        resolve(&mut raw, &test_vault(&server, 60)).await.unwrap();
+
+        assert_eq!(raw.get_string("nested.connection").unwrap(), "db-secret");
+        assert_eq!(
+            raw.get_array("nested.values").unwrap()[1]
+                .clone()
+                .into_string()
+                .unwrap(),
+            "keystone"
+        );
+        lookup.assert_calls(1);
+        metadata.assert_calls(1);
+        secret.assert_calls(1);
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_and_non_string_values_without_disclosing_them() {
+        for (data, expected) in [
+            (json!({"other": "SUPERSECRET"}), "not found"),
+            (json!({"password": 12345}), "must be a string"),
+        ] {
+            let server = MockServer::start();
+            let _lookup = mock_lookup(&server, false, 60);
+            let _metadata = mock_metadata(&server, 1);
+            let _secret = mock_secret(&server, 1, data);
+            let mut raw = config::Config::builder()
+                .add_source(File::from_str(
+                    "value = 'vault://secret/keystone/database#password'",
+                    FileFormat::Toml,
+                ))
+                .build()
+                .unwrap();
+
+            let error = resolve(&mut raw, &test_vault(&server, 60))
+                .await
+                .err()
+                .unwrap()
+                .to_string();
+            assert!(error.contains(expected), "{error}");
+            assert!(!error.contains("SUPERSECRET"));
+            assert!(!error.contains("12345"));
+        }
+    }
+
+    #[tokio::test]
+    async fn authentication_failure_is_redacted() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/auth/token/lookup-self");
+            then.status(403)
+                .json_body(json!({"errors": ["test-token SUPERSECRET"]}));
+        });
+        let mut raw = config::Config::builder()
+            .add_source(File::from_str(
+                "value = 'vault://secret/keystone/database#password'",
+                FileFormat::Toml,
+            ))
+            .build()
+            .unwrap();
+
+        let error = resolve(&mut raw, &test_vault(&server, 60))
+            .await
+            .err()
+            .unwrap()
+            .to_string();
+        assert_eq!(error, "Vault token authentication failed");
+        assert!(!error.contains("test-token"));
+        assert!(!error.contains("SUPERSECRET"));
+    }
+}


### PR DESCRIPTION
## TL;DR

Resolve complete `vault://mount/path#key` configuration values directly from Vault KV v2.

## Changes

- Add optional `[vault]` bootstrap configuration and async resolution after configuration source precedence is merged.
- Poll KV v2 metadata, renew renewable tokens, and atomically retain the last-known-good configuration on failures.
- Migrate Keystone and `keystone-manage` startup to the asynchronous loader.
- Add mock Vault coverage for validation, deduplication, redaction, renewal, reloads, and last-known-good retention.

## Tests

- Config: 106 unit tests and 2 doctests passed.
- Keystone manage: 95 tests passed.
- Keystone: 659 tests passed.
- Targeted Clippy, cargo fmt, pre-commit, and git diff check passed.

Closes #502