### PR TITLE
fix(api): Default enabled/domain_id on create

### DIFF
--- a/crates/api-types/src/v3/domain.rs
+++ b/crates/api-types/src/v3/domain.rs
@@ -100,6 +100,7 @@ pub struct DomainCreate {
 
     /// If set to true, domain is enabled. If set to false, domain is disabled.
     #[cfg_attr(feature = "builder", builder(default = "crate::default_true()"))]
+    #[serde(default = "crate::default_true")]
     pub enabled: bool,
 
     /// Additional domain properties.
@@ -174,6 +175,15 @@ mod tests {
         let sot = DomainCreateBuilder::default().name("name").build().unwrap();
         assert!(sot.enabled, "enabled defaults to true");
         assert!(sot.id.is_none());
+    }
+
+    #[test]
+    fn test_domain_create_deserialize_omitted_enabled_defaults_true() {
+        // Real clients (tempest, python-openstackclient) omit `enabled` on
+        // create and rely on the server defaulting it to true, matching
+        // python-keystone; deserializing must not 422 on a missing field.
+        let sot: super::DomainCreate = serde_json::from_str(r#"{"name": "name"}"#).unwrap();
+        assert!(sot.enabled);
     }
 
     #[cfg(feature = "builder")]

--- a/crates/api-types/src/v3/service.rs
+++ b/crates/api-types/src/v3/service.rs
@@ -96,7 +96,8 @@ pub struct ServiceCreate {
 
     /// Defines whether the service and its endpoints appear in the service
     /// catalog.
-    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "builder", builder(default = "crate::default_true()"))]
+    #[serde(default = "crate::default_true")]
     pub enabled: bool,
 
     /// The service name.
@@ -167,4 +168,15 @@ pub struct ServiceUpdateRequest {
     /// Service object.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub service: ServiceUpdate,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_service_create_deserialize_omitted_enabled_defaults_true() {
+        // Mirrors DomainCreate: real clients omit `enabled` on create and
+        // expect it to default to true rather than 422.
+        let sot: super::ServiceCreate = serde_json::from_str(r#"{"type": "identity"}"#).unwrap();
+        assert!(sot.enabled);
+    }
 }

--- a/crates/api-types/src/v3/user.rs
+++ b/crates/api-types/src/v3/user.rs
@@ -132,9 +132,12 @@ pub struct UserCreate {
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
     pub default_project_id: Option<String>,
 
-    /// User domain ID.
+    /// User domain ID. When omitted, defaults to the domain of the caller's
+    /// token scope.
+    #[cfg_attr(feature = "builder", builder(default))]
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
-    pub domain_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain_id: Option<String>,
 
     /// If the user is enabled, this value is true. If the user is disabled,
     /// this value is false.
@@ -571,6 +574,17 @@ mod tests {
             .build()
             .unwrap();
         assert!(!sot.enabled, "user enabled flag defaults to `false`");
+    }
+
+    #[test]
+    fn test_user_create_deserialize_omitted_domain_id_and_enabled() {
+        // Real clients (tempest, python-openstackclient) omit `domain_id` on
+        // create, relying on the server defaulting it from the caller's
+        // token scope (see `openstack_keystone_core::auth::scope_domain_id`);
+        // deserializing must not 422 on a missing field.
+        let sot: UserCreate = serde_json::from_str(r#"{"name": "name"}"#).unwrap();
+        assert!(sot.domain_id.is_none());
+        assert!(sot.enabled);
     }
 
     #[cfg(feature = "validate")]

--- a/crates/core-types/src/identity/user.rs
+++ b/crates/core-types/src/identity/user.rs
@@ -113,9 +113,11 @@ pub struct UserCreate {
     #[validate(length(min = 1, max = 64))]
     pub default_project_id: Option<String>,
 
-    /// The ID of the domain.
+    /// The ID of the domain. When omitted, defaults to the caller's token
+    /// scope domain (see `crate::auth::scope_domain_id` in `openstack-keystone-core`).
+    #[builder(default)]
     #[validate(length(min = 1, max = 64))]
-    pub domain_id: String,
+    pub domain_id: Option<String>,
 
     /// If the user is enabled, this value is true. If the user is disabled,
     /// this value is false.

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -600,6 +600,21 @@ impl<'a> Deref for ExecutionContext<'a> {
     }
 }
 
+/// Extracts the domain ID the caller's token is scoped to, if any.
+///
+/// Used to default a resource's `domain_id` when the create request omits
+/// it, matching python-keystone's behavior of inferring the domain from the
+/// token scope rather than requiring it explicitly on every create call.
+#[must_use]
+pub fn scope_domain_id(ctx: &ExecutionContext<'_>) -> Option<String> {
+    let scope = &ctx.ctx()?.authorization()?.scope;
+    match scope {
+        ScopeInfo::Domain(domain) => Some(domain.id.clone()),
+        ScopeInfo::Project { project_domain, .. } => Some(project_domain.id.clone()),
+        _ => None,
+    }
+}
+
 // Expand scope role information.
 // Fetch the virtual user shadow record from storage.
 async fn get_virtual_user_or_error(

--- a/crates/core/src/identity/service.rs
+++ b/crates/core/src/identity/service.rs
@@ -29,7 +29,7 @@ use openstack_keystone_core_types::identity::*;
 
 use crate::auth::{
     AuthenticationContext, AuthenticationError, AuthenticationResult, AuthenticationResultBuilder,
-    ExecutionContext, IdentityInfo, PrincipalInfo, UserIdentityInfoBuilder,
+    ExecutionContext, IdentityInfo, PrincipalInfo, UserIdentityInfoBuilder, scope_domain_id,
 };
 use crate::events::AuditDispatchError;
 use crate::identity::{IdentityApi, IdentityProviderError, backend::IdentityBackend};
@@ -635,6 +635,9 @@ impl IdentityApi for IdentityService {
         };
         if mod_user.enabled.is_none() {
             mod_user.enabled = Some(true);
+        }
+        if mod_user.domain_id.is_none() {
+            mod_user.domain_id = scope_domain_id(ctx);
         }
         mod_user.validate()?;
         // Validate password against configured regex pattern.
@@ -1463,11 +1466,42 @@ mod tests {
     };
 
     use super::*;
+    use crate::auth::ValidatedSecurityContext;
     use crate::credential::MockCredentialProvider;
     use crate::identity::backend::MockIdentityBackend;
     use crate::provider::Provider;
     use crate::resource::MockResourceProvider;
     use crate::tests::get_mocked_state;
+    use openstack_keystone_core_types::auth::{
+        AuthenticationContext, AuthzInfoBuilder, IdentityInfo, PrincipalInfo, ScopeInfo,
+        SecurityContext, UserIdentityInfoBuilder,
+    };
+    use openstack_keystone_core_types::resource::DomainBuilder as ResourceDomainBuilder;
+
+    fn make_vsc_scoped(scope: ScopeInfo) -> ValidatedSecurityContext {
+        let user = UserIdentityInfoBuilder::default()
+            .user_id("test-user-id".to_string())
+            .build()
+            .unwrap();
+        let authz = AuthzInfoBuilder::default().scope(scope).build().unwrap();
+        let sc = SecurityContext::test_build()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(PrincipalInfo {
+                identity: IdentityInfo::User(user),
+            })
+            .authorization(authz)
+            .build();
+        ValidatedSecurityContext::test_new(sc)
+    }
+
+    fn make_domain(id: &str) -> openstack_keystone_core_types::resource::Domain {
+        ResourceDomainBuilder::default()
+            .id(id)
+            .name(format!("{id}-name"))
+            .enabled(true)
+            .build()
+            .unwrap()
+    }
 
     fn get_config_with_password_regex(regex_str: &str) -> Config {
         let mut config = Config::default();
@@ -1512,6 +1546,40 @@ mod tests {
                 .build()
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn test_create_user_defaults_domain_id_from_scope() {
+        // Real clients (tempest, python-openstackclient) omit `domain_id` on
+        // user create and expect the server to infer it from the caller's
+        // token scope, matching python-keystone. Regression test for the
+        // 422 "missing field `domain_id`" compatibility gap.
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_create_user()
+            .withf(|_, user| user.domain_id.as_deref() == Some("scoped-did"))
+            .returning(|_, _| {
+                Ok(UserResponseBuilder::default()
+                    .id("id")
+                    .domain_id("scoped-did")
+                    .enabled(true)
+                    .name("uname")
+                    .build()
+                    .unwrap())
+            });
+        let provider = IdentityService::from_driver(backend);
+        let vsc = make_vsc_scoped(ScopeInfo::Domain(make_domain("scoped-did")));
+        let ctx = ExecutionContext::from_auth(&state, &vsc);
+
+        let created = provider
+            .create_user(
+                &ctx,
+                UserCreateBuilder::default().name("uname").build().unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(created.domain_id, "scoped-did");
     }
 
     #[tokio::test]

--- a/crates/core/src/mapping/service.rs
+++ b/crates/core/src/mapping/service.rs
@@ -2748,7 +2748,7 @@ mod tests {
             Ok(
                 openstack_keystone_core_types::identity::UserResponseBuilder::default()
                     .id(req.id.clone().unwrap())
-                    .domain_id(req.domain_id.clone())
+                    .domain_id(req.domain_id.clone().unwrap_or_default())
                     .name(req.name.clone())
                     .enabled(true)
                     .build()

--- a/crates/core/src/resource/service.rs
+++ b/crates/core/src/resource/service.rs
@@ -18,11 +18,10 @@ use uuid::Uuid;
 use validator::Validate;
 
 use openstack_keystone_config::Config;
-use openstack_keystone_core_types::auth::ScopeInfo;
 use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::resource::*;
 
-use crate::auth::ExecutionContext;
+use crate::auth::{ExecutionContext, scope_domain_id};
 use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
 use crate::resource::{ResourceApi, ResourceProviderError, backend::ResourceBackend};
@@ -119,16 +118,6 @@ impl ResourceService {
         Err(ResourceProviderError::ProjectNotFound(
             parent_id.to_string(),
         ))
-    }
-}
-
-/// Extracts the domain ID the caller's token is scoped to, if any.
-fn scope_domain_id(ctx: &ExecutionContext<'_>) -> Option<String> {
-    let scope = &ctx.ctx()?.authorization()?.scope;
-    match scope {
-        ScopeInfo::Domain(domain) => Some(domain.id.clone()),
-        ScopeInfo::Project { project_domain, .. } => Some(project_domain.id.clone()),
-        _ => None,
     }
 }
 

--- a/crates/identity-driver-sql/src/user/create.rs
+++ b/crates/identity-driver-sql/src/user/create.rs
@@ -72,7 +72,11 @@ impl db_user::ActiveModel {
                 .unwrap_or(NotSet)
                 .into(),
             created_at: Set(Some(created_at)),
-            domain_id: Set(user.domain_id.clone()),
+            domain_id: Set(user.domain_id.clone().ok_or_else(|| {
+                IdentityProviderError::Driver(
+                    "domain_id must be resolved before persisting a user".into(),
+                )
+            })?),
         })
     }
 }

--- a/crates/keystone/src/api/v3/user/create.rs
+++ b/crates/keystone/src/api/v3/user/create.rs
@@ -88,11 +88,13 @@ mod tests {
         let mut identity_mock = MockIdentityProvider::default();
         identity_mock
             .expect_create_user()
-            .withf(|_, req: &UserCreate| req.domain_id == "domain" && req.name == "name")
+            .withf(|_, req: &UserCreate| {
+                req.domain_id.as_deref() == Some("domain") && req.name == "name"
+            })
             .returning(|_, req| {
                 Ok(UserResponseBuilder::default()
                     .id("bar")
-                    .domain_id(req.domain_id.clone())
+                    .domain_id(req.domain_id.clone().unwrap_or_default())
                     .enabled(true)
                     .name(req.name.clone())
                     .build()

--- a/crates/keystone/src/api/v4/user/create.rs
+++ b/crates/keystone/src/api/v4/user/create.rs
@@ -101,11 +101,13 @@ mod tests {
         let mut identity_mock = MockIdentityProvider::default();
         identity_mock
             .expect_create_user()
-            .withf(|_, req: &UserCreate| req.domain_id == "domain" && req.name == "name")
+            .withf(|_, req: &UserCreate| {
+                req.domain_id.as_deref() == Some("domain") && req.name == "name"
+            })
             .returning(|_, req| {
                 Ok(UserResponseBuilder::default()
                     .id("bar")
-                    .domain_id(req.domain_id.clone())
+                    .domain_id(req.domain_id.clone().unwrap_or_default())
                     .enabled(true)
                     .name(req.name.clone())
                     .build()

--- a/crates/keystone/src/scim/types.rs
+++ b/crates/keystone/src/scim/types.rs
@@ -217,7 +217,7 @@ impl ScimUserWrite {
     pub fn to_user_create(&self, domain_id: &str, external_id: &str) -> UserCreate {
         UserCreate {
             default_project_id: None,
-            domain_id: domain_id.to_string(),
+            domain_id: Some(domain_id.to_string()),
             enabled: Some(self.active),
             extra: self.extra(),
             federated: None,

--- a/crates/keystone/src/scim/user/create.rs
+++ b/crates/keystone/src/scim/user/create.rs
@@ -217,7 +217,7 @@ mod tests {
         identity_mock.expect_create_user().returning(|_, req| {
             Ok(UserResponseBuilder::default()
                 .id("user-1")
-                .domain_id(req.domain_id.clone())
+                .domain_id(req.domain_id.clone().unwrap_or_default())
                 .enabled(true)
                 .name(req.name.clone())
                 .build()
@@ -307,7 +307,7 @@ mod tests {
         identity_mock.expect_create_user().returning(|_, req| {
             Ok(UserResponseBuilder::default()
                 .id("user-1")
-                .domain_id(req.domain_id.clone())
+                .domain_id(req.domain_id.clone().unwrap_or_default())
                 .enabled(true)
                 .name(req.name.clone())
                 .build()


### PR DESCRIPTION
Domain/service/user create requests 422'd whenever `enabled` or
`domain_id` was omitted from the JSON body, because the fields were
required at deserialize time. Real clients (tempest, osc,
python-keystone parity) omit them and expect server-side defaults:
`enabled` true, `domain_id` from the caller's token scope.

Adds `enabled: bool` serde defaults for domain/service create, and
makes user `domain_id` optional end-to-end, resolved in
identity::service::create_user via a new shared scope_domain_id()
helper (core::auth), mirroring the existing project-create pattern.
Backend persistence errors defensively if still unresolved at
insert time.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
