### PR TITLE
chore(ci): Enable caching of the openapi build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
       # Convert JUnit XML into an interactive GitHub Step Summary
       - name: Publish Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        if: success() || failure() # Run even if tests fail
+        if: needs.changes.outputs.code == 'true' && (success() || failure()) # Run even if tests fail
         with:
           name: Cargo Nextest Results
           path: target/nextest/*/junit.xml
@@ -305,6 +305,8 @@ jobs:
 
       - name: Rust Cache
         uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          shared-key: openapi-build
 
       - name: Generate OpenAPI
         run: cargo run --bin keystone -- --dump-openapi yaml > openapi.yaml

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -69,6 +69,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
+      - name: Rust Cache
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          shared-key: openapi-build
+
       - name: Generate OpenAPI
         run: cargo run --bin keystone -- --dump-openapi yaml > doc/src/openapi.yaml
 


### PR DESCRIPTION
mdbook.yml rebuilt the full keystone binary (raft/protobuf deps) just
to dump the same OpenAPI spec CI's `openapi` job already produces.
Unfortunately GH does not offer a safe way to reuse this artifact
produced by other workflow without introducing vulnerabilities. Enable
caching instead hoping to help CI to reuse what was already built once.