### PR TITLE
test(api): Phase 1 API test ergonomics (#992)

### DIFF
--- a/tests/api/README.md
+++ b/tests/api/README.md
@@ -6,6 +6,72 @@ These tests run against a real, running `keystone` binary with SPIRE and OPA
 enforcement, complementing `tests/integration`'s provider-level (mocked
 policy, real backend) coverage.
 
+## Test-writing toolkit
+
+The `test_api` support library ships helpers that make the mandated
+"≥3 tests per CRUD handler" pattern (valid auth + allowed policy, valid
+auth + denied policy, invalid auth) cheap to write. The v3 group suite
+(`tests/api_v3/identity/group.rs`) is the reference implementation of the
+full matrix.
+
+### Scoped sessions (`test_api::common`)
+
+```rust,ignore
+// Sync, composable CloudConfig builders:
+let config = get_domain_scope_config("domain-id")?;          // admin, domain scope
+let config = get_project_scope_config("proj-id", "dom-id")?; // admin, project scope
+let config = config_for_user("alice", "pw", "dom-id", Some(&scope))?; // any user
+
+// Async wrappers producing authenticated sessions:
+let session = get_domain_scope_session("domain-id").await?;
+let session = get_user_session("alice", "pw", "dom-id", Some(&scope)).await?;
+```
+
+Domain- and project-scoped credentials are scope-isolated: policies such as
+`domain_matches_domain_scope` only pass for a *genuinely domain-scoped*
+token — holding a role on a project inside the domain is not sufficient
+(`credentials.domain_id` is never populated from a project scope).
+
+### Negative assertions (`test_api::asserts`)
+
+```rust,ignore
+assert_forbidden(result, "manager without domain scope must not create groups");
+assert_unauthorized(result, "invalid token must be rejected");
+assert_status(result, StatusCode::NOT_FOUND, "deleted group must be gone");
+```
+
+All three extract the HTTP status from the `openstack_sdk` error chain via
+`status_from_error` and, on failure, report the expected status, the
+extracted status and the complete error chain. A denied-policy test is a
+one-liner on top of a scoped session:
+
+```rust,ignore
+let manager = ProjectScopedManager::provision(&admin, &domain.id).await?;
+assert_forbidden(
+    create_group(&manager.session, group_create(&domain.id)?).await,
+    "manager role without domain scope must not create groups",
+);
+```
+
+### CRUD endpoint boilerplate (`test_api::macros::crud_endpoint`)
+
+Crate-private macro generating request structs, `RestEndpoint` impls and
+public wrapper functions for the common create/show/update/list/delete
+shapes — see the module docs in `src/macros.rs` for the invocation syntax
+and `src/identity/group.rs` for a complete example. Operations are
+selectable and all names are explicit (no identifier generation). Endpoints
+that do not fit (sub-resources, grants, borrowed fields) keep hand-written
+impls.
+
+### Resource cleanup (`test_api::guard`)
+
+`AsyncResourceGuard` **requires an explicit `guard.delete().await?`** —
+Rust has no async `Drop`, so drop-time cleanup is impossible; the `Drop`
+impl only *detects* leaks (including on the panic path) and prints the
+leaked resource type. Create fixtures with an admin session and clean them
+up with that same session so cleanup never depends on an underprivileged
+session.
+
 ## OAuth2/OIDC provider (ADR 0026) manual compliance smoke check
 
 RFC 8628 (Device Authorization Grant) and RFC 8693 (Token Exchange) have no

--- a/tests/api/src/asserts.rs
+++ b/tests/api/src/asserts.rs
@@ -1,0 +1,231 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Negative-test assertion helpers (issue #992 deliverable 2).
+//!
+//! Every helper funnels through [`status_from_error`], which extracts the
+//! HTTP status code from the error chain of an [`eyre::Report`] produced by
+//! the `openstack_sdk` request machinery. Assertion failures always report
+//! the expected status, the extracted status, and the complete original
+//! error chain.
+
+use eyre::Report;
+use http::StatusCode;
+use openstack_sdk::{OpenStackError, RestError, api::ApiError};
+
+/// Extract the HTTP status code carried by an error chain, if any.
+///
+/// Walks the [`Report`] chain and inspects every cause for the
+/// status-bearing `openstack_sdk` error shapes:
+///
+/// - [`ApiError::OpenStack`], [`ApiError::OpenStackService`],
+///   [`ApiError::OpenStackUnrecognized`] (direct API errors),
+/// - [`OpenStackError::Api`] (session-level wrapper around an [`ApiError`]),
+/// - [`OpenStackError::Http`] (auth/session HTTP errors).
+///
+/// Both enums are `#[non_exhaustive]`; any variant that does not carry an
+/// HTTP status — including variants added by future SDK versions — yields
+/// `None`.
+pub fn status_from_error(report: &Report) -> Option<StatusCode> {
+    for cause in report.chain() {
+        if let Some(api_err) = cause.downcast_ref::<ApiError<RestError>>()
+            && let Some(status) = status_from_api_error(api_err)
+        {
+            return Some(status);
+        }
+        if let Some(os_err) = cause.downcast_ref::<OpenStackError>() {
+            match os_err {
+                OpenStackError::Http { status } => return Some(*status),
+                OpenStackError::Api { source } => {
+                    if let Some(status) = status_from_api_error(source) {
+                        return Some(status);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+fn status_from_api_error(err: &ApiError<RestError>) -> Option<StatusCode> {
+    match err {
+        ApiError::OpenStack { status, .. }
+        | ApiError::OpenStackService { status, .. }
+        | ApiError::OpenStackUnrecognized { status, .. } => Some(*status),
+        _ => None,
+    }
+}
+
+/// Assert that `result` failed with the given HTTP status.
+///
+/// Panics with `msg`, the expected status, the extracted status and the
+/// complete error chain when the result is `Ok` or carries a different (or
+/// no) status.
+#[track_caller]
+pub fn assert_status<T, E>(result: Result<T, E>, expected: StatusCode, msg: &str)
+where
+    T: std::fmt::Debug,
+    E: Into<Report>,
+{
+    match result {
+        Ok(value) => {
+            panic!("{msg}: expected HTTP {expected}, but the request succeeded with: {value:#?}")
+        }
+        Err(err) => {
+            let report: Report = err.into();
+            let actual = status_from_error(&report);
+            if actual != Some(expected) {
+                panic!("{msg}: expected HTTP {expected}, got {actual:?}; error chain: {report:?}");
+            }
+        }
+    }
+}
+
+/// Assert that `result` failed with HTTP 403 Forbidden (policy denial).
+#[track_caller]
+pub fn assert_forbidden<T, E>(result: Result<T, E>, msg: &str)
+where
+    T: std::fmt::Debug,
+    E: Into<Report>,
+{
+    assert_status(result, StatusCode::FORBIDDEN, msg);
+}
+
+/// Assert that `result` failed with HTTP 401 Unauthorized (invalid auth).
+#[track_caller]
+pub fn assert_unauthorized<T, E>(result: Result<T, E>, msg: &str)
+where
+    T: std::fmt::Debug,
+    E: Into<Report>,
+{
+    assert_status(result, StatusCode::UNAUTHORIZED, msg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use eyre::eyre;
+    use http::Uri;
+
+    fn forbidden_api_error() -> ApiError<RestError> {
+        ApiError::OpenStack {
+            status: StatusCode::FORBIDDEN,
+            uri: Uri::from_static("http://localhost/v3/groups"),
+            msg: "policy denied".into(),
+            req_id: Some("req-1".into()),
+        }
+    }
+
+    #[test]
+    fn extracts_status_from_direct_openstack_variant() {
+        let report = Report::new(forbidden_api_error());
+        assert_eq!(status_from_error(&report), Some(StatusCode::FORBIDDEN));
+    }
+
+    #[test]
+    fn extracts_status_from_openstack_service_variant() {
+        let report = Report::new(ApiError::<RestError>::OpenStackService {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            uri: Uri::from_static("/"),
+            data: "boom".into(),
+            req_id: None,
+        });
+        assert_eq!(
+            status_from_error(&report),
+            Some(StatusCode::INTERNAL_SERVER_ERROR)
+        );
+    }
+
+    #[test]
+    fn extracts_status_from_openstack_unrecognized_variant() {
+        let report = Report::new(ApiError::<RestError>::OpenStackUnrecognized {
+            status: StatusCode::UNAUTHORIZED,
+            uri: Uri::from_static("/"),
+            obj: serde_json::json!({"weird": true}),
+            req_id: None,
+        });
+        assert_eq!(status_from_error(&report), Some(StatusCode::UNAUTHORIZED));
+    }
+
+    #[test]
+    fn extracts_status_from_wrapped_openstack_error_api() {
+        let report = Report::new(OpenStackError::Api {
+            source: forbidden_api_error(),
+        });
+        assert_eq!(status_from_error(&report), Some(StatusCode::FORBIDDEN));
+    }
+
+    #[test]
+    fn extracts_status_from_openstack_error_http() {
+        let report = Report::new(OpenStackError::Http {
+            status: StatusCode::UNAUTHORIZED,
+        });
+        assert_eq!(status_from_error(&report), Some(StatusCode::UNAUTHORIZED));
+    }
+
+    #[test]
+    fn extracts_status_through_context_wrapping() {
+        let report = Report::new(forbidden_api_error()).wrap_err("creating group failed");
+        assert_eq!(status_from_error(&report), Some(StatusCode::FORBIDDEN));
+    }
+
+    #[test]
+    fn returns_none_for_error_without_status() {
+        let report = eyre!("some non-HTTP failure");
+        assert_eq!(status_from_error(&report), None);
+    }
+
+    #[test]
+    fn returns_none_for_statusless_api_error_variant() {
+        let report = Report::new(ApiError::<RestError>::ResourceNotFound);
+        assert_eq!(status_from_error(&report), None);
+    }
+
+    #[test]
+    fn assert_forbidden_accepts_403() {
+        let result: Result<(), Report> = Err(Report::new(forbidden_api_error()));
+        assert_forbidden(result, "must accept 403");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected HTTP 403")]
+    fn assert_forbidden_panics_on_success() {
+        let result: Result<(), Report> = Ok(());
+        assert_forbidden(result, "must reject Ok");
+    }
+
+    #[test]
+    #[should_panic(expected = "error chain")]
+    fn assert_forbidden_panics_on_wrong_status_with_chain() {
+        let result: Result<(), Report> = Err(Report::new(OpenStackError::Http {
+            status: StatusCode::UNAUTHORIZED,
+        }));
+        assert_forbidden(result, "401 is not 403");
+    }
+
+    #[test]
+    fn assert_unauthorized_accepts_401() {
+        let result: Result<(), Report> = Err(Report::new(OpenStackError::Http {
+            status: StatusCode::UNAUTHORIZED,
+        }));
+        assert_unauthorized(result, "must accept 401");
+    }
+
+    #[test]
+    fn assert_status_accepts_concrete_error_types() {
+        // `E: Into<Report>` must accept a bare SDK error, not only Report.
+        let result: Result<(), ApiError<RestError>> = Err(forbidden_api_error());
+        assert_status(result, StatusCode::FORBIDDEN, "bare ApiError");
+    }
+}

--- a/tests/api/src/common.rs
+++ b/tests/api/src/common.rs
@@ -72,6 +72,19 @@ impl TestClient {
     }
 
     pub async fn auth(&mut self, identity: Identity, scope: Option<Scope>) -> Result<&mut Self> {
+        self.authenticate(identity, scope).await
+    }
+
+    /// Shared authentication flow: POST the auth request to
+    /// `v3/auth/tokens`, extract the subject token and rebuild the inner
+    /// client with the `x-auth-token` default header. Used by both initial
+    /// authentication ([`Self::auth`]) and token rescoping
+    /// ([`Self::rescope`]).
+    async fn authenticate(
+        &mut self,
+        identity: Identity,
+        scope: Option<Scope>,
+    ) -> Result<&mut Self> {
         let new = self;
         let auth_request = AuthRequest {
             auth: AuthRequestInner { identity, scope },
@@ -177,6 +190,7 @@ impl TestClient {
         Ok(new)
     }
 
+    /// Rescope the stored token to a new scope via token authentication.
     pub async fn rescope(&mut self, scope: Option<Scope>) -> Result<&mut Self> {
         let new = self;
 
@@ -193,38 +207,7 @@ impl TestClient {
             )
             .build()?;
 
-        let auth_request = AuthRequest {
-            auth: AuthRequestInner { identity, scope },
-        };
-        let rsp = new
-            .client
-            .post(new.base_url.join("v3/auth/tokens")?)
-            .json(&serde_json::to_value(auth_request)?)
-            .send()
-            .await?;
-
-        if rsp.status() != StatusCode::CREATED {
-            return Err(authentication_error(rsp).await);
-        }
-
-        let token = rsp
-            .headers()
-            .get("X-Subject-Token")
-            .ok_or_else(|| eyre!("Token is missing in the {:?}", rsp))?
-            .to_str()?
-            .to_string();
-
-        new.token = Some(SecretString::from(token.clone()));
-        new.auth = Some(rsp.json().await?);
-        let mut token = HeaderValue::from_str(&token)?;
-        token.set_sensitive(true);
-        new.client = ClientBuilder::new()
-            .default_headers(HeaderMap::from_iter([(
-                HeaderName::from_static("x-auth-token"),
-                token,
-            )]))
-            .build()?;
-        Ok(new)
+        new.authenticate(identity, scope).await
     }
 }
 
@@ -321,4 +304,269 @@ pub async fn get_system_scope_session() -> Result<Arc<AsyncOpenStack>> {
         )
         .await?;
     Ok(Arc::new(test_client))
+}
+
+/// Base credentials from the environment (`OS_*` variables via
+/// [`CloudConfig::from_env`]). The deployment-specific admin
+/// username/password/user-domain are preserved as-is (Kubernetes and
+/// non-default environments configure these differently); only the scope
+/// fields are replaced by the requested scope.
+fn env_auth() -> Result<openstack_sdk::config::Auth> {
+    CloudConfig::from_env()?
+        .auth
+        .ok_or_eyre("auth section must be configured in the environment")
+}
+
+/// Clear every scope field, leaving only the credential fields.
+fn clear_scope(auth: &mut openstack_sdk::config::Auth) {
+    auth.project_id = None;
+    auth.project_name = None;
+    auth.project_domain_id = None;
+    auth.project_domain_name = None;
+    auth.domain_id = None;
+    auth.domain_name = None;
+    auth.system_scope = None;
+}
+
+/// Pure constructor: replace whatever scope `auth` carries with `scope`,
+/// keeping the credential fields untouched.
+fn rescope_config(mut auth: openstack_sdk::config::Auth, scope: &Scope) -> CloudConfig {
+    clear_scope(&mut auth);
+    apply_scope(&mut auth, scope);
+    CloudConfig {
+        auth: Some(auth),
+        ..Default::default()
+    }
+}
+
+/// Pure constructor: credentials for an arbitrary user with an optional
+/// scope.
+fn user_config(
+    auth_url: String,
+    name: &str,
+    password: &str,
+    user_domain_id: &str,
+    scope: Option<&Scope>,
+) -> CloudConfig {
+    let mut auth = openstack_sdk::config::Auth {
+        auth_url: Some(auth_url),
+        username: Some(name.to_string()),
+        user_domain_id: Some(user_domain_id.to_string()),
+        password: Some(password.into()),
+        ..Default::default()
+    };
+    if let Some(scope) = scope {
+        apply_scope(&mut auth, scope);
+    }
+    CloudConfig {
+        auth: Some(auth),
+        ..Default::default()
+    }
+}
+
+/// [`CloudConfig`] for the environment's admin scoped to the given domain.
+///
+/// Domain- and project-scoped credentials are subject to scope isolation:
+/// they must not be able to list or access resources outside their scope
+/// (enforced by the OPA policies, e.g. `domain_matches_domain_scope`).
+pub fn get_domain_scope_config(domain_id: &str) -> Result<CloudConfig> {
+    Ok(rescope_config(
+        env_auth()?,
+        &Scope::Domain(DomainBuilder::default().id(domain_id).build()?),
+    ))
+}
+
+/// [`CloudConfig`] for the environment's admin scoped to the given project.
+///
+/// `project_domain_id` is the ID of the domain the project belongs to.
+pub fn get_project_scope_config(project_id: &str, project_domain_id: &str) -> Result<CloudConfig> {
+    Ok(rescope_config(
+        env_auth()?,
+        &Scope::Project(
+            ScopeProjectBuilder::default()
+                .id(project_id)
+                .domain(DomainBuilder::default().id(project_domain_id).build()?)
+                .build()?,
+        ),
+    ))
+}
+
+/// [`CloudConfig`] for an arbitrary (typically non-admin) user with an
+/// optional scope. With `scope: None` the resulting session holds an
+/// unscoped token.
+///
+/// The returned config is not authenticated yet — pass it to
+/// [`session_for_config`] (or `AsyncOpenStack::new`) to obtain a live
+/// session and surface authentication/authorization errors.
+pub fn config_for_user(
+    name: &str,
+    password: &str,
+    user_domain_id: &str,
+    scope: Option<&Scope>,
+) -> Result<CloudConfig> {
+    let auth_url = env_auth()?
+        .auth_url
+        .ok_or_eyre("auth_url must be configured in the environment")?;
+    Ok(user_config(auth_url, name, password, user_domain_id, scope))
+}
+
+/// Map an API [`Scope`] onto the scope fields of a config `Auth` block.
+///
+/// - `Scope::Project` sets `project_id`/`project_name` and the project's
+///   domain,
+/// - `Scope::Domain` sets `domain_id`/`domain_name` (a genuinely
+///   *domain*-scoped token; note that policy `domain_matches_domain_scope`
+///   checks only pass for this scope, never for a project scope in the same
+///   domain),
+/// - `Scope::System` sets `system_scope=all`,
+/// - `Scope::Unscoped` leaves all scope fields unset.
+fn apply_scope(auth: &mut openstack_sdk::config::Auth, scope: &Scope) {
+    match scope {
+        Scope::Project(project) => {
+            auth.project_id = project.id.clone();
+            auth.project_name = project.name.clone();
+            if let Some(domain) = &project.domain {
+                auth.project_domain_id = domain.id.clone();
+                auth.project_domain_name = domain.name.clone();
+            }
+        }
+        Scope::Domain(domain) => {
+            auth.domain_id = domain.id.clone();
+            auth.domain_name = domain.name.clone();
+        }
+        Scope::System(_) => {
+            auth.system_scope = Some("all".to_string());
+        }
+        Scope::Unscoped => {}
+    }
+}
+
+/// Authenticate the given [`CloudConfig`] and return a live session.
+pub async fn session_for_config(config: &CloudConfig) -> Result<Arc<AsyncOpenStack>> {
+    Ok(Arc::new(AsyncOpenStack::new(config).await?))
+}
+
+/// Admin session scoped to the given domain (see [`get_domain_scope_config`]).
+pub async fn get_domain_scope_session(domain_id: &str) -> Result<Arc<AsyncOpenStack>> {
+    session_for_config(&get_domain_scope_config(domain_id)?).await
+}
+
+/// Admin session scoped to the given project (see
+/// [`get_project_scope_config`]).
+pub async fn get_project_scope_session(
+    project_id: &str,
+    project_domain_id: &str,
+) -> Result<Arc<AsyncOpenStack>> {
+    session_for_config(&get_project_scope_config(project_id, project_domain_id)?).await
+}
+
+/// Session for an arbitrary user with an optional scope (see
+/// [`config_for_user`]).
+pub async fn get_user_session(
+    name: &str,
+    password: &str,
+    user_domain_id: &str,
+    scope: Option<&Scope>,
+) -> Result<Arc<AsyncOpenStack>> {
+    session_for_config(&config_for_user(name, password, user_domain_id, scope)?).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const AUTH_URL: &str = "http://localhost:8080";
+
+    /// A base auth block as a K8s/non-default environment might provide
+    /// it: custom admin name, custom user domain, project-scoped.
+    fn base_auth() -> openstack_sdk::config::Auth {
+        openstack_sdk::config::Auth {
+            auth_url: Some(AUTH_URL.to_string()),
+            username: Some("cluster-admin".to_string()),
+            user_domain_id: Some("admin-domain".to_string()),
+            password: Some("secret".into()),
+            project_name: Some("admin".to_string()),
+            project_domain_id: Some("admin-domain".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rescope_to_domain_replaces_scope_keeps_credentials() -> Result<()> {
+        let config = rescope_config(
+            base_auth(),
+            &Scope::Domain(DomainBuilder::default().id("did").build()?),
+        );
+        let auth = config.auth.ok_or_eyre("auth must be set")?;
+        assert_eq!(auth.domain_id.as_deref(), Some("did"));
+        assert_eq!(auth.username.as_deref(), Some("cluster-admin"));
+        assert_eq!(auth.user_domain_id.as_deref(), Some("admin-domain"));
+        assert!(auth.project_id.is_none(), "prior project scope must go");
+        assert!(auth.project_name.is_none(), "prior project scope must go");
+        assert!(auth.system_scope.is_none(), "no system scope expected");
+        Ok(())
+    }
+
+    #[test]
+    fn rescope_to_project_replaces_scope() -> Result<()> {
+        let config = rescope_config(
+            base_auth(),
+            &Scope::Project(
+                ScopeProjectBuilder::default()
+                    .id("pid")
+                    .domain(DomainBuilder::default().id("did").build()?)
+                    .build()?,
+            ),
+        );
+        let auth = config.auth.ok_or_eyre("auth must be set")?;
+        assert_eq!(auth.project_id.as_deref(), Some("pid"));
+        assert_eq!(auth.project_domain_id.as_deref(), Some("did"));
+        assert!(
+            auth.project_name.is_none(),
+            "prior project-name scope must go"
+        );
+        assert!(auth.domain_id.is_none(), "no domain scope expected");
+        assert!(auth.system_scope.is_none(), "no system scope expected");
+        Ok(())
+    }
+
+    #[test]
+    fn user_config_unscoped_leaves_scope_unset() -> Result<()> {
+        let config = user_config(AUTH_URL.to_string(), "alice", "secret", "did", None);
+        let auth = config.auth.ok_or_eyre("auth must be set")?;
+        assert_eq!(auth.auth_url.as_deref(), Some(AUTH_URL));
+        assert_eq!(auth.username.as_deref(), Some("alice"));
+        assert_eq!(auth.user_domain_id.as_deref(), Some("did"));
+        assert!(auth.project_id.is_none(), "unscoped: no project fields");
+        assert!(auth.domain_id.is_none(), "unscoped: no domain fields");
+        assert!(auth.system_scope.is_none(), "unscoped: no system fields");
+        Ok(())
+    }
+
+    #[test]
+    fn user_config_project_scope_maps_all_fields() -> Result<()> {
+        let scope = Scope::Project(
+            ScopeProjectBuilder::default()
+                .id("pid")
+                .domain(DomainBuilder::default().id("pdid").build()?)
+                .build()?,
+        );
+        let config = user_config(AUTH_URL.to_string(), "alice", "secret", "did", Some(&scope));
+        let auth = config.auth.ok_or_eyre("auth must be set")?;
+        assert_eq!(auth.project_id.as_deref(), Some("pid"));
+        assert_eq!(auth.project_domain_id.as_deref(), Some("pdid"));
+        assert!(auth.domain_id.is_none(), "no domain scope expected");
+        Ok(())
+    }
+
+    #[test]
+    fn user_config_system_scope_sets_system_all() -> Result<()> {
+        let scope = Scope::System(ScopeSystem { all: Some(true) });
+        let config = user_config(AUTH_URL.to_string(), "alice", "secret", "did", Some(&scope));
+        let auth = config.auth.ok_or_eyre("auth must be set")?;
+        assert_eq!(auth.system_scope.as_deref(), Some("all"));
+        assert!(auth.project_id.is_none(), "no project scope expected");
+        assert!(auth.domain_id.is_none(), "no domain scope expected");
+        Ok(())
+    }
 }

--- a/tests/api/src/guard.rs
+++ b/tests/api/src/guard.rs
@@ -11,13 +11,30 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+//! RAII-style guards for API-created test resources.
+//!
+//! # Cleanup contract
+//!
+//! Rust has no async `Drop`, so the **only reliable cleanup is an explicit
+//! `guard.delete().await?` at the end of the test**. The [`Drop`]
+//! implementation is *leak detection*, not cleanup: when a guard is dropped
+//! without `.delete()` having run — including drops during a panic/failed
+//! assertion or an early `?` return — it prints a diagnostic naming the
+//! leaked resource type so the leak can be traced and removed from the
+//! shared server state (relevant for the long-lived K8s deployments).
+//!
+//! For negative tests, create fixtures with an *admin* session and delete
+//! them with that same admin session, so cleanup does not depend on an
+//! underprivileged session succeeding.
+
+use std::io::Write;
 use std::ops::Deref;
-/// Trait to allow State to delete various resource types T
 use std::sync::Arc;
 
 use eyre::Result;
 use openstack_sdk::AsyncOpenStack;
 
+/// Trait to allow State to delete various resource types T
 #[async_trait::async_trait]
 pub trait DeletableResource: Send + Sync {
     async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()>;
@@ -50,8 +67,22 @@ where
         }
     }
 
-    pub fn resource(&self) -> &T {
-        self.resource.as_ref().expect("Resource already deleted")
+    /// The guarded resource, or `None` when it has already been taken by
+    /// the consuming [`ResourceGuard::delete`].
+    pub fn resource(&self) -> Option<&T> {
+        self.resource.as_ref()
+    }
+}
+
+impl<T> std::fmt::Debug for AsyncResourceGuard<T>
+where
+    T: DeletableResource + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsyncResourceGuard")
+            .field("resource", &self.resource)
+            .field("was_deleted", &self.was_deleted)
+            .finish_non_exhaustive()
     }
 }
 
@@ -75,9 +106,24 @@ where
     T: DeletableResource,
 {
     fn drop(&mut self) {
-        if !self.was_deleted && !std::thread::panicking() {
-            eprintln!(
-                "\n[ERROR] AsyncResourceGuard leaked! .delete() was not called for resource."
+        if !self.was_deleted && self.resource.is_some() {
+            // Leak *detection* only — async cleanup cannot run reliably in
+            // `Drop` (current-thread `#[tokio::test]` runtimes, runtime
+            // shutdown, panic unwinding). Emit on the panic path too: a
+            // failed assertion is exactly when explicit cleanup is most
+            // likely to have been skipped. Never panics (a second panic
+            // while unwinding would abort the test process).
+            let during_panic = if std::thread::panicking() {
+                " while unwinding a panic"
+            } else {
+                ""
+            };
+            let _ = writeln!(
+                std::io::stderr(),
+                "\n[ERROR] AsyncResourceGuard<{}> leaked{}: .delete() was not \
+                 called; the resource is left behind on the server.",
+                std::any::type_name::<T>(),
+                during_panic,
             );
         }
     }
@@ -89,6 +135,14 @@ where
 {
     type Target = R;
     fn deref(&self) -> &Self::Target {
-        self.resource()
+        match self.resource.as_ref() {
+            Some(resource) => resource,
+            // `ResourceGuard::delete` consumes the guard, so no borrow can
+            // observe the taken state.
+            None => unreachable!(
+                "AsyncResourceGuard<{}> dereferenced after delete()",
+                std::any::type_name::<R>()
+            ),
+        }
     }
 }

--- a/tests/api/src/identity/group.rs
+++ b/tests/api/src/identity/group.rs
@@ -11,188 +11,60 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use std::borrow::Cow;
-use std::sync::Arc;
-
-use eyre::Result;
+//! v3 group CRUD helpers, generated with [`crate::macros::crud_endpoint`].
 
 use openstack_keystone_api_types::v3::group::*;
-use openstack_sdk::api::rest_endpoint_prelude::*;
-use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
-use crate::guard::*;
+use crate::macros::crud_endpoint;
 
-/// Create request for group
-#[derive(Clone, Debug)]
-struct GroupCreateRequest {
-    group: GroupCreate,
-}
-
-impl RestEndpoint for GroupCreateRequest {
-    fn method(&self) -> http::Method {
-        http::Method::POST
+crud_endpoint! {
+    create {
+        request = GroupCreateApiRequest,
+        func = create_group,
+        path = "groups",
+        body_key = "group",
+        create_type = GroupCreate,
+        model = Group,
+        response_key = "group",
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        "groups".to_string().into()
+    show {
+        request = GroupShowApiRequest,
+        func = get_group,
+        path = "groups",
+        model = Group,
+        response_key = "group",
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-        params.push("group", serde_json::to_value(&self.group)?);
-        params.into_body()
+    update {
+        request = GroupUpdateApiRequest,
+        func = update_group,
+        path = "groups",
+        body_key = "group",
+        update_type = GroupUpdate,
+        model = Group,
+        response_key = "group",
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
+    list {
+        request = GroupListRequest,
+        func = list_groups,
+        path = "groups",
+        model = Group,
+        response_key = "groups",
+        service = Identity,
+        api_version = (3, 0),
+        query = [domain_id, name],
     }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("group".into())
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Create group
-pub async fn create_group(
-    tc: &Arc<AsyncOpenStack>,
-    group: GroupCreate,
-) -> Result<AsyncResourceGuard<Group>> {
-    let obj: Group = GroupCreateRequest { group }
-        .query_async(tc.as_ref())
-        .await?;
-    Ok(AsyncResourceGuard::new(obj, tc.clone()))
-}
-
-/// Get request for a single group
-struct GroupShowRequest {
-    id: String,
-}
-
-impl RestEndpoint for GroupShowRequest {
-    fn method(&self) -> http::Method {
-        http::Method::GET
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        format!("groups/{id}", id = self.id).into()
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("group".into())
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Get a single group by ID
-pub async fn get_group(tc: &Arc<AsyncOpenStack>, id: impl Into<String>) -> Result<Group> {
-    Ok(GroupShowRequest { id: id.into() }
-        .query_async(tc.as_ref())
-        .await?)
-}
-
-/// Update request for group
-#[derive(Clone, Debug)]
-struct GroupUpdateRequest {
-    id: String,
-    group: GroupUpdate,
-}
-
-impl RestEndpoint for GroupUpdateRequest {
-    fn method(&self) -> http::Method {
-        http::Method::PATCH
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        format!("groups/{id}", id = self.id).into()
-    }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-        params.push("group", serde_json::to_value(&self.group)?);
-        params.into_body()
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("group".into())
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Update a group
-pub async fn update_group(
-    tc: &Arc<AsyncOpenStack>,
-    id: impl Into<String>,
-    group: GroupUpdate,
-) -> Result<Group> {
-    Ok(GroupUpdateRequest {
-        id: id.into(),
-        group,
-    }
-    .query_async(tc.as_ref())
-    .await?)
-}
-
-/// Delete request for group
-struct GroupDeleteRequest {
-    id: String,
-}
-
-impl RestEndpoint for GroupDeleteRequest {
-    fn method(&self) -> http::Method {
-        http::Method::DELETE
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        format!("groups/{id}", id = self.id).into()
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Delete a group
-pub async fn delete_group(tc: &Arc<AsyncOpenStack>, id: impl Into<String>) -> Result<()> {
-    Ok(
-        openstack_sdk::api::ignore(GroupDeleteRequest { id: id.into() })
-            .query_async(tc.as_ref())
-            .await?,
-    )
-}
-
-#[async_trait::async_trait]
-impl DeletableResource for Group {
-    async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(openstack_sdk::api::ignore(GroupDeleteRequest {
-            id: self.id.clone(),
-        })
-        .query_async(state.as_ref())
-        .await?)
+    delete {
+        request = GroupDeleteApiRequest,
+        func = delete_group,
+        path = "groups",
+        model = Group,
+        service = Identity,
+        api_version = (3, 0),
     }
 }

--- a/tests/api/src/identity/user.rs
+++ b/tests/api/src/identity/user.rs
@@ -11,170 +11,40 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-
-use std::borrow::Cow;
-use std::sync::Arc;
-
-use eyre::Result;
+//! v3 user CRUD helpers, generated with [`crate::macros::crud_endpoint`].
 
 use openstack_keystone_api_types::v3::user::*;
-use openstack_sdk::api::rest_endpoint_prelude::*;
-use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
-use crate::guard::*;
+use crate::macros::crud_endpoint;
 
-#[derive(Clone, Debug)]
-struct UserCreateRequest {
-    user: UserCreate,
-}
-
-impl RestEndpoint for UserCreateRequest {
-    fn method(&self) -> http::Method {
-        http::Method::POST
+crud_endpoint! {
+    create {
+        request = UserCreateRequest,
+        func = create_user,
+        path = "users",
+        body_key = "user",
+        create_type = UserCreate,
+        model = User,
+        response_key = "user",
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        "users".to_string().into()
+    update {
+        request = UserUpdateRequest,
+        func = update_user,
+        path = "users",
+        body_key = "user",
+        update_type = UserUpdate,
+        model = User,
+        response_key = "user",
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-        params.push("user", serde_json::to_value(&self.user)?);
-        params.into_body()
+    delete_impl {
+        request = UserDeleteRequest,
+        path = "users",
+        model = User,
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("user".into())
-    }
-
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Create user
-pub async fn create_user(
-    tc: &Arc<AsyncOpenStack>,
-    user: UserCreate,
-) -> Result<AsyncResourceGuard<User>> {
-    let obj: User = UserCreateRequest { user }.query_async(tc.as_ref()).await?;
-    Ok(AsyncResourceGuard::new(obj, tc.clone()))
-}
-
-//impl RestEndpoint for UserListParameters {
-//    fn method(&self) -> http::Method {
-//        http::Method::GET
-//    }
-//
-//    fn endpoint(&self) -> Cow<'static, str> {
-//        "users".to_string().into()
-//    }
-//
-//    fn parameters(&self) -> QueryParams<'_> {
-//        let mut params = QueryParams::default();
-//        params.push_opt("domain_id", self.domain_id.as_ref());
-//        params.push_opt("name", self.name.as_ref());
-//        params.push_opt("unique_id", self.unique_id.as_ref());
-//
-//        params
-//    }
-//
-//    fn service_type(&self) -> ServiceType {
-//        ServiceType::Identity
-//    }
-//
-//    fn response_key(&self) -> Option<Cow<'static, str>> {
-//        Some("users".into())
-//    }
-//
-//    /// Returns required API version
-//    fn api_version(&self) -> Option<ApiVersion> {
-//        Some(ApiVersion::new(3, 0))
-//    }
-//}
-
-struct UserDeleteRequest {
-    id: String,
-}
-
-impl RestEndpoint for UserDeleteRequest {
-    fn method(&self) -> http::Method {
-        http::Method::DELETE
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        format!("users/{id}", id = self.id).into()
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-#[async_trait::async_trait]
-impl DeletableResource for User {
-    async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(openstack_sdk::api::ignore(UserDeleteRequest {
-            id: self.id.clone(),
-        })
-        .query_async(state.as_ref())
-        .await?)
-    }
-}
-
-#[derive(Clone, Debug)]
-struct UserUpdateRequest {
-    id: String,
-    user: UserUpdate,
-}
-
-impl RestEndpoint for UserUpdateRequest {
-    fn method(&self) -> http::Method {
-        http::Method::PATCH
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        format!("users/{id}", id = self.id).into()
-    }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-        params.push("user", serde_json::to_value(&self.user)?);
-        params.into_body()
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("user".into())
-    }
-
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Update user
-pub async fn update_user(
-    tc: &Arc<AsyncOpenStack>,
-    user_id: &str,
-    user: UserUpdate,
-) -> Result<User> {
-    let obj: User = UserUpdateRequest {
-        id: user_id.to_string(),
-        user,
-    }
-    .query_async(tc.as_ref())
-    .await?;
-    Ok(obj)
 }

--- a/tests/api/src/lib.rs
+++ b/tests/api/src/lib.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 pub mod api_key;
+pub mod asserts;
 pub mod assignment;
 pub mod auth;
 pub mod common;
@@ -20,6 +21,7 @@ pub mod endpoint;
 pub mod federation;
 pub mod guard;
 pub mod identity;
+pub mod macros;
 pub mod mapping;
 pub mod oauth2;
 pub mod resource;

--- a/tests/api/src/macros.rs
+++ b/tests/api/src/macros.rs
@@ -1,0 +1,645 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `crud_endpoint!`: boilerplate reduction for `RestEndpoint` CRUD helpers
+//! (issue #992 deliverable 3).
+//!
+//! The macro is **crate-private** support tooling for `test_api`'s own
+//! `src/` helper modules — integration tests consume the generated public
+//! wrapper functions, never the macro itself.
+//!
+//! Every operation block is independent and fully explicit: request struct
+//! names, wrapper function names and all endpoint parameters are spelled
+//! out at the call site (no identifier concatenation), so compile errors
+//! point at readable names. Operations are selectable — a resource without
+//! an update handler simply omits the `update` block. Endpoints that do not
+//! fit these shapes (sub-resources, grants, borrowed fields, non-JSON
+//! bodies) should keep hand-written `RestEndpoint` impls.
+//!
+//! Canonical field order per operation (all fields required, see arms
+//! below):
+//!
+//! ```text
+//! crud_endpoint! {
+//!     create {
+//!         request = GroupCreateApiRequest,
+//!         func = create_group,
+//!         path = "groups",
+//!         body_key = "group",
+//!         create_type = GroupCreate,
+//!         model = Group,
+//!         response_key = "group",
+//!         service = Identity,
+//!         api_version = (3, 0),
+//!     }
+//!     show {
+//!         request = GroupShowApiRequest,
+//!         func = get_group,
+//!         path = "groups",
+//!         model = Group,
+//!         response_key = "group",
+//!         service = Identity,
+//!         api_version = (3, 0),
+//!     }
+//!     list {
+//!         request = GroupListRequest,
+//!         func = list_groups,
+//!         path = "groups",
+//!         model = Group,
+//!         response_key = "groups",
+//!         service = Identity,
+//!         api_version = (3, 0),
+//!         query = [domain_id, name],
+//!     }
+//!     delete {
+//!         request = GroupDeleteApiRequest,
+//!         func = delete_group,
+//!         path = "groups",
+//!         model = Group,
+//!         service = Identity,
+//!         api_version = (3, 0),
+//!     }
+//! }
+//! ```
+//!
+//! Generated per operation:
+//!
+//! - `create`: private request struct, `RestEndpoint` impl (POST `path`,
+//!   JSON body under `body_key`), and
+//!   `pub async fn <func>(tc, <create_type>) -> Result<AsyncResourceGuard<model>>`.
+//! - `show`: private request struct, `RestEndpoint` impl (GET
+//!   `path/{id}`), and `pub async fn <func>(tc, id) -> Result<model>`.
+//! - `update`: private request struct, `RestEndpoint` impl (PATCH
+//!   `path/{id}`, JSON body under `body_key`), and
+//!   `pub async fn <func>(tc, id, <update_type>) -> Result<model>`.
+//! - `list`: **public** request struct with `Option<String>` query fields,
+//!   `RestEndpoint` impl (GET `path`), and
+//!   `pub async fn <func>(tc, params) -> Result<Vec<model>>`.
+//! - `delete`: private request struct, `RestEndpoint` impl (DELETE
+//!   `path/{id}`), `impl DeletableResource for <model>` (requires `model`
+//!   to have an `id: String` field), and
+//!   `pub async fn <func>(tc, id) -> Result<()>`. Use `delete_impl` instead
+//!   of `delete` when only the `DeletableResource` impl is wanted without a
+//!   public delete function.
+macro_rules! crud_endpoint {
+    // Entry: one or more operation blocks.
+    ($($op:ident { $($body:tt)* })+) => {
+        $(crud_endpoint!(@ $op { $($body)* });)+
+    };
+
+    (@ create {
+        request = $request:ident,
+        func = $func:ident,
+        path = $path:literal,
+        body_key = $body_key:literal,
+        create_type = $create_type:ty,
+        model = $model:ty,
+        response_key = $response_key:literal,
+        service = $service:ident,
+        api_version = ($major:literal, $minor:literal) $(,)?
+    }) => {
+        #[derive(Clone, Debug)]
+        struct $request {
+            body: $create_type,
+        }
+
+        impl ::openstack_sdk::api::rest_endpoint_prelude::RestEndpoint for $request {
+            fn method(&self) -> ::http::Method {
+                ::http::Method::POST
+            }
+
+            fn endpoint(&self) -> ::std::borrow::Cow<'static, str> {
+                $path.into()
+            }
+
+            fn body(
+                &self,
+            ) -> ::std::result::Result<
+                Option<(&'static str, Vec<u8>)>,
+                ::openstack_sdk::api::rest_endpoint_prelude::BodyError,
+            > {
+                let mut params =
+                    ::openstack_sdk::api::rest_endpoint_prelude::JsonBodyParams::default();
+                params.push($body_key, ::serde_json::to_value(&self.body)?);
+                params.into_body()
+            }
+
+            fn service_type(
+                &self,
+            ) -> ::openstack_sdk::api::rest_endpoint_prelude::ServiceType {
+                ::openstack_sdk::api::rest_endpoint_prelude::ServiceType::$service
+            }
+
+            fn response_key(&self) -> Option<::std::borrow::Cow<'static, str>> {
+                Some($response_key.into())
+            }
+
+            fn api_version(
+                &self,
+            ) -> Option<::openstack_sdk::api::rest_endpoint_prelude::ApiVersion> {
+                Some(::openstack_sdk::api::rest_endpoint_prelude::ApiVersion::new(
+                    $major, $minor,
+                ))
+            }
+        }
+
+        /// Create the resource, returning a guard that must be explicitly
+        /// deleted with `.delete().await?` (see [`crate::guard`]).
+        pub async fn $func(
+            tc: &::std::sync::Arc<::openstack_sdk::AsyncOpenStack>,
+            body: $create_type,
+        ) -> ::eyre::Result<$crate::guard::AsyncResourceGuard<$model>> {
+            use ::openstack_sdk::api::QueryAsync;
+            let obj: $model = $request { body }.query_async(tc.as_ref()).await?;
+            Ok($crate::guard::AsyncResourceGuard::new(obj, tc.clone()))
+        }
+    };
+
+    (@ show {
+        request = $request:ident,
+        func = $func:ident,
+        path = $path:literal,
+        model = $model:ty,
+        response_key = $response_key:literal,
+        service = $service:ident,
+        api_version = ($major:literal, $minor:literal) $(,)?
+    }) => {
+        #[derive(Clone, Debug)]
+        struct $request {
+            id: String,
+        }
+
+        impl ::openstack_sdk::api::rest_endpoint_prelude::RestEndpoint for $request {
+            fn method(&self) -> ::http::Method {
+                ::http::Method::GET
+            }
+
+            fn endpoint(&self) -> ::std::borrow::Cow<'static, str> {
+                format!("{}/{}", $path, self.id).into()
+            }
+
+            fn service_type(
+                &self,
+            ) -> ::openstack_sdk::api::rest_endpoint_prelude::ServiceType {
+                ::openstack_sdk::api::rest_endpoint_prelude::ServiceType::$service
+            }
+
+            fn response_key(&self) -> Option<::std::borrow::Cow<'static, str>> {
+                Some($response_key.into())
+            }
+
+            fn api_version(
+                &self,
+            ) -> Option<::openstack_sdk::api::rest_endpoint_prelude::ApiVersion> {
+                Some(::openstack_sdk::api::rest_endpoint_prelude::ApiVersion::new(
+                    $major, $minor,
+                ))
+            }
+        }
+
+        /// Show a single resource by ID.
+        pub async fn $func(
+            tc: &::std::sync::Arc<::openstack_sdk::AsyncOpenStack>,
+            id: impl Into<String>,
+        ) -> ::eyre::Result<$model> {
+            use ::openstack_sdk::api::QueryAsync;
+            Ok($request { id: id.into() }.query_async(tc.as_ref()).await?)
+        }
+    };
+
+    (@ update {
+        request = $request:ident,
+        func = $func:ident,
+        path = $path:literal,
+        body_key = $body_key:literal,
+        update_type = $update_type:ty,
+        model = $model:ty,
+        response_key = $response_key:literal,
+        service = $service:ident,
+        api_version = ($major:literal, $minor:literal) $(,)?
+    }) => {
+        #[derive(Clone, Debug)]
+        struct $request {
+            id: String,
+            body: $update_type,
+        }
+
+        impl ::openstack_sdk::api::rest_endpoint_prelude::RestEndpoint for $request {
+            fn method(&self) -> ::http::Method {
+                ::http::Method::PATCH
+            }
+
+            fn endpoint(&self) -> ::std::borrow::Cow<'static, str> {
+                format!("{}/{}", $path, self.id).into()
+            }
+
+            fn body(
+                &self,
+            ) -> ::std::result::Result<
+                Option<(&'static str, Vec<u8>)>,
+                ::openstack_sdk::api::rest_endpoint_prelude::BodyError,
+            > {
+                let mut params =
+                    ::openstack_sdk::api::rest_endpoint_prelude::JsonBodyParams::default();
+                params.push($body_key, ::serde_json::to_value(&self.body)?);
+                params.into_body()
+            }
+
+            fn service_type(
+                &self,
+            ) -> ::openstack_sdk::api::rest_endpoint_prelude::ServiceType {
+                ::openstack_sdk::api::rest_endpoint_prelude::ServiceType::$service
+            }
+
+            fn response_key(&self) -> Option<::std::borrow::Cow<'static, str>> {
+                Some($response_key.into())
+            }
+
+            fn api_version(
+                &self,
+            ) -> Option<::openstack_sdk::api::rest_endpoint_prelude::ApiVersion> {
+                Some(::openstack_sdk::api::rest_endpoint_prelude::ApiVersion::new(
+                    $major, $minor,
+                ))
+            }
+        }
+
+        /// Update the resource identified by `id`.
+        pub async fn $func(
+            tc: &::std::sync::Arc<::openstack_sdk::AsyncOpenStack>,
+            id: &str,
+            body: $update_type,
+        ) -> ::eyre::Result<$model> {
+            use ::openstack_sdk::api::QueryAsync;
+            Ok($request {
+                id: id.to_string(),
+                body,
+            }
+            .query_async(tc.as_ref())
+            .await?)
+        }
+    };
+
+    (@ list {
+        request = $request:ident,
+        func = $func:ident,
+        path = $path:literal,
+        model = $model:ty,
+        response_key = $response_key:literal,
+        service = $service:ident,
+        api_version = ($major:literal, $minor:literal),
+        query = [$($query_field:ident),* $(,)?] $(,)?
+    }) => {
+        /// List request query parameters.
+        #[derive(Clone, Debug, Default)]
+        pub struct $request {
+            $(pub $query_field: Option<String>,)*
+        }
+
+        impl ::openstack_sdk::api::rest_endpoint_prelude::RestEndpoint for $request {
+            fn method(&self) -> ::http::Method {
+                ::http::Method::GET
+            }
+
+            fn endpoint(&self) -> ::std::borrow::Cow<'static, str> {
+                $path.into()
+            }
+
+            fn parameters(
+                &self,
+            ) -> ::openstack_sdk::api::rest_endpoint_prelude::QueryParams<'_> {
+                let mut params =
+                    ::openstack_sdk::api::rest_endpoint_prelude::QueryParams::default();
+                $(params.push_opt(stringify!($query_field), self.$query_field.as_ref());)*
+                params
+            }
+
+            fn service_type(
+                &self,
+            ) -> ::openstack_sdk::api::rest_endpoint_prelude::ServiceType {
+                ::openstack_sdk::api::rest_endpoint_prelude::ServiceType::$service
+            }
+
+            fn response_key(&self) -> Option<::std::borrow::Cow<'static, str>> {
+                Some($response_key.into())
+            }
+
+            fn api_version(
+                &self,
+            ) -> Option<::openstack_sdk::api::rest_endpoint_prelude::ApiVersion> {
+                Some(::openstack_sdk::api::rest_endpoint_prelude::ApiVersion::new(
+                    $major, $minor,
+                ))
+            }
+        }
+
+        /// List resources matching the query parameters.
+        pub async fn $func(
+            tc: &::std::sync::Arc<::openstack_sdk::AsyncOpenStack>,
+            params: $request,
+        ) -> ::eyre::Result<Vec<$model>> {
+            use ::openstack_sdk::api::QueryAsync;
+            Ok(params.query_async(tc.as_ref()).await?)
+        }
+    };
+
+    // Delete with a public wrapper function.
+    (@ delete {
+        request = $request:ident,
+        func = $func:ident,
+        path = $path:literal,
+        model = $model:ty,
+        service = $service:ident,
+        api_version = ($major:literal, $minor:literal) $(,)?
+    }) => {
+        crud_endpoint!(@ delete_impl {
+            request = $request,
+            path = $path,
+            model = $model,
+            service = $service,
+            api_version = ($major, $minor),
+        });
+
+        /// Delete the resource identified by `id`.
+        pub async fn $func(
+            tc: &::std::sync::Arc<::openstack_sdk::AsyncOpenStack>,
+            id: impl Into<String>,
+        ) -> ::eyre::Result<()> {
+            use ::openstack_sdk::api::QueryAsync;
+            Ok(
+                ::openstack_sdk::api::ignore($request { id: id.into() })
+                    .query_async(tc.as_ref())
+                    .await?,
+            )
+        }
+    };
+
+    // Delete without a public wrapper: only the request struct and the
+    // `DeletableResource` impl used by `AsyncResourceGuard`.
+    (@ delete_impl {
+        request = $request:ident,
+        path = $path:literal,
+        model = $model:ty,
+        service = $service:ident,
+        api_version = ($major:literal, $minor:literal) $(,)?
+    }) => {
+        #[derive(Clone, Debug)]
+        struct $request {
+            id: String,
+        }
+
+        impl ::openstack_sdk::api::rest_endpoint_prelude::RestEndpoint for $request {
+            fn method(&self) -> ::http::Method {
+                ::http::Method::DELETE
+            }
+
+            fn endpoint(&self) -> ::std::borrow::Cow<'static, str> {
+                format!("{}/{}", $path, self.id).into()
+            }
+
+            fn service_type(
+                &self,
+            ) -> ::openstack_sdk::api::rest_endpoint_prelude::ServiceType {
+                ::openstack_sdk::api::rest_endpoint_prelude::ServiceType::$service
+            }
+
+            fn api_version(
+                &self,
+            ) -> Option<::openstack_sdk::api::rest_endpoint_prelude::ApiVersion> {
+                Some(::openstack_sdk::api::rest_endpoint_prelude::ApiVersion::new(
+                    $major, $minor,
+                ))
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl $crate::guard::DeletableResource for $model {
+            async fn delete(
+                &self,
+                state: &::std::sync::Arc<::openstack_sdk::AsyncOpenStack>,
+            ) -> ::eyre::Result<()> {
+                use ::openstack_sdk::api::QueryAsync;
+                Ok(::openstack_sdk::api::ignore($request {
+                    id: self.id.clone(),
+                })
+                .query_async(state.as_ref())
+                .await?)
+            }
+        }
+    };
+}
+
+pub(crate) use crud_endpoint;
+
+#[cfg(test)]
+#[allow(dead_code)]
+mod tests {
+    //! Compile-oriented expansion checks: each block below validates a
+    //! distinct operation combination compiles and produces the expected
+    //! request shapes. Wire behavior is covered by the live API tests.
+
+    use openstack_sdk::api::rest_endpoint_prelude::RestEndpoint;
+    use serde::{Deserialize, Serialize};
+
+    /// Full CRUD-without-update combination (the v3 group shape).
+    mod widgets {
+        use super::*;
+
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct Widget {
+            pub id: String,
+            pub name: String,
+        }
+
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct WidgetCreate {
+            pub name: String,
+        }
+
+        crate::macros::crud_endpoint! {
+            create {
+                request = WidgetCreateApiRequest,
+                func = create_widget,
+                path = "widgets",
+                body_key = "widget",
+                create_type = WidgetCreate,
+                model = Widget,
+                response_key = "widget",
+                service = Identity,
+                api_version = (3, 0),
+            }
+            show {
+                request = WidgetShowApiRequest,
+                func = get_widget,
+                path = "widgets",
+                model = Widget,
+                response_key = "widget",
+                service = Identity,
+                api_version = (3, 0),
+            }
+            list {
+                request = WidgetListRequest,
+                func = list_widgets,
+                path = "widgets",
+                model = Widget,
+                response_key = "widgets",
+                service = Identity,
+                api_version = (3, 0),
+                query = [domain_id, name],
+            }
+            delete {
+                request = WidgetDeleteApiRequest,
+                func = delete_widget,
+                path = "widgets",
+                model = Widget,
+                service = Identity,
+                api_version = (3, 0),
+            }
+        }
+
+        fn create_request() -> WidgetCreateApiRequest {
+            WidgetCreateApiRequest {
+                body: WidgetCreate { name: "n".into() },
+            }
+        }
+
+        #[test]
+        fn create_request_shape() {
+            let req = create_request();
+            assert_eq!(req.method(), http::Method::POST);
+            assert_eq!(req.endpoint(), "widgets");
+            assert_eq!(req.response_key().as_deref(), Some("widget"));
+            let (content_type, body) = req.body().ok().flatten().unwrap_or(("missing", Vec::new()));
+            assert_eq!(content_type, "application/json");
+            assert_eq!(String::from_utf8_lossy(&body), r#"{"widget":{"name":"n"}}"#);
+        }
+
+        #[test]
+        fn show_request_interpolates_id() {
+            let req = WidgetShowApiRequest { id: "abc".into() };
+            assert_eq!(req.method(), http::Method::GET);
+            assert_eq!(req.endpoint(), "widgets/abc");
+        }
+
+        #[test]
+        fn delete_request_interpolates_id() {
+            let req = WidgetDeleteApiRequest { id: "abc".into() };
+            assert_eq!(req.method(), http::Method::DELETE);
+            assert_eq!(req.endpoint(), "widgets/abc");
+            assert_eq!(req.response_key(), None);
+        }
+
+        #[test]
+        fn list_request_defaults_and_endpoint() {
+            let req = WidgetListRequest {
+                domain_id: Some("did".into()),
+                ..Default::default()
+            };
+            assert_eq!(req.method(), http::Method::GET);
+            assert_eq!(req.endpoint(), "widgets");
+            assert_eq!(req.response_key().as_deref(), Some("widgets"));
+            assert!(req.name.is_none());
+        }
+    }
+
+    /// Create/update/delete_impl combination with a distinct list item
+    /// type and no public delete function (the v3 user shape).
+    mod gadgets {
+        use super::*;
+
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct Gadget {
+            pub id: String,
+        }
+
+        /// Reduced representation returned by list (like `ProjectShort`).
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct GadgetShort {
+            pub id: String,
+        }
+
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct GadgetCreate {
+            pub name: String,
+        }
+
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct GadgetUpdate {
+            pub name: Option<String>,
+        }
+
+        crate::macros::crud_endpoint! {
+            create {
+                request = GadgetCreateApiRequest,
+                func = create_gadget,
+                path = "gadgets",
+                body_key = "gadget",
+                create_type = GadgetCreate,
+                model = Gadget,
+                response_key = "gadget",
+                service = Identity,
+                api_version = (4, 0),
+            }
+            update {
+                request = GadgetUpdateApiRequest,
+                func = update_gadget,
+                path = "gadgets",
+                body_key = "gadget",
+                update_type = GadgetUpdate,
+                model = Gadget,
+                response_key = "gadget",
+                service = Identity,
+                api_version = (4, 0),
+            }
+            list {
+                request = GadgetListRequest,
+                func = list_gadgets,
+                path = "gadgets",
+                model = GadgetShort,
+                response_key = "gadgets",
+                service = Identity,
+                api_version = (4, 0),
+                query = [name],
+            }
+            delete_impl {
+                request = GadgetDeleteApiRequest,
+                path = "gadgets",
+                model = Gadget,
+                service = Identity,
+                api_version = (4, 0),
+            }
+        }
+    }
+
+    /// A single standalone operation must also expand.
+    mod single_op {
+        use super::*;
+
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct Sprocket {
+            pub id: String,
+        }
+
+        crate::macros::crud_endpoint! {
+            show {
+                request = SprocketShowApiRequest,
+                func = get_sprocket,
+                path = "sprockets",
+                model = Sprocket,
+                response_key = "sprocket",
+                service = Identity,
+                api_version = (3, 0),
+            }
+        }
+    }
+}

--- a/tests/api/src/resource/project.rs
+++ b/tests/api/src/resource/project.rs
@@ -11,239 +11,60 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use std::borrow::Cow;
-use std::sync::Arc;
-
-use eyre::Result;
+//! v3 project CRUD helpers, generated with [`crate::macros::crud_endpoint`].
 
 use openstack_keystone_api_types::v3::project::*;
-use openstack_sdk::api::rest_endpoint_prelude::*;
-use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
 
-use crate::guard::*;
+use crate::macros::crud_endpoint;
 
-/// Create request for project
-#[derive(Clone, Debug)]
-struct ProjectCreateRequest {
-    project: ProjectCreate,
-}
-
-impl RestEndpoint for ProjectCreateRequest {
-    fn method(&self) -> http::Method {
-        http::Method::POST
+crud_endpoint! {
+    create {
+        request = ProjectCreateRequest,
+        func = create_project,
+        path = "projects",
+        body_key = "project",
+        create_type = ProjectCreate,
+        model = Project,
+        response_key = "project",
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        "projects".to_string().into()
+    show {
+        request = ProjectShowRequest,
+        func = get_project,
+        path = "projects",
+        model = Project,
+        response_key = "project",
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-        params.push("project", serde_json::to_value(&self.project)?);
-        params.into_body()
+    update {
+        request = ProjectUpdateRequest,
+        func = update_project,
+        path = "projects",
+        body_key = "project",
+        update_type = ProjectUpdate,
+        model = Project,
+        response_key = "project",
+        service = Identity,
+        api_version = (3, 0),
     }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
+    list {
+        request = ProjectListRequest,
+        func = list_projects,
+        path = "projects",
+        model = ProjectShort,
+        response_key = "projects",
+        service = Identity,
+        api_version = (3, 0),
+        query = [domain_id, ids, name],
     }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("project".into())
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Create project (original API for AsyncOpenStack)
-pub async fn create_project(
-    tc: &Arc<AsyncOpenStack>,
-    project: ProjectCreate,
-) -> Result<AsyncResourceGuard<Project>> {
-    let obj: Project = ProjectCreateRequest { project }
-        .query_async(tc.as_ref())
-        .await?;
-    Ok(AsyncResourceGuard::new(obj, tc.clone()))
-}
-
-/// Create request for a project show
-struct ProjectShowRequest {
-    id: String,
-}
-
-impl RestEndpoint for ProjectShowRequest {
-    fn method(&self) -> http::Method {
-        http::Method::GET
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        format!("projects/{id}", id = self.id).into()
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("project".into())
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Get a single project by ID
-pub async fn get_project(tc: &Arc<AsyncOpenStack>, id: impl Into<String>) -> Result<Project> {
-    Ok(ProjectShowRequest { id: id.into() }
-        .query_async(tc.as_ref())
-        .await?)
-}
-
-/// Update request for project
-#[derive(Clone, Debug)]
-struct ProjectUpdateRequest {
-    id: String,
-    project: ProjectUpdate,
-}
-
-impl RestEndpoint for ProjectUpdateRequest {
-    fn method(&self) -> http::Method {
-        http::Method::PATCH
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        format!("projects/{id}", id = self.id).into()
-    }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-        params.push("project", serde_json::to_value(&self.project)?);
-        params.into_body()
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("project".into())
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Update a project
-pub async fn update_project(
-    tc: &Arc<AsyncOpenStack>,
-    id: impl Into<String>,
-    project: ProjectUpdate,
-) -> Result<Project> {
-    Ok(ProjectUpdateRequest {
-        id: id.into(),
-        project,
-    }
-    .query_async(tc.as_ref())
-    .await?)
-}
-
-/// List request for projects
-#[derive(Default)]
-pub struct ProjectListRequest {
-    /// Filter projects by domain ID.
-    pub domain_id: Option<String>,
-
-    /// Filter projects by the `id` attribute.
-    pub ids: Option<String>,
-
-    /// Filter projects by name.
-    pub name: Option<String>,
-}
-
-impl RestEndpoint for ProjectListRequest {
-    fn method(&self) -> http::Method {
-        http::Method::GET
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        "projects".to_string().into()
-    }
-
-    fn parameters(&self) -> QueryParams<'_> {
-        let mut params = QueryParams::default();
-        params.push_opt("domain_id", self.domain_id.as_ref());
-        params.push_opt("ids", self.ids.as_ref());
-        params.push_opt("name", self.name.as_ref());
-        params
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    fn response_key(&self) -> Option<Cow<'static, str>> {
-        Some("projects".into())
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// List projects
-pub async fn list_projects(
-    tc: &Arc<AsyncOpenStack>,
-    params: ProjectListRequest,
-) -> Result<Vec<ProjectShort>> {
-    Ok(params.query_async(tc.as_ref()).await?)
-}
-
-/// Delete request for project
-struct ProjectDeleteRequest {
-    id: String,
-}
-
-impl RestEndpoint for ProjectDeleteRequest {
-    fn method(&self) -> http::Method {
-        http::Method::DELETE
-    }
-
-    fn endpoint(&self) -> Cow<'static, str> {
-        format!("projects/{id}", id = self.id).into()
-    }
-
-    fn service_type(&self) -> ServiceType {
-        ServiceType::Identity
-    }
-
-    /// Returns required API version
-    fn api_version(&self) -> Option<ApiVersion> {
-        Some(ApiVersion::new(3, 0))
-    }
-}
-
-/// Delete a project
-pub async fn delete_project(tc: &Arc<AsyncOpenStack>, id: impl Into<String>) -> Result<()> {
-    Ok(
-        openstack_sdk::api::ignore(ProjectDeleteRequest { id: id.into() })
-            .query_async(tc.as_ref())
-            .await?,
-    )
-}
-#[async_trait::async_trait]
-impl DeletableResource for Project {
-    async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
-        Ok(openstack_sdk::api::ignore(ProjectDeleteRequest {
-            id: self.id.clone(),
-        })
-        .query_async(state.as_ref())
-        .await?)
+    delete {
+        request = ProjectDeleteRequest,
+        func = delete_project,
+        path = "projects",
+        model = Project,
+        service = Identity,
+        api_version = (3, 0),
     }
 }

--- a/tests/api/tests/api_v3/identity/group.rs
+++ b/tests/api/tests/api_v3/identity/group.rs
@@ -11,50 +11,420 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+//! v3 group CRUD authorization matrix (issue #992 vertical slice).
+//!
+//! Coverage matrix — every endpoint is exercised for the three mandated
+//! cases (valid auth + allowed policy / valid auth + denied policy /
+//! invalid auth):
+//!
+//! | endpoint          | 2xx admin                | 403 policy                                   | 401 invalid token |
+//! |-------------------|--------------------------|----------------------------------------------|-------------------|
+//! | POST   /v3/groups | `create_success_admin`   | `create_forbidden_for_project_scoped_manager`| `create_unauthorized` |
+//! | GET    /v3/groups/{id} | `show_success_admin`| `show_forbidden_for_project_scoped_manager`  | `show_unauthorized`   |
+//! | GET    /v3/groups | `list_success_admin`     | `list_forbidden_for_project_scoped_manager`  | `list_unauthorized`   |
+//! | PATCH  /v3/groups/{id} | `update_success_admin`| `update_forbidden_for_project_scoped_manager`| `update_unauthorized` |
+//! | DELETE /v3/groups/{id} | `delete_success_admin`| `delete_forbidden_for_project_scoped_manager`| `delete_unauthorized` |
+//!
+//! The 403 fixture is deliberate: the user *holds* the `manager` role
+//! (which implies `member` and `reader` via the bootstrap implication
+//! chain) but only on a **project** scope. `policy/identity/group/*.rego`
+//! requires the role together with a genuine **domain** scope
+//! (`domain_matches_domain_scope`), and `credentials.domain_id` is never
+//! populated from a project-scoped token (see `Credentials` in
+//! `crates/core/src/policy.rs`). A 403 here therefore proves the
+//! domain-scope gate itself, not mere role absence.
+//!
+//! The domain-scoped *success* path for `manager`/`reader` cannot be
+//! provisioned through the public API today: there is no
+//! `PUT /v3/domains/{domain_id}/users/{user_id}/roles/{role_id}` handler
+//! (only project and system grants exist), so no real user can obtain a
+//! domain-scoped token with those roles. Tracked as a coverage gap for
+//! Phase 2 (#993).
 
+use std::env;
 use std::sync::Arc;
 
-use eyre::Result;
-use tracing_test::traced_test;
+use eyre::{OptionExt, Result, WrapErr};
 use uuid::Uuid;
 
+use openstack_keystone_api_types::scope::{DomainBuilder, Scope, ScopeProjectBuilder};
+use openstack_keystone_api_types::v3::domain::DomainCreateBuilder;
 use openstack_keystone_api_types::v3::group::*;
-use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+use openstack_keystone_api_types::v3::project::{Project, ProjectCreateBuilder};
+use openstack_keystone_api_types::v3::user::{User, UserCreateBuilder};
+use openstack_sdk::AsyncOpenStack;
 
-use test_api::guard::ResourceGuard;
-use test_api::identity::group::{create_group, get_group, update_group};
+use test_api::asserts::{assert_forbidden, assert_status};
+use test_api::assignment::grant::add_project_grant;
+use test_api::common::get_user_session;
+use test_api::guard::{AsyncResourceGuard, ResourceGuard};
+use test_api::identity::group::*;
+use test_api::identity::user::create_user;
+use test_api::resource::domain::create_domain;
+use test_api::resource::get_system_scope_config;
+use test_api::resource::project::create_project;
+use test_api::role::list_roles;
 
-#[tokio::test]
-#[traced_test]
-async fn test_update() -> Result<()> {
-    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
-    let name = format!("grp_{}", Uuid::new_v4().simple());
-    let new_name = format!("{name}_updated");
+const FIXTURE_PASSWORD: &str = "group-fixture-password";
 
-    let guard = create_group(
-        &tc,
-        GroupCreateBuilder::default()
-            .name(&name)
-            .domain_id("default")
+/// System-scoped admin session for fixture management — the same
+/// convention as the v3 domain tests, which also create domains.
+async fn admin_session() -> Result<Arc<AsyncOpenStack>> {
+    Ok(Arc::new(
+        AsyncOpenStack::new(&get_system_scope_config()?).await?,
+    ))
+}
+
+/// A fresh, uniquely named domain owned by `admin`.
+async fn fresh_domain(
+    admin: &Arc<AsyncOpenStack>,
+) -> Result<AsyncResourceGuard<openstack_keystone_api_types::v3::domain::Domain>> {
+    create_domain(
+        admin,
+        DomainCreateBuilder::default()
+            .name(format!("grp-dom-{}", Uuid::new_v4().simple()))
+            .enabled(true)
             .build()?,
     )
+    .await
+}
+
+fn group_create(domain_id: &str) -> Result<GroupCreate> {
+    Ok(GroupCreateBuilder::default()
+        .name(format!("grp-{}", Uuid::new_v4().simple()))
+        .domain_id(domain_id)
+        .build()?)
+}
+
+/// A real user in `domain_id` holding the `manager` role (implies
+/// `member`/`reader`) on a project in the same domain, authenticated with
+/// a **project-scoped** token through the live password-auth path. All
+/// fixture resources are created by — and cleaned up with — the admin
+/// session, so cleanup never depends on the underprivileged session.
+struct ProjectScopedManager {
+    session: Arc<AsyncOpenStack>,
+    user: AsyncResourceGuard<User>,
+    project: AsyncResourceGuard<Project>,
+}
+
+impl ProjectScopedManager {
+    async fn provision(admin: &Arc<AsyncOpenStack>, domain_id: &str) -> Result<Self> {
+        let unique = Uuid::new_v4().simple().to_string();
+        let project = create_project(
+            admin,
+            ProjectCreateBuilder::default()
+                .name(format!("grp-proj-{unique}"))
+                .domain_id(domain_id)
+                .build()?,
+        )
+        .await?;
+        let user = create_user(
+            admin,
+            UserCreateBuilder::default()
+                .name(format!("grp-mgr-{unique}"))
+                .domain_id(domain_id)
+                .password(FIXTURE_PASSWORD)
+                .enabled(true)
+                .build()?,
+        )
+        .await?;
+        let manager_role = list_roles(admin)
+            .await?
+            .into_iter()
+            .find(|role| role.name == "manager")
+            .ok_or_eyre("bootstrap `manager` role must exist")?;
+        add_project_grant(admin, &project.id, &user.id, &manager_role.id).await?;
+
+        let scope = Scope::Project(
+            ScopeProjectBuilder::default()
+                .id(project.id.clone())
+                .domain(DomainBuilder::default().id(domain_id).build()?)
+                .build()?,
+        );
+        let session =
+            get_user_session(&user.name, FIXTURE_PASSWORD, domain_id, Some(&scope)).await?;
+        Ok(Self {
+            session,
+            user,
+            project,
+        })
+    }
+
+    async fn cleanup(self) -> Result<()> {
+        self.user.delete().await?;
+        self.project.delete().await?;
+        Ok(())
+    }
+}
+
+/// Raw request with an invalid token; returns the response status.
+async fn status_with_invalid_token(
+    method: http::Method,
+    path: &str,
+    body: Option<serde_json::Value>,
+) -> Result<reqwest::StatusCode> {
+    let base_url: url::Url = env::var("KEYSTONE_URL")
+        .wrap_err("KEYSTONE_URL must be set")?
+        .parse()?;
+    let mut request = reqwest::Client::new()
+        .request(method, base_url.join(path)?)
+        .header("x-auth-token", "invalid-token");
+    if let Some(body) = body {
+        request = request.json(&body);
+    }
+    Ok(request.send().await?.status())
+}
+
+// --- 2xx: valid auth + allowed policy (admin) --------------------------
+
+#[tokio::test]
+async fn test_group_create_success_admin() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+
+    let group = create_group(&admin, group_create(&domain.id)?).await?;
+    assert_eq!(group.domain_id, domain.id);
+    assert!(!group.id.is_empty(), "created group must have an id");
+
+    group.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_show_success_admin() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let group = create_group(&admin, group_create(&domain.id)?).await?;
+
+    let shown = get_group(&admin, &group.id).await?;
+    assert_eq!(shown.id, group.id);
+    assert_eq!(shown.name, group.name);
+    assert_eq!(shown.domain_id, domain.id);
+
+    group.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_list_success_admin() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let group = create_group(&admin, group_create(&domain.id)?).await?;
+
+    let by_domain = list_groups(
+        &admin,
+        GroupListRequest {
+            domain_id: Some(domain.id.clone()),
+            ..Default::default()
+        },
+    )
     .await?;
+    assert_eq!(by_domain.len(), 1, "fresh domain must contain one group");
+    assert_eq!(by_domain[0].id, group.id);
+
+    let by_name = list_groups(
+        &admin,
+        GroupListRequest {
+            name: Some(group.name.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    assert!(
+        by_name.iter().any(|found| found.id == group.id),
+        "name filter must find the created group"
+    );
+
+    group.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_update_success_admin() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let group = create_group(&admin, group_create(&domain.id)?).await?;
+    let new_name = format!("{}-updated", group.name);
 
     let updated = update_group(
-        &tc,
-        &guard.id,
+        &admin,
+        &group.id,
         GroupUpdateBuilder::default()
             .name(new_name.clone())
             .build()?,
     )
     .await?;
-
+    assert_eq!(updated.id, group.id);
     assert_eq!(updated.name, new_name);
-    assert_eq!(updated.id, guard.id);
 
-    let shown = get_group(&tc, &guard.id).await?;
-    assert_eq!(shown.name, new_name);
+    let shown = get_group(&admin, &group.id).await?;
+    assert_eq!(shown.name, new_name, "update must persist");
 
-    guard.delete().await?;
+    group.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_delete_success_admin() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let group = create_group(&admin, group_create(&domain.id)?).await?;
+    let group_id = group.id.clone();
+
+    group.delete().await?;
+    assert_status(
+        get_group(&admin, &group_id).await,
+        http::StatusCode::NOT_FOUND,
+        "deleted group must be gone",
+    );
+
+    domain.delete().await?;
+    Ok(())
+}
+
+// --- 403: valid auth + denied policy (project-scoped manager) ----------
+
+#[tokio::test]
+async fn test_group_create_forbidden_for_project_scoped_manager() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let manager = ProjectScopedManager::provision(&admin, &domain.id).await?;
+
+    assert_forbidden(
+        create_group(&manager.session, group_create(&domain.id)?).await,
+        "manager role without domain scope must not create groups",
+    );
+
+    manager.cleanup().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_show_forbidden_for_project_scoped_manager() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let group = create_group(&admin, group_create(&domain.id)?).await?;
+    let manager = ProjectScopedManager::provision(&admin, &domain.id).await?;
+
+    assert_forbidden(
+        get_group(&manager.session, &group.id).await,
+        "reader role without domain scope must not show groups",
+    );
+
+    manager.cleanup().await?;
+    group.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_list_forbidden_for_project_scoped_manager() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let manager = ProjectScopedManager::provision(&admin, &domain.id).await?;
+
+    assert_forbidden(
+        list_groups(&manager.session, GroupListRequest::default()).await,
+        "reader role without domain scope must not list groups",
+    );
+
+    manager.cleanup().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_update_forbidden_for_project_scoped_manager() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let group = create_group(&admin, group_create(&domain.id)?).await?;
+    let manager = ProjectScopedManager::provision(&admin, &domain.id).await?;
+
+    assert_forbidden(
+        update_group(
+            &manager.session,
+            &group.id,
+            GroupUpdateBuilder::default().name("renamed").build()?,
+        )
+        .await,
+        "manager role without domain scope must not update groups",
+    );
+
+    manager.cleanup().await?;
+    group.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_delete_forbidden_for_project_scoped_manager() -> Result<()> {
+    let admin = admin_session().await?;
+    let domain = fresh_domain(&admin).await?;
+    let group = create_group(&admin, group_create(&domain.id)?).await?;
+    let manager = ProjectScopedManager::provision(&admin, &domain.id).await?;
+
+    assert_forbidden(
+        delete_group(&manager.session, &group.id).await,
+        "manager role without domain scope must not delete groups",
+    );
+
+    manager.cleanup().await?;
+    // The group must have survived the forbidden delete; admin cleans up.
+    group.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+// --- 401: invalid authentication ----------------------------------------
+
+#[tokio::test]
+async fn test_group_create_unauthorized() -> Result<()> {
+    let status = status_with_invalid_token(
+        http::Method::POST,
+        "v3/groups",
+        Some(serde_json::json!({"group": {"name": "x", "domain_id": "default"}})),
+    )
+    .await?;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_show_unauthorized() -> Result<()> {
+    let status =
+        status_with_invalid_token(http::Method::GET, "v3/groups/some-group-id", None).await?;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_list_unauthorized() -> Result<()> {
+    let status = status_with_invalid_token(http::Method::GET, "v3/groups", None).await?;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_update_unauthorized() -> Result<()> {
+    let status = status_with_invalid_token(
+        http::Method::PATCH,
+        "v3/groups/some-group-id",
+        Some(serde_json::json!({"group": {"name": "x"}})),
+    )
+    .await?;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_group_delete_unauthorized() -> Result<()> {
+    let status =
+        status_with_invalid_token(http::Method::DELETE, "v3/groups/some-group-id", None).await?;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implements Phase 1 of #991 — closes #992. All five deliverables, plus the
recommended vertical slice (v3 groups) to validate the ergonomics:

- **Scope/config helpers** (`tests/api/src/common.rs`):
  `get_domain_scope_config` / `get_project_scope_config` / `config_for_user`
  as pure, composable `CloudConfig` builders deriving credentials from the
  `OS_*` environment (no hard-coded `admin`/`default`), plus async session
  wrappers (`get_domain_scope_session`, `get_user_session`, ...).
- **Negative-assertion helpers** (`tests/api/src/asserts.rs`): a single
  `status_from_error(&eyre::Report)` extracts the HTTP status from the
  `openstack_sdk` error chain (non-exhaustive fallback → `None`);
  `assert_status` / `assert_forbidden` / `assert_unauthorized` report the
  expected status, extracted status, and full error chain on failure.
- **`crud_endpoint!` macro** (`tests/api/src/macros.rs`): crate-private,
  fully explicit names (no identifier concatenation, no `paste`),
  selectable create/show/update/list/delete operations. `project.rs`
  (249→70 lines), `user.rs` (180→50) and the new `group.rs` are generated;
  public wrapper signatures unchanged.
- **`AsyncResourceGuard` leak handling** (`tests/api/src/guard.rs`):
  explicit `.delete().await?` is the documented cleanup contract; `Drop` is
  leak *detection* — non-panicking diagnostics on both normal and
  panic-path drops, naming the leaked resource type. Removes the `expect()`.
- **`TestClient` dedupe**: `auth()`/`rescope()` now share one private
  `authenticate()` (~50 duplicated lines removed).
- **v3 groups vertical slice**: groups previously had zero API tests. Adds
  a full 5×3 matrix — create/show/update/list/delete × {admin success,
  policy denial, invalid token}. The 403 fixture is a live-API-provisioned
  user holding `manager` (→`member`/`reader`) on a project in the group's
  own domain with a project-scoped token, so denials prove the
  `domain_matches_domain_scope` gate itself rather than role absence.
  Rebased over #1076: the group/project `update` helpers it introduced are
  now macro-generated with identical public APIs, and its update round-trip
  test is folded into the matrix.

Documented in `tests/api/README.md` (helper usage + the mandated
≥3-tests-per-handler pattern, with groups as the reference example).

**Known coverage gap (deferred to #993):** the domain-scoped
`manager`/`reader` *success* path cannot be provisioned via the public API —
there is no `PUT /v3/domains/{domain_id}/users/{user_id}/roles/{role_id}`
handler (only project and system grants), so no real user can obtain a
domain-scoped token carrying those roles.

### Metrics (before → after)

| Metric | Before | After |
|---|---|---|
| API test functions (source-level) | 175 | 193 |
| Structured status assertions in tests | 0 | 7 |
| v3 group handlers covered | 0/5 | 5/5 (full auth matrix) |
| `project.rs` / `user.rs` helper LOC | 249 / 180 | 70 / 50 |
| Hand-written `RestEndpoint` impls | 66 | 55 |
| Lines for a negative policy test | — | ~5 (goal: <10) |

## Test plan

- `cargo test -p test_api --lib` — 22/22 (assert-helper unit tests incl.
  every SDK error shape; macro expansion tests for each op combination;
  pure config-constructor tests, no env mutation)
- `cargo nextest run -p test_api --profile api --test integration_api_v3
  --test integration_api_v4` — **125/125 passed** (live keystone + SPIRE +
  OPA; includes all 15 group-matrix tests and the #1076 update tests
  running against the macro-generated helpers)
- `cargo nextest run -p test_api --profile api --test scim_v2` — 63/63
- `cargo clippy -p test_api --all-targets` clean;
  `pre-commit run --all-files` and `committed` pass on all commits

Test-only change (`tests/api` + its README); no production, policy, or CI
configuration touched.