### PR TITLE
fix: Widen Fernet key index from i8 to u32

### DIFF
--- a/crates/credential-driver-sql/src/error.rs
+++ b/crates/credential-driver-sql/src/error.rs
@@ -31,7 +31,7 @@ pub enum CredentialFernetError {
 
     /// A key file's contents could not be parsed as a Fernet key.
     #[error("key file `{0}` is not a valid Fernet key")]
-    InvalidKey(i8),
+    InvalidKey(u32),
 
     /// No usable key files were found in the repository.
     #[error("no Fernet keys found in the credential key repository")]
@@ -45,7 +45,7 @@ pub enum CredentialFernetError {
     )]
     NullKeyDetected,
 
-    /// Fernet index arithmetic would overflow the `i8` file-naming scheme.
+    /// Fernet index arithmetic would overflow the `u32` file-naming scheme.
     #[error("key rotation index overflow")]
     IndexOverflow,
 

--- a/crates/key-repository/src/error.rs
+++ b/crates/key-repository/src/error.rs
@@ -32,7 +32,7 @@ pub enum KeyRepositoryError {
 
     /// A key entry's contents do not decode as a valid Fernet key.
     #[error("key at index {0} is not a usable Fernet key")]
-    InvalidKey(i8),
+    InvalidKey(u32),
 
     /// A key entry decodes to the well-known Null Key
     /// (`base64.urlsafe_b64encode(b'\x00' * 32)`) and

--- a/crates/key-repository/src/filesystem.rs
+++ b/crates/key-repository/src/filesystem.rs
@@ -223,11 +223,13 @@ impl FilesystemKeySource {
         });
     }
 
-    fn path_for(&self, index: i8) -> PathBuf {
+    fn path_for(&self, index: u32) -> PathBuf {
         self.inner.key_repository.join(index.to_string())
     }
 
-    fn read_key_files_blocking(dir: &PathBuf) -> Result<BTreeMap<i8, Vec<u8>>, KeyRepositoryError> {
+    fn read_key_files_blocking(
+        dir: &PathBuf,
+    ) -> Result<BTreeMap<u32, Vec<u8>>, KeyRepositoryError> {
         let mut keys = BTreeMap::new();
         if !dir.exists() {
             return Ok(keys);
@@ -243,7 +245,7 @@ impl FilesystemKeySource {
             let Ok(fname) = entry.file_name().into_string() else {
                 continue;
             };
-            let Ok(idx) = fname.parse::<i8>() else {
+            let Ok(idx) = fname.parse::<u32>() else {
                 continue;
             };
             let raw = std::fs::read(entry.path()).map_err(|e| KeyRepositoryError::Io {
@@ -310,7 +312,7 @@ impl FilesystemKeySource {
 
 #[async_trait]
 impl KeySource for FilesystemKeySource {
-    async fn load(&self) -> Result<BTreeMap<i8, Vec<u8>>, KeyRepositoryError> {
+    async fn load(&self) -> Result<BTreeMap<u32, Vec<u8>>, KeyRepositoryError> {
         let dir = self.inner.key_repository.clone();
         let error_dir = dir.clone();
         spawn_blocking(move || Self::read_key_files_blocking(&dir))
@@ -321,7 +323,7 @@ impl KeySource for FilesystemKeySource {
             })?
     }
 
-    async fn write(&self, index: i8, contents: &[u8]) -> Result<(), KeyRepositoryError> {
+    async fn write(&self, index: u32, contents: &[u8]) -> Result<(), KeyRepositoryError> {
         let dir = self.inner.key_repository.clone();
         let error_dir = dir.clone();
         let name = index.to_string();
@@ -335,7 +337,7 @@ impl KeySource for FilesystemKeySource {
             })?
     }
 
-    async fn remove(&self, index: i8) -> Result<(), KeyRepositoryError> {
+    async fn remove(&self, index: u32) -> Result<(), KeyRepositoryError> {
         let path = self.path_for(index);
         let error_dir = self.inner.key_repository.clone();
         spawn_blocking(move || match std::fs::remove_file(&path) {
@@ -350,7 +352,12 @@ impl KeySource for FilesystemKeySource {
         })?
     }
 
-    async fn promote(&self, from: i8, to: i8, _contents: &[u8]) -> Result<(), KeyRepositoryError> {
+    async fn promote(
+        &self,
+        from: u32,
+        to: u32,
+        _contents: &[u8],
+    ) -> Result<(), KeyRepositoryError> {
         let from_path = self.path_for(from);
         let to_path = self.path_for(to);
         let error_dir = self.inner.key_repository.clone();
@@ -474,5 +481,28 @@ mod tests {
     fn test_is_null_key_raw_bytes_helper_sanity() {
         let null_key_raw = URL_SAFE.encode([0u8; 32]);
         assert_eq!(null_key_raw.len(), 44);
+    }
+
+    /// A long-lived repository accumulates one entry per rotation, so after
+    /// enough rotations (or when migrating a repository from Python
+    /// Keystone, whose index is an unbounded `int`) filenames well past
+    /// `i8`'s old 127 cap show up on disk, e.g. `0 285 286 287 288 289`.
+    /// `load` must return every one of them, not silently drop the
+    /// out-of-`i8`-range names.
+    #[tokio::test]
+    async fn test_load_handles_indices_beyond_former_i8_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let indices: [u32; 6] = [0, 285, 286, 287, 288, 289];
+        let mut written = BTreeMap::new();
+        for idx in indices {
+            let key = Fernet::generate_key();
+            std::fs::write(dir.path().join(idx.to_string()), key.as_bytes()).unwrap();
+            written.insert(idx, key.as_bytes().to_vec());
+        }
+
+        let source = FilesystemKeySource::new(dir.path().to_path_buf());
+        let loaded = source.load().await.unwrap();
+
+        assert_eq!(loaded, written);
     }
 }

--- a/crates/key-repository/src/lib.rs
+++ b/crates/key-repository/src/lib.rs
@@ -177,7 +177,7 @@ impl<S: KeySource> KeyRepository<S> {
 
     fn check_null_keys(
         &self,
-        key_files: &BTreeMap<i8, Vec<u8>>,
+        key_files: &BTreeMap<u32, Vec<u8>>,
         insecure_allow_null_key: bool,
     ) -> Result<(), KeyRepositoryError> {
         for (idx, raw) in key_files {
@@ -470,6 +470,42 @@ mod tests {
             remaining.contains_key(&0),
             "staged key must always survive pruning"
         );
+    }
+
+    /// Simulates a long-lived repository (or one migrated from Python
+    /// Keystone, whose key index is an unbounded `int`) that has already
+    /// accumulated indices past the Rust driver's former `i8` cap of 127,
+    /// e.g. `ls /etc/keystone/fernet-keys/` showing `0 285 286 287 288 289`.
+    /// `load_keys` must pick `289` as primary and `rotate` must continue
+    /// counting up from it instead of wrapping, truncating, or colliding
+    /// with an existing file.
+    #[tokio::test]
+    async fn test_repository_handles_indices_beyond_former_i8_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = repo(dir.path(), 10);
+        let indices: [u32; 6] = [0, 285, 286, 287, 288, 289];
+        let mut primary_raw = Vec::new();
+        for idx in indices {
+            let key = Fernet::generate_key().into_bytes();
+            std::fs::write(dir.path().join(idx.to_string()), &key).unwrap();
+            if idx == 289 {
+                primary_raw = key;
+            }
+        }
+
+        let loaded = repo.load_keys(false).await.unwrap();
+        assert_eq!(loaded.key_count, indices.len());
+        assert_eq!(
+            loaded.primary_key_hash,
+            KeyRepository::<FilesystemKeySource>::key_hash(&primary_raw)
+        );
+
+        repo.rotate().await.unwrap();
+        assert!(
+            dir.path().join("290").exists(),
+            "rotate must continue counting up past the former i8 cap"
+        );
+        assert!(dir.path().join("289").exists());
     }
 
     #[tokio::test]

--- a/crates/key-repository/src/source.rs
+++ b/crates/key-repository/src/source.rs
@@ -40,14 +40,14 @@ pub trait KeySource: Send + Sync {
     /// a valid, non-error state; callers decide whether that's acceptable
     /// (e.g. [`crate::KeyRepository::check_startup_null_key`] tolerates it,
     /// [`crate::KeyRepository::load_keys`] does not).
-    async fn load(&self) -> Result<BTreeMap<i8, Vec<u8>>, KeyRepositoryError>;
+    async fn load(&self) -> Result<BTreeMap<u32, Vec<u8>>, KeyRepositoryError>;
 
     /// Atomically create or overwrite the entry at `index` with `contents`.
-    async fn write(&self, index: i8, contents: &[u8]) -> Result<(), KeyRepositoryError>;
+    async fn write(&self, index: u32, contents: &[u8]) -> Result<(), KeyRepositoryError>;
 
     /// Remove the entry at `index`. Must not error if the entry is already
     /// absent (rotation pruning may race with manual cleanup).
-    async fn remove(&self, index: i8) -> Result<(), KeyRepositoryError>;
+    async fn remove(&self, index: u32) -> Result<(), KeyRepositoryError>;
 
     /// Move key material from `from` to `to` as atomically as the backend
     /// allows, used by [`crate::KeyRepository::rotate`] to promote the
@@ -61,7 +61,7 @@ pub trait KeySource: Send + Sync {
     /// [`crate::KeyRepository::rotate`] never removes `from` before `to` is
     /// durably written. Backends capable of a true move (the filesystem,
     /// via `rename(2)`) should override this for a stronger guarantee.
-    async fn promote(&self, from: i8, to: i8, contents: &[u8]) -> Result<(), KeyRepositoryError> {
+    async fn promote(&self, from: u32, to: u32, contents: &[u8]) -> Result<(), KeyRepositoryError> {
         self.write(to, contents).await?;
         self.remove(from).await?;
         Ok(())

--- a/crates/token-driver-fernet/src/error.rs
+++ b/crates/token-driver-fernet/src/error.rs
@@ -42,9 +42,9 @@ pub enum FernetDriverError {
 
     /// A key's contents could not be parsed as a Fernet key.
     #[error("fernet key at index {0} is not usable")]
-    InvalidKey(i8),
+    InvalidKey(u32),
 
-    /// Fernet index arithmetic would overflow the `i8` file-naming scheme.
+    /// Fernet index arithmetic would overflow the `u32` file-naming scheme.
     #[error("fernet key rotation index overflow")]
     IndexOverflow,
 


### PR DESCRIPTION
Python Keystone's key index is an unbounded int; the Rust i8 type
capped it at 127, silently mishandling repositories with higher
indices (e.g. from long rotation history or migration from Python).

Add tests covering indices past the old i8 cap for both
FilesystemKeySource::load and KeyRepository::load_keys/rotate.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
