### PR TITLE
fix: Address multiple tempest failures

### DIFF
--- a/crates/api-types/src/v3/endpoint.rs
+++ b/crates/api-types/src/v3/endpoint.rs
@@ -35,6 +35,10 @@ pub struct Endpoint {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "validate", validate(length(max = 255)))]
     pub region_id: Option<String>,
+    /// Deprecated alias for `region_id`, mirrored for clients still reading
+    /// the pre-v3.2 attribute name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
     /// The UUID of the service to which the endpoint belongs.
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
     pub service_id: String,

--- a/crates/api-types/src/v3/endpoint_conv.rs
+++ b/crates/api-types/src/v3/endpoint_conv.rs
@@ -21,6 +21,7 @@ impl From<provider_types::Endpoint> for api_types::Endpoint {
         Self {
             id: value.id,
             interface: value.interface,
+            region: value.region_id.clone(),
             region_id: value.region_id,
             service_id: value.service_id,
             url: value.url,

--- a/crates/api-types/src/v3/trust.rs
+++ b/crates/api-types/src/v3/trust.rs
@@ -33,9 +33,10 @@ pub struct TrustRoleRef {
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
     pub domain_id: Option<String>,
 
-    /// Role ID.
+    /// Role ID. May be omitted if `name` is given instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
-    pub id: String,
+    pub id: Option<String>,
 
     /// Role name.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -63,7 +64,6 @@ pub struct Trust {
 
     /// The ID of the project upon which the trustor is delegating
     /// authorization.
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
     pub project_id: Option<String>,
 
@@ -71,7 +71,9 @@ pub struct Trust {
     pub impersonation: bool,
 
     /// Trust expiration time.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    ///
+    /// Always present (as `null` when unset) to match python keystone --
+    /// tempest indexes `trust['expires_at']` unconditionally.
     pub expires_at: Option<DateTime<Utc>>,
 
     /// Remaining number of times the trust can be used to obtain a token.

--- a/crates/api-types/src/v3/trust_conv.rs
+++ b/crates/api-types/src/v3/trust_conv.rs
@@ -21,17 +21,20 @@ impl From<ProviderRoleRef> for api_types::TrustRoleRef {
     fn from(value: ProviderRoleRef) -> Self {
         Self {
             domain_id: value.domain_id,
-            id: value.id,
+            id: Some(value.id),
             name: value.name,
         }
     }
 }
 
+/// Converts a resolved `TrustRoleRef` (i.e. `id` filled in, either
+/// originally or by the create handler's name lookup) into the provider
+/// `RoleRef`.
 impl From<api_types::TrustRoleRef> for ProviderRoleRef {
     fn from(value: api_types::TrustRoleRef) -> Self {
         Self {
             domain_id: value.domain_id,
-            id: value.id,
+            id: value.id.unwrap_or_default(),
             name: value.name,
         }
     }

--- a/crates/keystone/src/api/json_rejection.rs
+++ b/crates/keystone/src/api/json_rejection.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Normalizes Axum's built-in `Json<T>` extractor rejections.
+//!
+//! Every v3/v4 handler takes its request body as a plain `axum::Json<T>`
+//! parameter. When the body fails to deserialize, Axum answers the request
+//! itself -- the handler never runs, so `KeystoneApiError` (which already
+//! has a `From<JsonRejection>` impl, `crates/api-types/src/error_conv.rs`)
+//! never gets a chance to apply. Axum's own rejection response is
+//! `text/plain`, and for a type-mismatch payload (e.g. a string where a
+//! bool is expected) it answers `422 Unprocessable Entity` -- but python
+//! keystone (and this codebase's own `KeystoneApiError::UnprocessableEntity`
+//! convention, reserved for semantic write-time validation) answers `400
+//! Bad Request` for a malformed body. Confirmed against tempest:
+//! `EndpointsNegativeTestJSON.test_create_with_enabled_False` sends
+//! `"enabled": "False"` (a string) and asserts a 400.
+//!
+//! This response-mapping middleware rewrites any `text/plain` response in
+//! the `400/415/422` family coming out of the v3/v4 router into the
+//! standard `{"error": {"code", "message"}}` JSON shape, remapping Axum's
+//! `422` (`JsonDataError`) down to `400` to match. Nothing else in this
+//! router ever answers `text/plain` (confirmed: only the `/metrics`
+//! endpoint and an outbound test HTTP mock use that content type, and
+//! neither is mounted under this router), so the content-type check alone
+//! is a safe discriminator.
+
+use axum::body::{Body, to_bytes};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+
+const MAX_BODY_BYTES: usize = 64 * 1024;
+
+pub(crate) async fn normalize_json_rejection(response: Response) -> Response {
+    let is_text_plain = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("text/plain"));
+
+    let status = response.status();
+    if !is_text_plain
+        || !matches!(
+            status,
+            StatusCode::BAD_REQUEST
+                | StatusCode::UNSUPPORTED_MEDIA_TYPE
+                | StatusCode::UNPROCESSABLE_ENTITY
+        )
+    {
+        return response;
+    }
+
+    let new_status = if status == StatusCode::UNPROCESSABLE_ENTITY {
+        StatusCode::BAD_REQUEST
+    } else {
+        status
+    };
+
+    let (parts, body) = response.into_parts();
+    let message = match to_bytes(body, MAX_BODY_BYTES).await {
+        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+        Err(_) => {
+            return Response::from_parts(parts, Body::empty());
+        }
+    };
+
+    (
+        new_status,
+        axum::Json(json!({"error": {"code": new_status.as_u16(), "message": message}})),
+    )
+        .into_response()
+}

--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -34,6 +34,7 @@ pub mod auth;
 pub(crate) mod common;
 pub mod error;
 pub mod health;
+mod json_rejection;
 pub mod types;
 pub mod v3;
 pub mod v4;
@@ -71,6 +72,9 @@ pub fn openapi_router() -> OpenApiRouter<ServiceState> {
         .nest("/v3", v3::openapi_router())
         .nest("/v4", v4::openapi_router())
         .routes(routes!(version))
+        .layer(axum::middleware::map_response(
+            json_rejection::normalize_json_rejection,
+        ))
 }
 
 /// Dedicated health/metrics router for the internal health/metrics interface.

--- a/crates/keystone/src/api/v3/endpoint/create.rs
+++ b/crates/keystone/src/api/v3/endpoint/create.rs
@@ -42,7 +42,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 pub(super) async fn create(
     Auth(user_auth): Auth,
     State(state): State<ServiceState>,
-    Json(payload): Json<EndpointCreateRequest>,
+    Json(mut payload): Json<EndpointCreateRequest>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     // Validate the request
     payload.validate()?;
@@ -73,6 +73,14 @@ pub(super) async fn create(
             identifier: payload.endpoint.service_id.clone(),
         });
     }
+
+    payload.endpoint.region_id = super::resolve_legacy_region(
+        &state,
+        &exec,
+        payload.endpoint.region_id.take(),
+        &mut payload.endpoint.extra,
+    )
+    .await?;
 
     // Create the endpoint
     let created_endpoint = state
@@ -189,6 +197,7 @@ mod tests {
                 id: "new_endpoint_id".into(),
                 interface: "public".into(),
                 region_id: None,
+                region: None,
                 service_id: "svc1".into(),
                 url: "https://example.com".into(),
                 enabled: true,

--- a/crates/keystone/src/api/v3/endpoint/list.rs
+++ b/crates/keystone/src/api/v3/endpoint/list.rs
@@ -138,6 +138,7 @@ mod tests {
                 id: "1".into(),
                 interface: "public".into(),
                 region_id: None,
+                region: None,
                 service_id: "svc1".into(),
                 url: "https://example.com".into(),
                 enabled: true,

--- a/crates/keystone/src/api/v3/endpoint/mod.rs
+++ b/crates/keystone/src/api/v3/endpoint/mod.rs
@@ -13,9 +13,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # Endpoint API
 
+use std::collections::HashMap;
+
+use serde_json::Value;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::catalog::RegionCreate;
 
 mod create;
 mod delete;
@@ -29,4 +35,50 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
         .routes(routes!(list::list, create::create))
         .routes(routes!(show::show, delete::delete))
         .routes(routes!(update::update))
+}
+
+/// Resolves the deprecated `region` endpoint attribute (captured in
+/// `extra` since it has no dedicated field) to `region_id`, auto-vivifying
+/// a `Region` with that id if none exists yet -- matching python
+/// keystone's back-compat behavior for the legacy `region` field.
+///
+/// Returns the resolved `region_id`, or the pre-existing one unchanged if
+/// `region_id` was already set or no legacy `region` was given.
+pub(super) async fn resolve_legacy_region<'a>(
+    state: &ServiceState,
+    exec: &ExecutionContext<'a>,
+    region_id: Option<String>,
+    extra: &mut HashMap<String, Value>,
+) -> Result<Option<String>, KeystoneApiError> {
+    if region_id.is_some() {
+        return Ok(region_id);
+    }
+    let Some(region_id) = extra
+        .remove("region")
+        .and_then(|v| v.as_str().map(str::to_string))
+    else {
+        return Ok(None);
+    };
+    if state
+        .provider
+        .get_catalog_provider()
+        .get_region(exec, &region_id)
+        .await?
+        .is_none()
+    {
+        state
+            .provider
+            .get_catalog_provider()
+            .create_region(
+                exec,
+                RegionCreate {
+                    id: Some(region_id.clone()),
+                    description: None,
+                    extra: Default::default(),
+                    parent_region_id: None,
+                },
+            )
+            .await?;
+    }
+    Ok(Some(region_id))
 }

--- a/crates/keystone/src/api/v3/endpoint/show.rs
+++ b/crates/keystone/src/api/v3/endpoint/show.rs
@@ -149,6 +149,7 @@ mod tests {
                 id: "foo".into(),
                 interface: "public".into(),
                 region_id: None,
+                region: None,
                 service_id: "svc1".into(),
                 url: "https://example.com".into(),
                 enabled: true,

--- a/crates/keystone/src/api/v3/endpoint/update.rs
+++ b/crates/keystone/src/api/v3/endpoint/update.rs
@@ -44,7 +44,7 @@ pub(super) async fn update(
     Auth(user_auth): Auth,
     Path(endpoint_id): Path<String>,
     State(state): State<ServiceState>,
-    Json(req): Json<EndpointUpdateRequest>,
+    Json(mut req): Json<EndpointUpdateRequest>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     // Validate the request
     req.validate()?;
@@ -86,6 +86,14 @@ pub(super) async fn update(
                     identifier: service_id.clone(),
                 });
             }
+
+            req.endpoint.region_id = super::resolve_legacy_region(
+                &state,
+                &exec,
+                req.endpoint.region_id.take(),
+                &mut req.endpoint.extra,
+            )
+            .await?;
 
             let endpoint = state
                 .provider
@@ -199,6 +207,7 @@ mod tests {
                 id: "foo".into(),
                 interface: "public".into(),
                 region_id: None,
+                region: None,
                 service_id: "svc1".into(),
                 url: "https://example.com".into(),
                 enabled: false,

--- a/crates/keystone/src/api/v3/os_trust/trust/create.rs
+++ b/crates/keystone/src/api/v3/os_trust/trust/create.rs
@@ -25,6 +25,7 @@ use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::role::RoleListParametersBuilder;
 
 /// Create a new trust.
 ///
@@ -48,9 +49,35 @@ use openstack_keystone_core::auth::ExecutionContext;
 pub(super) async fn create(
     Auth(user_auth): Auth,
     State(state): State<ServiceState>,
-    Json(payload): Json<TrustCreateRequest>,
+    Json(mut payload): Json<TrustCreateRequest>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     payload.validate()?;
+
+    // Roles may be referenced by `id` or by `name` (matching python
+    // keystone); resolve name-only references to an id here since the
+    // provider layer only deals in role ids.
+    for role in payload.trust.roles.iter_mut() {
+        if role.id.is_none() {
+            let name = role
+                .name
+                .clone()
+                .ok_or_else(|| KeystoneApiError::BadRequest("role id or name required".into()))?;
+            let resolved = state
+                .provider
+                .get_role_provider()
+                .list_roles(
+                    &ExecutionContext::internal(&state),
+                    &RoleListParametersBuilder::default()
+                        .name(name.clone())
+                        .build()?,
+                )
+                .await?
+                .into_iter()
+                .next()
+                .ok_or_else(|| KeystoneApiError::BadRequest(format!("role `{name}` not found")))?;
+            role.id = Some(resolved.id);
+        }
+    }
 
     state
         .policy_enforcer

--- a/crates/keystone/src/api/v3/region/create.rs
+++ b/crates/keystone/src/api/v3/region/create.rs
@@ -13,14 +13,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # Create region API
 use axum::{
-    extract::{Json, State},
+    extract::{Json, Path, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 use validator::Validate;
 
-use super::types::{RegionCreateRequest, RegionResponse};
+use super::types::{RegionCreateRequest, RegionResponse, RegionUpdate, RegionUpdateRequest};
 use crate::api::auth::Auth;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
@@ -70,6 +70,90 @@ pub(super) async fn create(
         StatusCode::CREATED,
         Json(RegionResponse {
             region: created_region.into(),
+        }),
+    )
+        .into_response())
+}
+
+/// Create (or update) a Region with a caller-supplied ID.
+///
+/// `PUT /regions/{region_id}` is python keystone's idempotent upsert form
+/// (api-ref "Create or update region"): create the region if `region_id`
+/// doesn't exist yet, otherwise update it in place. Distinct from `POST
+/// /regions`, which always generates a fresh id.
+#[utoipa::path(
+    put,
+    path = "/{region_id}",
+    responses(
+        (status = CREATED, description = "Region created or updated", body = RegionResponse),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal error")
+    ),
+    tag="regions"
+)]
+#[tracing::instrument(name = "api::v3::region_create_with_id", level = "debug", skip(state))]
+pub(super) async fn create_with_id(
+    Auth(user_auth): Auth,
+    Path(region_id): Path<String>,
+    State(state): State<ServiceState>,
+    Json(mut payload): Json<RegionCreateRequest>,
+) -> Result<impl IntoResponse, KeystoneApiError> {
+    payload.validate()?;
+    payload.region.id = Some(region_id.clone());
+
+    let exec = ExecutionContext::from_auth(&state, &user_auth);
+    let current = state
+        .provider
+        .get_catalog_provider()
+        .get_region(&exec, &region_id)
+        .await?;
+
+    state
+        .policy_enforcer
+        .enforce(
+            if current.is_some() {
+                "identity/region/update"
+            } else {
+                "identity/region/create"
+            },
+            &user_auth,
+            json!({"region": payload.region}),
+            current.as_ref().map(|c| json!({"region": c})),
+        )
+        .await?;
+
+    let region = match current {
+        Some(_) => {
+            state
+                .provider
+                .get_catalog_provider()
+                .update_region(
+                    &exec,
+                    &region_id,
+                    RegionUpdateRequest {
+                        region: RegionUpdate {
+                            description: payload.region.description,
+                            parent_region_id: payload.region.parent_region_id,
+                            extra: payload.region.extra,
+                        },
+                    }
+                    .into(),
+                )
+                .await?
+        }
+        None => {
+            state
+                .provider
+                .get_catalog_provider()
+                .create_region(&exec, payload.into())
+                .await?
+        }
+    };
+
+    Ok((
+        StatusCode::CREATED,
+        Json(RegionResponse {
+            region: region.into(),
         }),
     )
         .into_response())
@@ -213,6 +297,205 @@ mod tests {
                     .uri("/")
                     .header("Content-Type", "application/json")
                     .method("POST")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_create_with_id_creates_when_absent() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "specific-id")
+            .returning(|_, _| Ok(None));
+        catalog_mock
+            .expect_create_region()
+            .withf(|_, region_create: &RegionCreate| {
+                region_create.id.as_deref() == Some("specific-id")
+            })
+            .returning(|_, _| Ok(RegionBuilder::default().id("specific-id").build().unwrap()));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionCreateRequest {
+            region: crate::api::v3::region::types::RegionCreateBuilder::default()
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/specific-id")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("PUT")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RegionResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.region.id, "specific-id");
+    }
+
+    #[tokio::test]
+    async fn test_create_with_id_updates_when_present() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "specific-id")
+            .returning(|_, _| {
+                Ok(Some(
+                    RegionBuilder::default().id("specific-id").build().unwrap(),
+                ))
+            });
+        catalog_mock
+            .expect_update_region()
+            .withf(|_, id: &'_ str, _| id == "specific-id")
+            .returning(|_, _, _| {
+                Ok(RegionBuilder::default()
+                    .id("specific-id")
+                    .description("updated")
+                    .build()
+                    .unwrap())
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionCreateRequest {
+            region: crate::api::v3::region::types::RegionCreateBuilder::default()
+                .description("updated")
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/specific-id")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("PUT")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RegionResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.region.description.as_deref(), Some("updated"));
+    }
+
+    #[tokio::test]
+    async fn test_create_with_id_forbidden() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "specific-id")
+            .returning(|_, _| Ok(None));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            false,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionCreateRequest {
+            region: crate::api::v3::region::types::RegionCreateBuilder::default()
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/specific-id")
+                    .extension(vsc)
+                    .header("Content-Type", "application/json")
+                    .method("PUT")
+                    .body(Body::from(serde_json::to_string(&req).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_create_with_id_unauthorized() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_get_region()
+            .withf(|_, id: &'_ str| id == "specific-id")
+            .returning(|_, _| Ok(None));
+
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let req = crate::api::v3::region::types::RegionCreateRequest {
+            region: crate::api::v3::region::types::RegionCreateBuilder::default()
+                .build()
+                .unwrap(),
+        };
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/specific-id")
+                    .header("Content-Type", "application/json")
+                    .method("PUT")
                     .body(Body::from(serde_json::to_string(&req).unwrap()))
                     .unwrap(),
             )

--- a/crates/keystone/src/api/v3/region/mod.rs
+++ b/crates/keystone/src/api/v3/region/mod.rs
@@ -28,5 +28,5 @@ pub(super) fn openapi_router() -> OpenApiRouter<ServiceState> {
     OpenApiRouter::new()
         .routes(routes!(list::list, create::create))
         .routes(routes!(show::show, delete::delete))
-        .routes(routes!(update::update))
+        .routes(routes!(update::update, create::create_with_id))
 }

--- a/crates/keystone/src/api/v3/region/update.rs
+++ b/crates/keystone/src/api/v3/region/update.rs
@@ -297,28 +297,4 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
-
-    #[tokio::test]
-    async fn test_update_rejects_put() {
-        let state = get_mocked_state(Provider::mocked_builder(), true, None).await;
-
-        let mut api = openapi_router()
-            .layer(TraceLayer::new_for_http())
-            .with_state(state);
-
-        let response = api
-            .as_service()
-            .oneshot(
-                Request::builder()
-                    .method("PUT")
-                    .uri("/foo")
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(r#"{"region":{"description":"updated"}}"#))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
-    }
 }

--- a/policy/trust/create.rego
+++ b/policy/trust/create.rego
@@ -30,11 +30,13 @@ default allow := false
 # METADATA
 # description: >
 #   A trust is always self-issued: the caller must be its own trustor.
-#   Matches python keystone's `identity:create_trust` policy, which has no
-#   admin bypass -- even an admin cannot create a trust on behalf of another
-#   user.
+#   Matches python keystone's `identity:create_trust` policy
+#   ("user_id:%(target.trust.trustor_user_id)s"), which has no admin bypass
+#   -- even an admin cannot create a trust on behalf of another user -- and
+#   no role requirement either: whether the trustor actually holds the
+#   roles being delegated is checked provider-side
+#   (`TrustService::create_trust`), not here.
 allow if {
-	"member" in input.credentials.roles
 	trust_common.is_trustor(input.target.trust)
 	trust_common.not_delegated_or_bound_to_own_project(object.get(input.target.trust, "project_id", null))
 }

--- a/policy/trust/create_test.rego
+++ b/policy/trust/create_test.rego
@@ -4,6 +4,11 @@ import data.identity.trust.create
 
 test_allowed if {
 	create.allow with input as {"credentials": {"roles": ["member"], "user_id": "u1"}, "target": {"trust": {"trustor_user_id": "u1"}}}
+
+	# No role requirement: matches python keystone's identity:create_trust,
+	# which only checks trustor identity. Whether the trustor actually
+	# holds the delegated roles is checked provider-side.
+	create.allow with input as {"credentials": {"roles": [], "user_id": "u1"}, "target": {"trust": {"trustor_user_id": "u1"}}}
 }
 
 test_forbidden if {

--- a/tests/api/tests/api_v3/trust/create.rs
+++ b/tests/api/tests/api_v3/trust/create.rs
@@ -131,7 +131,12 @@ async fn test_create_with_granted_roles() -> Result<()> {
     .await?;
 
     assert_eq!(trust.project_id.as_deref(), Some(project.id.as_str()));
-    assert!(trust.roles.iter().any(|r| &r.id == member_role_id));
+    assert!(
+        trust
+            .roles
+            .iter()
+            .any(|r| r.id.as_deref() == Some(member_role_id.as_str()))
+    );
 
     trust.delete().await?;
     project.delete().await?;

--- a/tests/api/tests/api_v3/trust/create.rs
+++ b/tests/api/tests/api_v3/trust/create.rs
@@ -122,7 +122,7 @@ async fn test_create_with_granted_roles() -> Result<()> {
             redelegation_count: None,
             roles: vec![TrustRoleRef {
                 domain_id: None,
-                id: member_role_id.clone(),
+                id: Some(member_role_id.clone()),
                 name: None,
             }],
             extra: None,
@@ -181,7 +181,7 @@ async fn test_create_role_not_granted_fails() -> Result<()> {
             redelegation_count: None,
             roles: vec![TrustRoleRef {
                 domain_id: None,
-                id: member_role_id.clone(),
+                id: Some(member_role_id.clone()),
                 name: None,
             }],
             extra: None,

--- a/tools/run-tempest-local.sh
+++ b/tools/run-tempest-local.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Runs tempest identity tests against a locally started Keystone server,
+# without skaffold/k8s. This is the local-agent counterpart to the
+# `tempest` skaffold module (skaffold.yaml, tools/Dockerfile.tempest,
+# tools/tempest/run-tempest.sh) which only runs in-cluster.
+#
+# Reuses tools/start-api.sh to bring up SPIRE + OPA + Keystone exactly like
+# `cargo nextest run --profile api -p test_api` does, then drives tempest
+# directly from a local venv (no docker image needed) using the same
+# tools/tempest/tempest.conf.template the CI container renders.
+#
+# Server is left running on exit (same behavior as start-api.sh) so repeat
+# runs against the same server are cheap; use tools/teardown-api.sh to stop
+# it, or just re-run this script which tears down and restarts fresh.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TEMPEST_REGEX="${TEMPEST_REGEX:-tempest\.api\.identity\.(v3|admin\.v3)\.}"
+WORKSPACE="${TEMPEST_WORKSPACE:-/tmp/nextest/tempest-workspace}"
+VENV_DIR="${TEMPEST_VENV:-/tmp/nextest/tempest-venv}"
+
+# start-api.sh appends connection details (OS_*, KEYSTONE_URL, ...) as
+# KEY=VALUE lines to $NEXTEST_ENV; give it a real file so we can source
+# those vars even when not running under nextest.
+export NEXTEST_ENV
+NEXTEST_ENV="$(mktemp)"
+
+echo "=== Starting Keystone (SPIRE + OPA + server) via tools/start-api.sh ==="
+tools/start-api.sh
+
+set -a
+source "$NEXTEST_ENV"
+set +a
+# start-api.sh's bootstrap (crates/cli-manage/src/bootstrap.rs) registers
+# the identity service under type "identity" with only a "public"
+# interface endpoint - unlike the skaffold-deployed keystone-rs, which the
+# shared template's catalog_type/v3_endpoint_type defaults (identity-rs /
+# internal) target instead. Match what's actually in the catalog here.
+export OS_IDENTITY_SERVICE_TYPE=identity
+
+if [ ! -x "$VENV_DIR/bin/tempest" ]; then
+  echo "=== Installing tempest into ${VENV_DIR} ==="
+  python3 -m venv "$VENV_DIR"
+  "$VENV_DIR/bin/pip" install --quiet --upgrade pip
+  "$VENV_DIR/bin/pip" install --quiet tempest
+fi
+
+TEMPEST_WORKSPACE_NAME="$(basename "$WORKSPACE")"
+if [ ! -f "$WORKSPACE/.stestr.conf" ]; then
+  # `tempest init` also registers $TEMPEST_WORKSPACE_NAME -> $WORKSPACE in
+  # ~/.tempest/workspace.yaml and refuses to re-init a name it already
+  # knows, so drop any stale registration (e.g. from a run whose directory
+  # was since removed) before creating a fresh one.
+  sed -i "\#^${TEMPEST_WORKSPACE_NAME}:#d" ~/.tempest/workspace.yaml 2>/dev/null || true
+  rm -rf "$WORKSPACE"
+  mkdir -p "$WORKSPACE"
+  "$VENV_DIR/bin/tempest" init "$WORKSPACE"
+fi
+envsubst <tools/tempest/tempest.conf.template >"$WORKSPACE/etc/tempest.conf"
+# The template's log_file is hardcoded to /tempest/workspace, the fixed
+# mount path inside the CI verify container (tools/Dockerfile.tempest);
+# outside that container it must point at our real $WORKSPACE instead.
+sed -i "s#/tempest/workspace#${WORKSPACE}#" "$WORKSPACE/etc/tempest.conf"
+# Same reasoning as OS_IDENTITY_SERVICE_TYPE above: the template's
+# v3_endpoint_type is hardcoded to "internal" for the skaffold deployment;
+# start-api.sh's bootstrap only registers a "public" endpoint.
+sed -i "s#^v3_endpoint_type = internal#v3_endpoint_type = public#" "$WORKSPACE/etc/tempest.conf"
+# The template's admin_domain_name is hardcoded to "Default" to match
+# keystone-py's bootstrap (used by skaffold/devstack targets); the rust
+# bootstrap here (crates/cli-manage/src/bootstrap.rs) names it "default"
+# (lowercase), and domain lookup is case-sensitive.
+sed -i "s#^admin_domain_name = Default#admin_domain_name = default#" "$WORKSPACE/etc/tempest.conf"
+
+cd "$WORKSPACE"
+
+echo "=== Running tempest identity tests against ${OS_AUTH_URL} (regex=${TEMPEST_REGEX}) ==="
+set +e
+"$VENV_DIR/bin/tempest" run --config-file "$WORKSPACE/etc/tempest.conf" --regex "$TEMPEST_REGEX"
+RESULT=$?
+set -e
+
+echo ""
+echo "===== FAILED TESTS ====="
+"$VENV_DIR/bin/stestr" failing --list >/tmp/tempest-failed-tests.txt 2>/dev/null || true
+if [ -s /tmp/tempest-failed-tests.txt ]; then
+  cat /tmp/tempest-failed-tests.txt
+else
+  echo "(none)"
+fi
+echo "===== END FAILED TESTS ====="
+
+exit "$RESULT"


### PR DESCRIPTION
- **feat(identity): Add trust create/delete and REST CRUD**
- **fix(trust): Create by role name, drop bogus role gate**
- **fix: Switch json rejection from 422 to 400**
- **fix(catalog): Auto-vivify legacy region on endpoint write**
- **chore: Add local tempest runner**
