### PR TITLE
feat(identity): add PATCH groups and domains

### DIFF
--- a/crates/api-types/src/v3/domain.rs
+++ b/crates/api-types/src/v3/domain.rs
@@ -140,6 +140,50 @@ pub struct DomainCreateRequest {
     pub domain: DomainCreate,
 }
 
+/// Update domain data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct DomainUpdate {
+    /// The description of the domain.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub description: Option<String>,
+
+    /// If set to true, domain is enabled. If set to false, domain is disabled.
+    #[cfg_attr(feature = "builder", builder(default))]
+    pub enabled: Option<bool>,
+
+    /// Additional domain properties.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
+
+    /// The domain name.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub name: Option<String>,
+}
+
+/// Domain update request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct DomainUpdateRequest {
+    /// Domain object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub domain: DomainUpdate,
+}
+
 /// List of domains.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/crates/api-types/src/v3/domain_conv.rs
+++ b/crates/api-types/src/v3/domain_conv.rs
@@ -63,6 +63,18 @@ impl From<api_types::DomainCreate> for provider_types::DomainCreate {
     }
 }
 
+impl From<api_types::DomainUpdateRequest> for provider_types::DomainUpdate {
+    fn from(value: api_types::DomainUpdateRequest) -> Self {
+        let domain = value.domain;
+        Self {
+            description: domain.description.map(Some),
+            enabled: domain.enabled,
+            extra: domain.extra,
+            name: domain.name,
+        }
+    }
+}
+
 impl From<api_types::DomainListParameters> for provider_types::DomainListParameters {
     fn from(value: api_types::DomainListParameters) -> Self {
         Self {

--- a/crates/api-types/src/v3/group.rs
+++ b/crates/api-types/src/v3/group.rs
@@ -101,6 +101,44 @@ pub struct GroupCreateRequest {
     pub group: GroupCreate,
 }
 
+/// Update group data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct GroupUpdate {
+    /// Group description.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub description: Option<String>,
+
+    /// Group name.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(max = 64)))]
+    pub name: Option<String>,
+
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct GroupUpdateRequest {
+    /// Group object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub group: GroupUpdate,
+}
+
 /// Groups.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/crates/api-types/src/v3/group_conv.rs
+++ b/crates/api-types/src/v3/group_conv.rs
@@ -49,3 +49,14 @@ impl From<api_types::GroupListParameters> for provider_types::GroupListParameter
         }
     }
 }
+
+impl From<api_types::GroupUpdateRequest> for provider_types::GroupUpdate {
+    fn from(value: api_types::GroupUpdateRequest) -> Self {
+        let group = value.group;
+        Self {
+            description: group.description.map(Some),
+            extra: group.extra,
+            name: group.name,
+        }
+    }
+}

--- a/crates/api-types/src/v3/project.rs
+++ b/crates/api-types/src/v3/project.rs
@@ -211,6 +211,51 @@ pub struct ProjectCreateRequest {
     pub project: ProjectCreate,
 }
 
+/// Update project data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ProjectUpdate {
+    /// The description of the project.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub description: Option<String>,
+
+    /// If set to true, project is enabled. If set to false, project is
+    /// disabled.
+    #[cfg_attr(feature = "builder", builder(default))]
+    pub enabled: Option<bool>,
+
+    /// Additional project properties.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
+
+    /// The project name.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub name: Option<String>,
+}
+
+/// Project update request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ProjectUpdateRequest {
+    /// Project object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub project: ProjectUpdate,
+}
+
 /// List of projects.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/crates/api-types/src/v3/project_conv.rs
+++ b/crates/api-types/src/v3/project_conv.rs
@@ -71,6 +71,18 @@ impl From<api_types::ProjectCreate> for provider_types::ProjectCreate {
     }
 }
 
+impl From<api_types::ProjectUpdateRequest> for provider_types::ProjectUpdate {
+    fn from(value: api_types::ProjectUpdateRequest) -> Self {
+        let project = value.project;
+        Self {
+            description: project.description.map(Some),
+            enabled: project.enabled,
+            extra: project.extra,
+            name: project.name,
+        }
+    }
+}
+
 impl From<api_types::ProjectListParameters> for provider_types::ProjectListParameters {
     fn from(value: api_types::ProjectListParameters) -> Self {
         Self {

--- a/crates/api-types/src/v3/role.rs
+++ b/crates/api-types/src/v3/role.rs
@@ -200,6 +200,46 @@ pub struct RoleCreateRequest {
     pub role: RoleCreate,
 }
 
+/// Update role data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RoleUpdate {
+    /// The role description.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub description: Option<String>,
+
+    /// The role name.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub name: Option<String>,
+
+    /// Extra attributes for the role.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Role update request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RoleUpdateRequest {
+    /// Role object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub role: RoleUpdate,
+}
+
 impl From<&Role> for RoleRef {
     fn from(value: &Role) -> Self {
         Self {

--- a/crates/api-types/src/v3/role_conv.rs
+++ b/crates/api-types/src/v3/role_conv.rs
@@ -67,3 +67,14 @@ impl From<api_types::RoleCreateRequest> for provider_types::RoleCreate {
         }
     }
 }
+
+impl From<api_types::RoleUpdateRequest> for provider_types::RoleUpdate {
+    fn from(value: api_types::RoleUpdateRequest) -> Self {
+        let role = value.role;
+        Self {
+            description: role.description.map(Some),
+            extra: role.extra,
+            name: role.name,
+        }
+    }
+}

--- a/crates/config/src/application_credentials.rs
+++ b/crates/config/src/application_credentials.rs
@@ -28,11 +28,11 @@ pub struct ApplicationCredentialProvider {
     /// `access_rules` (per-endpoint restrictions) are stored and CRUD'd but
     /// **not enforced at request time** -- no middleware matches the
     /// incoming (service, method, path) against them yet (security review
-    /// V5, `doc/src/contributor/security-model.md` §5/§9). Until that enforcement lands, a
-    /// non-empty `access_rules` list is a restriction the operator believes
-    /// is active but is actually a no-op. Defaults to `false` to preserve
-    /// existing behavior (a warning is logged either way); set `true` to
-    /// fail loud instead.
+    /// V5, `doc/src/contributor/security-model.md` §5/§9). Until that
+    /// enforcement lands, a non-empty `access_rules` list is a restriction
+    /// the operator believes is active but is actually a no-op. Defaults to
+    /// `false` to preserve existing behavior (a warning is logged either
+    /// way); set `true` to fail loud instead.
     #[serde(default)]
     pub reject_unenforced_access_rules: bool,
 }

--- a/crates/core-types/src/application_credential/error.rs
+++ b/crates/core-types/src/application_credential/error.rs
@@ -26,9 +26,9 @@ pub enum ApplicationCredentialProviderError {
     AccessRuleConflict,
 
     /// `access_rules` were provided but request-time enforcement doesn't
-    /// exist yet (security review V5, `doc/src/contributor/security-model.md` §9): accepting
-    /// them would silently promise a restriction the server cannot honor.
-    /// Only returned when
+    /// exist yet (security review V5, `doc/src/contributor/security-model.md`
+    /// §9): accepting them would silently promise a restriction the server
+    /// cannot honor. Only returned when
     /// `application_credential.reject_unenforced_access_rules` is enabled.
     #[error(
         "access_rules are not enforced at request time yet (see doc/src/contributor/security-model.md §9); \

--- a/crates/core-types/src/identity/user.rs
+++ b/crates/core-types/src/identity/user.rs
@@ -114,7 +114,8 @@ pub struct UserCreate {
     pub default_project_id: Option<String>,
 
     /// The ID of the domain. When omitted, defaults to the caller's token
-    /// scope domain (see `crate::auth::scope_domain_id` in `openstack-keystone-core`).
+    /// scope domain (see `crate::auth::scope_domain_id` in
+    /// `openstack-keystone-core`).
     #[builder(default)]
     #[validate(length(min = 1, max = 64))]
     pub domain_id: Option<String>,

--- a/crates/core-types/src/resource/domain.rs
+++ b/crates/core-types/src/resource/domain.rs
@@ -76,6 +76,30 @@ pub struct DomainCreate {
     pub extra: HashMap<String, Value>,
 }
 
+/// Domain update data.
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct DomainUpdate {
+    /// New description. `None` = unchanged, `Some(None)` = clear.
+    #[builder(default)]
+    pub description: Option<Option<String>>,
+
+    /// New enabled state. `None` = unchanged.
+    #[builder(default)]
+    pub enabled: Option<bool>,
+
+    /// New name. `None` = unchanged.
+    #[builder(default)]
+    #[validate(length(min = 1, max = 255))]
+    pub name: Option<String>,
+
+    /// Additional domain properties. The provider merges this into the
+    /// existing `extra` before persisting; an empty map means unchanged.
+    #[builder(default)]
+    pub extra: HashMap<String, Value>,
+}
+
 /// Domain listing parameters.
 #[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
 #[builder(build_fn(error = "BuilderError"))]

--- a/crates/core-types/src/resource/project.rs
+++ b/crates/core-types/src/resource/project.rs
@@ -127,6 +127,30 @@ pub struct ProjectCreate {
     pub parent_id: Option<String>,
 }
 
+/// Project update data.
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct ProjectUpdate {
+    /// New description. `None` = unchanged, `Some(None)` = clear.
+    #[builder(default)]
+    pub description: Option<Option<String>>,
+
+    /// New enabled state. `None` = unchanged.
+    #[builder(default)]
+    pub enabled: Option<bool>,
+
+    /// New name. `None` = unchanged.
+    #[builder(default)]
+    #[validate(length(min = 1, max = 255))]
+    pub name: Option<String>,
+
+    /// Additional project properties. The provider merges this into the
+    /// existing `extra` before persisting; an empty map means unchanged.
+    #[builder(default)]
+    pub extra: HashMap<String, Value>,
+}
+
 /// Project listing parameters.
 #[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
 #[builder(build_fn(error = "BuilderError"))]

--- a/crates/core-types/src/role/role.rs
+++ b/crates/core-types/src/role/role.rs
@@ -138,6 +138,26 @@ pub struct RoleCreate {
     pub name: String,
 }
 
+/// Role update data.
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct RoleUpdate {
+    /// New description. `None` = unchanged, `Some(None)` = clear.
+    #[builder(default)]
+    pub description: Option<Option<String>>,
+
+    /// New name. `None` = unchanged.
+    #[builder(default)]
+    #[validate(length(min = 1, max = 255))]
+    pub name: Option<String>,
+
+    /// Additional role properties. The provider merges this into the
+    /// existing `extra` before persisting; an empty map means unchanged.
+    #[builder(default)]
+    pub extra: HashMap<String, Value>,
+}
+
 /// Role inference (imply) data.
 #[derive(Builder, Clone, Debug, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]

--- a/crates/core/src/application_credential/service.rs
+++ b/crates/core/src/application_credential/service.rs
@@ -158,10 +158,10 @@ impl ApplicationCredentialApi for ApplicationCredentialService {
                 ));
             }
         }
-        // V5 (security review, `doc/src/contributor/security-model.md` §9): `access_rules`
-        // are stored and CRUD'd but not enforced at request time yet -- no
-        // middleware matches the incoming (service, method, path) against
-        // them. Warn unconditionally so the gap is visible in logs, and
+        // V5 (security review, `doc/src/contributor/security-model.md` §9):
+        // `access_rules` are stored and CRUD'd but not enforced at request time
+        // yet -- no middleware matches the incoming (service, method, path)
+        // against them. Warn unconditionally so the gap is visible in logs, and
         // fail loud instead when the operator has opted in, rather than
         // silently accepting a restriction the server cannot honor.
         if rec

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -75,8 +75,9 @@ impl ValidatedSecurityContext {
     /// the context, [`SecurityContext::validate_scope_boundaries`] is
     /// enforced to guard the override. When it is unset, it is always
     /// enforced via [`SecurityContext::set_authorization_scope`] (every
-    /// fresh scope assignment is validated; see I5 in `doc/src/contributor/security-model.md`
-    /// -- there is no "first scope is trusted" carve-out).
+    /// fresh scope assignment is validated; see I5 in
+    /// `doc/src/contributor/security-model.md` -- there is no "first scope
+    /// is trusted" carve-out).
     ///
     /// Re-presenting an *already-validated* token with its stored scope
     /// unchanged (e.g. token/trust re-authentication, which reconstructs

--- a/crates/core/src/auth/tests.rs
+++ b/crates/core/src/auth/tests.rs
@@ -2654,8 +2654,8 @@ async fn test_new_for_scope_mapping_slow_path_is_system_true_project_not_upgrade
 // present, and asserts the resulting effective roles never exceed the
 // delegation's own restricted role set -- even when the delegating
 // principal personally holds broader roles on the target project. See
-// `doc/src/contributor/security-model.md` I4 and its reviewer-checklist item "New scope
-// shape or redemption path for a delegated auth?".
+// `doc/src/contributor/security-model.md` I4 and its reviewer-checklist item
+// "New scope shape or redemption path for a delegated auth?".
 #[tokio::test]
 async fn test_new_for_scope_delegated_roles_never_exceed_delegation_matrix() {
     let trustor = "trustor";

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -1233,6 +1233,20 @@ mod resource {
                 project: ProjectCreate,
             ) -> Result<Project, ResourceProviderError>;
 
+            async fn update_domain<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                domain_id: &'a str,
+                domain: DomainUpdate,
+            ) -> Result<Domain, ResourceProviderError>;
+
+            async fn update_project<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                project_id: &'a str,
+                project: ProjectUpdate,
+            ) -> Result<Project, ResourceProviderError>;
+
             async fn delete_domain<'a>(
                 &self,
                 ctx: &ExecutionContext<'a>,
@@ -1358,6 +1372,13 @@ mod role {
                 prior_role_id: &'a str,
                 implied_role_id: &'a str,
             ) -> Result<bool, RoleProviderError>;
+
+            async fn update_role<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                role_id: &'a str,
+                role: RoleUpdate,
+            ) -> Result<Role, RoleProviderError>;
 
             async fn delete_role<'a>(
                 &self,

--- a/crates/core/src/resource/backend.rs
+++ b/crates/core/src/resource/backend.rs
@@ -68,6 +68,40 @@ pub trait ResourceBackend: Send + Sync {
         project: ProjectCreate,
     ) -> Result<Project, ResourceProviderError>;
 
+    /// Update a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain to update.
+    /// - `domain`: The fields to change.
+    ///
+    /// # Returns
+    /// - `Result<Domain, ResourceProviderError>` - The updated `Domain` or an
+    ///   error.
+    async fn update_domain<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        domain: DomainUpdate,
+    ) -> Result<Domain, ResourceProviderError>;
+
+    /// Update a project.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `project_id`: The ID of the project to update.
+    /// - `project`: The fields to change.
+    ///
+    /// # Returns
+    /// - `Result<Project, ResourceProviderError>` - The updated `Project` or an
+    ///   error.
+    async fn update_project<'a>(
+        &self,
+        state: &ServiceState,
+        project_id: &'a str,
+        project: ProjectUpdate,
+    ) -> Result<Project, ResourceProviderError>;
+
     /// Delete a domain by the ID.
     ///
     /// # Parameters

--- a/crates/core/src/resource/provider_api.rs
+++ b/crates/core/src/resource/provider_api.rs
@@ -59,6 +59,34 @@ pub trait ResourceApi: Send + Sync {
         project: ProjectCreate,
     ) -> Result<Project, ResourceProviderError>;
 
+    /// Update a domain.
+    ///
+    /// * `state` - The current service state.
+    /// * `domain_id` - The ID of the domain to update.
+    /// * `domain` - The fields to change.
+    ///
+    /// A `Result` containing the updated `Domain`, or an `Error`.
+    async fn update_domain<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        domain: DomainUpdate,
+    ) -> Result<Domain, ResourceProviderError>;
+
+    /// Update a project.
+    ///
+    /// * `state` - The current service state.
+    /// * `project_id` - The ID of the project to update.
+    /// * `project` - The fields to change.
+    ///
+    /// A `Result` containing the updated `Project`, or an `Error`.
+    async fn update_project<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        project_id: &'a str,
+        project: ProjectUpdate,
+    ) -> Result<Project, ResourceProviderError>;
+
     /// Delete a domain by the ID.
     ///
     /// * `state` - The current service state.

--- a/crates/core/src/resource/service.rs
+++ b/crates/core/src/resource/service.rs
@@ -286,6 +286,112 @@ impl ResourceApi for ResourceService {
         Ok(project)
     }
 
+    /// Update a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain to update.
+    /// - `domain`: The fields to change.
+    ///
+    /// # Returns
+    /// - `Result<Domain, ResourceProviderError>` - The updated `Domain` or an
+    ///   error.
+    async fn update_domain<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        domain: DomainUpdate,
+    ) -> Result<Domain, ResourceProviderError> {
+        domain.validate()?;
+        let domain = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            let domain_id_clone = domain_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::Domain { id: domain_id_clone },
+                ),
+                operation: async {
+                    backend_driver.update_domain(state, domain_id, domain).await
+                },
+                on_audit_error: |_: AuditDispatchError| ResourceProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let domain = self
+                .backend_driver
+                .update_domain(ctx.state(), domain_id, domain)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::Domain {
+                        id: domain.id.clone(),
+                    },
+                ))
+                .await;
+            domain
+        };
+
+        Ok(domain)
+    }
+
+    /// Update a project.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `project_id`: The ID of the project to update.
+    /// - `project`: The fields to change.
+    ///
+    /// # Returns
+    /// - `Result<Project, ResourceProviderError>` - The updated `Project` or an
+    ///   error.
+    async fn update_project<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        project_id: &'a str,
+        project: ProjectUpdate,
+    ) -> Result<Project, ResourceProviderError> {
+        project.validate()?;
+        let project = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            let project_id_clone = project_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::Project { id: project_id_clone },
+                ),
+                operation: async {
+                    backend_driver.update_project(state, project_id, project).await
+                },
+                on_audit_error: |_: AuditDispatchError| ResourceProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let project = self
+                .backend_driver
+                .update_project(ctx.state(), project_id, project)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::Project {
+                        id: project.id.clone(),
+                    },
+                ))
+                .await;
+            project
+        };
+
+        Ok(project)
+    }
+
     /// Delete a domain by the ID.
     ///
     /// # Parameters

--- a/crates/core/src/role/backend.rs
+++ b/crates/core/src/role/backend.rs
@@ -59,6 +59,19 @@ pub trait RoleBackend: Send + Sync {
         implied_role_id: &'a str,
     ) -> Result<bool, RoleProviderError>;
 
+    /// Update a role.
+    ///
+    /// # Arguments
+    /// * `state` - The current service state.
+    /// * `role_id` - The ID of the role to update.
+    /// * `role` - The fields to change.
+    async fn update_role<'a>(
+        &self,
+        state: &ServiceState,
+        role_id: &'a str,
+        role: RoleUpdate,
+    ) -> Result<Role, RoleProviderError>;
+
     /// Delete a role by the ID.
     ///
     /// # Arguments

--- a/crates/core/src/role/provider_api.rs
+++ b/crates/core/src/role/provider_api.rs
@@ -62,6 +62,19 @@ pub trait RoleApi: Send + Sync {
         implied_role_id: &'a str,
     ) -> Result<bool, RoleProviderError>;
 
+    /// Update a role.
+    ///
+    /// # Arguments
+    /// * `state` - The current service state.
+    /// * `role_id` - The ID of the role to update.
+    /// * `role` - The fields to change.
+    async fn update_role<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        role_id: &'a str,
+        role: RoleUpdate,
+    ) -> Result<Role, RoleProviderError>;
+
     /// Delete a role by the ID.
     ///
     /// # Arguments

--- a/crates/core/src/role/service.rs
+++ b/crates/core/src/role/service.rs
@@ -178,6 +178,55 @@ impl RoleApi for RoleService {
             .await
     }
 
+    /// Update a role.
+    ///
+    /// # Arguments
+    /// * `state` - The current service state.
+    /// * `role_id` - The ID of the role to update.
+    /// * `role` - The fields to change.
+    async fn update_role<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        role_id: &'a str,
+        role: RoleUpdate,
+    ) -> Result<Role, RoleProviderError> {
+        role.validate()?;
+        let role = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let state = ctx.state();
+            let role_id_clone = role_id.to_string();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Update,
+                    EventPayload::Role { id: role_id_clone },
+                ),
+                operation: async {
+                    backend_driver.update_role(state, role_id, role).await
+                },
+                on_audit_error: |_: AuditDispatchError| RoleProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let role = self
+                .backend_driver
+                .update_role(ctx.state(), role_id, role)
+                .await?;
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Update,
+                    EventPayload::Role {
+                        id: role.id.clone(),
+                    },
+                ))
+                .await;
+            role
+        };
+
+        Ok(role)
+    }
+
     /// Delete a role by the ID.
     ///
     /// # Arguments

--- a/crates/keystone/src/api/v3/domain/mod.rs
+++ b/crates/keystone/src/api/v3/domain/mod.rs
@@ -22,6 +22,7 @@ mod delete;
 mod list;
 mod show;
 pub mod types;
+mod update;
 
 /// OpenApi specification for the domain API.
 #[derive(OpenApi)]
@@ -38,5 +39,5 @@ pub(crate) fn openapi_router() -> OpenApiRouter<ServiceState> {
         .routes(routes!(create::create))
         .routes(routes!(delete::remove))
         .routes(routes!(list::list))
-        .routes(routes!(show::show))
+        .routes(routes!(show::show, update::update))
 }

--- a/crates/keystone/src/api/v3/domain/update.rs
+++ b/crates/keystone/src/api/v3/domain/update.rs
@@ -1,0 +1,332 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Update domain API
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{Domain, DomainResponse, DomainUpdateRequest};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Update existing domain
+#[utoipa::path(
+    patch,
+    path = "/{domain_id}",
+    description = "Update domain by ID",
+    params(),
+    responses(
+        (status = OK, description = "Updated domain", body = DomainResponse),
+        (status = 404, description = "Domain not found", example = json!(KeystoneApiError::NotFound{resource: "domain".into(), identifier: "id = 1".into()}))
+    ),
+    tag="domains"
+)]
+#[tracing::instrument(name = "api::v3::domain_update", level = "debug", skip(state))]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path(domain_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<DomainUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    // Fetch the current domain to pass it as existing object into the
+    // policy evaluation
+    let current = state
+        .provider
+        .get_resource_provider()
+        .get_domain(&ExecutionContext::from_auth(&state, &user_auth), &domain_id)
+        .await?;
+
+    let existing_domain = current.as_ref().map(|c| json!({"domain": c}));
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/resource/domain/update",
+            &user_auth,
+            json!({"domain": req.domain}),
+            existing_domain,
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            let domain = state
+                .provider
+                .get_resource_provider()
+                .update_domain(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &domain_id,
+                    req.into(),
+                )
+                .await?;
+            Ok((
+                StatusCode::OK,
+                Json(DomainResponse {
+                    domain: Domain::from(domain),
+                }),
+            )
+                .into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "domain".into(),
+            identifier: domain_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::resource::Domain as ProviderDomain;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::domain::types::*;
+    use crate::provider::Provider;
+    use crate::resource::MockResourceProvider;
+
+    #[tokio::test]
+    async fn test_update_success() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_domain()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(ProviderDomain {
+                    id: "foo".into(),
+                    name: "old_name".into(),
+                    enabled: true,
+                    ..Default::default()
+                }))
+            });
+        resource_mock
+            .expect_update_domain()
+            .withf(|_, id: &'_ str, _| id == "foo")
+            .returning(|_, _, _| {
+                Ok(ProviderDomain {
+                    id: "foo".into(),
+                    name: "new_name".into(),
+                    enabled: true,
+                    ..Default::default()
+                })
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = DomainUpdateRequest {
+            domain: DomainUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: DomainResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.domain.name, "new_name");
+        assert_eq!(res.domain.id, "foo");
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_domain()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = DomainUpdateRequest {
+            domain: DomainUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_forbidden() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_domain()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(ProviderDomain {
+                    id: "foo".into(),
+                    name: "old_name".into(),
+                    enabled: true,
+                    ..Default::default()
+                }))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = DomainUpdateRequest {
+            domain: DomainUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = DomainUpdateRequest {
+            domain: DomainUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_put() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"domain":{"name":"updated"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/crates/keystone/src/api/v3/group/mod.rs
+++ b/crates/keystone/src/api/v3/group/mod.rs
@@ -21,11 +21,12 @@ pub mod delete;
 pub mod list;
 pub mod show;
 pub mod types;
+pub mod update;
 
 pub(crate) fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new()
         .routes(routes!(list::list, create::create))
-        .routes(routes!(show::show, delete::delete))
+        .routes(routes!(show::show, delete::delete, update::update))
 }
 
 #[cfg(test)]

--- a/crates/keystone/src/api/v3/group/update.rs
+++ b/crates/keystone/src/api/v3/group/update.rs
@@ -1,0 +1,319 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{Group, GroupResponse, GroupUpdateRequest};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Update existing group
+#[utoipa::path(
+    patch,
+    path = "/{group_id}",
+    description = "Update group by ID",
+    params(),
+    responses(
+        (status = OK, description = "Updated group", body = GroupResponse),
+        (status = 404, description = "Group not found", example = json!(KeystoneApiError::NotFound{resource: "group".into(), identifier: "id = 1".into()}))
+    ),
+    tag="groups"
+)]
+#[tracing::instrument(name = "api::update_group", level = "debug", skip(state))]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path(group_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<GroupUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    // Fetch the current group to pass it as existing object into the policy
+    // evaluation
+    let current = state
+        .provider
+        .get_identity_provider()
+        .get_group(&ExecutionContext::from_auth(&state, &user_auth), &group_id)
+        .await?;
+
+    let existing_group = current.as_ref().map(|c| json!({"group": c}));
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/group/update",
+            &user_auth,
+            json!({"group": req.group}),
+            existing_group,
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            let group = state
+                .provider
+                .get_identity_provider()
+                .update_group(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &group_id,
+                    req.into(),
+                )
+                .await?;
+            Ok((
+                StatusCode::OK,
+                Json(GroupResponse {
+                    group: Group::from(group),
+                }),
+            )
+                .into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "group".into(),
+            identifier: group_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::identity::*;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::group::types::{GroupResponse, GroupUpdateBuilder as ApiGroupUpdate};
+    use crate::identity::MockIdentityProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_update_success() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(Group {
+                    id: "foo".into(),
+                    name: "old_name".into(),
+                    domain_id: "did".into(),
+                    ..Default::default()
+                }))
+            });
+        identity_mock
+            .expect_update_group()
+            .withf(|_, id: &'_ str, _: &GroupUpdate| id == "foo")
+            .returning(|_, _, _| {
+                Ok(Group {
+                    id: "foo".into(),
+                    name: "new_name".into(),
+                    domain_id: "did".into(),
+                    ..Default::default()
+                })
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::group::types::GroupUpdateRequest {
+            group: ApiGroupUpdate::default().name("new_name").build().unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: GroupResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.group.name, "new_name");
+        assert_eq!(res.group.id, "foo");
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::group::types::GroupUpdateRequest {
+            group: ApiGroupUpdate::default().name("new_name").build().unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_forbidden() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_get_group()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(Group {
+                    id: "foo".into(),
+                    name: "old_name".into(),
+                    domain_id: "did".into(),
+                    ..Default::default()
+                }))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::group::types::GroupUpdateRequest {
+            group: ApiGroupUpdate::default().name("new_name").build().unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::group::types::GroupUpdateRequest {
+            group: ApiGroupUpdate::default().name("new_name").build().unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_put() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"group":{"name":"updated"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/crates/keystone/src/api/v3/project/mod.rs
+++ b/crates/keystone/src/api/v3/project/mod.rs
@@ -22,6 +22,7 @@ mod delete;
 mod list;
 mod show;
 pub mod types;
+mod update;
 
 /// OpenApi specification for the project API.
 #[derive(OpenApi)]
@@ -50,5 +51,5 @@ pub(crate) fn openapi_router() -> OpenApiRouter<ServiceState> {
         .routes(routes!(create::create))
         .routes(routes!(delete::remove))
         .routes(routes!(list::list))
-        .routes(routes!(show::show))
+        .routes(routes!(show::show, update::update))
 }

--- a/crates/keystone/src/api/v3/project/update.rs
+++ b/crates/keystone/src/api/v3/project/update.rs
@@ -1,0 +1,338 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Update project API
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{Project, ProjectResponse, ProjectUpdateRequest};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Update existing project
+#[utoipa::path(
+    patch,
+    path = "/{project_id}",
+    description = "Update project by ID",
+    params(),
+    responses(
+        (status = OK, description = "Updated project", body = ProjectResponse),
+        (status = 404, description = "Project not found", example = json!(KeystoneApiError::NotFound{resource: "project".into(), identifier: "id = 1".into()}))
+    ),
+    tag="projects"
+)]
+#[tracing::instrument(name = "api::v3::project_update", level = "debug", skip(state))]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path(project_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<ProjectUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    // Fetch the current project to pass it as existing object into the
+    // policy evaluation
+    let current = state
+        .provider
+        .get_resource_provider()
+        .get_project(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &project_id,
+        )
+        .await?;
+
+    let existing_project = current.as_ref().map(|c| json!({"project": c}));
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/resource/project/update",
+            &user_auth,
+            json!({"project": req.project}),
+            existing_project,
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            let project = state
+                .provider
+                .get_resource_provider()
+                .update_project(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &project_id,
+                    req.into(),
+                )
+                .await?;
+            Ok((
+                StatusCode::OK,
+                Json(ProjectResponse {
+                    project: Project::from(project),
+                }),
+            )
+                .into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "project".into(),
+            identifier: project_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::resource::Project as ProviderProject;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::project::types::*;
+    use crate::provider::Provider;
+    use crate::resource::MockResourceProvider;
+
+    #[tokio::test]
+    async fn test_update_success() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_project()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(ProviderProject {
+                    id: "foo".into(),
+                    name: "old_name".into(),
+                    domain_id: "did".into(),
+                    enabled: true,
+                    ..Default::default()
+                }))
+            });
+        resource_mock
+            .expect_update_project()
+            .withf(|_, id: &'_ str, _| id == "foo")
+            .returning(|_, _, _| {
+                Ok(ProviderProject {
+                    id: "foo".into(),
+                    name: "new_name".into(),
+                    domain_id: "did".into(),
+                    enabled: true,
+                    ..Default::default()
+                })
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = ProjectUpdateRequest {
+            project: ProjectUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ProjectResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.project.name, "new_name");
+        assert_eq!(res.project.id, "foo");
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_project()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = ProjectUpdateRequest {
+            project: ProjectUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_forbidden() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_get_project()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(ProviderProject {
+                    id: "foo".into(),
+                    name: "old_name".into(),
+                    domain_id: "did".into(),
+                    enabled: true,
+                    ..Default::default()
+                }))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = ProjectUpdateRequest {
+            project: ProjectUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = ProjectUpdateRequest {
+            project: ProjectUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_put() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"project":{"name":"updated"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/crates/keystone/src/api/v3/role/mod.rs
+++ b/crates/keystone/src/api/v3/role/mod.rs
@@ -22,6 +22,7 @@ mod imply;
 mod list;
 mod show;
 pub mod types;
+mod update;
 
 /// OpenApi specification for the roles.
 #[derive(OpenApi)]
@@ -105,6 +106,6 @@ pub struct ApiDoc;
 pub(crate) fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new()
         .routes(routes!(list::list, create::create))
-        .routes(routes!(show::show, delete::delete))
+        .routes(routes!(show::show, delete::delete, update::update))
         .merge(imply::openapi_router())
 }

--- a/crates/keystone/src/api/v3/role/update.rs
+++ b/crates/keystone/src/api/v3/role/update.rs
@@ -1,0 +1,322 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Update role API.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{Role, RoleResponse, RoleUpdateRequest};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Update existing role
+#[utoipa::path(
+    patch,
+    path = "/{role_id}",
+    description = "Update role by ID",
+    params(),
+    responses(
+        (status = OK, description = "Updated role", body = RoleResponse),
+        (status = 404, description = "Role not found", example = json!(KeystoneApiError::NotFound{resource: "role".into(), identifier: "id = 1".into()}))
+    ),
+    tag="roles"
+)]
+#[tracing::instrument(name = "api::role_update", level = "debug", skip(state))]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path(role_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<RoleUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    req.validate()?;
+
+    // Fetch the current role to pass it as existing object into the policy
+    // evaluation
+    let current = state
+        .provider
+        .get_role_provider()
+        .get_role(&ExecutionContext::from_auth(&state, &user_auth), &role_id)
+        .await?;
+
+    let existing_role = current.as_ref().map(|c| json!({"role": c}));
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/role/update",
+            &user_auth,
+            json!({"role": req.role}),
+            existing_role,
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            let role = state
+                .provider
+                .get_role_provider()
+                .update_role(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &role_id,
+                    req.into(),
+                )
+                .await?;
+            Ok((
+                StatusCode::OK,
+                Json(RoleResponse {
+                    role: Role::from(role),
+                }),
+            )
+                .into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "role".into(),
+            identifier: role_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode, header},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::role::RoleBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::role::types::*;
+    use crate::provider::Provider;
+    use crate::role::MockRoleProvider;
+
+    #[tokio::test]
+    async fn test_update_success() {
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("foo")
+                        .name("old_name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        role_mock
+            .expect_update_role()
+            .withf(|_, id: &'_ str, _| id == "foo")
+            .returning(|_, _, _| {
+                Ok(RoleBuilder::default()
+                    .id("foo")
+                    .name("new_name")
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let state =
+            get_mocked_state(Provider::mocked_builder().mock_role(role_mock), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = RoleUpdateRequest {
+            role: RoleUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RoleResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.role.name, "new_name");
+        assert_eq!(res.role.id, "foo");
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state =
+            get_mocked_state(Provider::mocked_builder().mock_role(role_mock), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = RoleUpdateRequest {
+            role: RoleUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_forbidden() {
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_get_role()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    RoleBuilder::default()
+                        .id("foo")
+                        .name("old_name")
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state =
+            get_mocked_state(Provider::mocked_builder().mock_role(role_mock), false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = RoleUpdateRequest {
+            role: RoleUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = RoleUpdateRequest {
+            role: RoleUpdateBuilder::default()
+                .name("new_name")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_put() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"role":{"name":"updated"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/crates/keystone/src/api/v3/user/os_ec2/mod.rs
+++ b/crates/keystone/src/api/v3/user/os_ec2/mod.rs
@@ -88,7 +88,8 @@ pub(super) fn to_ec2_credential(
 /// `blob` holds the *decrypted* EC2 access/secret pair. No `os_ec2` `.rego`
 /// rule references it, so it must never reach the policy engine -- see the
 /// analogous `credential_policy_input` in the sibling `/v3/credentials`
-/// module (`crate::api::v3::credential`) and `doc/src/contributor/security-model.md` I7.
+/// module (`crate::api::v3::credential`) and
+/// `doc/src/contributor/security-model.md` I7.
 pub(super) fn ec2_credential_policy_input(cred: &CoreCredential) -> Value {
     serde_json::to_value(cred)
         .map(|mut v| {

--- a/crates/resource-driver-sql/src/domain.rs
+++ b/crates/resource-driver-sql/src/domain.rs
@@ -25,11 +25,13 @@ mod create;
 mod delete;
 mod get;
 mod list;
+mod update;
 
 pub use create::create;
 pub use delete::delete;
 pub use get::{get_domain_by_id, get_domain_by_name, get_domain_enabled};
 pub use list::list;
+pub use update::update;
 
 use crate::entity::project as db_project;
 

--- a/crates/resource-driver-sql/src/domain/update.rs
+++ b/crates/resource-driver-sql/src/domain/update.rs
@@ -1,0 +1,116 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Update Domain
+
+use sea_orm::ConnectionTrait;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::resource::ResourceProviderError;
+use openstack_keystone_core_types::resource::{Domain, DomainUpdate};
+
+use crate::entity::{prelude::Project as DbProject, project as db_project};
+
+/// Update an existing domain.
+///
+/// Only the fields set in `domain` are changed; the rest are left as-is.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain to update.
+/// - `domain`: The fields to change.
+///
+/// # Returns
+/// A `Result` containing the updated `Domain`, or an `Error` (including
+/// `DomainNotFound` if no domain with that ID exists).
+pub async fn update<C>(
+    db: &C,
+    domain_id: &str,
+    domain: DomainUpdate,
+) -> Result<Domain, ResourceProviderError>
+where
+    C: ConnectionTrait,
+{
+    let existing = DbProject::find_by_id(domain_id)
+        .filter(db_project::Column::IsDomain.eq(true))
+        .one(db)
+        .await
+        .context("fetching domain for update")?
+        .ok_or_else(|| ResourceProviderError::DomainNotFound(domain_id.to_string()))?;
+
+    let mut update_model: db_project::ActiveModel = existing.into();
+
+    if let Some(name) = domain.name {
+        update_model.name = Set(name);
+    }
+    if let Some(enabled) = domain.enabled {
+        update_model.enabled = Set(Some(enabled));
+    }
+    if let Some(description) = domain.description {
+        update_model.description = Set(description);
+    }
+    if !domain.extra.is_empty() {
+        update_model.extra = Set(Some(serde_json::to_string(&domain.extra)?));
+    }
+
+    update_model
+        .update(db)
+        .await
+        .context("updating domain")?
+        .try_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    use super::super::tests::get_domain_mock;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_domain_mock("1")], vec![get_domain_mock("1")]])
+            .into_connection();
+
+        let req = DomainUpdate {
+            name: Some("new_name".into()),
+            enabled: Some(false),
+            description: None,
+            extra: Default::default(),
+        };
+        let result = update(&db, "1", req).await.unwrap();
+        assert_eq!(result, get_domain_mock("1").try_into().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<db_project::Model>::new()])
+            .into_connection();
+
+        let req = DomainUpdate {
+            name: Some("new_name".into()),
+            enabled: None,
+            description: None,
+            extra: Default::default(),
+        };
+        let result = update(&db, "missing", req).await;
+        assert!(matches!(
+            result,
+            Err(ResourceProviderError::DomainNotFound(_))
+        ));
+    }
+}

--- a/crates/resource-driver-sql/src/lib.rs
+++ b/crates/resource-driver-sql/src/lib.rs
@@ -95,6 +95,44 @@ impl ResourceBackend for SqlBackend {
         Ok(project::create(&state.db, project).await?)
     }
 
+    /// Update domain.
+    ///
+    /// # Parameters
+    /// - `state`: Service state containing the database connection.
+    /// - `domain_id`: ID of the domain to update.
+    /// - `domain`: The fields to change.
+    ///
+    /// # Returns
+    /// The updated `Domain`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn update_domain<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        domain: DomainUpdate,
+    ) -> Result<Domain, ResourceProviderError> {
+        Ok(domain::update(&state.db, domain_id, domain).await?)
+    }
+
+    /// Update a project.
+    ///
+    /// # Parameters
+    /// - `state`: Service state containing the database connection.
+    /// - `project_id`: ID of the project to update.
+    /// - `project`: The fields to change.
+    ///
+    /// # Returns
+    /// The updated `Project`.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn update_project<'a>(
+        &self,
+        state: &ServiceState,
+        project_id: &'a str,
+        project: ProjectUpdate,
+    ) -> Result<Project, ResourceProviderError> {
+        Ok(project::update(&state.db, project_id, project).await?)
+    }
+
     /// Delete domain by the ID.
     ///
     /// # Parameters

--- a/crates/resource-driver-sql/src/project.rs
+++ b/crates/resource-driver-sql/src/project.rs
@@ -26,6 +26,7 @@ mod delete;
 mod get;
 mod list;
 mod tree;
+mod update;
 
 pub use create::create;
 pub use delete::delete;
@@ -33,6 +34,7 @@ pub use get::get_project;
 pub use get::get_project_by_name;
 pub use list::list;
 pub use tree::get_project_parents;
+pub use update::update;
 
 use crate::entity::project as db_project;
 

--- a/crates/resource-driver-sql/src/project/update.rs
+++ b/crates/resource-driver-sql/src/project/update.rs
@@ -1,0 +1,116 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Update Project
+
+use sea_orm::ConnectionTrait;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::resource::ResourceProviderError;
+use openstack_keystone_core_types::resource::{Project, ProjectUpdate};
+
+use crate::entity::{prelude::Project as DbProject, project as db_project};
+
+/// Update an existing project.
+///
+/// Only the fields set in `project` are changed; the rest are left as-is.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `project_id`: The ID of the project to update.
+/// - `project`: The fields to change.
+///
+/// # Returns
+/// A `Result` containing the updated `Project`, or an `Error` (including
+/// `ProjectNotFound` if no project with that ID exists).
+pub async fn update<C>(
+    db: &C,
+    project_id: &str,
+    project: ProjectUpdate,
+) -> Result<Project, ResourceProviderError>
+where
+    C: ConnectionTrait,
+{
+    let existing = DbProject::find_by_id(project_id)
+        .filter(db_project::Column::IsDomain.eq(false))
+        .one(db)
+        .await
+        .context("fetching project for update")?
+        .ok_or_else(|| ResourceProviderError::ProjectNotFound(project_id.to_string()))?;
+
+    let mut update_model: db_project::ActiveModel = existing.into();
+
+    if let Some(name) = project.name {
+        update_model.name = Set(name);
+    }
+    if let Some(enabled) = project.enabled {
+        update_model.enabled = Set(Some(enabled));
+    }
+    if let Some(description) = project.description {
+        update_model.description = Set(description);
+    }
+    if !project.extra.is_empty() {
+        update_model.extra = Set(Some(serde_json::to_string(&project.extra)?));
+    }
+
+    update_model
+        .update(db)
+        .await
+        .context("updating project")?
+        .try_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    use super::super::tests::get_project_mock;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_project_mock("1")], vec![get_project_mock("1")]])
+            .into_connection();
+
+        let req = ProjectUpdate {
+            name: Some("new_name".into()),
+            enabled: Some(false),
+            description: None,
+            extra: Default::default(),
+        };
+        let result = update(&db, "1", req).await.unwrap();
+        assert_eq!(result, get_project_mock("1").try_into().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<db_project::Model>::new()])
+            .into_connection();
+
+        let req = ProjectUpdate {
+            name: Some("new_name".into()),
+            enabled: None,
+            description: None,
+            extra: Default::default(),
+        };
+        let result = update(&db, "missing", req).await;
+        assert!(matches!(
+            result,
+            Err(ResourceProviderError::ProjectNotFound(_))
+        ));
+    }
+}

--- a/crates/role-driver-sql/src/lib.rs
+++ b/crates/role-driver-sql/src/lib.rs
@@ -146,6 +146,24 @@ impl RoleBackend for SqlBackend {
         Ok(implied_role::check(&state.db, prior_role_id, implied_role_id).await?)
     }
 
+    /// Update a role.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `role_id`: The ID of the role to update.
+    /// - `role`: The fields to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the updated `Role`, or an `Error`.
+    async fn update_role<'a>(
+        &self,
+        state: &ServiceState,
+        role_id: &'a str,
+        role: RoleUpdate,
+    ) -> Result<Role, RoleProviderError> {
+        Ok(role::update(&state.db, role_id, role).await?)
+    }
+
     /// Delete a role by the ID.
     ///
     /// # Parameters

--- a/crates/role-driver-sql/src/role.rs
+++ b/crates/role-driver-sql/src/role.rs
@@ -25,11 +25,13 @@ mod create;
 mod delete;
 mod get;
 mod list;
+mod update;
 
 pub use create::create;
 pub use delete::delete;
 pub use get::get;
 pub use list::list;
+pub use update::update;
 
 use crate::entity::role as db_role;
 

--- a/crates/role-driver-sql/src/role/update.rs
+++ b/crates/role-driver-sql/src/role/update.rs
@@ -1,0 +1,105 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Update Role
+
+use sea_orm::ConnectionTrait;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::role::RoleProviderError;
+use openstack_keystone_core_types::role::{Role, RoleUpdate};
+
+use crate::entity::{prelude::Role as DbRole, role as db_role};
+
+/// Update an existing role.
+///
+/// Only the fields set in `role` are changed; the rest are left as-is.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `role_id`: The ID of the role to update.
+/// - `role`: The fields to change.
+///
+/// # Returns
+/// A `Result` containing the updated `Role`, or an `Error` (including
+/// `RoleNotFound` if no role with that ID exists).
+pub async fn update<C>(db: &C, role_id: &str, role: RoleUpdate) -> Result<Role, RoleProviderError>
+where
+    C: ConnectionTrait,
+{
+    let existing = DbRole::find_by_id(role_id)
+        .one(db)
+        .await
+        .context("fetching role for update")?
+        .ok_or_else(|| RoleProviderError::RoleNotFound(role_id.to_string()))?;
+
+    let mut update_model: db_role::ActiveModel = existing.into();
+
+    if let Some(name) = role.name {
+        update_model.name = Set(name);
+    }
+    if let Some(description) = role.description {
+        update_model.description = Set(description);
+    }
+    if !role.extra.is_empty() {
+        update_model.extra = Set(Some(serde_json::to_string(&role.extra)?));
+    }
+
+    update_model
+        .update(db)
+        .await
+        .context("updating role")?
+        .try_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    use super::super::tests::get_role_mock;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([
+                vec![get_role_mock("1", "foo")],
+                vec![get_role_mock("1", "new_name")],
+            ])
+            .into_connection();
+
+        let req = RoleUpdate {
+            name: Some("new_name".into()),
+            description: None,
+            extra: Default::default(),
+        };
+        let result = update(&db, "1", req).await.unwrap();
+        assert_eq!(result, get_role_mock("1", "new_name").try_into().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<db_role::Model>::new()])
+            .into_connection();
+
+        let req = RoleUpdate {
+            name: Some("new_name".into()),
+            description: None,
+            extra: Default::default(),
+        };
+        let result = update(&db, "missing", req).await;
+        assert!(matches!(result, Err(RoleProviderError::RoleNotFound(_))));
+    }
+}

--- a/policy/identity/group/update.rego
+++ b/policy/identity/group/update.rego
@@ -1,0 +1,40 @@
+# METADATA
+# description: Policy for updating identity groups
+package identity.group.update
+
+import data.identity
+
+# Update an existing user group
+#
+# The `input.target.group` is the update patch (GroupUpdate):
+#   name:         string (optional)  Group name.
+#   description:  string (optional)  Group description.
+#
+# The `input.existing.group` is the stored group object:
+#   domain_id:    string            Group domain ID.
+#   description:  string (optional)  Group description.
+#   id:           string            Group ID.
+#   name:         string            Group name.
+#
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	"manager" in input.credentials.roles
+	identity.domain_matches_domain_scope
+}
+
+violation contains {"field": "domain_id", "msg": "updating a user group in domain different to the domain scope requires `admin` role."} if {
+	not "admin" in input.credentials.roles
+	"manager" in input.credentials.roles
+	not identity.domain_matches_domain_scope
+}
+
+violation contains {"field": "domain_id", "msg": "updating a user group requires a manager role with the domain scope."} if {
+	not "admin" in input.credentials.roles
+	not "manager" in input.credentials.roles
+	identity.domain_matches_domain_scope
+}

--- a/policy/identity/group/update_test.rego
+++ b/policy/identity/group/update_test.rego
@@ -1,0 +1,15 @@
+package test_group_update
+
+import data.identity.group.update
+
+test_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}}
+	update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"group": {"domain_id": "foo"}}}
+}
+
+test_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "foo"}, "existing": {"group": {"domain_id": "foo1"}}}
+	not update.allow with input as {"credentials": {"roles": ["manager"]}, "existing": {"group": {"domain_id": "foo"}}}
+	not update.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "foo"}, "existing": {"group": {"domain_id": "foo"}}}
+}

--- a/policy/resource/domain/update.rego
+++ b/policy/resource/domain/update.rego
@@ -1,0 +1,32 @@
+# METADATA
+# description: Policy for updating domains
+package identity.resource.domain.update
+
+import data.identity
+
+# Update a domain.
+#
+# The `input.target.domain` is the update patch (DomainUpdate):
+#   description: string (optional)  The domain description.
+#   enabled:     bool (optional)    Whether the domain is enabled.
+#   name:        string (optional)  The domain name.
+#
+# The `input.existing.domain` is the stored resource object (Domain):
+#   description: string (optional)  The domain description.
+#   enabled:     bool               Whether the domain is enabled.
+#   id:          string             The domain ID.
+#   name:        string             The domain name.
+#
+default allow := false
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+violation contains {"field": "", "msg": "updating domains requires system admin privileges."} if {
+	not input.credentials.is_admin
+}

--- a/policy/resource/domain/update_test.rego
+++ b/policy/resource/domain/update_test.rego
@@ -1,0 +1,13 @@
+package test_domain_update
+
+import data.identity.resource.domain.update
+
+test_admin_allowed if {
+	update.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	update.allow with input as {"credentials": {"roles": ["admin"]}}
+}
+
+test_non_admin_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["member"], "domain_id": "foo"}}
+}

--- a/policy/resource/project/update.rego
+++ b/policy/resource/project/update.rego
@@ -1,0 +1,42 @@
+# METADATA
+# description: Policy for updating projects
+package identity.resource.project.update
+
+import data.identity
+
+# Update a project.
+#
+# The `input.target.project` is the update patch (ProjectUpdate):
+#   description: string (optional)  The project description.
+#   enabled:     bool (optional)    Whether the project is enabled.
+#   name:        string (optional)  The project name.
+#
+# The `input.existing.project` is the stored resource object (Project):
+#   description: string (optional)  The project description.
+#   domain_id:   string             The ID of the domain for the project.
+#   enabled:     bool               Whether the project is enabled.
+#   id:          string             The project ID.
+#   name:        string             The project name.
+#   is_domain:   bool               Whether the project also acts as a domain.
+#   parent_id:   string (optional)  The ID of the parent project.
+#
+default allow := false
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	"manager" in input.credentials.roles
+	identity.domain_matches_domain_scope
+}
+
+violation contains {"field": "domain_id", "msg": "updating a project requires system admin or `manager` role in the domain scope."} if {
+	not input.credentials.is_admin
+	not "manager" in input.credentials.roles
+	identity.domain_matches_domain_scope
+}

--- a/policy/resource/project/update_test.rego
+++ b/policy/resource/project/update_test.rego
@@ -1,0 +1,27 @@
+package test_project_update
+
+import data.identity.resource.project.update
+
+test_admin_allowed if {
+	update.allow with input as {"credentials": {"roles": [], "is_admin": true}}
+	update.allow with input as {"credentials": {"roles": ["admin"]}}
+}
+
+test_manager_in_domain_scope_allowed if {
+	update.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "domain1"},
+		"existing": {"project": {"domain_id": "domain1"}},
+	}
+}
+
+test_manager_outside_domain_scope_forbidden if {
+	not update.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "domain1"},
+		"existing": {"project": {"domain_id": "domain2"}},
+	}
+}
+
+test_non_admin_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["member"], "domain_id": "foo"}}
+}

--- a/policy/role/update.rego
+++ b/policy/role/update.rego
@@ -1,0 +1,37 @@
+# METADATA
+# title: Update role
+# description: Policy for updating a role
+package identity.role.update
+
+import data.identity
+
+# Update role.
+#
+# The `input.target.role` is the update patch (RoleUpdate):
+#   description: string (optional)  Role description.
+#   name:        string (optional)  Role name.
+#
+# The `input.existing.role` is the stored role object (Role):
+#   description:  string (optional)  Role description.
+#   domain_id:    string (optional)  Role domain ID.
+#   id:           string            Role ID.
+#   name:         string            Role name.
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+# METADATA
+# description: "`Manager` is allowed for global roles and roles belonging to the scope domain."
+allow if {
+	"manager" in input.credentials.roles
+	identity.own_role_or_global_role
+}

--- a/policy/role/update_test.rego
+++ b/policy/role/update_test.rego
@@ -1,0 +1,14 @@
+package test_role_update
+
+import data.identity.role.update
+
+test_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}}
+	update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "domain_a"}, "existing": {"role": {"domain_id": "domain_a"}}}
+}
+
+test_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["reader"], "domain_id": "domain"}, "existing": {"role": {"domain_id": "other_domain"}}}
+	not update.allow with input as {"credentials": {"roles": ["manager"], "domain_id": "domain"}, "existing": {"role": {"domain_id": "other_domain"}}}
+}

--- a/tests/api/src/identity.rs
+++ b/tests/api/src/identity.rs
@@ -11,4 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+pub mod group;
 pub mod user;

--- a/tests/api/src/identity/group.rs
+++ b/tests/api/src/identity/group.rs
@@ -1,0 +1,198 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone_api_types::v3::group::*;
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
+
+use crate::guard::*;
+
+/// Create request for group
+#[derive(Clone, Debug)]
+struct GroupCreateRequest {
+    group: GroupCreate,
+}
+
+impl RestEndpoint for GroupCreateRequest {
+    fn method(&self) -> http::Method {
+        http::Method::POST
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "groups".to_string().into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("group", serde_json::to_value(&self.group)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("group".into())
+    }
+
+    /// Returns required API version
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Create group
+pub async fn create_group(
+    tc: &Arc<AsyncOpenStack>,
+    group: GroupCreate,
+) -> Result<AsyncResourceGuard<Group>> {
+    let obj: Group = GroupCreateRequest { group }
+        .query_async(tc.as_ref())
+        .await?;
+    Ok(AsyncResourceGuard::new(obj, tc.clone()))
+}
+
+/// Get request for a single group
+struct GroupShowRequest {
+    id: String,
+}
+
+impl RestEndpoint for GroupShowRequest {
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("groups/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("group".into())
+    }
+
+    /// Returns required API version
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Get a single group by ID
+pub async fn get_group(tc: &Arc<AsyncOpenStack>, id: impl Into<String>) -> Result<Group> {
+    Ok(GroupShowRequest { id: id.into() }
+        .query_async(tc.as_ref())
+        .await?)
+}
+
+/// Update request for group
+#[derive(Clone, Debug)]
+struct GroupUpdateRequest {
+    id: String,
+    group: GroupUpdate,
+}
+
+impl RestEndpoint for GroupUpdateRequest {
+    fn method(&self) -> http::Method {
+        http::Method::PATCH
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("groups/{id}", id = self.id).into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("group", serde_json::to_value(&self.group)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("group".into())
+    }
+
+    /// Returns required API version
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Update a group
+pub async fn update_group(
+    tc: &Arc<AsyncOpenStack>,
+    id: impl Into<String>,
+    group: GroupUpdate,
+) -> Result<Group> {
+    Ok(GroupUpdateRequest {
+        id: id.into(),
+        group,
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+/// Delete request for group
+struct GroupDeleteRequest {
+    id: String,
+}
+
+impl RestEndpoint for GroupDeleteRequest {
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("groups/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    /// Returns required API version
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Delete a group
+pub async fn delete_group(tc: &Arc<AsyncOpenStack>, id: impl Into<String>) -> Result<()> {
+    Ok(
+        openstack_sdk::api::ignore(GroupDeleteRequest { id: id.into() })
+            .query_async(tc.as_ref())
+            .await?,
+    )
+}
+
+#[async_trait::async_trait]
+impl DeletableResource for Group {
+    async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
+        Ok(openstack_sdk::api::ignore(GroupDeleteRequest {
+            id: self.id.clone(),
+        })
+        .query_async(state.as_ref())
+        .await?)
+    }
+}

--- a/tests/api/src/resource/domain.rs
+++ b/tests/api/src/resource/domain.rs
@@ -109,6 +109,58 @@ pub async fn get_domain(tc: &Arc<AsyncOpenStack>, id: impl Into<String>) -> Resu
         .await?)
 }
 
+/// Update request for domain
+#[derive(Builder)]
+#[builder(setter(strip_option, into))]
+#[derive(Clone, Debug)]
+struct DomainUpdateRequestInternal {
+    id: String,
+    domain: DomainUpdate,
+}
+
+impl RestEndpoint for DomainUpdateRequestInternal {
+    fn method(&self) -> http::Method {
+        http::Method::PATCH
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("domains/{id}", id = self.id).into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("domain", serde_json::to_value(&self.domain)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("domain".into())
+    }
+
+    /// Returns required API version
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Update a domain
+pub async fn update_domain(
+    tc: &Arc<AsyncOpenStack>,
+    id: impl Into<String>,
+    domain: DomainUpdate,
+) -> Result<Domain> {
+    Ok(DomainUpdateRequestInternalBuilder::default()
+        .id(id)
+        .domain(domain)
+        .build()?
+        .query_async(tc.as_ref())
+        .await?)
+}
+
 /// List request for domains
 #[derive(Default)]
 pub struct DomainListRequest {

--- a/tests/api/src/resource/project.rs
+++ b/tests/api/src/resource/project.rs
@@ -103,6 +103,56 @@ pub async fn get_project(tc: &Arc<AsyncOpenStack>, id: impl Into<String>) -> Res
         .await?)
 }
 
+/// Update request for project
+#[derive(Clone, Debug)]
+struct ProjectUpdateRequest {
+    id: String,
+    project: ProjectUpdate,
+}
+
+impl RestEndpoint for ProjectUpdateRequest {
+    fn method(&self) -> http::Method {
+        http::Method::PATCH
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("projects/{id}", id = self.id).into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("project", serde_json::to_value(&self.project)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("project".into())
+    }
+
+    /// Returns required API version
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Update a project
+pub async fn update_project(
+    tc: &Arc<AsyncOpenStack>,
+    id: impl Into<String>,
+    project: ProjectUpdate,
+) -> Result<Project> {
+    Ok(ProjectUpdateRequest {
+        id: id.into(),
+        project,
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
 /// List request for projects
 #[derive(Default)]
 pub struct ProjectListRequest {

--- a/tests/api/src/role.rs
+++ b/tests/api/src/role.rs
@@ -98,6 +98,56 @@ pub async fn list_roles(client: &Arc<AsyncOpenStack>) -> Result<Vec<Role>> {
         .await?)
 }
 
+#[derive(Clone, Debug)]
+struct RoleUpdateRequest {
+    id: String,
+    role: RoleUpdate,
+}
+
+impl RestEndpoint for RoleUpdateRequest {
+    fn method(&self) -> http::Method {
+        http::Method::PATCH
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("roles/{id}", id = self.id).into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+
+        params.push("role", serde_json::to_value(&self.role)?);
+
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("role".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Update role.
+pub async fn update_role(
+    tc: &Arc<AsyncOpenStack>,
+    id: impl Into<String>,
+    role: RoleUpdate,
+) -> Result<Role> {
+    Ok(RoleUpdateRequest {
+        id: id.into(),
+        role,
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
 /// Delete role.
 pub async fn delete_role(client: &Arc<AsyncOpenStack>, id: &str) -> Result<()> {
     delete_role_internal(client, id).await

--- a/tests/api/tests/api_v3/identity.rs
+++ b/tests/api/tests/api_v3/identity.rs
@@ -11,4 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+mod group;
 mod user;

--- a/tests/api/tests/api_v3/identity/group.rs
+++ b/tests/api/tests/api_v3/identity/group.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::group::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::identity::group::{create_group, get_group, update_group};
+
+#[tokio::test]
+#[traced_test]
+async fn test_update() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("grp_{}", Uuid::new_v4().simple());
+    let new_name = format!("{name}_updated");
+
+    let guard = create_group(
+        &tc,
+        GroupCreateBuilder::default()
+            .name(&name)
+            .domain_id("default")
+            .build()?,
+    )
+    .await?;
+
+    let updated = update_group(
+        &tc,
+        &guard.id,
+        GroupUpdateBuilder::default()
+            .name(new_name.clone())
+            .build()?,
+    )
+    .await?;
+
+    assert_eq!(updated.name, new_name);
+    assert_eq!(updated.id, guard.id);
+
+    let shown = get_group(&tc, &guard.id).await?;
+    assert_eq!(shown.name, new_name);
+
+    guard.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/resource/domain.rs
+++ b/tests/api/tests/api_v3/resource/domain.rs
@@ -86,6 +86,39 @@ async fn test_domain_list() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_domain_update() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
+    let domain = create_domain(
+        &test_client,
+        DomainCreateBuilder::default()
+            .name(Uuid::new_v4().to_string())
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+    let updated = update_domain(
+        &test_client,
+        &domain.id,
+        DomainUpdateBuilder::default()
+            .name("updated_name")
+            .enabled(false)
+            .build()?,
+    )
+    .await?;
+    assert_eq!(updated.name, "updated_name");
+    assert!(!updated.enabled);
+
+    let shown = get_domain(&test_client, &domain.id)
+        .await?
+        .expect("domain must be found");
+    assert_eq!(shown.name, "updated_name");
+    assert!(!shown.enabled);
+
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_domain_delete() -> Result<()> {
     let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
     let domain = create_domain(

--- a/tests/api/tests/api_v3/resource/project.rs
+++ b/tests/api/tests/api_v3/resource/project.rs
@@ -97,6 +97,40 @@ async fn test_project_list() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_project_update() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
+    let domain = create_test_domain(&test_client).await?;
+    let project = create_project(
+        &test_client,
+        ProjectCreateBuilder::default()
+            .name(Uuid::new_v4().to_string())
+            .enabled(true)
+            .domain_id(domain.id.clone())
+            .build()?,
+    )
+    .await?;
+    let updated = update_project(
+        &test_client,
+        &project.id,
+        ProjectUpdateBuilder::default()
+            .name("updated_name")
+            .enabled(false)
+            .build()?,
+    )
+    .await?;
+    assert_eq!(updated.name, "updated_name");
+    assert!(!updated.enabled);
+
+    let shown = get_project(&test_client, &project.id).await?;
+    assert_eq!(shown.name, "updated_name");
+    assert!(!shown.enabled);
+
+    project.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_project_delete() -> Result<()> {
     let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
     let domain = create_test_domain(&test_client).await?;

--- a/tests/api/tests/api_v3/role.rs
+++ b/tests/api/tests/api_v3/role.rs
@@ -15,3 +15,4 @@ mod create;
 mod delete;
 mod imply;
 mod list;
+mod update;

--- a/tests/api/tests/api_v3/role/update.rs
+++ b/tests/api/tests/api_v3/role/update.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::role::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::role::*;
+
+#[tokio::test]
+#[traced_test]
+async fn test_update() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("role_{}", Uuid::new_v4().simple());
+    let role: Role = create_role(
+        &tc,
+        RoleCreateBuilder::default().name(name.clone()).build()?,
+    )
+    .await?;
+
+    let updated = update_role(
+        &tc,
+        &role.id,
+        RoleUpdateBuilder::default().name("updated_name").build()?,
+    )
+    .await?;
+    assert_eq!(updated.name, "updated_name");
+
+    delete_role(&tc, &role.id).await?;
+
+    Ok(())
+}

--- a/tests/integration/src/identity.rs
+++ b/tests/integration/src/identity.rs
@@ -25,6 +25,7 @@ use openstack_keystone_core_types::identity::*;
 use crate::common::*;
 use crate::impl_deleter;
 
+mod group;
 mod service_account;
 mod user;
 mod user_group;

--- a/tests/integration/src/identity/group.rs
+++ b/tests/integration/src/identity/group.rs
@@ -1,0 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod update;

--- a/tests/integration/src/identity/group/update.rs
+++ b/tests/integration/src/identity/group/update.rs
@@ -1,0 +1,73 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test group update.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::identity::GroupUpdateBuilder;
+
+use crate::common::get_state;
+use crate::{create_domain, create_group};
+
+#[traced_test]
+#[tokio::test]
+async fn test_update() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let group = create_group!(state, &domain.id)?;
+
+    let updated = state
+        .provider
+        .get_identity_provider()
+        .update_group(
+            &ExecutionContext::internal(&state),
+            &group.id,
+            GroupUpdateBuilder::default().name("updated_name").build()?,
+        )
+        .await?;
+
+    assert_eq!(updated.name, "updated_name");
+
+    let fetched = state
+        .provider
+        .get_identity_provider()
+        .get_group(&ExecutionContext::internal(&state), &group.id)
+        .await?
+        .expect("group should still exist");
+    assert_eq!(fetched.name, "updated_name");
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let result = state
+        .provider
+        .get_identity_provider()
+        .update_group(
+            &ExecutionContext::internal(&state),
+            "missing_group_id",
+            GroupUpdateBuilder::default().name("new_name").build()?,
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/tests/integration/src/resource/domain.rs
+++ b/tests/integration/src/resource/domain.rs
@@ -16,3 +16,4 @@ mod create;
 mod delete;
 mod get;
 mod list;
+mod update;

--- a/tests/integration/src/resource/domain/update.rs
+++ b/tests/integration/src/resource/domain/update.rs
@@ -1,0 +1,77 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test domain update.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::resource::DomainUpdateBuilder;
+
+use crate::common::get_state;
+use crate::create_domain;
+
+#[traced_test]
+#[tokio::test]
+async fn test_update() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let updated = state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .name("updated_name")
+                .enabled(false)
+                .build()?,
+        )
+        .await?;
+
+    assert_eq!(updated.name, "updated_name");
+    assert!(!updated.enabled);
+
+    let fetched = state
+        .provider
+        .get_resource_provider()
+        .get_domain(&ExecutionContext::internal(&state), &domain.id)
+        .await?
+        .expect("domain should still exist");
+    assert_eq!(fetched.name, "updated_name");
+    assert!(!fetched.enabled);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            "missing_domain_id",
+            DomainUpdateBuilder::default().name("new_name").build()?,
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/tests/integration/src/resource/project.rs
+++ b/tests/integration/src/resource/project.rs
@@ -16,3 +16,4 @@ mod create;
 mod delete;
 mod get;
 mod list;
+mod update;

--- a/tests/integration/src/resource/project/update.rs
+++ b/tests/integration/src/resource/project/update.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test project update.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::resource::ProjectUpdateBuilder;
+
+use crate::common::get_state;
+use crate::{create_domain, create_project};
+
+#[traced_test]
+#[tokio::test]
+async fn test_update() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, &domain.id)?;
+
+    let updated = state
+        .provider
+        .get_resource_provider()
+        .update_project(
+            &ExecutionContext::internal(&state),
+            &project.id,
+            ProjectUpdateBuilder::default()
+                .name("updated_name")
+                .enabled(false)
+                .build()?,
+        )
+        .await?;
+
+    assert_eq!(updated.name, "updated_name");
+    assert!(!updated.enabled);
+
+    let fetched = state
+        .provider
+        .get_resource_provider()
+        .get_project(&ExecutionContext::internal(&state), &project.id)
+        .await?
+        .expect("project should still exist");
+    assert_eq!(fetched.name, "updated_name");
+    assert!(!fetched.enabled);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .update_project(
+            &ExecutionContext::internal(&state),
+            "missing_project_id",
+            ProjectUpdateBuilder::default().name("new_name").build()?,
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/tests/integration/src/role.rs
+++ b/tests/integration/src/role.rs
@@ -28,6 +28,7 @@ use crate::impl_deleter;
 mod create;
 mod imply_rules;
 mod list;
+mod update;
 
 impl_deleter!(Service, Role, get_role_provider, delete_role);
 

--- a/tests/integration/src/role/update.rs
+++ b/tests/integration/src/role/update.rs
@@ -1,0 +1,72 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test role update.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::role::RoleUpdateBuilder;
+
+use crate::common::get_state;
+use crate::create_role;
+
+#[traced_test]
+#[tokio::test]
+async fn test_update() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let role = create_role!(state)?;
+
+    let updated = state
+        .provider
+        .get_role_provider()
+        .update_role(
+            &ExecutionContext::internal(&state),
+            &role.id,
+            RoleUpdateBuilder::default().name("updated_name").build()?,
+        )
+        .await?;
+
+    assert_eq!(updated.name, "updated_name");
+
+    let fetched = state
+        .provider
+        .get_role_provider()
+        .get_role(&ExecutionContext::internal(&state), &role.id)
+        .await?
+        .expect("role should still exist");
+    assert_eq!(fetched.name, "updated_name");
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let result = state
+        .provider
+        .get_role_provider()
+        .update_role(
+            &ExecutionContext::internal(&state),
+            "missing_role_id",
+            RoleUpdateBuilder::default().name("new_name").build()?,
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
Group update was already implemented at the provider and SQL-driver
layer (update_group) but had no HTTP handler, wire types, or OPA
policy, so PATCH always 404'd. Wires the existing stack up: adds
GroupUpdate/GroupUpdateRequest api-types, the request handler, and
policy/identity/group/update.rego (admin, or manager within domain
scope, matching group create/delete).

Domain update had no support at any layer (trait, backend, SQL
driver, wire types) — PATCH always 404'd. Adds update_domain to
ResourceApi/ResourceBackend, a SQL driver implementation (domains
are rows in the project table with is_domain=true), DomainUpdate
core-types/api-types, the request handler, and
policy/resource/domain/update.rego (system-admin only, matching
domain delete).

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
