### PR TITLE
feat(devstack): Add devstack plugin and CI workflow

### DIFF
--- a/.github/workflows/devstack.yml
+++ b/.github/workflows/devstack.yml
@@ -1,0 +1,197 @@
+---
+name: Devstack with rust Keystone
+
+on:
+  workflow_dispatch:
+  pull_request:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.run_id || github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required checks must always report a status, so the workflow triggers
+    # unconditionally; this job decides whether the real work is needed.
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/devstack.yml'
+              - 'crates/**'
+              - 'policy/**'
+              - 'devstack/**'
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Enable cache
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: |
+            ~/.cargo
+          key: ${{ runner.os }}-devstack
+
+      - name: Rust Cache
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921 # stable
+        with:
+          toolchain: stable
+
+      - name: Install protobuf-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libtss2-dev pkg-config
+
+      - name: Build Keystone
+        run: cargo build --release
+
+      - name: Move artifacts to the root
+        run: mv target/release/keystone target/release/keystone-manage ./
+
+      - name: Upload built binaries
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: keystone-devstack-bin
+          path: |
+            keystone
+            keystone-manage
+
+  devstack:
+    runs-on: ubuntu-24.04
+    needs:
+      - build
+    permissions:
+      contents: read
+    env:
+      OS_CLOUD: devstack-admin
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Materialize local branch ref for devstack's file:// plugin clone
+        # actions/checkout leaves the workspace in detached HEAD, so there is
+        # no refs/heads/<branch> for devstack's `git fetch origin <branch>`
+        # (fetch_plugins, invoked against this checkout via `enable_plugin
+        # key-rs file://...`) to find.
+        run: |
+          ref="$(git symbolic-ref --short -q HEAD || true)"
+          if [[ -z "$ref" ]]; then
+            ref="${{ github.head_ref || github.ref_name }}"
+            git branch -f "$ref" HEAD
+          fi
+          echo "KEYSTONE_RS_GIT_REF=$ref" >> "$GITHUB_ENV"
+
+      - name: Download built binaries
+        uses: actions/download-artifact@abefc31eafcfbdf6c5336127c1346fdae79ff41c # v5.0.0
+        with:
+          name: keystone-devstack-bin
+          path: ${{ github.workspace }}/bin
+
+      - name: Fix binary permissions
+        run: chmod u+x ${{ github.workspace }}/bin/keystone ${{ github.workspace }}/bin/keystone-manage
+
+      - name: Remove pre-installed MySQL
+        # ubuntu-24.04 runners ship with a MySQL system service already
+        # running (root auth via auth_socket, no password set). devstack's
+        # `enable_service mysql` then tries to configure/start its own
+        # instance on top of it and fails authenticating as
+        # root/DATABASE_PASSWORD against the pre-existing one. Purge it so
+        # devstack's own install_database step sets it up from scratch.
+        run: |
+          sudo systemctl stop mysql.service || true
+          sudo apt-get purge -y --auto-remove 'mysql-*' 'mariadb-*' || true
+          sudo rm -rf /etc/mysql /var/lib/mysql
+
+      - name: Clone devstack
+        run: git clone https://opendev.org/openstack/devstack /opt/stack/devstack
+
+      - name: Write local.conf
+        run: |
+          cat <<EOF > /opt/stack/devstack/local.conf
+          [[local|localrc]]
+          ADMIN_PASSWORD=password
+          DATABASE_PASSWORD=password
+          RABBIT_PASSWORD=password
+          SERVICE_PASSWORD=password
+          SERVICE_TOKEN=service-token
+
+          disable_all_services
+          enable_service mysql
+          enable_service rabbit
+          enable_service key
+          enable_service key-rs
+
+          enable_plugin key-rs file://${{ github.workspace }} ${{ env.KEYSTONE_RS_GIT_REF }}
+
+          KEYSTONE_RS_BIN_DIR=${{ github.workspace }}/bin
+
+          LOGFILE=\$HOME/devstack.log
+          LOG_COLOR=False
+          EOF
+          cat /opt/stack/devstack/local.conf
+
+      - name: Run stack.sh
+        working-directory: /opt/stack/devstack
+        run: FORCE=yes ./stack.sh
+
+      - name: Verify rust Keystone is serving directly
+        run: curl -sf http://127.0.0.1:8080/v3
+
+      - name: Verify Apache routes /identity to rust Keystone
+        run: |
+          sudo systemctl is-active devstack@key-rs
+          curl -sf http://127.0.0.1/identity/v3
+
+      - name: Issue a token via the openstack CLI
+        run: |
+          source /opt/stack/devstack/openrc admin admin
+          openstack token issue
+
+      - name: Dump devstack log
+        if: failure()
+        run: cat "$HOME/devstack.log" || true
+
+      - name: Dump rust Keystone service log
+        if: failure()
+        run: sudo journalctl -u devstack@key-rs --no-pager || true
+
+      - name: Dump OPA service log
+        if: failure()
+        run: sudo journalctl -u devstack@key-rs-opa --no-pager || true
+
+      - name: Dump Apache error log
+        if: failure()
+        run: sudo cat /var/log/apache2/error.log || true

--- a/devstack/lib/keystone-rs
+++ b/devstack/lib/keystone-rs
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# devstack lib functions for the rust Keystone ("key-rs") service.
+#
+# python Keystone ("key") remains fully responsible for the base DB schema,
+# fernet key repository and initial admin bootstrap - this file only adds
+# the rust binary on top of that (additive DB migrations, its own config
+# file) and, once it is up, repoints the Apache "/identity" ProxyPass at it
+# so it ends up serving the traffic python used to serve. See
+# doc/src/install.md ("Parallel installation with the python Keystone") for
+# the rationale; this automates exactly that manual Apache reroute.
+#
+# Standard devstack function naming: install_/configure_/init_/start_/
+# stop_/cleanup_<service>.
+
+# Source directory of this checkout (devstack/lib/keystone-rs -> repo root)
+KEYSTONE_RS_LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+KEYSTONE_RS_SRC_DIR=${KEYSTONE_RS_SRC_DIR:-$(cd "$KEYSTONE_RS_LIB_DIR/../.." && pwd)}
+
+KEYSTONE_RS_BIN_DIR=${KEYSTONE_RS_BIN_DIR:-}
+KEYSTONE_RS_CONF=${KEYSTONE_RS_CONF:-$KEYSTONE_CONF_DIR/keystone-rs.conf}
+KEYSTONE_RS_BIND_HOST=${KEYSTONE_RS_BIND_HOST:-127.0.0.1}
+KEYSTONE_RS_SERVICE_PORT=${KEYSTONE_RS_SERVICE_PORT:-8080}
+KEYSTONE_RS_OPA_PORT=${KEYSTONE_RS_OPA_PORT:-8181}
+KEYSTONE_RS_OPA_VERSION=${KEYSTONE_RS_OPA_VERSION:-1.13.2}
+KEYSTONE_RS_DEV_KEK=${KEYSTONE_RS_DEV_KEK:-4242424242424242424242424242424242424242424242424242424242424242}
+
+function install_keystone_rs {
+    if [[ -n "$KEYSTONE_RS_BIN_DIR" ]]; then
+        # CI passes a directory with already-built binaries so we don't pay
+        # for a second `cargo build --release` inside stack.sh.
+        sudo install -m 0755 "$KEYSTONE_RS_BIN_DIR/keystone" /usr/local/bin/keystone
+        sudo install -m 0755 "$KEYSTONE_RS_BIN_DIR/keystone-manage" /usr/local/bin/keystone-manage
+    else
+        pushd "$KEYSTONE_RS_SRC_DIR" >/dev/null
+        cargo build --release
+        sudo install -m 0755 target/release/keystone /usr/local/bin/keystone
+        sudo install -m 0755 target/release/keystone-manage /usr/local/bin/keystone-manage
+        popd >/dev/null
+    fi
+
+    if [[ ! -x /usr/local/bin/opa ]]; then
+        # Same GitHub-releases URL tools/Dockerfile.skaffold already uses
+        # (the openpolicyagent.org/downloads mirror doesn't reliably serve a
+        # valid binary for every pinned version).
+        curl --proto '=https' --tlsv1.2 -sSfL \
+            "https://github.com/open-policy-agent/opa/releases/download/v${KEYSTONE_RS_OPA_VERSION}/opa_linux_amd64_static" \
+            -o /tmp/opa
+        sudo install -m 0755 /tmp/opa /usr/local/bin/opa
+        rm -f /tmp/opa
+    fi
+}
+
+function configure_keystone_rs {
+    local db_connection
+
+    # Reuse the DB connection python Keystone was already configured with
+    # instead of re-deriving devstack's DB credentials; rust ignores/rejects
+    # the "+pymysql" driver segment (doc/src/install.md), so strip it.
+    db_connection=$(iniget "$KEYSTONE_CONF" database connection)
+    db_connection=${db_connection/+pymysql/}
+
+    # `iniset` writes directly as the current (unprivileged, non-root) stack
+    # user, so the file must be owned by it, not root - a plain `sudo touch`
+    # would leave it root-owned and every iniset call below would fail with
+    # "Permission denied".
+    sudo install -d -m 0755 "$(dirname "$KEYSTONE_RS_CONF")"
+    sudo install -o "$STACK_USER" -m 0644 /dev/null "$KEYSTONE_RS_CONF"
+
+    iniset "$KEYSTONE_RS_CONF" DEFAULT debug True
+    # Don't copy python's [auth] methods verbatim: devstack's keystone.conf
+    # usually never sets that key at all (python falls back to oslo.config's
+    # own built-in default instead), so `iniget` returns an empty string and
+    # rust's fernet driver ends up with an empty methods list - every token,
+    # including a plain password-auth one, then 500s with "unsupported
+    # authentication methods password in token payload", since the fernet
+    # driver's auth_methods bitmask is positional over this exact list
+    # (crates/token-driver-fernet/src/lib.rs). Use the same fixed list
+    # tools/start-api.sh already relies on for live-server tests.
+    iniset "$KEYSTONE_RS_CONF" auth methods "password,token,openid,application_credential,x509,mapped,hacked_appcred_handler"
+    iniset "$KEYSTONE_RS_CONF" database connection "$db_connection"
+    # Same fernet key repository python already populated, so tokens issued
+    # by either implementation validate on both.
+    iniset "$KEYSTONE_RS_CONF" fernet_tokens key_repository "$KEYSTONE_CONF_DIR/fernet-keys"
+    iniset "$KEYSTONE_RS_CONF" fernet_receipts key_repository "$KEYSTONE_CONF_DIR/fernet-keys"
+    iniset "$KEYSTONE_RS_CONF" api_policy opa_base_url "http://${KEYSTONE_RS_BIND_HOST}:${KEYSTONE_RS_OPA_PORT}"
+
+    # Defaults to /var/lib/keystone/audit, which the unprivileged stack user
+    # (running as the ExecStart target of devstack@key-rs) can't create -
+    # keystone-manage/keystone then die with "failed to create audit spool
+    # directory: Permission denied". Point it at devstack's own per-service
+    # data dir instead, which is already owned by $STACK_USER.
+    local audit_spool_dir="$DATA_DIR/keystone-rs/audit"
+    sudo install -d -o "$STACK_USER" -m 0755 "$audit_spool_dir"
+    iniset "$KEYSTONE_RS_CONF" audit spool_dir "$audit_spool_dir"
+
+    _keystone_rs_reroute_apache
+}
+
+function _keystone_rs_reroute_apache {
+    # lib/keystone's own configure_keystone (core devstack, runs before any
+    # plugin post-config hook) already wrote an Apache site proxying
+    # "/identity" to python's uwsgi socket, via write_uwsgi_config's own
+    # `apache_site_config_for $name` (name = "keystone-api" as of the
+    # current devstack master, but this has moved across releases - e.g.
+    # cleanup_keystone still references "keystone-wsgi-public"). Rather
+    # than guess at that site/socket name, find it by grepping
+    # $APACHE_CONF_DIR for whichever generated site actually proxies
+    # "/identity", then surgically rewrite its ProxyPass/ProxyPassReverse
+    # targets for that path to point at the rust binary instead - the same
+    # single-vhost edit doc/src/install.md's Apache sample shows doing by
+    # hand.
+    local site_conf
+    site_conf=$(grep -lE 'ProxyPass[[:space:]]+"/identity"[[:space:]]' "$APACHE_CONF_DIR"/*.conf 2>/dev/null | head -n1)
+
+    if [[ -z "$site_conf" || ! -f "$site_conf" ]]; then
+        die $LINENO "Could not find the Apache site config devstack generated for keystone"
+    fi
+
+    # The site was generated for a "uwsgi://" ProxyPass target, so only
+    # mod_proxy/mod_proxy_uwsgi were enabled for it. Rewriting the target to
+    # a plain "http://" backend below needs mod_proxy_http too, or Apache
+    # can't service the directive at all (502/503 on every /identity
+    # request).
+    enable_apache_mod proxy_http
+
+    sudo cp "$site_conf" "${site_conf}.pre-keystone-rs"
+    sudo sed -i -E \
+        -e "s#(ProxyPass[[:space:]]+\"/identity\"[[:space:]]+).*#\1\"http://${KEYSTONE_RS_BIND_HOST}:${KEYSTONE_RS_SERVICE_PORT}\"#" \
+        -e "s#(ProxyPassReverse[[:space:]]+\"/identity\"[[:space:]]+).*#\1\"http://${KEYSTONE_RS_BIND_HOST}:${KEYSTONE_RS_SERVICE_PORT}\"#" \
+        "$site_conf"
+
+    if ! grep -q "$KEYSTONE_RS_SERVICE_PORT" "$site_conf"; then
+        die $LINENO "Failed to reroute the keystone Apache site to rust Keystone"
+    fi
+}
+
+function init_keystone_rs {
+    run_process key-rs-opa "/usr/local/bin/opa run -s $KEYSTONE_RS_SRC_DIR/policy --addr ${KEYSTONE_RS_BIND_HOST}:${KEYSTONE_RS_OPA_PORT}"
+
+    if ! wait_for_connection "http://${KEYSTONE_RS_BIND_HOST}:${KEYSTONE_RS_OPA_PORT}/health"; then
+        die $LINENO "OPA did not become ready for rust Keystone"
+    fi
+
+    KEYSTONE_DEV_KEK="$KEYSTONE_RS_DEV_KEK" KEYSTONE_ALLOW_ENV_KEK=1 \
+        /usr/local/bin/keystone-manage -c "$KEYSTONE_RS_CONF" db up
+}
+
+function start_keystone_rs {
+    # systemd's ExecStart (what devstack's run_process ultimately drives)
+    # doesn't expand "VAR=val command" prefixes the way a shell does, so
+    # export the dev-mode KEK through a small wrapper script instead of
+    # trying to pass environment through run_process directly.
+    local wrapper=/usr/local/bin/keystone-rs-run
+    sudo bash -c "cat > $wrapper" <<EOF
+#!/bin/bash
+export KEYSTONE_DEV_KEK=$KEYSTONE_RS_DEV_KEK
+export KEYSTONE_ALLOW_ENV_KEK=1
+exec /usr/local/bin/keystone -c $KEYSTONE_RS_CONF
+EOF
+    sudo chmod 0755 "$wrapper"
+
+    run_process key-rs "$wrapper"
+
+    if ! wait_for_connection "http://${KEYSTONE_RS_BIND_HOST}:${KEYSTONE_RS_SERVICE_PORT}/v3"; then
+        die $LINENO "rust Keystone did not become ready"
+    fi
+
+    restart_apache_server
+}
+
+function stop_keystone_rs {
+    stop_process key-rs
+    stop_process key-rs-opa
+}
+
+function cleanup_keystone_rs {
+    sudo rm -f "$KEYSTONE_RS_CONF" /usr/local/bin/keystone-rs-run
+}
+
+# Small retry helper - devstack ships several similarly-named helpers across
+# releases (wait_for_service, etc.) that aren't reliably present, so keep
+# this self-contained.
+function wait_for_connection {
+    local url=$1
+    local i
+    for i in {1..60}; do
+        if curl -sf -o /dev/null "$url"; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}

--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# devstack plugin dispatcher for the rust Keystone ("key-rs") service.
+#
+# Standard devstack plugin phase hooks. python Keystone ("key") is left
+# fully in charge of the base DB schema and initial bootstrap; this plugin
+# only adds the rust binary on top and repoints Apache's /identity proxy
+# at it once it is up, so it ends up serving traffic in python's place.
+#
+# See devstack/lib/keystone-rs for the actual install/configure/init/start
+# functions, and doc/src/install.md ("Parallel installation with the
+# python Keystone") for the deployment rationale.
+
+KEYSTONE_RS_PLUGIN_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+source "$KEYSTONE_RS_PLUGIN_DIR/lib/keystone-rs"
+
+if is_service_enabled key-rs; then
+    # key-rs-opa is an internal implementation detail (the OPA sidecar this
+    # plugin's run_process calls target), not a user-facing toggle - devstack's
+    # run_process silently no-ops for any service name that isn't enabled, so
+    # it must be enabled here rather than left for local.conf to opt into.
+    enable_service key-rs-opa
+
+    if [[ "$1" == "stack" && "$2" == "install" ]]; then
+        install_keystone_rs
+    elif [[ "$1" == "stack" && "$2" == "post-config" ]]; then
+        configure_keystone_rs
+    elif [[ "$1" == "stack" && "$2" == "extra" ]]; then
+        init_keystone_rs
+        start_keystone_rs
+    fi
+
+    if [[ "$1" == "unstack" ]]; then
+        stop_keystone_rs
+    fi
+
+    if [[ "$1" == "clean" ]]; then
+        cleanup_keystone_rs
+    fi
+fi

--- a/devstack/settings
+++ b/devstack/settings
@@ -1,0 +1,5 @@
+# Service group declaration for the rust Keystone devstack plugin.
+# Enabled independently of core "key" (python Keystone) so operators can
+# opt in via `enable_service key-rs` in local.conf.
+
+enable_service key-rs

--- a/doc/src/install.md
+++ b/doc/src/install.md
@@ -149,3 +149,24 @@ server {
     ProxyPass "/identity" http://localhost:8080 retry=0
 </VirtualHost>
 ```
+
+## Devstack integration
+
+The `devstack/` directory in the project source tree is a standard
+out-of-tree [devstack](https://docs.openstack.org/devstack/latest/) plugin
+that automates the Apache reroute described above. Python Keystone still
+owns the base DB schema and initial admin bootstrap; the plugin builds/runs
+the rust binary alongside it, applies the additive DB migrations, and
+rewrites the Apache site devstack generated for Keystone so that
+`/identity` is proxied to the rust binary instead of python's uwsgi socket.
+
+To use it, add to `local.conf`:
+
+```ini
+[[local|localrc]]
+enable_plugin key-rs https://github.com/openstack-experimental/keystone
+enable_service key-rs
+```
+
+See `.github/workflows/devstack.yml` for a working example that runs a
+minimal devstack (mysql, rabbitmq, keystone) in CI with the plugin enabled.


### PR DESCRIPTION
## Summary

Add a standard out-of-tree devstack plugin (devstack/settings,
devstack/plugin.sh, devstack/lib/keystone-rs) that builds/runs the
rust Keystone binary alongside python Keystone and reroutes the
Apache /identity proxy to it, automating the manual steps already
documented in doc/src/install.md instead of reimplementing devstack.

Add .github/workflows/devstack.yml, which builds the rust binaries
and runs a minimal devstack (mysql, rabbitmq, keystone) with the
plugin enabled, verifying the Apache-fronted /identity endpoint is
served by rust Keystone.