### PR TITLE
feat(logging): Add native journald log writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4673,6 +4673,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-error",
+ "tracing-journald",
  "tracing-subscriber",
  "tracing-test",
  "url",
@@ -9217,6 +9218,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-journald"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
+dependencies = [
+ "libc",
+ "tracing-core",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ tower = { version = "0.5" }
 tower-http = { version = "0.7" }
 tracing = { version = "0.1" }
 tracing-appender = { version = "0.2" }
+tracing-journald = { version = "0.3" }
 tracing-subscriber = { version = "0.3" }
 tracing-test = { version = "0.2" }
 url = { version = "2.5" }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -29,6 +29,16 @@ pub struct DefaultSection {
     /// Public endpoint.
     pub public_endpoint: Option<Url>,
 
+    /// Log output directly to the systemd journal (native journald
+    /// protocol), instead of relying on a container/service manager to
+    /// capture and forward stderr. Mutually exclusive with `use_stderr`:
+    /// enabling both under a container log driver that also forwards
+    /// stderr to journald (e.g. podman `--log-driver=journald`) produces
+    /// duplicate entries in `journalctl` — one from the native write, one
+    /// from the driver capturing the stderr text.
+    #[serde(default)]
+    pub use_journal: bool,
+
     /// Log output to standard error.
     #[serde(default)]
     pub use_stderr: bool,

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -93,6 +93,7 @@ tower-http = { workspace = true, features = ["compression-full", "normalize-path
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-error = "0.2"
+tracing-journald.workspace = true
 tracing-subscriber.workspace = true
 url = { workspace = true, features = ["serde"] }
 utoipa = { workspace = true, features = ["axum_extras", "yaml"] }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -380,8 +380,9 @@ async fn main() -> Result<(), Report> {
     Ok(())
 }
 
-/// Initialize the tracing subscriber registry (stderr, and optionally a
-/// rotating file appender) based on CLI verbosity and the loaded config.
+/// Initialize the tracing subscriber registry (stderr, optionally a native
+/// systemd journal writer, and optionally a rotating file appender) based on
+/// CLI verbosity and the loaded config.
 ///
 /// Returns the file-appender's `WorkerGuard`, if file logging is enabled.
 /// The caller must keep this alive for the process lifetime — dropping it
@@ -419,6 +420,37 @@ fn init_tracing(verbose: u8, cfg: &Config) -> Option<tracing_appender::non_block
 
     if cfg.default.use_stderr {
         log_layers.push(stderr_layer);
+    }
+
+    if cfg.default.use_journal {
+        let journald_log_filter = Targets::new()
+            .with_default(if cfg.default.debug {
+                LevelFilter::DEBUG
+            } else {
+                LevelFilter::INFO
+            })
+            .with_target("cranelift_codegen", LevelFilter::ERROR)
+            .with_target("wasmtime_internal_cranelift", LevelFilter::ERROR)
+            .with_target("wasmtime", LevelFilter::ERROR)
+            .with_target("h2", external_deps_log_level)
+            .with_target("rustls", external_deps_log_level)
+            .with_target("tower", external_deps_log_level)
+            .with_target("openraft", external_deps_log_level)
+            .with_target("lsm_tree", external_deps_log_level);
+
+        match tracing_journald::layer() {
+            Ok(journald_layer) => {
+                log_layers.push(journald_layer.with_filter(journald_log_filter).boxed());
+            }
+            Err(err) => {
+                // Can't use `error!`/`warn!` yet — the subscriber isn't
+                // installed until `.init()` below, so fall back to stderr
+                // directly for this one diagnostic.
+                eprintln!(
+                    "Failed to connect to the systemd journal socket, use_journal logging disabled: {err}"
+                );
+            }
+        }
     }
 
     let mut guard = None;
@@ -770,7 +802,13 @@ async fn build_router(
                         x_request_id = ?request.headers().get("x-openstack-request-id")
                     )
                 })
-                .on_request(DefaultOnRequest::new().level(Level::INFO))
+                // `on_response` alone (method/uri/status/latency, plus the
+                // request-id/client-addr already in the span) is enough at
+                // INFO for one line per request; the separate start-of-
+                // request event only matters when debugging, so keep it at
+                // DEBUG (tower-http's own upstream default) instead of
+                // doubling every request's log volume at INFO.
+                .on_request(DefaultOnRequest::new().level(Level::DEBUG))
                 .on_response(
                     DefaultOnResponse::new()
                         .level(Level::INFO)

--- a/doc/src/configuration/options.md
+++ b/doc/src/configuration/options.md
@@ -9,7 +9,7 @@ the feature guide for constraints and safe production values.
 
 | Section | Options |
 | --- | --- |
-| `[DEFAULT]` | `debug`, `log_dir`, `public_endpoint`, `use_stderr` |
+| `[DEFAULT]` | `debug`, `log_dir`, `public_endpoint`, `use_stderr`, `use_journal` |
 | `[database]` | `connection` |
 | `[interface_public]` | `tcp_address`, listener `type`, and listener-specific TLS/SPIFFE fields |
 | `[interface_internal]` | `tcp_address`, listener `type`, `trust_domains`, and TLS content/file fields |


### PR DESCRIPTION
Podman only forwards a container's stdout/stderr to journald,
and no output path existed unless use_stderr was set. Add
use_journal (parity with python-keystone's oslo.log option)
using tracing-journald to write structured entries straight to
the journal socket, independent of the log driver.

Enabling both use_stderr and use_journal under a journald log
driver double-logs every line (driver-forwarded stderr text +
native write) — documented on the new config field.

TraceLayer emitted both on_request and on_response at INFO,
so each request wrote two log lines. on_response already
carries method/uri/status/latency plus the span's
request-id/client-addr, making the start-of-request line
redundant. Drop on_request to DEBUG (tower-http's own
upstream default) to halve steady-state log volume; still
visible at -vv/debug=true.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
