### PR TITLE
chore(ci): Disable merge_group triggers for some jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,6 @@ on:
       - 'Cargo.lock'
       - 'benches/**'
       - 'crates/**'
-  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/benchmark_fork_run.yml
+++ b/.github/workflows/benchmark_fork_run.yml
@@ -8,7 +8,6 @@ on:
       - 'Cargo.toml'
       - 'benches/**'
       - 'crates/**'
-  merge_group:
 
 jobs:
   benchmark_fork_pr_branch:

--- a/.github/workflows/benchmark_fork_track.yml
+++ b/.github/workflows/benchmark_fork_track.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: ["Run Benchmarks"]
     types: ["completed"]
-  merge_group:
 
 jobs:
   track_fork_pr_branch:

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -11,7 +11,6 @@ on:
       - 'Cargo.toml'
       - 'benches/**'
       - 'crates/**'
-  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-keystone-py-image.yml
+++ b/.github/workflows/build-keystone-py-image.yml
@@ -13,7 +13,6 @@ on:
       - 'tools/Dockerfile.py-keystone' # Trigger build only when Dockerfile changes
       - '.github/workflows/build-keystone-py-image.yml'
   workflow_dispatch: # Allows manual trigger
-  merge_group:
 
 env:
   REGISTRY_IMAGE: ghcr.io/openstack-experimental/keystone/py-keystone


### PR DESCRIPTION
benchmark jobs do not need to be executed in the merge_group
