### PR TITLE
feat(devstack): Run tempest identity tests after stack.sh

### DIFF
--- a/.github/workflows/devstack.yml
+++ b/.github/workflows/devstack.yml
@@ -153,6 +153,7 @@ jobs:
           enable_service rabbit
           enable_service key
           enable_service key-rs
+          enable_service tempest
 
           enable_plugin key-rs file://${{ github.workspace }} ${{ env.KEYSTONE_RS_GIT_REF }}
 
@@ -179,6 +180,36 @@ jobs:
         run: |
           source /opt/stack/devstack/openrc admin admin
           openstack token issue
+
+      - name: Run tempest identity tests
+        # Best-effort signal only: rust Keystone doesn't yet implement the
+        # full python surface tempest's identity suite exercises, so
+        # failures here must not fail the job (per the request this step
+        # was added for).
+        working-directory: /opt/stack/tempest
+        continue-on-error: true
+        run: |
+          source /opt/stack/devstack/openrc admin admin
+          # devstack's install_tempest pip-installs tempest into its shared
+          # per-stack venv (USE_VENV, default since Bobcat), not onto the
+          # system PATH - that venv's bin/ is only on PATH inside stack.sh's
+          # own process, so a later, separate workflow step has to source it
+          # itself before the `tempest` console script is found.
+          if [[ -f /opt/stack/data/venv/bin/activate ]]; then
+            source /opt/stack/data/venv/bin/activate
+          fi
+          tempest run --regex '^tempest\.api\.identity'
+
+      - name: Upload tempest results
+        # if: always() (not failure()) since the previous step's failures
+        # are intentionally swallowed by continue-on-error above.
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: tempest-results
+          path: |
+            /opt/stack/tempest/tempest.log
+            /opt/stack/tempest/.stestr
 
       - name: Dump devstack log
         if: failure()


### PR DESCRIPTION
Add enable_service tempest to local.conf so devstack's built-in
tempest lib clones tempest and auto-generates tempest.conf/accounts
from the already-stacked services, matching this plugin's existing
philosophy of reusing devstack's own mechanisms instead of hand
rolling test config.

Run `tempest run --regex tempest.api.identity` after the existing
token-issue smoke check, scoped to identity API tests only to keep CI
runtime reasonable. Mark the step continue-on-error: true since rust
Keystone doesn't yet implement the full python surface tempest's
identity suite exercises - this is a best-effort signal, not a gate.
Upload the tempest log/results as a build artifact unconditionally
(if: always()) since the step itself no longer fails the job on
tempest failures.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
