### PR TITLE
feat(identity): Add trust create/delete and REST CRUD

### DIFF
--- a/crates/api-types/src/trust.rs
+++ b/crates/api-types/src/trust.rs
@@ -28,9 +28,15 @@ impl From<TrustProviderError> for crate::error::KeystoneApiError {
         match source {
             TrustProviderError::Conflict(x) => Self::Conflict(x),
             TrustProviderError::ExpirationImpossible => Self::forbidden(source),
+            TrustProviderError::ProjectRolesPairingInvalid => Self::BadRequest(source.to_string()),
             TrustProviderError::RedelegatedRolesNotAvailable => Self::forbidden(source),
             TrustProviderError::RedelegationDeepnessExceed { .. } => Self::forbidden(source),
             TrustProviderError::RemainingUsesExceed => Self::forbidden(source),
+            TrustProviderError::RoleNotGranted { .. } => Self::forbidden(source),
+            TrustProviderError::TrustNotFound(id) => Self::NotFound {
+                resource: "trust".into(),
+                identifier: id,
+            },
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/api-types/src/v3.rs
+++ b/crates/api-types/src/v3.rs
@@ -24,6 +24,7 @@ pub mod region;
 pub mod role;
 pub mod role_assignment;
 pub mod service;
+pub mod trust;
 pub mod user;
 
 #[cfg(feature = "conv")]
@@ -46,5 +47,7 @@ mod role_assignment_conv;
 mod role_conv;
 #[cfg(feature = "conv")]
 mod service_conv;
+#[cfg(feature = "conv")]
+mod trust_conv;
 #[cfg(feature = "conv")]
 mod user_conv;

--- a/crates/api-types/src/v3/trust.rs
+++ b/crates/api-types/src/v3/trust.rs
@@ -1,0 +1,212 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Trust REST resource types
+//!
+//! Distinct from `crate::trust::TokenTrustRepr`, which is the trust
+//! representation embedded in a token response body. These types represent
+//! `/v3/OS-TRUST/trusts` as its own resource.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+#[cfg(feature = "validate")]
+use validator::Validate;
+
+/// A role reference as accepted/returned by the trust API.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct TrustRoleRef {
+    /// Role domain ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub domain_id: Option<String>,
+
+    /// Role ID.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub id: String,
+
+    /// Role name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
+    pub name: Option<String>,
+}
+
+/// The trust data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct Trust {
+    /// Trust ID.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub id: String,
+
+    /// The ID of the user who created the trust, and who's authorization is
+    /// being delegated.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub trustor_user_id: String,
+
+    /// The ID of the user who is capable of consuming the trust.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub trustee_user_id: String,
+
+    /// The ID of the project upon which the trustor is delegating
+    /// authorization.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub project_id: Option<String>,
+
+    /// Allow the trustee to impersonate the trustor.
+    pub impersonation: bool,
+
+    /// Trust expiration time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+
+    /// Remaining number of times the trust can be used to obtain a token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remaining_uses: Option<u32>,
+
+    /// The ID of the redelegated trust, if this trust was created by
+    /// redelegation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub redelegated_trust_id: Option<String>,
+
+    /// Maximum remaining depth of the redelegated trust chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redelegation_count: Option<u32>,
+
+    /// Roles delegated by this trust.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub roles: Vec<TrustRoleRef>,
+
+    /// Arbitrary additional attributes stored with the trust.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct TrustResponse {
+    /// Trust object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub trust: Trust,
+}
+
+/// Trusts.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct TrustList {
+    /// Collection of trust objects.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub trusts: Vec<Trust>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct TrustListParameters {
+    /// Whether to include soft-deleted trusts.
+    #[serde(default)]
+    pub include_deleted: Option<bool>,
+}
+
+/// Trust create request body.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct TrustCreate {
+    /// The ID of the trust. A UUID is generated when omitted.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub id: Option<String>,
+
+    /// The ID of the user who created the trust, and who's authorization is
+    /// being delegated.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub trustor_user_id: String,
+
+    /// The ID of the user who is capable of consuming the trust.
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub trustee_user_id: String,
+
+    /// The ID of the project upon which the trustor is delegating
+    /// authorization. Must be set together with `roles`, or omitted together
+    /// with `roles`.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub project_id: Option<String>,
+
+    /// Allow the trustee to impersonate the trustor.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(default)]
+    pub impersonation: bool,
+
+    /// Trust expiration time.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+
+    /// Limit the number of times the trust can be used to obtain a token.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remaining_uses: Option<u32>,
+
+    /// The ID of the trust to redelegate from.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
+    pub redelegated_trust_id: Option<String>,
+
+    /// Maximum remaining depth of the redelegated trust chain.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redelegation_count: Option<u32>,
+
+    /// Roles to delegate. Must be set together with `project_id`, or omitted
+    /// together with `project_id`.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub roles: Vec<TrustRoleRef>,
+
+    /// Arbitrary additional attributes to store with the trust.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<Value>,
+}
+
+/// New trust creation request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct TrustCreateRequest {
+    /// Trust object.
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub trust: TrustCreate,
+}

--- a/crates/api-types/src/v3/trust_conv.rs
+++ b/crates/api-types/src/v3/trust_conv.rs
@@ -1,0 +1,89 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use openstack_keystone_core_types::role::RoleRef as ProviderRoleRef;
+use openstack_keystone_core_types::trust as provider_types;
+
+use crate::v3::trust as api_types;
+
+impl From<ProviderRoleRef> for api_types::TrustRoleRef {
+    fn from(value: ProviderRoleRef) -> Self {
+        Self {
+            domain_id: value.domain_id,
+            id: value.id,
+            name: value.name,
+        }
+    }
+}
+
+impl From<api_types::TrustRoleRef> for ProviderRoleRef {
+    fn from(value: api_types::TrustRoleRef) -> Self {
+        Self {
+            domain_id: value.domain_id,
+            id: value.id,
+            name: value.name,
+        }
+    }
+}
+
+impl From<provider_types::Trust> for api_types::Trust {
+    fn from(value: provider_types::Trust) -> Self {
+        Self {
+            id: value.id,
+            trustor_user_id: value.trustor_user_id,
+            trustee_user_id: value.trustee_user_id,
+            project_id: value.project_id,
+            impersonation: value.impersonation,
+            expires_at: value.expires_at,
+            remaining_uses: value.remaining_uses,
+            redelegated_trust_id: value.redelegated_trust_id,
+            redelegation_count: value.redelegation_count,
+            roles: value
+                .roles
+                .unwrap_or_default()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            extra: value.extra,
+        }
+    }
+}
+
+impl From<api_types::TrustListParameters> for provider_types::TrustListParameters {
+    fn from(value: api_types::TrustListParameters) -> Self {
+        Self {
+            include_deleted: value.include_deleted,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<api_types::TrustCreateRequest> for provider_types::TrustCreate {
+    fn from(value: api_types::TrustCreateRequest) -> Self {
+        let trust = value.trust;
+        Self {
+            id: trust.id,
+            trustor_user_id: trust.trustor_user_id,
+            trustee_user_id: trust.trustee_user_id,
+            project_id: trust.project_id,
+            impersonation: trust.impersonation,
+            expires_at: trust.expires_at,
+            remaining_uses: trust.remaining_uses,
+            redelegated_trust_id: trust.redelegated_trust_id,
+            redelegation_count: trust.redelegation_count,
+            roles: trust.roles.into_iter().map(Into::into).collect(),
+            extra: trust.extra,
+        }
+    }
+}

--- a/crates/core-types/src/trust/error.rs
+++ b/crates/core-types/src/trust/error.rs
@@ -14,13 +14,23 @@
 //! # Trust Error
 use thiserror::Error;
 
+use crate::assignment::AssignmentProviderError;
 use crate::auth::AuthenticationError;
 use crate::error::BuilderError;
+use crate::revoke::RevokeProviderError;
 use crate::role::RoleProviderError;
 
 /// Trust extension error.
 #[derive(Error, Debug)]
 pub enum TrustProviderError {
+    /// Assignment provider error.
+    #[error(transparent)]
+    AssignmentProvider {
+        /// The source of the error.
+        #[from]
+        source: AssignmentProviderError,
+    },
+
     /// Supported authentication error.
     #[error(transparent)]
     AuthenticationInfo {
@@ -55,6 +65,10 @@ pub enum TrustProviderError {
     #[error("some of the requested roles are not in the redelegated trust")]
     RedelegatedRolesNotAvailable,
 
+    /// `project_id` and `roles` must both be set or both be unset.
+    #[error("project_id and roles must both be set, or both be unset")]
+    ProjectRolesPairingInvalid,
+
     /// Redelegation chain is longer than allowed.
     #[error("redelegation depth of {length} is out of allowed range [0..{max_depth}]")]
     RedelegationDeepnessExceed { length: usize, max_depth: usize },
@@ -66,6 +80,22 @@ pub enum TrustProviderError {
     /// Remaining uses must be unset to redelegate a trust.
     #[error("remaining uses is set while it must not be set in order to redelegate a trust")]
     RemainingUsesMustBeUnset,
+
+    /// The trustor does not currently hold one of the requested roles on the
+    /// target project.
+    #[error("trustor does not hold role `{role_id}` on the target project")]
+    RoleNotGranted {
+        /// The ID of the role that is not currently granted to the trustor.
+        role_id: String,
+    },
+
+    /// Revoke provider error.
+    #[error(transparent)]
+    RevokeProvider {
+        /// The source of the error.
+        #[from]
+        source: RevokeProviderError,
+    },
 
     /// Role provider error.
     #[error(transparent)]

--- a/crates/core-types/src/trust/trust.rs
+++ b/crates/core-types/src/trust/trust.rs
@@ -120,6 +120,67 @@ pub struct Trust {
     pub trustee_user_id: String,
 }
 
+/// A trust object to be created.
+#[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct TrustCreate {
+    #[builder(default)]
+    pub extra: Option<Value>,
+
+    /// The ID of the trust.
+    #[builder(default)]
+    #[validate(length(min = 1, max = 64))]
+    pub id: Option<String>,
+
+    /// Specifies the expiration time of the trust.
+    #[builder(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+
+    /// If set to `true`, then the user attribute of tokens generated based on
+    /// the trust will represent that of the `trustor` rather than the
+    /// `trustee`, thus allowing the `trustee` to impersonate the `trustor`.
+    #[builder(default)]
+    pub impersonation: bool,
+
+    /// Identifies the project upon which the trustor is delegating
+    /// authorization. Must be set together with `roles`, or omitted together
+    /// with `roles` (a trust may not implicitly delegate all roles).
+    #[builder(default)]
+    #[validate(length(min = 1, max = 64))]
+    pub project_id: Option<String>,
+
+    /// Specifies how many times the trust can be used to obtain a token.
+    #[builder(default)]
+    pub remaining_uses: Option<u32>,
+
+    /// The ID of the trust this trust redelegates from, when the trust is
+    /// being created by the trustee of a redelegatable trust-scoped token.
+    #[builder(default)]
+    #[validate(length(min = 1, max = 64))]
+    pub redelegated_trust_id: Option<String>,
+
+    /// Specifies the maximum remaining depth of the redelegated trust chain.
+    #[builder(default)]
+    pub redelegation_count: Option<u32>,
+
+    /// Specifies the subset of the trustor's roles on the `project_id` to be
+    /// granted to the `trustee` when the token is consumed. Must be set
+    /// together with `project_id`, or omitted together with `project_id`.
+    #[builder(default)]
+    #[validate(nested)]
+    pub roles: Vec<RoleRef>,
+
+    /// Represents the user who created the trust, and who's authorization is
+    /// being delegated.
+    #[validate(length(min = 1, max = 64))]
+    pub trustor_user_id: String,
+
+    /// Represents the user who is capable of consuming the trust.
+    #[validate(length(min = 1, max = 64))]
+    pub trustee_user_id: String,
+}
+
 /// A trust list parameters.
 #[derive(Builder, Clone, Debug, Default, PartialEq, Validate)]
 #[builder(setter(strip_option, into))]

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -1636,6 +1636,18 @@ mod trust {
 
         #[async_trait]
         impl TrustApi for TrustProvider {
+            async fn create_trust<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                trust: TrustCreate,
+            ) -> Result<Trust, TrustProviderError>;
+
+            async fn delete_trust<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                id: &'a str,
+            ) -> Result<(), TrustProviderError>;
+
             async fn get_trust<'a>(
                 &self,
                 ctx: &ExecutionContext<'a>,

--- a/crates/core/src/trust/backend.rs
+++ b/crates/core/src/trust/backend.rs
@@ -25,6 +25,34 @@ use crate::trust::TrustProviderError;
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait TrustBackend: Send + Sync {
+    /// Create a new trust.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `trust`: The trust creation data.
+    ///
+    /// # Returns
+    /// - `Result<Trust, TrustProviderError>` - The created trust or an error.
+    async fn create_trust(
+        &self,
+        state: &ServiceState,
+        trust: TrustCreate,
+    ) -> Result<Trust, TrustProviderError>;
+
+    /// Delete a trust by ID.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `id`: The ID of the trust to delete.
+    ///
+    /// # Returns
+    /// - `Result<(), TrustProviderError>` - `Ok(())` on success, or an error.
+    async fn delete_trust<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), TrustProviderError>;
+
     /// Get trust by ID.
     ///
     /// # Parameters

--- a/crates/core/src/trust/provider_api.rs
+++ b/crates/core/src/trust/provider_api.rs
@@ -23,6 +23,30 @@ use crate::trust::TrustProviderError;
 /// Trust extension provider interface.
 #[async_trait]
 pub trait TrustApi: Send + Sync {
+    /// Create a new trust.
+    ///
+    /// * `ctx` - The execution context.
+    /// * `trust` - The trust creation data.
+    ///
+    /// A `Result` containing the created `Trust`, or an `Error`.
+    async fn create_trust<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        trust: TrustCreate,
+    ) -> Result<Trust, TrustProviderError>;
+
+    /// Delete a trust by ID.
+    ///
+    /// * `ctx` - The execution context.
+    /// * `id` - The ID of the trust to delete.
+    ///
+    /// A `Result` containing `()`, or an `Error`.
+    async fn delete_trust<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        id: &'a str,
+    ) -> Result<(), TrustProviderError>;
+
     /// Get trust by ID.
     ///
     /// * `state` - The current service state.

--- a/crates/core/src/trust/service.rs
+++ b/crates/core/src/trust/service.rs
@@ -20,12 +20,17 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use tracing::debug;
+use uuid::Uuid;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core_types::assignment::RoleAssignmentListParametersBuilder;
+use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
+use openstack_keystone_core_types::revoke::RevocationEventCreate;
 use openstack_keystone_core_types::role::*;
 use openstack_keystone_core_types::trust::*;
 
 use crate::auth::ExecutionContext;
+use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
 use crate::trust::{TrustApi, TrustProviderError, backend::TrustBackend};
 
@@ -56,8 +61,278 @@ impl TrustService {
     }
 }
 
+impl TrustService {
+    /// Walk a prospective trust delegation chain (oldest ancestor first is
+    /// not required; iterated newest-to-oldest via `.rev()`) and enforce the
+    /// redelegation invariants. Shared by `validate_trust_delegation_chain`
+    /// (chain already persisted) and `create_trust` (chain includes the
+    /// not-yet-persisted trust being created).
+    fn validate_chain(
+        chain: &[Trust],
+        max_redelegation_count: usize,
+    ) -> Result<bool, TrustProviderError> {
+        if chain.len() > max_redelegation_count {
+            return Err(TrustProviderError::RedelegationDeepnessExceed {
+                length: chain.len(),
+                max_depth: max_redelegation_count,
+            });
+        }
+        let mut parent_trust: Option<Trust> = None;
+        let mut parent_expiration: Option<DateTime<Utc>> = None;
+        for delegation in chain.iter().rev() {
+            // None of the trusts can specify the redelegation_count > delegation_count of
+            // the top level trust
+            if let Some(current_redelegation_count) = delegation.redelegation_count
+                && current_redelegation_count > max_redelegation_count as u32
+            {
+                return Err(TrustProviderError::RedelegationDeepnessExceed {
+                    length: current_redelegation_count as usize,
+                    max_depth: max_redelegation_count,
+                });
+            }
+            if delegation.remaining_uses.is_some() {
+                return Err(TrustProviderError::RemainingUsesMustBeUnset);
+            }
+            // Check that the parent trust is not expiring earlier than the redelegated
+            if let Some(trust_expiry) = delegation.expires_at {
+                if let Some(parent_expiry) = parent_trust
+                    .as_ref()
+                    .and_then(|x| x.expires_at)
+                    .or(parent_expiration)
+                {
+                    if trust_expiry > parent_expiry {
+                        return Err(TrustProviderError::ExpirationImpossible);
+                    }
+                    // reset the parent_expiration to the one of the current delegation.
+                    parent_expiration = Some(trust_expiry);
+                }
+                // Ensure we set the parent_expiration with the first met value.
+                if parent_expiration.is_none() {
+                    parent_expiration = Some(trust_expiry);
+                }
+            }
+            // Check that the redelegation is not adding new roles
+            if let Some(parent_trust) = &parent_trust
+                && !HashSet::<String, RandomState>::from_iter(
+                    delegation
+                        .roles
+                        .as_deref()
+                        .unwrap_or_default()
+                        .iter()
+                        .map(|role| role.id.clone()),
+                )
+                .is_subset(&HashSet::from_iter(
+                    parent_trust
+                        .roles
+                        .as_deref()
+                        .unwrap_or_default()
+                        .iter()
+                        .map(|role| role.id.clone()),
+                ))
+            {
+                debug!(
+                    "Trust roles {:?} are missing for the trustor {:?}",
+                    delegation.roles, parent_trust.roles,
+                );
+                return Err(TrustProviderError::RedelegatedRolesNotAvailable);
+            }
+            // Check the impersonation
+            if delegation.impersonation && !parent_trust.is_some_and(|x| x.impersonation) {
+                return Err(TrustProviderError::RedelegatedImpersonationNotAllowed);
+            }
+            parent_trust = Some(delegation.clone());
+        }
+        Ok(true)
+    }
+}
+
 #[async_trait]
 impl TrustApi for TrustService {
+    /// Create a new trust.
+    ///
+    /// - `project_id` and `roles` must both be set, or both be unset.
+    /// - the trustor must currently hold every requested role on `project_id`.
+    /// - if `redelegated_trust_id` is set, the prospective chain (this trust
+    ///   prepended to the parent's persisted chain) must satisfy the same
+    ///   redelegation invariants as `validate_trust_delegation_chain`.
+    ///
+    /// # Parameters
+    /// - `ctx`: The execution context.
+    /// - `trust`: The trust creation data.
+    ///
+    /// # Returns
+    /// - `Result<Trust, TrustProviderError>` - The created trust or an error.
+    async fn create_trust<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        trust: TrustCreate,
+    ) -> Result<Trust, TrustProviderError> {
+        if trust.project_id.is_some() != !trust.roles.is_empty() {
+            return Err(TrustProviderError::ProjectRolesPairingInvalid);
+        }
+
+        if let Some(project_id) = &trust.project_id {
+            let trustor_assignments = ctx
+                .state()
+                .provider
+                .get_assignment_provider()
+                .list_role_assignments(
+                    &ExecutionContext::internal(ctx.state()),
+                    &RoleAssignmentListParametersBuilder::default()
+                        .user_id(trust.trustor_user_id.clone())
+                        .project_id(project_id.clone())
+                        .include_names(true)
+                        .effective(true)
+                        .resolve_implied_roles(true)
+                        .build()?,
+                )
+                .await?;
+            let trustor_role_ids: HashSet<String> =
+                trustor_assignments.into_iter().map(|a| a.role_id).collect();
+            let mut requested_roles = trust.roles.clone();
+            ctx.state()
+                .provider
+                .get_role_provider()
+                .expand_implied_roles(ctx, &mut requested_roles)
+                .await?;
+            for role in &requested_roles {
+                if !trustor_role_ids.contains(&role.id) {
+                    return Err(TrustProviderError::RoleNotGranted {
+                        role_id: role.id.clone(),
+                    });
+                }
+            }
+        }
+
+        let id = trust
+            .id
+            .clone()
+            .unwrap_or_else(|| Uuid::new_v4().simple().to_string());
+        let prospective = Trust {
+            deleted_at: None,
+            expires_at: trust.expires_at,
+            extra: trust.extra.clone(),
+            id: id.clone(),
+            impersonation: trust.impersonation,
+            project_id: trust.project_id.clone(),
+            remaining_uses: trust.remaining_uses,
+            redelegated_trust_id: trust.redelegated_trust_id.clone(),
+            redelegation_count: trust.redelegation_count,
+            roles: if trust.roles.is_empty() {
+                None
+            } else {
+                Some(trust.roles.clone())
+            },
+            trustor_user_id: trust.trustor_user_id.clone(),
+            trustee_user_id: trust.trustee_user_id.clone(),
+        };
+
+        if let Some(parent_id) = &trust.redelegated_trust_id {
+            let config = ctx.state().config_manager.config.read().await;
+            let mut prospective_chain = vec![prospective.clone()];
+            if let Some(parent_chain) = self.get_trust_delegation_chain(ctx, parent_id).await? {
+                prospective_chain.extend(parent_chain);
+            }
+            Self::validate_chain(&prospective_chain, config.trust.max_redelegation_count)?;
+        }
+
+        let mut trust = trust;
+        trust.id = Some(id);
+
+        let created = if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            let trust_clone = trust.clone();
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Create,
+                    EventPayload::Trust { id: trust_clone.id.clone().unwrap_or_default() },
+                ),
+                operation: async {
+                    backend_driver.create_trust(ctx.state(), trust_clone).await
+                },
+                on_audit_error: |_: AuditDispatchError| TrustProviderError::Driver("audit dispatch failed".into()),
+            }?
+        } else {
+            let created = self.backend_driver.create_trust(ctx.state(), trust).await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Create,
+                    EventPayload::Trust {
+                        id: created.id.clone(),
+                    },
+                ))
+                .await;
+
+            created
+        };
+
+        Ok(created)
+    }
+
+    /// Delete a trust by ID.
+    ///
+    /// Emits a revocation event for the trust so any tokens issued from it
+    /// are immediately revoked, per the trust immutability/deletion contract.
+    ///
+    /// # Parameters
+    /// - `ctx`: The execution context.
+    /// - `id`: The ID of the trust to delete.
+    ///
+    /// # Returns
+    /// - `Result<(), TrustProviderError>` - `Ok(())` on success, or an error.
+    async fn delete_trust<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        id: &'a str,
+    ) -> Result<(), TrustProviderError> {
+        if let Some(vsc) = ctx.ctx() {
+            let backend_driver = &self.backend_driver;
+            crate::audited_op! {
+                dispatcher: &ctx.state().event_dispatcher,
+                ctx: vsc,
+                event: Event::new(
+                    Operation::Delete,
+                    EventPayload::Trust { id: id.to_string() },
+                ),
+                operation: async {
+                    backend_driver.delete_trust(ctx.state(), id).await
+                },
+                on_audit_error: |_: AuditDispatchError| TrustProviderError::Driver("audit dispatch failed".into()),
+            }?;
+        } else {
+            self.backend_driver.delete_trust(ctx.state(), id).await?;
+
+            ctx.state()
+                .event_dispatcher
+                .emit(Event::new(
+                    Operation::Delete,
+                    EventPayload::Trust { id: id.to_string() },
+                ))
+                .await;
+        }
+
+        let now = Utc::now();
+        ctx.state()
+            .provider
+            .get_revoke_provider()
+            .create_revocation_event(
+                ctx,
+                RevocationEventCreate {
+                    trust_id: Some(id.to_string()),
+                    issued_before: now,
+                    revoked_at: now,
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+
     /// Get trust by ID.
     ///
     /// # Parameters
@@ -196,77 +471,7 @@ impl TrustApi for TrustService {
             && let Some(chain) = self.get_trust_delegation_chain(ctx, &trust.id).await?
         {
             let config = ctx.state().config_manager.config.read().await;
-            if chain.len() > config.trust.max_redelegation_count {
-                return Err(TrustProviderError::RedelegationDeepnessExceed {
-                    length: chain.len(),
-                    max_depth: config.trust.max_redelegation_count,
-                });
-            }
-            let mut parent_trust: Option<Trust> = None;
-            let mut parent_expiration: Option<DateTime<Utc>> = None;
-            for delegation in chain.iter().rev() {
-                // None of the trusts can specify the redelegation_count > delegation_count of
-                // the top level trust
-                if let Some(current_redelegation_count) = delegation.redelegation_count
-                    && current_redelegation_count > config.trust.max_redelegation_count as u32
-                {
-                    return Err(TrustProviderError::RedelegationDeepnessExceed {
-                        length: current_redelegation_count as usize,
-                        max_depth: config.trust.max_redelegation_count,
-                    });
-                }
-                if delegation.remaining_uses.is_some() {
-                    return Err(TrustProviderError::RemainingUsesMustBeUnset);
-                }
-                // Check that the parent trust is not expiring earlier than the redelegated
-                if let Some(trust_expiry) = delegation.expires_at {
-                    if let Some(parent_expiry) = parent_trust
-                        .as_ref()
-                        .and_then(|x| x.expires_at)
-                        .or(parent_expiration)
-                    {
-                        if trust_expiry > parent_expiry {
-                            return Err(TrustProviderError::ExpirationImpossible);
-                        }
-                        // reset the parent_expiration to the one of the current delegation.
-                        parent_expiration = Some(trust_expiry);
-                    }
-                    // Ensure we set the parent_expiration with the first met value.
-                    if parent_expiration.is_none() {
-                        parent_expiration = Some(trust_expiry);
-                    }
-                }
-                // Check that the redelegation is not adding new roles
-                if let Some(parent_trust) = &parent_trust
-                    && !HashSet::<String, RandomState>::from_iter(
-                        delegation
-                            .roles
-                            .as_deref()
-                            .unwrap_or_default()
-                            .iter()
-                            .map(|role| role.id.clone()),
-                    )
-                    .is_subset(&HashSet::from_iter(
-                        parent_trust
-                            .roles
-                            .as_deref()
-                            .unwrap_or_default()
-                            .iter()
-                            .map(|role| role.id.clone()),
-                    ))
-                {
-                    debug!(
-                        "Trust roles {:?} are missing for the trustor {:?}",
-                        trust.roles, parent_trust.roles,
-                    );
-                    return Err(TrustProviderError::RedelegatedRolesNotAvailable);
-                }
-                // Check the impersonation
-                if delegation.impersonation && !parent_trust.is_some_and(|x| x.impersonation) {
-                    return Err(TrustProviderError::RedelegatedImpersonationNotAllowed);
-                }
-                parent_trust = Some(delegation.clone());
-            }
+            Self::validate_chain(&chain, config.trust.max_redelegation_count)?;
         }
 
         Ok(true)
@@ -837,5 +1042,163 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(list.len(), 2);
+    }
+
+    // ---- create_trust / delete_trust ----
+
+    use openstack_keystone_core_types::assignment::*;
+    use openstack_keystone_core_types::revoke::RevocationEvent;
+
+    use crate::assignment::MockAssignmentProvider;
+    use crate::revoke::MockRevokeProvider;
+
+    fn assignment_with_role(rid: impl Into<String>) -> Assignment {
+        Assignment {
+            actor_id: "trustor".into(),
+            role_id: rid.into(),
+            role_name: Some("admin".to_string()),
+            target_id: "pid".to_string(),
+            r#type: AssignmentType::UserProject,
+            inherited: false,
+            implied_via: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_trust_project_roles_pairing_invalid() {
+        let backend = MockTrustBackend::new();
+        let state = get_mocked_state(None, None).await;
+        let trust_provider = create_trust_service(backend);
+
+        let create = TrustCreateBuilder::default()
+            .trustor_user_id("trustor")
+            .trustee_user_id("trustee")
+            .project_id("pid")
+            .build()
+            .unwrap();
+
+        match trust_provider
+            .create_trust(&ExecutionContext::internal(&state), create)
+            .await
+        {
+            Err(TrustProviderError::ProjectRolesPairingInvalid) => {}
+            other => panic!("expected ProjectRolesPairingInvalid, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_trust_role_not_granted() {
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .returning(|_e, _q| Ok(Vec::new()));
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(|_e, _roles| Ok(()));
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_role(role_mock);
+        let state = get_mocked_state(None, Some(provider_builder)).await;
+
+        let backend = MockTrustBackend::new();
+        let trust_provider = create_trust_service(backend);
+
+        let create = TrustCreateBuilder::default()
+            .trustor_user_id("trustor")
+            .trustee_user_id("trustee")
+            .project_id("pid")
+            .roles(vec![RoleRefBuilder::default().id("rid1").build().unwrap()])
+            .build()
+            .unwrap();
+
+        match trust_provider
+            .create_trust(&ExecutionContext::internal(&state), create)
+            .await
+        {
+            Err(TrustProviderError::RoleNotGranted { role_id }) => assert_eq!(role_id, "rid1"),
+            other => panic!("expected RoleNotGranted, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_trust_success() {
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, q: &RoleAssignmentListParameters| {
+                q.user_id.as_deref() == Some("trustor") && q.project_id.as_deref() == Some("pid")
+            })
+            .returning(|_e, _q| Ok(vec![assignment_with_role("rid1")]));
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_expand_implied_roles()
+            .returning(|_e, _roles| Ok(()));
+        let provider_builder = Provider::mocked_builder()
+            .mock_assignment(assignment_mock)
+            .mock_role(role_mock);
+        let state = get_mocked_state(None, Some(provider_builder)).await;
+
+        let mut backend = MockTrustBackend::new();
+        backend
+            .expect_create_trust()
+            .withf(|_, t: &TrustCreate| {
+                t.trustor_user_id == "trustor" && t.roles.iter().any(|r| r.id == "rid1")
+            })
+            .returning(|_, t| {
+                Ok(Trust {
+                    id: t.id.clone().unwrap_or_default(),
+                    trustor_user_id: t.trustor_user_id.clone(),
+                    trustee_user_id: t.trustee_user_id.clone(),
+                    project_id: t.project_id.clone(),
+                    roles: Some(t.roles.clone()),
+                    ..Default::default()
+                })
+            });
+
+        let trust_provider = create_trust_service(backend);
+
+        let create = TrustCreateBuilder::default()
+            .trustor_user_id("trustor")
+            .trustee_user_id("trustee")
+            .project_id("pid")
+            .roles(vec![RoleRefBuilder::default().id("rid1").build().unwrap()])
+            .build()
+            .unwrap();
+
+        let created = trust_provider
+            .create_trust(&ExecutionContext::internal(&state), create)
+            .await
+            .unwrap();
+        assert_eq!(created.trustor_user_id, "trustor");
+        assert!(!created.id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_delete_trust() {
+        let mut revoke_mock = MockRevokeProvider::default();
+        revoke_mock
+            .expect_create_revocation_event()
+            .withf(
+                |_, e: &openstack_keystone_core_types::revoke::RevocationEventCreate| {
+                    e.trust_id.as_deref() == Some("trust_id")
+                },
+            )
+            .returning(|_, _| Ok(RevocationEvent::default()));
+        let provider_builder = Provider::mocked_builder().mock_revoke(revoke_mock);
+        let state = get_mocked_state(None, Some(provider_builder)).await;
+
+        let mut backend = MockTrustBackend::new();
+        backend
+            .expect_delete_trust()
+            .withf(|_, id: &'_ str| id == "trust_id")
+            .returning(|_, _| Ok(()));
+
+        let trust_provider = create_trust_service(backend);
+
+        trust_provider
+            .delete_trust(&ExecutionContext::internal(&state), "trust_id")
+            .await
+            .unwrap();
     }
 }

--- a/crates/keystone/src/api/v3/mod.rs
+++ b/crates/keystone/src/api/v3/mod.rs
@@ -32,6 +32,7 @@ pub mod domain;
 pub mod ec2tokens;
 pub mod endpoint;
 pub mod group;
+pub mod os_trust;
 pub mod project;
 pub mod region;
 pub mod role;
@@ -59,6 +60,7 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
         .nest("/ec2tokens", ec2tokens::openapi_router())
         .nest("/endpoints", endpoint::openapi_router())
         .nest("/groups", group::openapi_router())
+        .nest("/OS-TRUST", os_trust::openapi_router())
         .nest("/projects", project::openapi_router())
         .nest("/regions", region::openapi_router())
         .nest("/roles", role::openapi_router())

--- a/crates/keystone/src/api/v3/os_trust/mod.rs
+++ b/crates/keystone/src/api/v3/os_trust/mod.rs
@@ -11,32 +11,14 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # Integration tests
-//!
-//! Test the functionality on the provider level (not through the API).
+//! # OS-TRUST extension API
 
-mod api_key;
-mod application_credential;
-mod assignment;
-mod audit;
-mod catalog;
-mod common;
-mod credential;
-mod identity;
-mod k8s_auth;
-mod mapping;
-mod oauth2_device_grant;
-mod oauth2_emergency_rotation;
-mod oauth2_key_janitor;
-mod oauth2_session;
-mod oauth2_token_exchange;
-mod oauth2_token_verify;
-mod resource;
-mod revoke;
-mod role;
-mod scim_realm;
-mod token;
-mod trust;
+use utoipa_axum::router::OpenApiRouter;
 
-#[macro_use]
-mod macros;
+use crate::keystone::ServiceState;
+
+pub mod trust;
+
+pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new().nest("/trusts", trust::openapi_router())
+}

--- a/crates/keystone/src/api/v3/os_trust/trust/create.rs
+++ b/crates/keystone/src/api/v3/os_trust/trust/create.rs
@@ -1,0 +1,244 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Create trust API
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use validator::Validate;
+
+use super::types::{TrustCreateRequest, TrustResponse};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Create a new trust.
+///
+/// Trust authorization is decided by `policy/trust/create.rego` off the
+/// caller's identity (`credentials.user_id` must match the requested
+/// `trustor_user_id`) rather than the resource's own role list -- the
+/// trustor-holds-the-role invariant is enforced provider-side
+/// (`TrustService::create_trust`), not by policy.
+#[utoipa::path(
+    post,
+    path = "/",
+    responses(
+        (status = CREATED, description = "Trust created", body = TrustResponse),
+        (status = 400, description = "Invalid input"),
+        (status = 403, description = "Forbidden"),
+        (status = 500, description = "Internal error")
+    ),
+    tag="OS-TRUST"
+)]
+#[tracing::instrument(name = "api::v3::trust_create", level = "debug", skip(state))]
+pub(super) async fn create(
+    Auth(user_auth): Auth,
+    State(state): State<ServiceState>,
+    Json(payload): Json<TrustCreateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    payload.validate()?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/trust/create",
+            &user_auth,
+            json!({"trust": payload.trust}),
+            None,
+        )
+        .await?;
+
+    let created = state
+        .provider
+        .get_trust_provider()
+        .create_trust(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            payload.into(),
+        )
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(TrustResponse {
+            trust: created.into(),
+        }),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::trust::TrustBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::os_trust::trust::types::{
+        Trust as ApiTrust, TrustCreate, TrustCreateRequest, TrustResponse,
+    };
+    use crate::provider::Provider;
+    use crate::trust::MockTrustProvider;
+
+    fn create_request() -> TrustCreateRequest {
+        TrustCreateRequest {
+            trust: TrustCreate {
+                id: None,
+                trustor_user_id: "trustor".into(),
+                trustee_user_id: "trustee".into(),
+                project_id: None,
+                impersonation: false,
+                expires_at: None,
+                remaining_uses: None,
+                redelegated_trust_id: None,
+                redelegation_count: None,
+                roles: Vec::new(),
+                extra: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create() {
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock.expect_create_trust().returning(|_, t| {
+            Ok(TrustBuilder::default()
+                .id("new_trust_id")
+                .trustor_user_id(t.trustor_user_id)
+                .trustee_user_id(t.trustee_user_id)
+                .impersonation(t.impersonation)
+                .build()
+                .unwrap())
+        });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(
+                        serde_json::to_string(&create_request()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: TrustResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiTrust {
+                id: "new_trust_id".into(),
+                trustor_user_id: "trustor".into(),
+                trustee_user_id: "trustee".into(),
+                project_id: None,
+                impersonation: false,
+                expires_at: None,
+                remaining_uses: None,
+                redelegated_trust_id: None,
+                redelegation_count: None,
+                roles: Vec::new(),
+                extra: None,
+            },
+            res.trust,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_forbidden() {
+        let trust_mock = MockTrustProvider::default();
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(
+                        serde_json::to_string(&create_request()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_create_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("Content-Type", "application/json")
+                    .method("POST")
+                    .body(Body::from(
+                        serde_json::to_string(&create_request()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/os_trust/trust/delete.rs
+++ b/crates/keystone/src/api/v3/os_trust/trust/delete.rs
@@ -1,0 +1,252 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Delete trust API.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Delete a trust.
+///
+/// Deleting a trust immediately revokes any tokens issued from it (see
+/// `TrustService::delete_trust`).
+#[utoipa::path(
+    delete,
+    path = "/{trust_id}",
+    description = "Delete trust by ID",
+    params(),
+    responses(
+        (status = NO_CONTENT, description = "Trust deleted"),
+        (status = 404, description = "Trust not found", example = json!(KeystoneApiError::NotFound{resource: "trust".into(), identifier: "id = 1".into()}))
+    ),
+    tag="OS-TRUST"
+)]
+#[tracing::instrument(name = "api::trust_delete", level = "debug", skip(state))]
+pub(super) async fn delete(
+    Auth(user_auth): Auth,
+    Path(trust_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_trust_provider()
+        .get_trust(&ExecutionContext::from_auth(&state, &user_auth), &trust_id)
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/trust/delete",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(json!({"trust": current})),
+        )
+        .await?;
+
+    match current {
+        Some(_) => {
+            state
+                .provider
+                .get_trust_provider()
+                .delete_trust(&ExecutionContext::from_auth(&state, &user_auth), &trust_id)
+                .await?;
+
+            Ok(StatusCode::NO_CONTENT.into_response())
+        }
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "trust".into(),
+            identifier: trust_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::trust::TrustBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::provider::Provider;
+    use crate::trust::MockTrustProvider;
+
+    #[tokio::test]
+    async fn test_delete_success() {
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_get_trust()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    TrustBuilder::default()
+                        .id("foo")
+                        .trustor_user_id("trustor")
+                        .trustee_user_id("trustee")
+                        .impersonation(false)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+        trust_mock
+            .expect_delete_trust()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(()));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_get_trust()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_delete_forbidden() {
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_get_trust()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    TrustBuilder::default()
+                        .id("foo")
+                        .trustor_user_id("trustor")
+                        .trustee_user_id("trustee")
+                        .impersonation(false)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_delete_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/foo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/os_trust/trust/list.rs
+++ b/crates/keystone/src/api/v3/os_trust/trust/list.rs
@@ -1,0 +1,223 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use super::types::{Trust, TrustList, TrustListParameters};
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core::policy::PolicyError;
+
+/// List trusts.
+///
+/// Two-phase policy check (I8, CVE-2019-19687 class): the collection-level
+/// `identity/trust/list` policy is enforced first against the filter hints,
+/// then every returned trust is individually re-checked against
+/// `identity/trust/show` using that record's own trustor/trustee identity,
+/// dropping any the caller may not read -- authorization here depends on
+/// per-item identity, not a uniform collection-level rule.
+#[utoipa::path(
+    get,
+    path = "/",
+    params(TrustListParameters),
+    description = "List trusts",
+    responses(
+        (status = OK, description = "List of trusts", body = TrustList),
+        (status = 500, description = "Internal error")
+    ),
+    tag="OS-TRUST"
+)]
+#[tracing::instrument(name = "api::trust_list", level = "debug", skip(state))]
+pub(super) async fn list(
+    Auth(user_auth): Auth,
+    Query(query): Query<TrustListParameters>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/trust/list",
+            &user_auth,
+            json!({"trust": query}),
+            None,
+        )
+        .await?;
+
+    let raw = state
+        .provider
+        .get_trust_provider()
+        .list_trusts(
+            &ExecutionContext::from_auth(&state, &user_auth),
+            &query.into(),
+        )
+        .await?;
+
+    let mut trusts = Vec::with_capacity(raw.len());
+    for item in raw {
+        match state
+            .policy_enforcer
+            .enforce(
+                "identity/trust/show",
+                &user_auth,
+                serde_json::Value::Null,
+                Some(json!({"trust": item})),
+            )
+            .await
+        {
+            Ok(_) => trusts.push(Trust::from(item)),
+            Err(PolicyError::Forbidden(_)) => continue,
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    Ok((StatusCode::OK, Json(TrustList { trusts })).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::trust::{TrustBuilder, TrustListParameters};
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::os_trust::trust::types::TrustList;
+    use crate::provider::Provider;
+    use crate::trust::MockTrustProvider;
+
+    #[tokio::test]
+    async fn test_list() {
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_list_trusts()
+            .withf(|_, _: &TrustListParameters| true)
+            .returning(|_, _| {
+                Ok(vec![
+                    TrustBuilder::default()
+                        .id("1")
+                        .trustor_user_id("trustor")
+                        .trustee_user_id("trustee")
+                        .impersonation(false)
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: TrustList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.trusts.len(), 1);
+        assert_eq!(res.trusts[0].id, "1");
+    }
+
+    #[tokio::test]
+    async fn test_list_collection_denied_drops_all_items() {
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock.expect_list_trusts().returning(|_, _| {
+            Ok(vec![
+                TrustBuilder::default()
+                    .id("1")
+                    .trustor_user_id("trustor")
+                    .trustee_user_id("trustee")
+                    .impersonation(false)
+                    .build()
+                    .unwrap(),
+            ])
+        });
+
+        let vsc = test_fixture_scoped();
+        // policy_allow = false: the initial list-level check is rejected,
+        // so the handler must not reach the per-item loop.
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_list_unauth() {
+        let state = get_mocked_state(Provider::mocked_builder(), false, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/os_trust/trust/mod.rs
+++ b/crates/keystone/src/api/v3/os_trust/trust/mod.rs
@@ -11,32 +11,23 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # Integration tests
+//! # Trust API
 //!
-//! Test the functionality on the provider level (not through the API).
+//! Trusts are immutable (no `update`) -- see
+//! `openstack_keystone_core::trust` module docs.
 
-mod api_key;
-mod application_credential;
-mod assignment;
-mod audit;
-mod catalog;
-mod common;
-mod credential;
-mod identity;
-mod k8s_auth;
-mod mapping;
-mod oauth2_device_grant;
-mod oauth2_emergency_rotation;
-mod oauth2_key_janitor;
-mod oauth2_session;
-mod oauth2_token_exchange;
-mod oauth2_token_verify;
-mod resource;
-mod revoke;
-mod role;
-mod scim_realm;
-mod token;
-mod trust;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
-#[macro_use]
-mod macros;
+use crate::keystone::ServiceState;
+
+mod create;
+mod delete;
+mod list;
+mod show;
+pub mod types;
+
+pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
+    OpenApiRouter::new()
+        .routes(routes!(list::list, create::create))
+        .routes(routes!(show::show, delete::delete))
+}

--- a/crates/keystone/src/api/v3/os_trust/trust/show.rs
+++ b/crates/keystone/src/api/v3/os_trust/trust/show.rs
@@ -1,0 +1,212 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+
+use openstack_keystone_api_types::v3::trust::{Trust, TrustResponse};
+
+use crate::api::auth::Auth;
+use crate::api::error::KeystoneApiError;
+use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+
+/// Get single trust.
+#[utoipa::path(
+    get,
+    path = "/{trust_id}",
+    description = "Get trust by ID",
+    params(),
+    responses(
+        (status = OK, description = "Trust object", body = TrustResponse),
+        (status = 404, description = "Trust not found", example = json!(KeystoneApiError::NotFound{resource: "trust".into(), identifier: "id = 1".into()}))
+    ),
+    tag="OS-TRUST"
+)]
+#[tracing::instrument(name = "api::trust_get", level = "debug", skip(state))]
+pub(super) async fn show(
+    Auth(user_auth): Auth,
+    Path(trust_id): Path<String>,
+    State(state): State<ServiceState>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    let current = state
+        .provider
+        .get_trust_provider()
+        .get_trust(&ExecutionContext::from_auth(&state, &user_auth), &trust_id)
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            "identity/trust/show",
+            &user_auth,
+            serde_json::Value::Null,
+            Some(json!({"trust": current})),
+        )
+        .await?;
+
+    match current {
+        Some(current) => Ok((
+            StatusCode::OK,
+            Json(TrustResponse {
+                trust: Trust::from(current),
+            }),
+        )
+            .into_response()),
+        _ => Err(KeystoneApiError::NotFound {
+            resource: "trust".into(),
+            identifier: trust_id,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+
+    use openstack_keystone_core_types::trust::TrustBuilder;
+
+    use super::super::openapi_router;
+    use crate::api::tests::{get_mocked_state, test_fixture_scoped};
+    use crate::api::v3::os_trust::trust::types::{Trust as ApiTrust, TrustResponse};
+    use crate::provider::Provider;
+    use crate::trust::MockTrustProvider;
+
+    #[tokio::test]
+    async fn test_show_success() {
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_get_trust()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| {
+                Ok(Some(
+                    TrustBuilder::default()
+                        .id("foo")
+                        .trustor_user_id("trustor")
+                        .trustee_user_id("trustee")
+                        .impersonation(false)
+                        .build()
+                        .unwrap(),
+                ))
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: TrustResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            ApiTrust {
+                id: "foo".into(),
+                trustor_user_id: "trustor".into(),
+                trustee_user_id: "trustee".into(),
+                project_id: None,
+                impersonation: false,
+                expires_at: None,
+                remaining_uses: None,
+                redelegated_trust_id: None,
+                redelegation_count: None,
+                roles: Vec::new(),
+                extra: None,
+            },
+            res.trust,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_show_not_found_not_allowed() {
+        let mut trust_mock = MockTrustProvider::default();
+        trust_mock
+            .expect_get_trust()
+            .withf(|_, id: &'_ str| id == "foo")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_trust(trust_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/foo")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_show_unauthorized() {
+        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(Request::builder().uri("/foo").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/keystone/src/api/v3/os_trust/trust/types.rs
+++ b/crates/keystone/src/api/v3/os_trust/trust/types.rs
@@ -11,32 +11,5 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! # Integration tests
-//!
-//! Test the functionality on the provider level (not through the API).
 
-mod api_key;
-mod application_credential;
-mod assignment;
-mod audit;
-mod catalog;
-mod common;
-mod credential;
-mod identity;
-mod k8s_auth;
-mod mapping;
-mod oauth2_device_grant;
-mod oauth2_emergency_rotation;
-mod oauth2_key_janitor;
-mod oauth2_session;
-mod oauth2_token_exchange;
-mod oauth2_token_verify;
-mod resource;
-mod revoke;
-mod role;
-mod scim_realm;
-mod token;
-mod trust;
-
-#[macro_use]
-mod macros;
+pub use openstack_keystone_api_types::v3::trust::*;

--- a/crates/trust-driver-sql/src/lib.rs
+++ b/crates/trust-driver-sql/src/lib.rs
@@ -45,6 +45,26 @@ inventory::submit! {
 
 #[async_trait]
 impl TrustBackend for SqlBackend {
+    /// Create a new trust.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn create_trust(
+        &self,
+        state: &ServiceState,
+        trust: TrustCreate,
+    ) -> Result<Trust, TrustProviderError> {
+        trust::create(&state.db, trust).await
+    }
+
+    /// Delete a trust by ID.
+    #[tracing::instrument(level = "debug", skip(self, state))]
+    async fn delete_trust<'a>(
+        &self,
+        state: &ServiceState,
+        id: &'a str,
+    ) -> Result<(), TrustProviderError> {
+        trust::delete(&state.db, id).await
+    }
+
     /// Get trust by ID.
     #[tracing::instrument(level = "debug", skip(self, state))]
     async fn get_trust<'a>(

--- a/crates/trust-driver-sql/src/trust.rs
+++ b/crates/trust-driver-sql/src/trust.rs
@@ -22,9 +22,13 @@ use openstack_keystone_core_types::trust::*;
 
 use crate::entity::{trust as db_trust, trust_role as db_trust_role};
 
+mod create;
+mod delete;
 mod get;
 mod list;
 
+pub use create::create;
+pub use delete::delete;
 pub use get::{get, get_delegation_chain};
 pub use list::list;
 

--- a/crates/trust-driver-sql/src/trust/create.rs
+++ b/crates/trust-driver-sql/src/trust/create.rs
@@ -1,0 +1,91 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use sea_orm::TransactionTrait;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::trust::TrustProviderError;
+use openstack_keystone_core_types::trust::*;
+
+use crate::entity::{
+    prelude::TrustRole as DbTrustRole, trust as db_trust, trust_role as db_trust_role,
+};
+
+impl TryFrom<TrustCreate> for db_trust::ActiveModel {
+    type Error = TrustProviderError;
+
+    fn try_from(value: TrustCreate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            // The trust id is always populated by `TrustService::create_trust`
+            // before the backend is invoked.
+            id: Set(value.id.unwrap_or_default()),
+            trustor_user_id: Set(value.trustor_user_id),
+            trustee_user_id: Set(value.trustee_user_id),
+            project_id: Set(value.project_id),
+            impersonation: Set(value.impersonation),
+            deleted_at: NotSet,
+            expires_at: NotSet,
+            remaining_uses: Set(value.remaining_uses),
+            extra: Set(value.extra.map(|v| serde_json::to_string(&v)).transpose()?),
+            expires_at_int: Set(value.expires_at.map(|v| v.timestamp_micros())),
+            redelegated_trust_id: Set(value.redelegated_trust_id),
+            redelegation_count: Set(value.redelegation_count),
+        })
+    }
+}
+
+/// Create the trust.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `rec`: The trust to create.
+///
+/// # Returns
+/// A `Result` containing the created `Trust` or an `Error`.
+pub async fn create(
+    db: &DatabaseConnection,
+    rec: TrustCreate,
+) -> Result<Trust, TrustProviderError> {
+    let txn = db
+        .begin()
+        .await
+        .context("starting transaction for persisting trust")?;
+
+    let roles = rec.roles.clone();
+    let model = db_trust::ActiveModel::try_from(rec)?;
+
+    let db_entry = model.insert(&txn).await.context("persisting trust")?;
+
+    if !roles.is_empty() {
+        DbTrustRole::insert_many(roles.iter().map(|role| db_trust_role::ActiveModel {
+            trust_id: Set(db_entry.id.clone()),
+            role_id: Set(role.id.clone()),
+        }))
+        .exec(&txn)
+        .await
+        .context("persisting trust role relations")?;
+    }
+
+    txn.commit()
+        .await
+        .context("committing transaction for persisting trust")?;
+
+    let mut trust: Trust = db_entry.try_into()?;
+    if !roles.is_empty() {
+        trust.roles = Some(roles);
+    }
+    Ok(trust)
+}

--- a/crates/trust-driver-sql/src/trust/delete.rs
+++ b/crates/trust-driver-sql/src/trust/delete.rs
@@ -1,0 +1,44 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::DatabaseConnection;
+use sea_orm::entity::*;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::trust::TrustProviderError;
+
+use crate::entity::prelude::Trust as DbTrust;
+
+/// Soft-delete the trust by ID.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `id`: The ID of the trust to delete.
+pub async fn delete<I: AsRef<str>>(
+    db: &DatabaseConnection,
+    id: I,
+) -> Result<(), TrustProviderError> {
+    if let Some(entry) = DbTrust::find_by_id(id.as_ref())
+        .one(db)
+        .await
+        .context("fetching trust by id")?
+    {
+        let mut model: crate::entity::trust::ActiveModel = entry.into();
+        model.deleted_at = Set(Some(chrono::Utc::now().naive_utc()));
+        model.update(db).await.context("soft-deleting trust")?;
+    } else {
+        return Err(TrustProviderError::TrustNotFound(id.as_ref().to_string()));
+    }
+    Ok(())
+}

--- a/crates/trust-driver-sql/src/trust/get.rs
+++ b/crates/trust-driver-sql/src/trust/get.rs
@@ -23,15 +23,20 @@ use openstack_keystone_core_types::trust::Trust;
 
 use crate::entity::{
     prelude::{Trust as DbTrust, TrustRole as DbTrustRole},
-    trust_role as db_trust_role,
+    trust as db_trust, trust_role as db_trust_role,
 };
 
 /// Get trust credential by the ID.
+///
+/// Excludes soft-deleted trusts, mirroring `list()`'s default
+/// `include_deleted = false` behaviour -- once deleted a trust must read as
+/// gone (404) via `get`/`show`/`delete`'s existence check, not merely marked.
 pub async fn get<I: AsRef<str>>(
     db: &DatabaseConnection,
     id: I,
 ) -> Result<Option<Trust>, TrustProviderError> {
     if let Some(ref entry) = DbTrust::find_by_id(id.as_ref())
+        .filter(db_trust::Column::DeletedAt.is_null())
         .one(db)
         .await
         .context("fetching trust by id")?
@@ -133,7 +138,7 @@ mod tests {
             [
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "trust"."id", "trust"."trustor_user_id", "trust"."trustee_user_id", "trust"."project_id", "trust"."impersonation", "trust"."deleted_at", "trust"."expires_at", "trust"."remaining_uses", "trust"."extra", "trust"."expires_at_int", "trust"."redelegated_trust_id", "trust"."redelegation_count" FROM "trust" WHERE "trust"."id" = $1 LIMIT $2"#,
+                    r#"SELECT "trust"."id", "trust"."trustor_user_id", "trust"."trustee_user_id", "trust"."project_id", "trust"."impersonation", "trust"."deleted_at", "trust"."expires_at", "trust"."remaining_uses", "trust"."extra", "trust"."expires_at_int", "trust"."redelegated_trust_id", "trust"."redelegation_count" FROM "trust" WHERE "trust"."id" = $1 AND "trust"."deleted_at" IS NULL LIMIT $2"#,
                     ["trust_id".into(), 1u64.into()]
                 ),
                 Transaction::from_sql_and_values(

--- a/policy/trust/common.rego
+++ b/policy/trust/common.rego
@@ -1,0 +1,52 @@
+# METADATA
+# title: Trust identity/delegation-boundary helpers
+# description: >
+#   Shared predicates for identity.trust.* policies. `is_trustor`/`is_trustee`
+#   decide "did the caller create/consume this trust"; the delegation-project
+#   boundary helper mirrors identity.credential's (OSSA-2026-015) for the case
+#   where a delegated caller (trust, application credential) itself attempts
+#   to create a new trust (see `doc/src/contributor/security-model.md` I2/I3).
+package identity.trust
+
+# METADATA
+# description: "True when the caller is the trust's trustor."
+is_trustor(trust) if {
+	trust.trustor_user_id == input.credentials.user_id
+}
+
+# METADATA
+# description: "True when the caller is the trust's trustee."
+is_trustee(trust) if {
+	trust.trustee_user_id == input.credentials.user_id
+}
+
+# METADATA
+# description: >
+#   True when `project_id` is the delegation's own immutable project
+#   (chain-derived `input.credentials.delegated_project_id`), with the token
+#   scope pinned to the same project as a scope-drift tripwire (I3).
+bound_to_own_delegation_project(project_id) if {
+	project_id == input.credentials.delegated_project_id
+	input.credentials.delegated_project_id != null
+	input.credentials.project_id == input.credentials.delegated_project_id
+}
+
+# METADATA
+# description: >
+#   True when the caller is not delegated at all, or is delegated and
+#   `project_id` is bound to the delegation's own project.
+#
+#   Callers MUST pass a value that is never undefined (e.g.
+#   `object.get(input.target.trust, "project_id", null)`, not a bare
+#   `input.target.trust.project_id`) -- Rego evaluates a function's argument
+#   before dispatching to either body below, so an undefined argument makes
+#   the whole call (including the "not delegated" fast path, which never
+#   reads it) undefined too.
+not_delegated_or_bound_to_own_project(project_id) if {
+	not input.credentials.is_delegated
+}
+
+not_delegated_or_bound_to_own_project(project_id) if {
+	input.credentials.is_delegated
+	bound_to_own_delegation_project(project_id)
+}

--- a/policy/trust/create.rego
+++ b/policy/trust/create.rego
@@ -1,0 +1,40 @@
+# METADATA
+# title: Create trust
+# description: Policy for creating a trust
+package identity.trust.create
+
+import data.identity.trust as trust_common
+
+# Create trust.
+#
+# The `input.target.trust` is the new trust object (TrustCreate):
+#   trustor_user_id: string            Must equal the caller's own user_id;
+#                                      a trust is always self-issued by its
+#                                      trustor.
+#   trustee_user_id: string            The user the authorization is
+#                                      delegated to.
+#   project_id:      string (optional) Project being delegated on.
+#   roles:           array             Roles being delegated.
+#
+# The `input.existing` is null
+#
+# Delegation boundary (OSSA-2026-015): a delegated caller (trust,
+# application credential) may only create a new trust bound to its own
+# delegation project -- never an unscoped trust and never one bound to a
+# different project -- anchored on the chain-derived
+# `input.credentials.delegated_project_id`, not the token scope, with the
+# scope pinned equal as a drift tripwire.
+#
+default allow := false
+
+# METADATA
+# description: >
+#   A trust is always self-issued: the caller must be its own trustor.
+#   Matches python keystone's `identity:create_trust` policy, which has no
+#   admin bypass -- even an admin cannot create a trust on behalf of another
+#   user.
+allow if {
+	"member" in input.credentials.roles
+	trust_common.is_trustor(input.target.trust)
+	trust_common.not_delegated_or_bound_to_own_project(object.get(input.target.trust, "project_id", null))
+}

--- a/policy/trust/create_test.rego
+++ b/policy/trust/create_test.rego
@@ -1,0 +1,37 @@
+package test_trust_create
+
+import data.identity.trust.create
+
+test_allowed if {
+	create.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1"}, "target": {"trust": {"trustor_user_id": "u1"}}}
+}
+
+test_forbidden if {
+	# Not the trustor.
+	not create.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1"}, "target": {"trust": {"trustor_user_id": "other"}}}
+
+	not create.allow with input as {"credentials": {"roles": []}, "target": {"trust": {"trustor_user_id": "u1"}}}
+
+	# No admin bypass: matches python keystone's identity:create_trust,
+	# which has no admin_required clause.
+	not create.allow with input as {"credentials": {"roles": ["admin"], "user_id": "u2"}, "target": {"trust": {"trustor_user_id": "other"}}}
+
+	not create.allow with input as {"credentials": {"roles": ["admin"], "is_admin": true, "user_id": "u2"}, "target": {"trust": {"trustor_user_id": "other"}}}
+}
+
+# OSSA-2026-015: a delegated (trust/app-cred) caller creating a *new* trust
+# must only bind it to its own delegation project.
+test_delegated_allowed if {
+	create.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1", "is_delegated": true, "project_id": "p1", "delegated_project_id": "p1"}, "target": {"trust": {"trustor_user_id": "u1", "project_id": "p1"}}}
+}
+
+test_delegated_forbidden if {
+	# Different project than the delegation is bound to.
+	not create.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1", "is_delegated": true, "project_id": "p2", "delegated_project_id": "p2"}, "target": {"trust": {"trustor_user_id": "u1", "project_id": "p1"}}}
+
+	# Unscoped trust is out-of-scope for any delegated caller.
+	not create.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1", "is_delegated": true, "project_id": "p1", "delegated_project_id": "p1"}, "target": {"trust": {"trustor_user_id": "u1"}}}
+
+	# Scope-drift tripwire: token scope diverges from the delegation's own project.
+	not create.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1", "is_delegated": true, "project_id": "p2", "delegated_project_id": "p1"}, "target": {"trust": {"trustor_user_id": "u1", "project_id": "p1"}}}
+}

--- a/policy/trust/delete.rego
+++ b/policy/trust/delete.rego
@@ -1,0 +1,33 @@
+# METADATA
+# title: Delete trust
+# description: Policy for deleting a trust
+package identity.trust.delete
+
+import data.identity.trust as trust_common
+
+# Delete trust.
+#
+# The `input.existing.trust` is the stored trust object (Trust), see
+# `identity/trust/show`.
+#
+# The `input.target` is null
+#
+# Only the trustor (or admin) may delete a trust -- the trustee has no
+# authority to revoke a delegation it did not grant.
+#
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+# METADATA
+# description: "The trustor may delete a trust they created."
+allow if {
+	"member" in input.credentials.roles
+	trust_common.is_trustor(input.existing.trust)
+}

--- a/policy/trust/delete_test.rego
+++ b/policy/trust/delete_test.rego
@@ -1,0 +1,15 @@
+package test_trust_delete
+
+import data.identity.trust.delete
+
+test_allowed if {
+	delete.allow with input as {"credentials": {"roles": ["admin"]}, "existing": {"trust": {"trustor_user_id": "other", "trustee_user_id": "other2"}}}
+	delete.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1"}, "existing": {"trust": {"trustor_user_id": "u1", "trustee_user_id": "other"}}}
+}
+
+test_forbidden if {
+	# The trustee has no authority to revoke a trust it did not grant.
+	not delete.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1"}, "existing": {"trust": {"trustor_user_id": "other", "trustee_user_id": "u1"}}}
+
+	not delete.allow with input as {"credentials": {"roles": []}, "existing": {"trust": {"trustor_user_id": "u1", "trustee_user_id": "other"}}}
+}

--- a/policy/trust/list.rego
+++ b/policy/trust/list.rego
@@ -1,0 +1,38 @@
+# METADATA
+# title: List trusts
+# description: Policy for listing trusts
+package identity.trust.list
+
+# List trusts.
+#
+# The `input.target.trust` contains query parameters.
+#
+# The `input.existing` is null
+#
+# This is only the first of the two policy checks required to list trusts
+# safely (ADR 0019 §2 pattern, CVE-2019-19687): the API layer additionally
+# re-enforces `identity/trust/show` against every individual record before
+# returning it, so this rule only needs to gate who may attempt a list at
+# all -- the trustor/trustee narrowing happens entirely in that per-item
+# re-check.
+#
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	"reader" in input.credentials.roles
+	input.credentials.system == "all"
+}
+
+# METADATA
+# description: "Any authenticated member may attempt to list; the per-item `identity/trust/show` re-check narrows the result to trusts they are the trustor or trustee of."
+allow if {
+	"member" in input.credentials.roles
+}

--- a/policy/trust/list_test.rego
+++ b/policy/trust/list_test.rego
@@ -1,0 +1,13 @@
+package test_trust_list
+
+import data.identity.trust.list
+
+test_allowed if {
+	list.allow with input as {"credentials": {"roles": ["admin"]}, "target": {"trust": {}}}
+	list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}, "target": {"trust": {}}}
+	list.allow with input as {"credentials": {"roles": ["member"]}, "target": {"trust": {}}}
+}
+
+test_forbidden if {
+	not list.allow with input as {"credentials": {"roles": []}, "target": {"trust": {}}}
+}

--- a/policy/trust/show.rego
+++ b/policy/trust/show.rego
@@ -1,0 +1,43 @@
+# METADATA
+# title: Show trust
+# description: Policy for fetching a single trust
+package identity.trust.show
+
+import data.identity.trust as trust_common
+
+# Show trust.
+#
+# The `input.existing.trust` is the stored trust object (Trust), or null if
+# not found -- see `identity/trust/create` for field shapes.
+#
+# The `input.target` is null
+#
+# This is also invoked by `identity/trust/list`'s per-item re-enforcement
+# pass (ADR 0019 §2 pattern, CVE-2019-19687).
+#
+default allow := false
+
+allow if {
+	"admin" in input.credentials.roles
+}
+
+allow if {
+	input.credentials.is_admin
+}
+
+allow if {
+	"reader" in input.credentials.roles
+	input.credentials.system == "all"
+}
+
+# METADATA
+# description: "The trustor may always read a trust they created."
+allow if {
+	trust_common.is_trustor(input.existing.trust)
+}
+
+# METADATA
+# description: "The trustee may always read a trust delegated to them."
+allow if {
+	trust_common.is_trustee(input.existing.trust)
+}

--- a/policy/trust/show_test.rego
+++ b/policy/trust/show_test.rego
@@ -1,0 +1,15 @@
+package test_trust_show
+
+import data.identity.trust.show
+
+test_allowed if {
+	show.allow with input as {"credentials": {"roles": ["admin"]}, "existing": {"trust": {"trustor_user_id": "other", "trustee_user_id": "other2"}}}
+	show.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}, "existing": {"trust": {"trustor_user_id": "other", "trustee_user_id": "other2"}}}
+	show.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1"}, "existing": {"trust": {"trustor_user_id": "u1", "trustee_user_id": "other"}}}
+	show.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1"}, "existing": {"trust": {"trustor_user_id": "other", "trustee_user_id": "u1"}}}
+}
+
+test_forbidden if {
+	# Neither trustor nor trustee, no elevated role.
+	not show.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1"}, "existing": {"trust": {"trustor_user_id": "other", "trustee_user_id": "other2"}}}
+}

--- a/tests/api/src/lib.rs
+++ b/tests/api/src/lib.rs
@@ -31,6 +31,7 @@ pub mod scim;
 pub mod scim_realm;
 pub mod service;
 pub mod token_restriction;
+pub mod trust;
 pub mod webauthn;
 
 pub mod k8s_auth {

--- a/tests/api/src/macros.rs
+++ b/tests/api/src/macros.rs
@@ -74,23 +74,22 @@
 //!
 //! Generated per operation:
 //!
-//! - `create`: private request struct, `RestEndpoint` impl (POST `path`,
-//!   JSON body under `body_key`), and
-//!   `pub async fn <func>(tc, <create_type>) -> Result<AsyncResourceGuard<model>>`.
-//! - `show`: private request struct, `RestEndpoint` impl (GET
-//!   `path/{id}`), and `pub async fn <func>(tc, id) -> Result<model>`.
-//! - `update`: private request struct, `RestEndpoint` impl (PATCH
-//!   `path/{id}`, JSON body under `body_key`), and
-//!   `pub async fn <func>(tc, id, <update_type>) -> Result<model>`.
+//! - `create`: private request struct, `RestEndpoint` impl (POST `path`, JSON
+//!   body under `body_key`), and `pub async fn <func>(tc, <create_type>) ->
+//!   Result<AsyncResourceGuard<model>>`.
+//! - `show`: private request struct, `RestEndpoint` impl (GET `path/{id}`), and
+//!   `pub async fn <func>(tc, id) -> Result<model>`.
+//! - `update`: private request struct, `RestEndpoint` impl (PATCH `path/{id}`,
+//!   JSON body under `body_key`), and `pub async fn <func>(tc, id,
+//!   <update_type>) -> Result<model>`.
 //! - `list`: **public** request struct with `Option<String>` query fields,
-//!   `RestEndpoint` impl (GET `path`), and
-//!   `pub async fn <func>(tc, params) -> Result<Vec<model>>`.
+//!   `RestEndpoint` impl (GET `path`), and `pub async fn <func>(tc, params) ->
+//!   Result<Vec<model>>`.
 //! - `delete`: private request struct, `RestEndpoint` impl (DELETE
-//!   `path/{id}`), `impl DeletableResource for <model>` (requires `model`
-//!   to have an `id: String` field), and
-//!   `pub async fn <func>(tc, id) -> Result<()>`. Use `delete_impl` instead
-//!   of `delete` when only the `DeletableResource` impl is wanted without a
-//!   public delete function.
+//!   `path/{id}`), `impl DeletableResource for <model>` (requires `model` to
+//!   have an `id: String` field), and `pub async fn <func>(tc, id) ->
+//!   Result<()>`. Use `delete_impl` instead of `delete` when only the
+//!   `DeletableResource` impl is wanted without a public delete function.
 macro_rules! crud_endpoint {
     // Entry: one or more operation blocks.
     ($($op:ident { $($body:tt)* })+) => {

--- a/tests/api/src/trust.rs
+++ b/tests/api/src/trust.rs
@@ -1,0 +1,62 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! v3 trust CRUD helpers, generated with [`crate::macros::crud_endpoint`].
+//!
+//! Trusts are immutable server-side (no PATCH), so only create/show/list/
+//! delete are generated.
+
+use openstack_keystone_api_types::v3::trust::*;
+
+use crate::macros::crud_endpoint;
+
+crud_endpoint! {
+    create {
+        request = TrustCreateRequestApi,
+        func = create_trust,
+        path = "OS-TRUST/trusts",
+        body_key = "trust",
+        create_type = TrustCreate,
+        model = Trust,
+        response_key = "trust",
+        service = Identity,
+        api_version = (3, 0),
+    }
+    show {
+        request = TrustShowRequest,
+        func = show_trust,
+        path = "OS-TRUST/trusts",
+        model = Trust,
+        response_key = "trust",
+        service = Identity,
+        api_version = (3, 0),
+    }
+    list {
+        request = TrustListRequest,
+        func = list_trusts,
+        path = "OS-TRUST/trusts",
+        model = Trust,
+        response_key = "trusts",
+        service = Identity,
+        api_version = (3, 0),
+        query = [include_deleted],
+    }
+    delete {
+        request = TrustDeleteRequest,
+        func = delete_trust,
+        path = "OS-TRUST/trusts",
+        model = Trust,
+        service = Identity,
+        api_version = (3, 0),
+    }
+}

--- a/tests/api/tests/api_v3.rs
+++ b/tests/api/tests/api_v3.rs
@@ -26,4 +26,5 @@ mod api_v3 {
     mod resource;
     mod role;
     mod service;
+    mod trust;
 }

--- a/tests/api/tests/api_v3/trust.rs
+++ b/tests/api/tests/api_v3/trust.rs
@@ -1,0 +1,105 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod create;
+mod delete;
+mod list;
+mod show;
+
+use std::sync::Arc;
+
+use eyre::{OptionExt, Result};
+use uuid::Uuid;
+
+use openstack_keystone_api_types::scope::{DomainBuilder, Scope, ScopeProjectBuilder};
+use openstack_keystone_api_types::v3::project::{Project, ProjectCreateBuilder};
+use openstack_keystone_api_types::v3::user::{User, UserCreateBuilder};
+use openstack_sdk::AsyncOpenStack;
+
+use test_api::assignment::grant::add_project_grant;
+use test_api::common::get_user_session;
+use test_api::guard::{AsyncResourceGuard, ResourceGuard};
+use test_api::identity::user::create_user;
+use test_api::resource::project::create_project;
+use test_api::role::list_roles;
+
+pub(crate) const TRUST_FIXTURE_PASSWORD: &str = "trust-fixture-password";
+
+/// A trustor user holding the `member` role on a project, authenticated
+/// through the live password-auth path.
+///
+/// `identity/trust/create` requires the caller to self-issue (be its own
+/// `trustor_user_id`) and to carry `member` in its token's role set --
+/// there is no admin bypass, matching python keystone's
+/// `identity:create_trust` -- so trust-creation tests must act through this
+/// session rather than the admin `tc`. All fixture resources are created
+/// by, and cleaned up with, the admin session.
+pub(crate) struct TrustorSession {
+    pub session: Arc<AsyncOpenStack>,
+    pub user: AsyncResourceGuard<User>,
+    pub project: AsyncResourceGuard<Project>,
+}
+
+impl TrustorSession {
+    pub(crate) async fn provision(admin: &Arc<AsyncOpenStack>, domain_id: &str) -> Result<Self> {
+        let unique = Uuid::new_v4().simple().to_string();
+        let project = create_project(
+            admin,
+            ProjectCreateBuilder::default()
+                .name(format!("trust-proj-{unique}"))
+                .domain_id(domain_id)
+                .parent_id(domain_id)
+                .is_domain(false)
+                .enabled(true)
+                .build()?,
+        )
+        .await?;
+        let user = create_user(
+            admin,
+            UserCreateBuilder::default()
+                .name(format!("trustor-{unique}"))
+                .domain_id(domain_id)
+                .password(TRUST_FIXTURE_PASSWORD)
+                .enabled(true)
+                .build()?,
+        )
+        .await?;
+        let member_role = list_roles(admin)
+            .await?
+            .into_iter()
+            .find(|role| role.name == "member")
+            .ok_or_eyre("bootstrap `member` role must exist")?;
+        add_project_grant(admin, &project.id, &user.id, &member_role.id).await?;
+
+        let scope = Scope::Project(
+            ScopeProjectBuilder::default()
+                .id(project.id.clone())
+                .domain(DomainBuilder::default().id(domain_id).build()?)
+                .build()?,
+        );
+        let session =
+            get_user_session(&user.name, TRUST_FIXTURE_PASSWORD, domain_id, Some(&scope)).await?;
+        Ok(Self {
+            session,
+            user,
+            project,
+        })
+    }
+
+    pub(crate) async fn cleanup(self) -> Result<()> {
+        self.user.delete().await?;
+        self.project.delete().await?;
+        Ok(())
+    }
+}

--- a/tests/api/tests/api_v3/trust/create.rs
+++ b/tests/api/tests/api_v3/trust/create.rs
@@ -1,0 +1,246 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::project::ProjectCreateBuilder;
+use openstack_keystone_api_types::v3::trust::*;
+use openstack_keystone_api_types::v3::user::{User, UserCreateBuilder};
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::assignment::grant::add_project_grant;
+use test_api::guard::{AsyncResourceGuard, ResourceGuard};
+use test_api::identity::user::create_user;
+use test_api::resource::project::create_project;
+use test_api::role::list_roles;
+use test_api::trust::create_trust;
+
+use super::TrustorSession;
+
+async fn new_trustee(tc: &Arc<AsyncOpenStack>) -> Result<AsyncResourceGuard<User>> {
+    create_user(
+        tc,
+        UserCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .enabled(true)
+            .build()?,
+    )
+    .await
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_unscoped_trust() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let trustor = TrustorSession::provision(&tc, "default").await?;
+    let trustee = new_trustee(&tc).await?;
+
+    let trust = create_trust(
+        &trustor.session,
+        TrustCreate {
+            id: None,
+            trustor_user_id: trustor.user.id.clone(),
+            trustee_user_id: trustee.id.clone(),
+            project_id: None,
+            impersonation: false,
+            expires_at: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: Vec::new(),
+            extra: None,
+        },
+    )
+    .await?;
+
+    assert!(!trust.id.is_empty());
+    assert_eq!(trust.trustor_user_id, trustor.user.id);
+    assert_eq!(trust.trustee_user_id, trustee.id);
+    assert!(trust.project_id.is_none());
+
+    trust.delete().await?;
+    trustee.delete().await?;
+    trustor.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_with_granted_roles() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let trustor = TrustorSession::provision(&tc, "default").await?;
+    let trustee = new_trustee(&tc).await?;
+
+    let project = create_project(
+        &tc,
+        ProjectCreateBuilder::default()
+            .domain_id("default")
+            .parent_id("default")
+            .name(Uuid::new_v4().simple().to_string())
+            .is_domain(false)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let roles: HashMap<String, String> = list_roles(&tc)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let member_role_id = roles.get("member").expect("member role must exist");
+    add_project_grant(&tc, &project.id, &trustor.user.id, member_role_id).await?;
+
+    let trust = create_trust(
+        &trustor.session,
+        TrustCreate {
+            id: None,
+            trustor_user_id: trustor.user.id.clone(),
+            trustee_user_id: trustee.id.clone(),
+            project_id: Some(project.id.clone()),
+            impersonation: false,
+            expires_at: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: vec![TrustRoleRef {
+                domain_id: None,
+                id: member_role_id.clone(),
+                name: None,
+            }],
+            extra: None,
+        },
+    )
+    .await?;
+
+    assert_eq!(trust.project_id.as_deref(), Some(project.id.as_str()));
+    assert!(trust.roles.iter().any(|r| &r.id == member_role_id));
+
+    trust.delete().await?;
+    project.delete().await?;
+    trustee.delete().await?;
+    trustor.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_role_not_granted_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let trustor = TrustorSession::provision(&tc, "default").await?;
+    let trustee = new_trustee(&tc).await?;
+
+    let project = create_project(
+        &tc,
+        ProjectCreateBuilder::default()
+            .domain_id("default")
+            .parent_id("default")
+            .name(Uuid::new_v4().simple().to_string())
+            .is_domain(false)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let roles: HashMap<String, String> = list_roles(&tc)
+        .await?
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+    let member_role_id = roles.get("member").expect("member role must exist");
+    // No grant to the trustor on `project`.
+
+    let result = create_trust(
+        &trustor.session,
+        TrustCreate {
+            id: None,
+            trustor_user_id: trustor.user.id.clone(),
+            trustee_user_id: trustee.id.clone(),
+            project_id: Some(project.id.clone()),
+            impersonation: false,
+            expires_at: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: vec![TrustRoleRef {
+                domain_id: None,
+                id: member_role_id.clone(),
+                name: None,
+            }],
+            extra: None,
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "creating a trust with an ungranted role must fail"
+    );
+
+    project.delete().await?;
+    trustee.delete().await?;
+    trustor.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_project_without_roles_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let trustor = TrustorSession::provision(&tc, "default").await?;
+    let trustee = new_trustee(&tc).await?;
+
+    let project = create_project(
+        &tc,
+        ProjectCreateBuilder::default()
+            .domain_id("default")
+            .parent_id("default")
+            .name(Uuid::new_v4().simple().to_string())
+            .is_domain(false)
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let result = create_trust(
+        &trustor.session,
+        TrustCreate {
+            id: None,
+            trustor_user_id: trustor.user.id.clone(),
+            trustee_user_id: trustee.id.clone(),
+            project_id: Some(project.id.clone()),
+            impersonation: false,
+            expires_at: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: Vec::new(),
+            extra: None,
+        },
+    )
+    .await;
+
+    assert!(result.is_err(), "project_id without roles must be rejected");
+
+    project.delete().await?;
+    trustee.delete().await?;
+    trustor.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/trust/delete.rs
+++ b/tests/api/tests/api_v3/trust/delete.rs
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::trust::*;
+use openstack_keystone_api_types::v3::user::UserCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::identity::user::create_user;
+use test_api::trust::{create_trust, show_trust};
+
+use super::TrustorSession;
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_trust() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let trustor = TrustorSession::provision(&tc, "default").await?;
+
+    let trustee = create_user(
+        &tc,
+        UserCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let trust = create_trust(
+        &trustor.session,
+        TrustCreate {
+            id: None,
+            trustor_user_id: trustor.user.id.clone(),
+            trustee_user_id: trustee.id.clone(),
+            project_id: None,
+            impersonation: false,
+            expires_at: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: Vec::new(),
+            extra: None,
+        },
+    )
+    .await?;
+    let trust_id = trust.id.clone();
+
+    trust.delete().await?;
+
+    let result = show_trust(&tc, &trust_id).await;
+    assert!(result.is_err(), "trust must be gone after deletion");
+
+    trustee.delete().await?;
+    trustor.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/trust/list.rs
+++ b/tests/api/tests/api_v3/trust/list.rs
@@ -1,0 +1,75 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::trust::*;
+use openstack_keystone_api_types::v3::user::UserCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::identity::user::create_user;
+use test_api::trust::{TrustListRequest, create_trust, list_trusts};
+
+use super::TrustorSession;
+
+#[tokio::test]
+#[traced_test]
+async fn test_list_includes_created_trust() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let trustor = TrustorSession::provision(&tc, "default").await?;
+
+    let trustee = create_user(
+        &tc,
+        UserCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let trust = create_trust(
+        &trustor.session,
+        TrustCreate {
+            id: None,
+            trustor_user_id: trustor.user.id.clone(),
+            trustee_user_id: trustee.id.clone(),
+            project_id: None,
+            impersonation: false,
+            expires_at: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: Vec::new(),
+            extra: None,
+        },
+    )
+    .await?;
+
+    let all = list_trusts(&tc, TrustListRequest::default()).await?;
+    assert!(
+        all.iter().any(|t| t.id == trust.id),
+        "created trust must appear in the unfiltered list"
+    );
+
+    trust.delete().await?;
+    trustee.delete().await?;
+    trustor.cleanup().await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/trust/show.rs
+++ b/tests/api/tests/api_v3/trust/show.rs
@@ -1,0 +1,85 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use eyre::Result;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_api_types::v3::trust::*;
+use openstack_keystone_api_types::v3::user::UserCreateBuilder;
+use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
+
+use test_api::guard::ResourceGuard;
+use test_api::identity::user::create_user;
+use test_api::trust::{create_trust, show_trust};
+
+use super::TrustorSession;
+
+#[tokio::test]
+#[traced_test]
+async fn test_show_trust() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let trustor = TrustorSession::provision(&tc, "default").await?;
+
+    let trustee = create_user(
+        &tc,
+        UserCreateBuilder::default()
+            .name(Uuid::new_v4().simple().to_string())
+            .domain_id("default")
+            .enabled(true)
+            .build()?,
+    )
+    .await?;
+
+    let trust = create_trust(
+        &trustor.session,
+        TrustCreate {
+            id: None,
+            trustor_user_id: trustor.user.id.clone(),
+            trustee_user_id: trustee.id.clone(),
+            project_id: None,
+            impersonation: false,
+            expires_at: None,
+            remaining_uses: None,
+            redelegated_trust_id: None,
+            redelegation_count: None,
+            roles: Vec::new(),
+            extra: None,
+        },
+    )
+    .await?;
+
+    let fetched = show_trust(&trustor.session, &trust.id).await?;
+    assert_eq!(fetched.id, trust.id);
+    assert_eq!(fetched.trustor_user_id, trustor.user.id);
+    assert_eq!(fetched.trustee_user_id, trustee.id);
+
+    trust.delete().await?;
+    trustee.delete().await?;
+    trustor.cleanup().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_show_missing_trust_fails() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+
+    let result = show_trust(&tc, format!("missing-{}", Uuid::new_v4().simple())).await;
+
+    assert!(result.is_err(), "showing a missing trust must fail");
+    Ok(())
+}

--- a/tests/integration/src/trust.rs
+++ b/tests/integration/src/trust.rs
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod create;
+mod delete;
+mod get;
+mod list;
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone::keystone::Service;
+use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::trust::*;
+
+use crate::common::*;
+use crate::impl_deleter;
+
+impl_deleter!(Service, Trust, get_trust_provider, delete_trust);
+
+/// Create a trust through the trust provider, returning a guard that deletes
+/// it again when dropped.
+pub async fn create_trust(
+    state: &ServiceState,
+    data: TrustCreate,
+) -> Result<AsyncResourceGuard<Trust, ServiceState>> {
+    let res = state
+        .provider
+        .get_trust_provider()
+        .create_trust(&ExecutionContext::internal(state), data)
+        .await?;
+    Ok(AsyncResourceGuard::new(res, state.clone()))
+}

--- a/tests/integration/src/trust/create.rs
+++ b/tests/integration/src/trust/create.rs
@@ -1,0 +1,202 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test trust creation.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core::trust::TrustProviderError;
+use openstack_keystone_core_types::role::RoleRef;
+use openstack_keystone_core_types::trust::TrustCreateBuilder;
+
+use crate::assignment::grant_role_to_user_on_project;
+use crate::common::get_state;
+use crate::trust::create_trust;
+use crate::{create_domain, create_project, create_role, create_user};
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_unscoped() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+
+    let trust = create_trust(
+        &state,
+        TrustCreateBuilder::default()
+            .trustor_user_id(trustor.id.clone())
+            .trustee_user_id(trustee.id.clone())
+            .impersonation(false)
+            .build()?,
+    )
+    .await?;
+
+    // An ID is generated when none is provided.
+    assert!(!trust.id.is_empty());
+    assert_eq!(trust.trustor_user_id, trustor.id);
+    assert_eq!(trust.trustee_user_id, trustee.id);
+    assert!(trust.project_id.is_none());
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_with_granted_roles() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+    let role = create_role!(state)?;
+
+    grant_role_to_user_on_project(
+        &state,
+        trustor.id.clone(),
+        project.id.clone(),
+        role.id.clone(),
+    )
+    .await?;
+
+    let trust = create_trust(
+        &state,
+        TrustCreateBuilder::default()
+            .trustor_user_id(trustor.id.clone())
+            .trustee_user_id(trustee.id.clone())
+            .project_id(project.id.clone())
+            .impersonation(false)
+            .roles(vec![RoleRef {
+                id: role.id.clone(),
+                name: None,
+                domain_id: None,
+            }])
+            .build()?,
+    )
+    .await?;
+
+    assert_eq!(trust.project_id.as_deref(), Some(project.id.as_str()));
+    let trust_role_ids: Vec<&str> = trust
+        .roles
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|r| r.id.as_str())
+        .collect();
+    assert!(trust_role_ids.contains(&role.id.as_str()));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_role_not_granted() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+    let role = create_role!(state)?;
+
+    // The trustor never received this role on the project.
+    let result = state
+        .provider
+        .get_trust_provider()
+        .create_trust(
+            &ExecutionContext::internal(&state),
+            TrustCreateBuilder::default()
+                .trustor_user_id(trustor.id.clone())
+                .trustee_user_id(trustee.id.clone())
+                .project_id(project.id.clone())
+                .impersonation(false)
+                .roles(vec![RoleRef {
+                    id: role.id.clone(),
+                    name: None,
+                    domain_id: None,
+                }])
+                .build()?,
+        )
+        .await;
+
+    match result {
+        Err(TrustProviderError::RoleNotGranted { role_id }) => {
+            assert_eq!(role_id, role.id);
+        }
+        other => panic!("expected RoleNotGranted, got {:?}", other),
+    }
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_project_without_roles_invalid() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+
+    let result = state
+        .provider
+        .get_trust_provider()
+        .create_trust(
+            &ExecutionContext::internal(&state),
+            TrustCreateBuilder::default()
+                .trustor_user_id(trustor.id.clone())
+                .trustee_user_id(trustee.id.clone())
+                .project_id(project.id.clone())
+                .impersonation(false)
+                .build()?,
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(TrustProviderError::ProjectRolesPairingInvalid)
+    ));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_roles_without_project_invalid() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+    let role = create_role!(state)?;
+
+    let result = state
+        .provider
+        .get_trust_provider()
+        .create_trust(
+            &ExecutionContext::internal(&state),
+            TrustCreateBuilder::default()
+                .trustor_user_id(trustor.id.clone())
+                .trustee_user_id(trustee.id.clone())
+                .impersonation(false)
+                .roles(vec![RoleRef {
+                    id: role.id.clone(),
+                    name: None,
+                    domain_id: None,
+                }])
+                .build()?,
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(TrustProviderError::ProjectRolesPairingInvalid)
+    ));
+    Ok(())
+}

--- a/tests/integration/src/trust/delete.rs
+++ b/tests/integration/src/trust/delete.rs
@@ -1,0 +1,75 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test deleting a trust.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::trust::TrustCreateBuilder;
+
+use crate::common::get_state;
+use crate::create_domain;
+use crate::create_user;
+use crate::trust::create_trust;
+
+#[traced_test]
+#[tokio::test]
+async fn test_delete() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+
+    let trust = create_trust(
+        &state,
+        TrustCreateBuilder::default()
+            .trustor_user_id(trustor.id.clone())
+            .trustee_user_id(trustee.id.clone())
+            .impersonation(false)
+            .build()?,
+    )
+    .await?;
+    let trust_id = trust.id.clone();
+
+    state
+        .provider
+        .get_trust_provider()
+        .delete_trust(&ExecutionContext::internal(&state), &trust_id)
+        .await?;
+    // The guard's own Drop-time delete is now a redundant no-op since the
+    // trust is already gone; forget it rather than let it run.
+    trust.cleanup().await;
+
+    let fetched = state
+        .provider
+        .get_trust_provider()
+        .get_trust(&ExecutionContext::internal(&state), &trust_id)
+        .await?;
+    assert!(fetched.is_none(), "trust should be gone after delete");
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_delete_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let result = state
+        .provider
+        .get_trust_provider()
+        .delete_trust(&ExecutionContext::internal(&state), "does-not-exist")
+        .await;
+    assert!(result.is_err(), "deleting a missing trust must fail");
+    Ok(())
+}

--- a/tests/integration/src/trust/get.rs
+++ b/tests/integration/src/trust/get.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test fetching a single trust.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::trust::TrustCreateBuilder;
+
+use crate::common::get_state;
+use crate::create_domain;
+use crate::create_user;
+use crate::trust::create_trust;
+
+#[traced_test]
+#[tokio::test]
+async fn test_get() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+
+    let trust = create_trust(
+        &state,
+        TrustCreateBuilder::default()
+            .trustor_user_id(trustor.id.clone())
+            .trustee_user_id(trustee.id.clone())
+            .impersonation(false)
+            .build()?,
+    )
+    .await?;
+
+    let fetched = state
+        .provider
+        .get_trust_provider()
+        .get_trust(&ExecutionContext::internal(&state), &trust.id)
+        .await?;
+
+    assert!(fetched.is_some());
+    let fetched = fetched.unwrap();
+    assert_eq!(fetched.id, trust.id);
+    assert_eq!(fetched.trustor_user_id, trustor.id);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_get_not_found() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let fetched = state
+        .provider
+        .get_trust_provider()
+        .get_trust(&ExecutionContext::internal(&state), "does-not-exist")
+        .await?;
+    assert!(fetched.is_none());
+    Ok(())
+}

--- a/tests/integration/src/trust/list.rs
+++ b/tests/integration/src/trust/list.rs
@@ -1,0 +1,112 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test listing trusts.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::trust::{TrustCreateBuilder, TrustListParameters};
+
+use crate::common::get_state;
+use crate::create_domain;
+use crate::create_user;
+use crate::trust::create_trust;
+
+#[traced_test]
+#[tokio::test]
+async fn test_list() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+
+    let t1 = create_trust(
+        &state,
+        TrustCreateBuilder::default()
+            .trustor_user_id(trustor.id.clone())
+            .trustee_user_id(trustee.id.clone())
+            .impersonation(false)
+            .build()?,
+    )
+    .await?;
+    let t2 = create_trust(
+        &state,
+        TrustCreateBuilder::default()
+            .trustor_user_id(trustor.id.clone())
+            .trustee_user_id(trustee.id.clone())
+            .impersonation(false)
+            .build()?,
+    )
+    .await?;
+
+    let trusts = state
+        .provider
+        .get_trust_provider()
+        .list_trusts(
+            &ExecutionContext::internal(&state),
+            &TrustListParameters::default(),
+        )
+        .await?;
+
+    let ids: Vec<&str> = trusts.iter().map(|t| t.id.as_str()).collect();
+    assert!(ids.contains(&t1.id.as_str()));
+    assert!(ids.contains(&t2.id.as_str()));
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_list_excludes_deleted_by_default() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let trustor = create_user!(state, domain.id.clone())?;
+    let trustee = create_user!(state, domain.id.clone())?;
+
+    let trust = create_trust(
+        &state,
+        TrustCreateBuilder::default()
+            .trustor_user_id(trustor.id.clone())
+            .trustee_user_id(trustee.id.clone())
+            .impersonation(false)
+            .build()?,
+    )
+    .await?;
+    let trust_id = trust.id.clone();
+    trust.cleanup().await;
+
+    let trusts = state
+        .provider
+        .get_trust_provider()
+        .list_trusts(
+            &ExecutionContext::internal(&state),
+            &TrustListParameters::default(),
+        )
+        .await?;
+    assert!(!trusts.iter().any(|t| t.id == trust_id));
+
+    let trusts_with_deleted = state
+        .provider
+        .get_trust_provider()
+        .list_trusts(
+            &ExecutionContext::internal(&state),
+            &TrustListParameters {
+                include_deleted: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(trusts_with_deleted.iter().any(|t| t.id == trust_id));
+    Ok(())
+}


### PR DESCRIPTION
TrustBackend/TrustApi previously only supported get/list; there was
no create_trust/delete_trust anywhere and no REST DTOs beyond the
token-embedded TokenTrustRepr. Delegation is security-sensitive
(security-model.md I1-I8), so this implements the full vertical
rather than a partial read-only wrapper.

- core-types/core: TrustCreate, project_id/roles pairing check,
  trustor role-holding check (mirrors auth.rs resolve_trust_roles),
  redelegation chain validation reused from the existing read-time
  validator, audited create/delete via audited_op!
- trust-driver-sql: transactional create (trust + trust_role),
  soft-delete via deleted_at; fixes get() to filter deleted_at,
  which previously let a deleted trust stay visible via show/delete
- delete_trust emits a RevocationEventCreate so trust-derived tokens
  are revoked immediately on deletion
- keystone: /v3/OS-TRUST/trusts REST handlers (no update - trusts
  are immutable by design), list uses two-phase per-item re-check
  (I8) since visibility is per-trustor/trustee, not collection-wide
- policy/trust/*: create is self-issuance only, no admin bypass
  (matches python keystone's identity:create_trust); show/list open
  to trustor, trustee, admin, or reader+system=all; delete restricted
  to trustor/admin
- tests/integration, tests/api: coverage for create/get/list/delete
  including role-not-granted and pairing-invariant rejections

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

<!--
Thanks for the contribution! Fill in the sections below.
-->

## Summary

<!-- What does this PR change, and why? -->

## Test plan

<!-- How was this verified? cargo test output, manual steps, screenshots, etc. -->

## Security review checklist

**Required if this diff touches authentication, scope, delegation, tokens,
credentials, EC2, trusts, application credentials, or OPA policy input.**
Delete this section entirely if it doesn't apply. See
[`doc/src/security.md`](../doc/src/security.md) §7 for the full context
behind each item.

- [ ] Does any delegation/authorization decision read the **scope**
      (`project_id`, `ScopeInfo`) where it should read the **chain**
      (`authentication_context()`, delegation object)? (I1/I2)
- [ ] New delegation-sensitive policy rule? Is the fact it needs projected
      onto `Credentials` from the chain, and does the rule anchor on
      `delegated_project_id` + carry the scope-drift tripwire? (I2/I3)
- [ ] New scope shape or redemption path for a delegated auth? Are effective
      roles still bounded by the delegation? Added a test that a restricted
      delegation cannot exceed its roles via the new path? (I4)
- [ ] New `ScopeInfo` variant or auth method? Updated
      `validate_scope_boundaries()`, `calculate_effective_roles()`,
      `fully_resolved()`, and `Credentials::try_from` — all without adding a
      wildcard `_ =>` arm? (I5, Gate J)
- [ ] New lookup by a client-derivable key (like `sha256(access)`)? Does it
      re-assert `type`/shape after fetch? (I6)
- [ ] Does any new data reaching OPA include secrets/decrypted blobs? (I7,
      Gate I)
- [ ] New list/collection endpoint? Does it re-check each item with the
      per-item read policy? (I8)
- [ ] Does the change let a narrow auth method be broadened by a
      request-supplied scope? (I5)
- [ ] Are there negative tests proving the escape is blocked, not just
      positive tests proving the happy path works?
- [ ] Does the test drive `ValidatedSecurityContext::new_for_scope()`
      end-to-end, not just the inner helper (`calculate_effective_roles`,
      `validate_scope_boundaries`) in isolation?
