### PR TITLE
fix(security): Do not allow ec2cred token to do anything

### DIFF
--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -105,6 +105,77 @@ pub mod tests {
         ValidatedSecurityContext::test_new(sc)
     }
 
+    /// Build a project-scoped ValidatedSecurityContext with EC2 authentication
+    /// context, for testing the `reject_if_ec2` guard.
+    #[cfg(any(test, feature = "mock"))]
+    pub fn test_fixture_ec2_scoped() -> ValidatedSecurityContext {
+        let user = openstack_keystone_core_types::identity::UserResponseBuilder::default()
+            .id("uid")
+            .domain_id("domain_id")
+            .enabled(true)
+            .name("testuser")
+            .build()
+            .unwrap();
+
+        let authz = AuthzInfoBuilder::default()
+            .roles(vec![RoleRef {
+                id: "admin".to_string(),
+                name: Some("admin".to_string()),
+                domain_id: None,
+            }])
+            .scope(ScopeInfo::Project {
+                project: Project {
+                    id: "project_id".to_string(),
+                    domain_id: "domain_id".to_string(),
+                    enabled: true,
+                    name: "admin".to_string(),
+                    ..Default::default()
+                },
+                project_domain: Domain {
+                    id: "domain_id".to_string(),
+                    name: "domain_name".to_string(),
+                    enabled: true,
+                    ..Default::default()
+                },
+            })
+            .build()
+            .unwrap();
+
+        let sc = SecurityContext::test_build()
+            .authentication_context(AuthenticationContext::Ec2Credential)
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(
+                    UserIdentityInfoBuilder::default()
+                        .user_id("uid")
+                        .user(user)
+                        .user_domain(openstack_keystone_core_types::resource::Domain {
+                            id: "domain_id".to_string(),
+                            name: "domain_name".to_string(),
+                            enabled: true,
+                            ..Default::default()
+                        })
+                        .build()
+                        .unwrap(),
+                ),
+            })
+            .token(
+                openstack_keystone_core_types::token::FernetToken::ProjectScope(
+                    openstack_keystone_core_types::token::ProjectScopePayload {
+                        user_id: "bar".into(),
+                        methods: vec!["ec2credential".into()],
+                        audit_ids: vec![],
+                        expires_at: chrono::Utc::now(),
+                        project_id: "pid".into(),
+                        ..Default::default()
+                    },
+                ),
+            )
+            .authorization(authz)
+            .build();
+
+        ValidatedSecurityContext::test_new(sc)
+    }
+
     /// Initialize the mocked service state.
     ///
     /// # Arguments

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -169,6 +169,7 @@ where
                 .map_err(|_| KeystoneApiError::UnauthorizedNoContext)?;
 
             vsc.fully_resolved()?;
+            reject_if_ec2(&vsc)?;
             return Ok(Auth(vsc));
         }
 
@@ -198,6 +199,25 @@ fn flat_spiffe_claims(svid: &SpiffeId) -> MappingAuthRequest {
         claims,
         rule_name: None,
     }
+}
+
+/// Reject requests authenticated via an EC2 token.
+///
+/// A token minted at `POST /v3/ec2tokens` must not be usable for any
+/// operation except being simply a valid token accepted by the GET
+/// `/v3/auth/tokens`.
+///
+/// # Returns
+///
+/// `Ok(())` when the auth type is not EC2, `Err(403 Forbidden)` otherwise.
+fn reject_if_ec2(user_auth: &ValidatedSecurityContext) -> Result<(), KeystoneApiError> {
+    if matches!(
+        user_auth.inner().authentication_context(),
+        AuthenticationContext::Ec2Credential
+    ) {
+        return Err(KeystoneApiError::SelectedAuthenticationForbidden);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -655,5 +675,85 @@ mod tests {
 
         let result = Auth::from_request_parts(&mut parts, &state).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_x_auth_token_ec2credential_rejected() {
+        use crate::token::MockTokenProvider;
+
+        let config = Config::default();
+        let config_manager = ConfigManager::not_watched(config);
+        let policy_enforcer = Arc::new(MockPolicy::default());
+        let db = sea_orm::DatabaseConnection::Disconnected;
+
+        let mut token_mock = MockTokenProvider::new();
+        token_mock.expect_authorize_by_token().once().returning(
+            move |_exec, _token, _allow_rescope, _restrict_to| {
+                let mut security_context = SecurityContextTestingBuilder::default()
+                    .authentication_context(AuthenticationContext::Ec2Credential)
+                    .principal(
+                        PrincipalInfoBuilder::default()
+                            .identity(IdentityInfo::Principal(
+                                PrincipalIdentityInfoBuilder::default()
+                                    .id("token-user")
+                                    .issuer("test.domain")
+                                    .build()
+                                    .unwrap(),
+                            ))
+                            .build()
+                            .unwrap(),
+                    )
+                    .build();
+                // Fully resolve the context by setting authorization
+                security_context.set_authorization_scope(ScopeInfo::Unscoped)?;
+                Ok(ValidatedSecurityContext::test_new(security_context))
+            },
+        );
+
+        let provider = Provider::mocked_builder()
+            .mock_mapping(MockMappingProvider::new())
+            .mock_token(token_mock)
+            .build()
+            .unwrap();
+        let state = Arc::new(Service {
+            config_manager,
+            db,
+            policy_enforcer,
+            provider,
+            event_dispatcher: crate::events::EventDispatcher::production(),
+
+            audit_dispatcher: openstack_keystone_audit::AuditDispatcher::noop(),
+
+            storage: None,
+            local_emergency_store: tokio::sync::RwLock::new(None),
+            local_emergency_leaderless_tracker:
+                openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
+            api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
+                governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
+            )),
+            oauth2_token_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
+                governor::Quota::per_minute(std::num::NonZeroU32::new(60).unwrap()),
+            )),
+            auth_plugin_registry: tokio::sync::RwLock::new(Arc::new(
+                openstack_keystone_auth_plugin_runtime::WasmPluginRegistry::default(),
+            )),
+            core_host_functions: tokio::sync::RwLock::new(None),
+            rate_limiters: crate::rate_limit::RateLimitState::default(),
+            auth_plugin_limiters: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+            auth_plugin_load_failures: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+            shutdown: false,
+        });
+
+        let mut parts = make_parts();
+        parts
+            .headers
+            .insert("X-Auth-Token", "valid-token-string".parse().unwrap());
+
+        let result = Auth::from_request_parts(&mut parts, &state).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            KeystoneApiError::SelectedAuthenticationForbidden
+        ));
     }
 }

--- a/crates/keystone/src/api/v3/auth/token/show.rs
+++ b/crates/keystone/src/api/v3/auth/token/show.rs
@@ -140,6 +140,13 @@ mod tests {
     use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
     use tower_http::trace::TraceLayer;
 
+    use openstack_keystone_core::{
+        api::tests::test_fixture_ec2_scoped, auth::ValidatedSecurityContext,
+    };
+    use openstack_keystone_core_types::auth::{AuthzInfoBuilder, *};
+    use openstack_keystone_core_types::resource::Domain as CoreDomain;
+    use openstack_keystone_core_types::token::{FernetToken, UnscopedPayload};
+
     use super::super::openapi_router;
     use crate::api::tests::{get_mocked_state, test_fixture_scoped};
     use crate::api::v3::auth::token::types::*;
@@ -150,10 +157,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_get() {
-        use openstack_keystone_core_types::auth::*;
-        use openstack_keystone_core_types::resource::Domain as CoreDomain;
-        use openstack_keystone_core_types::token::UnscopedPayload;
-
         let user_domain = CoreDomain {
             id: "user_domain_id".into(),
             enabled: true,
@@ -169,7 +172,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let vsc_for_mock = openstack_keystone_core::auth::ValidatedSecurityContext::test_new(
+        let vsc_for_mock = ValidatedSecurityContext::test_new(
             SecurityContext::test_build()
                 .authentication_context(AuthenticationContext::Password)
                 .principal(PrincipalInfo {
@@ -181,12 +184,10 @@ mod tests {
                             .unwrap(),
                     ),
                 })
-                .token(openstack_keystone_core_types::token::FernetToken::Unscoped(
-                    UnscopedPayload {
-                        user_id: "bar".into(),
-                        ..Default::default()
-                    },
-                ))
+                .token(FernetToken::Unscoped(UnscopedPayload {
+                    user_id: "bar".into(),
+                    ..Default::default()
+                }))
                 .authorization(authz)
                 .build(),
         );
@@ -388,10 +389,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_show_domain() {
-        use openstack_keystone_core_types::auth::{AuthzInfoBuilder, *};
-        use openstack_keystone_core_types::resource::Domain as CoreDomain;
-        use openstack_keystone_core_types::token::UnscopedPayload;
-
         let user_domain = CoreDomain {
             id: "user_domain_id".into(),
             enabled: true,
@@ -561,5 +558,59 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_get_ec2credential() {
+        let vsc_for_mock = test_fixture_ec2_scoped();
+
+        let mut token_mock = MockTokenProvider::default();
+        token_mock
+            .expect_validate_to_context()
+            .withf(|_, token: &'_ str, _, _| token == "bar")
+            .returning(move |_exec, _, _, _| Ok(vsc_for_mock.clone()));
+
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_catalog()
+            .returning(|_exec, _| Ok(Vec::new()));
+
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_domain()
+            .withf(|_exec, id: &'_ str| id == "user_domain_id")
+            .returning(|_exec, _| {
+                Ok(Some(CoreDomain {
+                    id: "user_domain_id".into(),
+                    ..Default::default()
+                }))
+            });
+
+        let provider = Provider::mocked_builder()
+            .mock_resource(resource_mock)
+            .mock_token(token_mock)
+            .mock_catalog(catalog_mock);
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("x-subject-token", "bar")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
A token obtained through the ec2credentials endpoint only exists for
Swift. Due to several attack vectors it is necessary to restrict what
this token is capable to do. Instead of expanding the code and policies
just do not accept this token as a valid token by the auth extractor
middleware. This makes keystone to return 401 for such token on any
endpoint except of /v3/auth/tokens where the token is expanded and
checked for validity. It is still possible to reauth with such token
(token from token).

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

<!--
Thanks for the contribution! Fill in the sections below.
-->

## Summary

<!-- What does this PR change, and why? -->

## Test plan

<!-- How was this verified? cargo test output, manual steps, screenshots, etc. -->

## Security review checklist

**Required if this diff touches authentication, scope, delegation, tokens,
credentials, EC2, trusts, application credentials, or OPA policy input.**
Delete this section entirely if it doesn't apply. See
[`doc/src/security.md`](../doc/src/security.md) §7 for the full context
behind each item.

- [ ] Does any delegation/authorization decision read the **scope**
      (`project_id`, `ScopeInfo`) where it should read the **chain**
      (`authentication_context()`, delegation object)? (I1/I2)
- [ ] New delegation-sensitive policy rule? Is the fact it needs projected
      onto `Credentials` from the chain, and does the rule anchor on
      `delegated_project_id` + carry the scope-drift tripwire? (I2/I3)
- [ ] New scope shape or redemption path for a delegated auth? Are effective
      roles still bounded by the delegation? Added a test that a restricted
      delegation cannot exceed its roles via the new path? (I4)
- [ ] New `ScopeInfo` variant or auth method? Updated
      `validate_scope_boundaries()`, `calculate_effective_roles()`,
      `fully_resolved()`, and `Credentials::try_from` — all without adding a
      wildcard `_ =>` arm? (I5, Gate J)
- [ ] New lookup by a client-derivable key (like `sha256(access)`)? Does it
      re-assert `type`/shape after fetch? (I6)
- [ ] Does any new data reaching OPA include secrets/decrypted blobs? (I7,
      Gate I)
- [ ] New list/collection endpoint? Does it re-check each item with the
      per-item read policy? (I8)
- [ ] Does the change let a narrow auth method be broadened by a
      request-supplied scope? (I5)
- [x] Are there negative tests proving the escape is blocked, not just
      positive tests proving the happy path works?
- [ ] Does the test drive `ValidatedSecurityContext::new_for_scope()`
      end-to-end, not just the inner helper (`calculate_effective_roles`,
      `validate_scope_boundaries`) in isolation?
