### PR TITLE
feat(catalog): Expose /v3/regions REST API

### DIFF
--- a/crates/api-types/src/v3.rs
+++ b/crates/api-types/src/v3.rs
@@ -20,6 +20,7 @@ pub mod endpoint;
 pub mod group;
 pub mod os_ec2_credential;
 pub mod project;
+pub mod region;
 pub mod role;
 pub mod role_assignment;
 pub mod service;
@@ -37,6 +38,8 @@ mod endpoint_conv;
 mod group_conv;
 #[cfg(feature = "conv")]
 mod project_conv;
+#[cfg(feature = "conv")]
+mod region_conv;
 #[cfg(feature = "conv")]
 mod role_assignment_conv;
 #[cfg(feature = "conv")]

--- a/crates/api-types/src/v3/region.rs
+++ b/crates/api-types/src/v3/region.rs
@@ -1,0 +1,160 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+#[cfg(feature = "validate")]
+use validator::Validate;
+
+/// The region data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct Region {
+    /// Region ID.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub id: String,
+    /// The region description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub description: Option<String>,
+    /// The ID of the parent region.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub parent_region_id: Option<String>,
+
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RegionResponse {
+    /// Region object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub region: Region,
+}
+
+/// Regions.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RegionList {
+    /// Collection of region objects.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub regions: Vec<Region>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RegionListParameters {
+    /// Filters the response by a parent region ID.
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub parent_region_id: Option<String>,
+}
+
+/// Region create request body.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RegionCreate {
+    /// The ID of the region. A UUID is generated when omitted.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub id: Option<String>,
+
+    /// The region description.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub description: Option<String>,
+
+    /// The ID of the parent region.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub parent_region_id: Option<String>,
+
+    /// Extra attributes for the region.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// New region creation request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RegionCreateRequest {
+    /// Region object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub region: RegionCreate,
+}
+
+/// Update region data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RegionUpdate {
+    /// New region description.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub description: Option<String>,
+
+    /// New parent region ID.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(max = 255)))]
+    pub parent_region_id: Option<String>,
+
+    /// Extra attributes for the region (replaces the existing extra).
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Region update request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RegionUpdateRequest {
+    /// Region object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub region: RegionUpdate,
+}

--- a/crates/api-types/src/v3/region_conv.rs
+++ b/crates/api-types/src/v3/region_conv.rs
@@ -1,0 +1,57 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use openstack_keystone_core_types::catalog as provider_types;
+
+use crate::v3::region as api_types;
+
+impl From<provider_types::Region> for api_types::Region {
+    fn from(value: provider_types::Region) -> Self {
+        Self {
+            id: value.id,
+            description: value.description,
+            parent_region_id: value.parent_region_id,
+            extra: value.extra,
+        }
+    }
+}
+
+impl From<api_types::RegionListParameters> for provider_types::RegionListParameters {
+    fn from(value: api_types::RegionListParameters) -> Self {
+        Self {
+            parent_region_id: value.parent_region_id,
+        }
+    }
+}
+
+impl From<api_types::RegionCreateRequest> for provider_types::RegionCreate {
+    fn from(value: api_types::RegionCreateRequest) -> Self {
+        Self {
+            id: value.region.id,
+            description: value.region.description,
+            parent_region_id: value.region.parent_region_id,
+            extra: value.region.extra,
+        }
+    }
+}
+
+impl From<api_types::RegionUpdateRequest> for provider_types::RegionUpdate {
+    fn from(value: api_types::RegionUpdateRequest) -> Self {
+        Self {
+            description: value.region.description,
+            parent_region_id: value.region.parent_region_id,
+            extra: value.region.extra,
+        }
+    }
+}

--- a/crates/core-types/src/catalog/region.rs
+++ b/crates/core-types/src/catalog/region.rs
@@ -15,12 +15,13 @@
 use std::collections::HashMap;
 
 use derive_builder::Builder;
+use serde::Serialize;
 use serde_json::Value;
 use validator::Validate;
 
 use crate::error::BuilderError;
 
-#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[derive(Builder, Clone, Debug, Default, PartialEq, Serialize, Validate)]
 #[builder(build_fn(error = "BuilderError"))]
 #[builder(setter(strip_option, into))]
 pub struct Region {

--- a/crates/keystone/src/api/v3/mod.rs
+++ b/crates/keystone/src/api/v3/mod.rs
@@ -33,6 +33,7 @@ pub mod ec2tokens;
 pub mod endpoint;
 pub mod group;
 pub mod project;
+pub mod region;
 pub mod role;
 pub mod role_assignment;
 pub mod role_inferences;
@@ -59,6 +60,7 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
         .nest("/endpoints", endpoint::openapi_router())
         .nest("/groups", group::openapi_router())
         .nest("/projects", project::openapi_router())
+        .nest("/regions", region::openapi_router())
         .nest("/roles", role::openapi_router())
         .nest("/role_inferences", role_inferences::openapi_router())
         .nest("/services", service::openapi_router())

--- a/crates/keystone/src/api/v3/region/create.rs
+++ b/crates/keystone/src/api/v3/region/create.rs
@@ -1,0 +1,224 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Create region API
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{RegionCreateRequest, RegionResponse};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Create a new Region.
+#[utoipa::path(
+    post,
+    path = "/",
+    responses(
+        (status = CREATED, description = "Region created", body = RegionResponse),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal error")
+    ),
+    tag="regions"
+)]
+#[tracing::instrument(name = "api::v3::region_create", level = "debug", skip(state))]
+pub(super) async fn create(
+    Auth(user_auth): Auth,
+    State(state): State<ServiceState>,
+    Json(payload): Json<RegionCreateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    // Validate the request
+    payload.validate()?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/region/create",
+            &user_auth,
+            json!({"region": payload.region}),
+            None,
+        )
+        .await?;
+    // Create the region
+    let created_region = state
+        .provider
+        .get_catalog_provider()
+        .create_region(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            payload.into(),
+        )
+        .await?;
+
+    // Return response with 201 Created status
+    Ok((
+        StatusCode::CREATED,
+        Json(RegionResponse {
+            region: created_region.into(),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt; // for `collect`
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::{RegionBuilder, RegionCreate};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::region::types::{Region as ApiRegion, RegionResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_create() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_create_region()
+            .withf(|_, region_create: &RegionCreate| region_create.id.is_none())
+            .returning(|_, _| {
+                Ok(RegionBuilder::default()
+                    .id("new_region_id")
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let req = crate::api::v3::region::types::RegionCreateRequest {
+            region: crate::api::v3::region::types::RegionCreateBuilder::default()
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RegionResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiRegion {
+                id: "new_region_id".into(),
+                description: None,
+                parent_region_id: None,
+                extra: std::collections::HashMap::new(),
+            },
+            res.region,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_forbidden() {
+        let catalog_mock = MockCatalogProvider::default();
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionCreateRequest {
+            region: crate::api::v3::region::types::RegionCreateBuilder::default()
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_create_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionCreateRequest {
+            region: crate::api::v3::region::types::RegionCreateBuilder::default()
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/region/delete.rs
+++ b/crates/keystone/src/api/v3/region/delete.rs
@@ -1,0 +1,230 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Delete region API.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Delete a region.
+#[utoipa::path(
+    delete,
+    path = "/{region_id}",
+    description = "Delete region by ID",
+    params(),
+    responses(
+        (status = NO_CONTENT, description = "Region deleted"),
+        (status = 404, description = "Region not found", example = json!(KeystoneApiError::NotFound{resource: "region".into(), identifier: "id = 1".into()}))
+    ),
+    tag="regions"
+)]
+#[tracing::instrument(name = "api::region_delete", level = "debug", skip(state))]
+pub(super) async fn delete(
+    Auth(user_auth): Auth,
+    Path(region_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_region(&ExecutionContext::from_auth(&state, &user_auth), &region_id)
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/region/delete",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(json!({"region": current})),
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            state
+                .provider
+                .get_catalog_provider()
+                .delete_region(&ExecutionContext::from_auth(&state, &user_auth), &region_id)
+                .await?;
+
+            Ok(StatusCode::NO_CONTENT.into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "region".into(),
+            identifier: region_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::RegionBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_delete_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(Some(RegionBuilder::default().id("foo").build().unwrap())));
+        catalog_mock
+            .expect_delete_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(()));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_delete_forbidden() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(Some(RegionBuilder::default().id("foo").build().unwrap())));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_delete_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/region/list.rs
+++ b/crates/keystone/src/api/v3/region/list.rs
@@ -1,0 +1,194 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use super::types::{Region, RegionList, RegionListParameters};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// List regions
+#[utoipa::path(
+    get,
+    path = "/",
+    params(RegionListParameters),
+    description = "List regions",
+    responses(
+        (status = OK, description = "List of regions", body = RegionList),
+        (status = 500, description = "Internal error", example = json!(KeystoneApiError::InternalError(String::from("id = 1"))))
+    ),
+    tag="regions"
+)]
+#[tracing::instrument(name = "api::region_list", level = "debug", skip(state))]
+pub(super) async fn list(
+    Auth(user_auth): Auth,
+    Query(query): Query<RegionListParameters>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/region/list",
+            &user_auth,
+            json!({"region": query}),
+            None,
+        )
+        .await?;
+    let regions: Vec<Region> = state
+        .provider
+        .get_catalog_provider()
+        .list_regions(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    Ok((StatusCode::OK, Json(RegionList { regions })).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt; // for `collect`
+
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::{RegionBuilder, RegionListParameters};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::region::types::{Region as ApiRegion, RegionList};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_list() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_regions()
+            .withf(|_, _: &RegionListParameters| true)
+            .returning(|_, _| Ok(vec![RegionBuilder::default().id("1").build().unwrap()]));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RegionList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            vec![ApiRegion {
+                id: "1".into(),
+                description: None,
+                parent_region_id: None,
+                extra: std::collections::HashMap::new(),
+            }],
+            res.regions
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_qp() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_regions()
+            .withf(|_, qp: &RegionListParameters| {
+                RegionListParameters {
+                    parent_region_id: Some("parent".into()),
+                } == *qp
+            })
+            .returning(|_, _| Ok(Vec::new()));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?parent_region_id=parent")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let _res: RegionList = serde_json::from_slice(&body).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_unauth() {
+        let state = get_mocked_state(Provider::mocked_builder(), false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/region/mod.rs
+++ b/crates/keystone/src/api/v3/region/mod.rs
@@ -11,19 +11,22 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Keystone API v3 functional tests.
-//!
-//! This suite can be executed against python Keystone to verify API
-//! compatibility.
+//! # Region API
 
-mod api_v3 {
-    mod assignment;
-    mod auth;
-    mod credential;
-    mod endpoint;
-    mod identity;
-    mod region;
-    mod resource;
-    mod role;
-    mod service;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::keystone::ServiceState;
+
+mod create;
+mod delete;
+mod list;
+mod show;
+pub mod types;
+mod update;
+
+pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new()
+        .routes(routes!(list::list, create::create))
+        .routes(routes!(show::show, delete::delete))
+        .routes(routes!(update::update))
 }

--- a/crates/keystone/src/api/v3/region/show.rs
+++ b/crates/keystone/src/api/v3/region/show.rs
@@ -1,0 +1,195 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use openstack_keystone_api_types::v3::region::{Region, RegionResponse};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Get single region
+#[utoipa::path(
+    get,
+    path = "/{region_id}",
+    description = "Get region by ID",
+    params(),
+    responses(
+        (status = OK, description = "Region object", body = RegionResponse),
+        (status = 404, description = "Region not found", example = json!(KeystoneApiError::NotFound{resource: "region".into(), identifier: "id = 1".into()}))
+    ),
+    tag="regions"
+)]
+#[tracing::instrument(name = "api::region_get", level = "debug", skip(state))]
+pub(super) async fn show(
+    Auth(user_auth): Auth,
+    Path(region_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_region(&ExecutionContext::from_auth(&state, &user_auth), &region_id)
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/region/show",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(json!({"region": current})),
+        )
+        .await?;
+
+    match current {
+        Some(current) => Ok((
+            StatusCode::OK,
+            Json(RegionResponse {
+                region: Region::from(current),
+            }),
+        )
+            .into_response()),
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "region".into(),
+            identifier: region_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::RegionBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::region::types::{Region as ApiRegion, RegionResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_show_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(Some(RegionBuilder::default().id("foo").build().unwrap())));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RegionResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiRegion {
+                id: "foo".into(),
+                description: None,
+                parent_region_id: None,
+                extra: std::collections::HashMap::new(),
+            },
+            res.region,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_show_not_found_not_allowed() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_show_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(Request::builder().uri("/foo").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/region/types.rs
+++ b/crates/keystone/src/api/v3/region/types.rs
@@ -11,19 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Keystone API v3 functional tests.
-//!
-//! This suite can be executed against python Keystone to verify API
-//! compatibility.
 
-mod api_v3 {
-    mod assignment;
-    mod auth;
-    mod credential;
-    mod endpoint;
-    mod identity;
-    mod region;
-    mod resource;
-    mod role;
-    mod service;
-}
+pub use openstack_keystone_api_types::v3::region::*;

--- a/crates/keystone/src/api/v3/region/update.rs
+++ b/crates/keystone/src/api/v3/region/update.rs
@@ -1,0 +1,324 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{Region, RegionResponse, RegionUpdateRequest};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Update existing region
+#[utoipa::path(
+    patch,
+    path = "/{region_id}",
+    description = "Update region by ID",
+    params(),
+    responses(
+        (status = OK, description = "Updated region", body = RegionResponse),
+        (status = 404, description = "Region not found", example = json!(KeystoneApiError::NotFound{resource: "region".into(), identifier: "id = 1".into()}))
+    ),
+    tag="regions"
+)]
+#[tracing::instrument(name = "api::update_region", level = "debug", skip(state))]
+pub(super) async fn update(
+    Auth(user_auth): Auth,
+    Path(region_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(req): Json<RegionUpdateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    // Validate the request
+    req.validate()?;
+
+    // Fetch the current region to pass it as existing object into the
+    // policy evaluation
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_region(&ExecutionContext::from_auth(&state, &user_auth), &region_id)
+        .await?;
+
+    let existing_region = current.as_ref().map(|c| json!({"region": c}));
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/region/update",
+            &user_auth,
+            json!({"region": req.region}),
+            existing_region,
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            let region = state
+                .provider
+                .get_catalog_provider()
+                .update_region(
+                    &ExecutionContext::from_auth(&state, &user_auth),
+                    &region_id,
+                    req.into(),
+                )
+                .await?;
+            Ok((
+                StatusCode::OK,
+                Json(RegionResponse {
+                    region: Region::from(region),
+                }),
+            )
+                .into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "region".into(),
+            identifier: region_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::catalog::RegionBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::region::types::{Region as ApiRegion, RegionResponse};
+    use crate::catalog::MockCatalogProvider;
+    use crate::provider::Provider;
+
+    #[tokio::test]
+    async fn test_update_success() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(Some(RegionBuilder::default().id("foo").build().unwrap())));
+        catalog_mock
+            .expect_update_region()
+            .withf(|_, id: &'_ str, _| id == "foo")
+            .returning(|_, _, _| {
+                Ok(RegionBuilder::default()
+                    .id("foo")
+                    .description("updated")
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionUpdateRequest {
+            region: crate::api::v3::region::types::RegionUpdateBuilder::default()
+                .description("updated")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RegionResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiRegion {
+                id: "foo".into(),
+                description: Some("updated".into()),
+                parent_region_id: None,
+                extra: std::collections::HashMap::new(),
+            },
+            res.region,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionUpdateRequest {
+            region: crate::api::v3::region::types::RegionUpdateBuilder::default()
+                .description("updated")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_forbidden() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(Some(RegionBuilder::default().id("foo").build().unwrap())));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionUpdateRequest {
+            region: crate::api::v3::region::types::RegionUpdateBuilder::default()
+                .description("updated")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_update_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionUpdateRequest {
+            region: crate::api::v3::region::types::RegionUpdateBuilder::default()
+                .description("updated")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/foo")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_put() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/foo")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"region":{"description":"updated"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/policy/region/create.rego
+++ b/policy/region/create.rego
@@ -1,0 +1,27 @@
+# METADATA
+# title: Create region
+# description: Policy for creating a catalog region
+package identity.region.create
+
+import data.identity
+
+# Create region.
+#
+# The `input.target.region` is the new region object (RegionCreate):
+#   id:                 string (optional)  The region ID.
+#   description:        string (optional)  The region description.
+#   parent_region_id:   string (optional)  The ID of the parent region.
+#
+# The `input.existing` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/region/create_test.rego
+++ b/policy/region/create_test.rego
@@ -1,0 +1,14 @@
+package test_region_create
+
+import data.identity.region.create
+
+test_allowed if {
+	create.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"region": {}}}
+	create.allow with input as {"credentials": {"is_admin": true}, "target": {"region": {}}}
+}
+
+test_forbidden if {
+	not create.allow with input as {"credentials": {"roles": []}}
+	not create.allow with input as {"credentials": {"roles": ["reader"]}, "target": {"region": {}}}
+	not create.allow with input as {"credentials": {"roles": ["manager"]}, "target": {"region": {}}}
+}

--- a/policy/region/delete.rego
+++ b/policy/region/delete.rego
@@ -1,0 +1,27 @@
+# METADATA
+# title: Delete region
+# description: Policy for deleting a catalog region
+package identity.region.delete
+
+import data.identity
+
+# Delete region.
+#
+# The `input.existing.region` is the stored region object (Region):
+#   id:                 string             Region ID.
+#   description:        string (optional)  The region description.
+#   parent_region_id:   string (optional)  The ID of the parent region.
+#
+# The `input.target` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/region/delete_test.rego
+++ b/policy/region/delete_test.rego
@@ -1,0 +1,14 @@
+package test_region_delete
+
+import data.identity.region.delete
+
+test_allowed if {
+	delete.allow with input as {"credentials": {"roles": ["admin"]}}
+	delete.allow with input as {"credentials": {"is_admin": true}}
+}
+
+test_forbidden if {
+	not delete.allow with input as {"credentials": {"roles": []}}
+	not delete.allow with input as {"credentials": {"roles": ["reader"]}}
+	not delete.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/region/list.rego
+++ b/policy/region/list.rego
@@ -1,0 +1,33 @@
+# METADATA
+# title: List regions
+# description: Policy for listing catalog regions
+package identity.region.list
+
+import data.identity
+
+# List regions.
+#
+# The `input.target.region` contains query parameters (RegionListParameters):
+#   parent_region_id:  string (optional)  Filters the response by a parent region ID.
+#
+# The `input.existing` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+# METADATA
+# description: "'reader' in the system scope can list any regions."
+allow if {
+	"reader" in input.credentials.roles
+	input.credentials.system_scope != null
+	"all" == input.credentials.system_scope
+}

--- a/policy/region/list_test.rego
+++ b/policy/region/list_test.rego
@@ -1,0 +1,16 @@
+package test_region_list
+
+import data.identity.region.list
+
+test_allowed if {
+	list.allow with input as {"credentials": {"roles": ["admin"]}}
+	list.allow with input as {"credentials": {"is_admin": true}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+}
+
+test_forbidden if {
+	not list.allow with input as {"credentials": {"roles": []}}
+	not list.allow with input as {"credentials": {"roles": ["reader"]}}
+	not list.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not list.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/region/show.rego
+++ b/policy/region/show.rego
@@ -1,0 +1,35 @@
+# METADATA
+# title: Show region
+# description: Policy for fetching a single catalog region
+package identity.region.show
+
+import data.identity
+
+# Show region.
+#
+# The `input.existing.region` is the stored region object (Region):
+#   id:                 string             Region ID.
+#   description:        string (optional)  The region description.
+#   parent_region_id:   string (optional)  The ID of the parent region.
+#
+# The `input.target` is null
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+# METADATA
+# description: "'reader' in the system scope can show any region."
+allow if {
+	"reader" in input.credentials.roles
+	input.credentials.system_scope != null
+	"all" == input.credentials.system_scope
+}

--- a/policy/region/show_test.rego
+++ b/policy/region/show_test.rego
@@ -1,0 +1,16 @@
+package test_region_show
+
+import data.identity.region.show
+
+test_allowed if {
+	show.allow with input as {"credentials": {"roles": ["admin"]}}
+	show.allow with input as {"credentials": {"is_admin": true}}
+	show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "all"}}
+}
+
+test_forbidden if {
+	not show.allow with input as {"credentials": {"roles": []}}
+	not show.allow with input as {"credentials": {"roles": ["reader"]}}
+	not show.allow with input as {"credentials": {"roles": ["reader"], "system_scope": "domain"}}
+	not show.allow with input as {"credentials": {"roles": ["manager"]}}
+}

--- a/policy/region/update.rego
+++ b/policy/region/update.rego
@@ -1,0 +1,27 @@
+# METADATA
+# title: Update region
+# description: Policy for updating a catalog region
+package identity.region.update
+
+import data.identity
+
+# Update region.
+#
+# The `input.target.region` contains the fields to change (RegionUpdate):
+#   description:        string (optional)  New region description.
+#   parent_region_id:   string (optional)  New parent region ID.
+#
+# The `input.existing.region` is the stored region object (Region), or
+# null if it does not exist.
+#
+default allow := false
+
+# METADATA
+# description: "`Admin` is allowed by default"
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}

--- a/policy/region/update_test.rego
+++ b/policy/region/update_test.rego
@@ -1,0 +1,14 @@
+package test_region_update
+
+import data.identity.region.update
+
+test_allowed if {
+	update.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"region": {"description": "updated"}}}
+	update.allow with input as {"credentials": {"is_admin": true}, "target": {"region": {"description": "updated"}}}
+}
+
+test_forbidden if {
+	not update.allow with input as {"credentials": {"roles": []}}
+	not update.allow with input as {"credentials": {"roles": ["reader"]}, "target": {"region": {"description": "updated"}}}
+	not update.allow with input as {"credentials": {"roles": ["manager"]}, "target": {"region": {"description": "updated"}}}
+}

--- a/tests/api/src/lib.rs
+++ b/tests/api/src/lib.rs
@@ -22,6 +22,7 @@ pub mod guard;
 pub mod identity;
 pub mod mapping;
 pub mod oauth2;
+pub mod region;
 pub mod resource;
 pub mod role;
 pub mod scim;

--- a/tests/api/src/region.rs
+++ b/tests/api/src/region.rs
@@ -1,0 +1,225 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone_api_types::v3::region::*;
+use openstack_sdk::api::rest_endpoint_prelude::*;
+use openstack_sdk::{AsyncOpenStack, api::QueryAsync};
+
+use crate::guard::*;
+
+#[derive(Clone, Debug)]
+struct RegionCreateRequestInternal {
+    region: RegionCreate,
+}
+
+impl RestEndpoint for RegionCreateRequestInternal {
+    fn method(&self) -> http::Method {
+        http::Method::POST
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "regions".to_string().into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("region", serde_json::to_value(&self.region)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("region".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RegionShowRequest<'a> {
+    id: Cow<'a, str>,
+}
+
+impl RestEndpoint for RegionShowRequest<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("regions/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("region".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+struct RegionListRequest {}
+
+impl RestEndpoint for RegionListRequest {
+    fn method(&self) -> http::Method {
+        http::Method::GET
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        "regions".into()
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("regions".into())
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RegionUpdateRequestInternal<'a> {
+    id: Cow<'a, str>,
+    region: RegionUpdate,
+}
+
+impl RestEndpoint for RegionUpdateRequestInternal<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::PATCH
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("regions/{id}", id = self.id).into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        let mut params = JsonBodyParams::default();
+        params.push("region", serde_json::to_value(&self.region)?);
+        params.into_body()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn response_key(&self) -> Option<Cow<'static, str>> {
+        Some("region".into())
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+struct RegionDeleteRequest<'a> {
+    id: Cow<'a, str>,
+}
+
+impl RestEndpoint for RegionDeleteRequest<'_> {
+    fn method(&self) -> http::Method {
+        http::Method::DELETE
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        format!("regions/{id}", id = self.id).into()
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+/// Create a region.
+pub async fn create_region(
+    tc: &Arc<AsyncOpenStack>,
+    region: RegionCreate,
+) -> Result<AsyncResourceGuard<Region>> {
+    let obj: Region = RegionCreateRequestInternal { region }
+        .query_async(tc.as_ref())
+        .await?;
+    Ok(AsyncResourceGuard::new(obj, tc.clone()))
+}
+
+/// Get a region by ID.
+pub async fn show_region<I: AsRef<str>>(tc: &Arc<AsyncOpenStack>, id: I) -> Result<Region> {
+    Ok(RegionShowRequest {
+        id: id.as_ref().into(),
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+/// List regions.
+pub async fn list_regions(tc: &Arc<AsyncOpenStack>) -> Result<Vec<Region>> {
+    Ok(RegionListRequest::default()
+        .query_async(tc.as_ref())
+        .await?)
+}
+
+/// Update a region.
+pub async fn update_region<I: AsRef<str>>(
+    tc: &Arc<AsyncOpenStack>,
+    id: I,
+    region: RegionUpdate,
+) -> Result<Region> {
+    Ok(RegionUpdateRequestInternal {
+        id: id.as_ref().into(),
+        region,
+    }
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+/// Delete a region.
+pub async fn delete_region<I: AsRef<str>>(tc: &Arc<AsyncOpenStack>, id: I) -> Result<()> {
+    Ok(openstack_sdk::api::ignore(RegionDeleteRequest {
+        id: id.as_ref().into(),
+    })
+    .query_async(tc.as_ref())
+    .await?)
+}
+
+#[async_trait::async_trait]
+impl DeletableResource for Region {
+    async fn delete(&self, state: &Arc<AsyncOpenStack>) -> Result<()> {
+        Ok(openstack_sdk::api::ignore(RegionDeleteRequest {
+            id: self.id.clone().into(),
+        })
+        .query_async(state.as_ref())
+        .await?)
+    }
+}

--- a/tests/api/tests/api_v3/region.rs
+++ b/tests/api/tests/api_v3/region.rs
@@ -11,19 +11,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Keystone API v3 functional tests.
-//!
-//! This suite can be executed against python Keystone to verify API
-//! compatibility.
-
-mod api_v3 {
-    mod assignment;
-    mod auth;
-    mod credential;
-    mod endpoint;
-    mod identity;
-    mod region;
-    mod resource;
-    mod role;
-    mod service;
-}
+mod create;
+mod delete;
+mod list;
+mod show;
+mod update;

--- a/tests/api/tests/api_v3/region/create.rs
+++ b/tests/api/tests/api_v3/region/create.rs
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::region::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::region::create_region;
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_region() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let id = format!("region_{}", Uuid::new_v4().simple());
+
+    let guard = create_region(
+        &tc,
+        RegionCreateBuilder::default()
+            .id(id.clone())
+            .description("a region")
+            .build()?,
+    )
+    .await?;
+
+    assert_eq!(guard.id, id);
+    assert_eq!(guard.description.as_deref(), Some("a region"));
+
+    guard.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/region/delete.rs
+++ b/tests/api/tests/api_v3/region/delete.rs
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::region::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::region::{create_region, show_region};
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_region() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let id = format!("region_{}", Uuid::new_v4().simple());
+
+    let guard = create_region(&tc, RegionCreateBuilder::default().id(id.clone()).build()?).await?;
+
+    guard.delete().await?;
+
+    let result = show_region(&tc, &id).await;
+    assert!(result.is_err(), "region must be gone after deletion");
+    Ok(())
+}

--- a/tests/api/tests/api_v3/region/list.rs
+++ b/tests/api/tests/api_v3/region/list.rs
@@ -1,0 +1,43 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::region::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::region::{create_region, list_regions};
+
+#[tokio::test]
+#[traced_test]
+async fn test_list_includes_created_region() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let id = format!("region_{}", Uuid::new_v4().simple());
+
+    let guard = create_region(&tc, RegionCreateBuilder::default().id(id.clone()).build()?).await?;
+
+    let all = list_regions(&tc).await?;
+    assert!(
+        all.iter().any(|r| r.id == guard.id),
+        "created region must appear in the unfiltered list"
+    );
+
+    guard.delete().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/region/show.rs
+++ b/tests/api/tests/api_v3/region/show.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::region::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::region::{create_region, show_region};
+
+#[tokio::test]
+#[traced_test]
+async fn test_show_region() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let id = format!("region_{}", Uuid::new_v4().simple());
+
+    let guard = create_region(
+        &tc,
+        RegionCreateBuilder::default()
+            .id(id.clone())
+            .description("a region")
+            .build()?,
+    )
+    .await?;
+
+    let fetched = show_region(&tc, &guard.id).await?;
+    assert_eq!(fetched.id, guard.id);
+    assert_eq!(fetched.description.as_deref(), Some("a region"));
+
+    guard.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_show_missing_region_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let result = show_region(&tc, format!("missing-{}", Uuid::new_v4().simple())).await;
+
+    assert!(result.is_err(), "showing a missing region must fail");
+    Ok(())
+}

--- a/tests/api/tests/api_v3/region/update.rs
+++ b/tests/api/tests/api_v3/region/update.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::region::*;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::region::{create_region, show_region, update_region};
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_description() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let id = format!("region_{}", Uuid::new_v4().simple());
+
+    let guard = create_region(&tc, RegionCreateBuilder::default().id(id.clone()).build()?).await?;
+
+    let updated = update_region(
+        &tc,
+        &guard.id,
+        RegionUpdateBuilder::default()
+            .description("updated")
+            .build()?,
+    )
+    .await?;
+
+    assert_eq!(updated.id, guard.id);
+    assert_eq!(updated.description.as_deref(), Some("updated"));
+
+    // Re-fetch to verify the change is persisted, not just echoed back.
+    let fetched = show_region(&tc, &guard.id).await?;
+    assert_eq!(fetched.description.as_deref(), Some("updated"));
+
+    guard.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_missing_region_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let result = update_region(
+        &tc,
+        format!("missing-{}", Uuid::new_v4().simple()),
+        RegionUpdateBuilder::default().description("x").build()?,
+    )
+    .await;
+
+    assert!(result.is_err(), "updating a missing region must fail");
+    Ok(())
+}


### PR DESCRIPTION
Region had full backend/SQL CRUD and mocks but no HTTP
handlers, unlike service and endpoint. Add api-types,
keystone handlers, and OPA policy mirroring the service
resource's admin-only tier.

Region gains a Serialize derive so its stored value can be
passed into show/delete/update policy input, matching Service.

test: add region coverage in tests/integration and tests/api

Backend-level region tests already existed; tests/api had no
client module or live-server tests for regions at all. Add the
REST client (create/show/list/update/delete) and functional
tests mirroring the service suite.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

<!--
Thanks for the contribution! Fill in the sections below.
-->

## Summary

<!-- What does this PR change, and why? -->

## Test plan

<!-- How was this verified? cargo test output, manual steps, screenshots, etc. -->

## Security review checklist

**Required if this diff touches authentication, scope, delegation, tokens,
credentials, EC2, trusts, application credentials, or OPA policy input.**
Delete this section entirely if it doesn't apply. See
[`doc/src/security.md`](../doc/src/security.md) §7 for the full context
behind each item.

- [ ] Does any delegation/authorization decision read the **scope**
      (`project_id`, `ScopeInfo`) where it should read the **chain**
      (`authentication_context()`, delegation object)? (I1/I2)
- [ ] New delegation-sensitive policy rule? Is the fact it needs projected
      onto `Credentials` from the chain, and does the rule anchor on
      `delegated_project_id` + carry the scope-drift tripwire? (I2/I3)
- [ ] New scope shape or redemption path for a delegated auth? Are effective
      roles still bounded by the delegation? Added a test that a restricted
      delegation cannot exceed its roles via the new path? (I4)
- [ ] New `ScopeInfo` variant or auth method? Updated
      `validate_scope_boundaries()`, `calculate_effective_roles()`,
      `fully_resolved()`, and `Credentials::try_from` — all without adding a
      wildcard `_ =>` arm? (I5, Gate J)
- [ ] New lookup by a client-derivable key (like `sha256(access)`)? Does it
      re-assert `type`/shape after fetch? (I6)
- [ ] Does any new data reaching OPA include secrets/decrypted blobs? (I7,
      Gate I)
- [ ] New list/collection endpoint? Does it re-check each item with the
      per-item read policy? (I8)
- [ ] Does the change let a narrow auth method be broadened by a
      request-supplied scope? (I5)
- [ ] Are there negative tests proving the escape is blocked, not just
      positive tests proving the happy path works?
- [ ] Does the test drive `ValidatedSecurityContext::new_for_scope()`
      end-to-end, not just the inner helper (`calculate_effective_roles`,
      `validate_scope_boundaries`) in isolation?
