### PR TITLE
feat: Generalize marker pagination for v3/v4 lists

### DIFF
--- a/crates/api-key-driver-raft/src/lib.rs
+++ b/crates/api-key-driver-raft/src/lib.rs
@@ -193,6 +193,25 @@ impl RaftBackend {
             }
             res.push(candidate);
         }
+
+        res.sort_by(|a, b| a.client_id.cmp(&b.client_id));
+        if let Some(marker) = &params.pagination.marker {
+            if params.pagination.page_reverse {
+                res.retain(|x| x.client_id.as_str() < marker.as_str());
+            } else {
+                res.retain(|x| x.client_id.as_str() > marker.as_str());
+            }
+        }
+        if let Some(limit) = params.pagination.limit {
+            let limit = (limit + 1) as usize;
+            if params.pagination.page_reverse {
+                if res.len() > limit {
+                    res = res.split_off(res.len() - limit);
+                }
+            } else {
+                res.truncate(limit);
+            }
+        }
         Ok(res)
     }
 
@@ -646,6 +665,7 @@ mod tests {
             domain_id: "domain-1".to_string(),
             provider_id: None,
             enabled: None,
+            ..Default::default()
         };
         let listed = backend.list_impl(&storage, &params).await.unwrap();
         assert_eq!(listed.len(), 2);

--- a/crates/api-types/src/federation/identity_provider.rs
+++ b/crates/api-types/src/federation/identity_provider.rs
@@ -431,17 +431,6 @@ pub struct IdentityProviderListParameters {
     #[cfg_attr(feature = "openapi", param(nullable = false))]
     #[cfg_attr(feature = "validate", validate(length(max = 64)))]
     pub domain_id: Option<String>,
-
-    /// Limit number of entries on the single response page.
-    #[serde(default = "default_list_limit")]
-    pub limit: Option<u64>,
-
-    /// Page marker (id of the last entry on the previous page.
-    pub marker: Option<String>,
-}
-
-fn default_list_limit() -> Option<u64> {
-    Some(20)
 }
 
 #[cfg(test)]

--- a/crates/api-types/src/federation/identity_provider_conv.rs
+++ b/crates/api-types/src/federation/identity_provider_conv.rs
@@ -90,8 +90,7 @@ impl From<api_types::IdentityProviderListParameters>
         Self {
             name: value.name,
             domain_ids: None, //value.domain_id
-            limit: value.limit,
-            marker: value.marker,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/k8s_auth/instance_conv.rs
+++ b/crates/api-types/src/k8s_auth/instance_conv.rs
@@ -63,6 +63,7 @@ impl From<api_types::K8sAuthInstanceListParameters>
         Self {
             domain_id: value.domain_id,
             name: value.name,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -63,3 +63,32 @@ impl Link {
 pub fn default_true() -> bool {
     true
 }
+
+/// Default page size applied when the client does not supply `limit`.
+pub fn default_list_limit() -> Option<u64> {
+    Some(20)
+}
+
+/// Shared pagination query parameters, reused by every v3/v4 list endpoint.
+///
+/// Handlers take this as a *second*, independent `Query<PaginationQuery>`
+/// extractor alongside each resource's own filter-only params type — axum
+/// re-parses the full query string per extractor and ignores fields it
+/// doesn't declare, so this composes cleanly without `#[serde(flatten)]`
+/// (which breaks typed-field deserialization over `serde_urlencoded`).
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
+pub struct PaginationQuery {
+    /// Limit number of entries on the single response page.
+    #[serde(default = "default_list_limit")]
+    pub limit: Option<u64>,
+    /// Page marker (id of the last entry of the previous page).
+    pub marker: Option<String>,
+    /// Fetch the page preceding `marker` instead of the page following it.
+    ///
+    /// v3 endpoints accept this field (unknown-to-python-keystone query
+    /// params are harmless) but never read or forward it; only v4 endpoints
+    /// wire it through.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub page_reverse: bool,
+}

--- a/crates/api-types/src/v3/credential.rs
+++ b/crates/api-types/src/v3/credential.rs
@@ -72,6 +72,10 @@ pub struct CredentialList {
     /// Collection of credential objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub credentials: Vec<Credential>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<crate::Link>>,
 }
 
 /// Query parameters for `GET /v3/credentials`.

--- a/crates/api-types/src/v3/credential_conv.rs
+++ b/crates/api-types/src/v3/credential_conv.rs
@@ -34,6 +34,7 @@ impl From<api_types::CredentialListParameters> for provider_types::CredentialLis
         Self {
             r#type: value.r#type,
             user_id: value.user_id,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v3/domain.rs
+++ b/crates/api-types/src/v3/domain.rs
@@ -17,6 +17,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "validate")]
 use validator::Validate;
 
+use crate::Link;
+
 /// Short domain representation.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(
@@ -192,6 +194,10 @@ pub struct DomainList {
     /// Collection of domain objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub domains: Vec<Domain>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
 }
 
 /// Domain list parameters.

--- a/crates/api-types/src/v3/domain_conv.rs
+++ b/crates/api-types/src/v3/domain_conv.rs
@@ -80,6 +80,7 @@ impl From<api_types::DomainListParameters> for provider_types::DomainListParamet
         Self {
             ids: value.ids.map(|s| HashSet::from([s])),
             name: value.name,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v3/endpoint.rs
+++ b/crates/api-types/src/v3/endpoint.rs
@@ -69,6 +69,10 @@ pub struct EndpointList {
     /// Collection of endpoint objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub endpoints: Vec<Endpoint>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<crate::Link>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/api-types/src/v3/endpoint_conv.rs
+++ b/crates/api-types/src/v3/endpoint_conv.rs
@@ -37,6 +37,7 @@ impl From<api_types::EndpointListParameters> for provider_types::EndpointListPar
             interface: value.interface,
             service_id: value.service_id,
             region_id: value.region_id,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v3/group.rs
+++ b/crates/api-types/src/v3/group.rs
@@ -18,6 +18,8 @@ use serde_json::Value;
 #[cfg(feature = "validate")]
 use validator::Validate;
 
+use crate::Link;
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(
     feature = "builder",
@@ -147,6 +149,10 @@ pub struct GroupList {
     /// Collection of group objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub groups: Vec<Group>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/api-types/src/v3/group_conv.rs
+++ b/crates/api-types/src/v3/group_conv.rs
@@ -46,6 +46,7 @@ impl From<api_types::GroupListParameters> for provider_types::GroupListParameter
         Self {
             domain_id: value.domain_id,
             name: value.name,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v3/project.rs
+++ b/crates/api-types/src/v3/project.rs
@@ -14,6 +14,8 @@
 //! Project API types.
 
 use serde::{Deserialize, Serialize};
+
+use crate::Link;
 #[cfg(feature = "validate")]
 use validator::Validate;
 
@@ -264,6 +266,10 @@ pub struct ProjectShortList {
     /// Collection of project objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub projects: Vec<ProjectShort>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
 }
 
 /// Project list parameters.

--- a/crates/api-types/src/v3/project_conv.rs
+++ b/crates/api-types/src/v3/project_conv.rs
@@ -89,6 +89,7 @@ impl From<api_types::ProjectListParameters> for provider_types::ProjectListParam
             domain_id: value.domain_id,
             ids: value.ids.map(|s| HashSet::from([s])),
             name: value.name,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v3/region.rs
+++ b/crates/api-types/src/v3/region.rs
@@ -58,6 +58,10 @@ pub struct RegionList {
     /// Collection of region objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub regions: Vec<Region>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<crate::Link>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/api-types/src/v3/region_conv.rs
+++ b/crates/api-types/src/v3/region_conv.rs
@@ -31,6 +31,7 @@ impl From<api_types::RegionListParameters> for provider_types::RegionListParamet
     fn from(value: api_types::RegionListParameters) -> Self {
         Self {
             parent_region_id: value.parent_region_id,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v3/role.rs
+++ b/crates/api-types/src/v3/role.rs
@@ -19,6 +19,8 @@ use serde_json::Value;
 #[cfg(feature = "validate")]
 use validator::Validate;
 
+use crate::Link;
+
 /// The role data.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -140,6 +142,10 @@ pub struct RoleList {
     /// Collection of role objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub roles: Vec<Role>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/api-types/src/v3/role_conv.rs
+++ b/crates/api-types/src/v3/role_conv.rs
@@ -52,6 +52,7 @@ impl From<api_types::RoleListParameters> for provider_types::RoleListParameters 
         Self {
             domain_id: Some(value.domain_id),
             name: value.name,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v3/service.rs
+++ b/crates/api-types/src/v3/service.rs
@@ -61,6 +61,10 @@ pub struct ServiceList {
     /// Collection of service objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub services: Vec<Service>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<crate::Link>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/api-types/src/v3/service_conv.rs
+++ b/crates/api-types/src/v3/service_conv.rs
@@ -36,6 +36,7 @@ impl From<api_types::ServiceListParameters> for provider_types::ServiceListParam
         Self {
             name: value.name,
             r#type: value.r#type,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v3/user.rs
+++ b/crates/api-types/src/v3/user.rs
@@ -17,6 +17,8 @@ use chrono::{DateTime, Utc};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+use crate::Link;
 #[cfg(feature = "validate")]
 use validator::Validate;
 
@@ -407,6 +409,10 @@ pub struct UserList {
     /// Collection of user objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub users: Vec<User>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
 }
 
 /// User list parameters.

--- a/crates/api-types/src/v4/api_key.rs
+++ b/crates/api-types/src/v4/api_key.rs
@@ -166,6 +166,10 @@ pub struct ApiKeyResponse {
 pub struct ApiKeyList {
     /// Collection of API Keys.
     pub api_keys: Vec<ApiKey>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<crate::Link>>,
 }
 
 /// API Key list query parameters.

--- a/crates/api-types/src/v4/api_key_conv.rs
+++ b/crates/api-types/src/v4/api_key_conv.rs
@@ -63,6 +63,7 @@ impl From<api::ApiKeyListParameters> for core::ApiClientResourceListParameters {
             domain_id: value.domain_id,
             provider_id: value.provider_id,
             enabled: value.enabled,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v4/scim_realm_conv.rs
+++ b/crates/api-types/src/v4/scim_realm_conv.rs
@@ -63,6 +63,7 @@ impl From<api::ScimRealmListParameters> for core::ScimRealmResourceListParameter
         Self {
             domain_id: value.domain_id,
             enabled: value.enabled,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/api-types/src/v4/token_restriction.rs
+++ b/crates/api-types/src/v4/token_restriction.rs
@@ -179,4 +179,8 @@ pub struct TokenRestrictionListParameters {
 pub struct TokenRestrictionList {
     /// Token restrictions.
     pub restrictions: Vec<TokenRestriction>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<crate::Link>>,
 }

--- a/crates/api-types/src/v4/token_restriction_conv.rs
+++ b/crates/api-types/src/v4/token_restriction_conv.rs
@@ -25,6 +25,7 @@ impl From<api_types::TokenRestrictionListParameters>
             domain_id: value.domain_id,
             user_id: value.user_id,
             project_id: value.project_id,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/catalog-driver-sql/src/endpoint/list.rs
+++ b/crates/catalog-driver-sql/src/endpoint/list.rs
@@ -15,12 +15,58 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
+use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_core::catalog::CatalogProviderError;
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core_types::catalog::*;
 
 use crate::entity::{endpoint as db_endpoint, prelude::Endpoint as DbEndpoint};
+
+/// Prepare the paginated query for listing endpoints.
+///
+/// # Parameters
+/// - `params`: The parameters for listing endpoints.
+///
+/// # Returns
+/// A `Result` containing a `Cursor` for the select model.
+fn get_list_query(
+    params: &EndpointListParameters,
+) -> Result<Cursor<SelectModel<db_endpoint::Model>>, CatalogProviderError> {
+    let mut select = DbEndpoint::find();
+
+    if let Some(val) = &params.interface {
+        select = select.filter(db_endpoint::Column::Interface.eq(val));
+    }
+    if let Some(val) = &params.service_id {
+        select = select.filter(db_endpoint::Column::ServiceId.eq(val));
+    }
+    if let Some(val) = &params.region_id {
+        select = select.filter(db_endpoint::Column::RegionId.eq(val));
+    }
+
+    let mut cursor = select.cursor_by(db_endpoint::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
+}
 
 /// Lists endpoints.
 ///
@@ -34,33 +80,49 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &EndpointListParameters,
 ) -> Result<Vec<Endpoint>, CatalogProviderError> {
-    let mut select = DbEndpoint::find();
-
-    if let Some(val) = &params.interface {
-        select = select.filter(db_endpoint::Column::Interface.eq(val));
-    }
-    if let Some(val) = &params.service_id {
-        select = select.filter(db_endpoint::Column::ServiceId.eq(val));
-    }
-    if let Some(val) = &params.region_id {
-        select = select.filter(db_endpoint::Column::RegionId.eq(val));
-    }
-
-    select
+    Ok(get_list_query(params)?
         .all(db)
         .await
         .context("fetching endpoints")?
         .into_iter()
         .map(TryInto::<Endpoint>::try_into)
-        .collect()
+        .collect::<Result<_, _>>()?)
 }
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
 
     use super::super::tests::get_endpoint_mock;
     use super::*;
+
+    #[tokio::test]
+    async fn test_query_all() {
+        assert_eq!(
+            r#"SELECT "endpoint"."id", "endpoint"."legacy_endpoint_id", "endpoint"."interface", "endpoint"."service_id", "endpoint"."url", "endpoint"."extra", "endpoint"."enabled", "endpoint"."region_id" FROM "endpoint""#,
+            QueryOrder::query(&mut get_list_query(&EndpointListParameters::default()).unwrap())
+                .to_string(PostgresQueryBuilder)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_filters() {
+        assert!(
+            QueryOrder::query(
+                &mut get_list_query(&EndpointListParameters {
+                    interface: Some("public".into()),
+                    service_id: Some("service_id".into()),
+                    region_id: Some("region_id".into()),
+                    ..Default::default()
+                })
+                .unwrap()
+            )
+            .to_string(PostgresQueryBuilder)
+            .contains(
+                r#""endpoint"."interface" = 'public' AND "endpoint"."service_id" = 'service_id' AND "endpoint"."region_id" = 'region_id'"#
+            )
+        );
+    }
 
     #[tokio::test]
     async fn test_list() {
@@ -76,7 +138,8 @@ mod tests {
                 &EndpointListParameters {
                     interface: Some("public".into()),
                     service_id: Some("service_id".into()),
-                    region_id: Some("region_id".into())
+                    region_id: Some("region_id".into()),
+                    ..Default::default()
                 }
             )
             .await
@@ -98,15 +161,42 @@ mod tests {
             [
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "endpoint"."id", "endpoint"."legacy_endpoint_id", "endpoint"."interface", "endpoint"."service_id", "endpoint"."url", "endpoint"."extra", "endpoint"."enabled", "endpoint"."region_id" FROM "endpoint""#,
+                    r#"SELECT "endpoint"."id", "endpoint"."legacy_endpoint_id", "endpoint"."interface", "endpoint"."service_id", "endpoint"."url", "endpoint"."extra", "endpoint"."enabled", "endpoint"."region_id" FROM "endpoint" ORDER BY "endpoint"."id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "endpoint"."id", "endpoint"."legacy_endpoint_id", "endpoint"."interface", "endpoint"."service_id", "endpoint"."url", "endpoint"."extra", "endpoint"."enabled", "endpoint"."region_id" FROM "endpoint" WHERE "endpoint"."interface" = $1 AND "endpoint"."service_id" = $2 AND "endpoint"."region_id" = $3"#,
+                    r#"SELECT "endpoint"."id", "endpoint"."legacy_endpoint_id", "endpoint"."interface", "endpoint"."service_id", "endpoint"."url", "endpoint"."extra", "endpoint"."enabled", "endpoint"."region_id" FROM "endpoint" WHERE "endpoint"."interface" = $1 AND "endpoint"."service_id" = $2 AND "endpoint"."region_id" = $3 ORDER BY "endpoint"."id" ASC"#,
                     ["public".into(), "service_id".into(), "region_id".into()]
                 ),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_endpoint_mock("1"), get_endpoint_mock("2")]])
+            .into_connection();
+
+        let endpoints = list(
+            &db,
+            &EndpointListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("0".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(endpoints.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""endpoint"."id" >"#));
+        assert!(sql.contains("LIMIT"));
     }
 }

--- a/crates/catalog-driver-sql/src/region/list.rs
+++ b/crates/catalog-driver-sql/src/region/list.rs
@@ -15,12 +15,52 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
+use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_core::catalog::CatalogProviderError;
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core_types::catalog::*;
 
 use crate::entity::{prelude::Region as DbRegion, region as db_region};
+
+/// Prepare the paginated query for listing regions.
+///
+/// # Parameters
+/// - `params`: The parameters for listing regions.
+///
+/// # Returns
+/// A `Result` containing a `Cursor` for the select model.
+fn get_list_query(
+    params: &RegionListParameters,
+) -> Result<Cursor<SelectModel<db_region::Model>>, CatalogProviderError> {
+    let mut select = DbRegion::find();
+
+    if let Some(parent_region_id) = &params.parent_region_id {
+        select = select.filter(db_region::Column::ParentRegionId.eq(parent_region_id));
+    }
+
+    let mut cursor = select.cursor_by(db_region::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
+}
 
 /// Lists regions.
 ///
@@ -34,28 +74,46 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &RegionListParameters,
 ) -> Result<Vec<Region>, CatalogProviderError> {
-    let mut select = DbRegion::find();
-
-    if let Some(parent_region_id) = &params.parent_region_id {
-        select = select.filter(db_region::Column::ParentRegionId.eq(parent_region_id));
-    }
-
-    select
+    Ok(get_list_query(params)?
         .all(db)
         .await
         .context("fetching regions")?
         .into_iter()
         .map(TryInto::<Region>::try_into)
-        .collect()
+        .collect::<Result<_, _>>()?)
 }
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
     use serde_json::json;
 
     use super::super::tests::get_region_mock;
     use super::*;
+
+    #[tokio::test]
+    async fn test_query_all() {
+        assert_eq!(
+            r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region""#,
+            QueryOrder::query(&mut get_list_query(&RegionListParameters::default()).unwrap())
+                .to_string(PostgresQueryBuilder)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_parent_region_id() {
+        assert!(
+            QueryOrder::query(
+                &mut get_list_query(&RegionListParameters {
+                    parent_region_id: Some("parent".into()),
+                    ..Default::default()
+                })
+                .unwrap()
+            )
+            .to_string(PostgresQueryBuilder)
+            .contains(r#""region"."parent_region_id" = 'parent'"#)
+        );
+    }
 
     #[tokio::test]
     async fn test_list() {
@@ -70,6 +128,7 @@ mod tests {
                 &db,
                 &RegionListParameters {
                     parent_region_id: Some("parent".into()),
+                    ..Default::default()
                 }
             )
             .await
@@ -88,15 +147,42 @@ mod tests {
             [
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region""#,
+                    r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region" ORDER BY "region"."id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region" WHERE "region"."parent_region_id" = $1"#,
+                    r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region" WHERE "region"."parent_region_id" = $1 ORDER BY "region"."id" ASC"#,
                     ["parent".into()]
                 ),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_region_mock("1"), get_region_mock("2")]])
+            .into_connection();
+
+        let regions = list(
+            &db,
+            &RegionListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("0".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(regions.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""region"."id" >"#));
+        assert!(sql.contains("LIMIT"));
     }
 }

--- a/crates/catalog-driver-sql/src/service/list.rs
+++ b/crates/catalog-driver-sql/src/service/list.rs
@@ -15,12 +15,52 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
+use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_core::catalog::CatalogProviderError;
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core_types::catalog::*;
 
 use crate::entity::{prelude::Service as DbService, service as db_service};
+
+/// Prepare the paginated query for listing services.
+///
+/// # Parameters
+/// - `params`: The parameters for listing services.
+///
+/// # Returns
+/// A `Result` containing a `Cursor` for the select model.
+fn get_list_query(
+    params: &ServiceListParameters,
+) -> Result<Cursor<SelectModel<db_service::Model>>, CatalogProviderError> {
+    let mut select = DbService::find();
+
+    if let Some(typ) = &params.r#type {
+        select = select.filter(db_service::Column::Type.eq(typ));
+    }
+
+    let mut cursor = select.cursor_by(db_service::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
+}
 
 /// Lists services.
 ///
@@ -34,13 +74,7 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &ServiceListParameters,
 ) -> Result<Vec<Service>, CatalogProviderError> {
-    let mut select = DbService::find();
-
-    if let Some(typ) = &params.r#type {
-        select = select.filter(db_service::Column::Type.eq(typ));
-    }
-
-    let mut services: Vec<Service> = select
+    let mut services: Vec<Service> = get_list_query(params)?
         .all(db)
         .await
         .context("fetching services")?
@@ -60,11 +94,35 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
     use serde_json::json;
 
     use super::super::tests::get_service_mock;
     use super::*;
+
+    #[tokio::test]
+    async fn test_query_all() {
+        assert_eq!(
+            r#"SELECT "service"."id", "service"."type", "service"."enabled", "service"."extra" FROM "service""#,
+            QueryOrder::query(&mut get_list_query(&ServiceListParameters::default()).unwrap())
+                .to_string(PostgresQueryBuilder)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_type() {
+        assert!(
+            QueryOrder::query(
+                &mut get_list_query(&ServiceListParameters {
+                    r#type: Some("type".into()),
+                    ..Default::default()
+                })
+                .unwrap()
+            )
+            .to_string(PostgresQueryBuilder)
+            .contains(r#""service"."type" = 'type'"#)
+        );
+    }
 
     #[tokio::test]
     async fn test_list() {
@@ -90,6 +148,7 @@ mod tests {
                 &ServiceListParameters {
                     r#type: Some("type".into()),
                     name: None,
+                    ..Default::default()
                 }
             )
             .await
@@ -104,12 +163,12 @@ mod tests {
             [
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "service"."id", "service"."type", "service"."enabled", "service"."extra" FROM "service""#,
+                    r#"SELECT "service"."id", "service"."type", "service"."enabled", "service"."extra" FROM "service" ORDER BY "service"."id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "service"."id", "service"."type", "service"."enabled", "service"."extra" FROM "service" WHERE "service"."type" = $1"#,
+                    r#"SELECT "service"."id", "service"."type", "service"."enabled", "service"."extra" FROM "service" WHERE "service"."type" = $1 ORDER BY "service"."id" ASC"#,
                     ["type".into()]
                 ),
             ]
@@ -141,6 +200,7 @@ mod tests {
             &ServiceListParameters {
                 name: Some("alpha".into()),
                 r#type: None,
+                ..Default::default()
             },
         )
         .await
@@ -148,5 +208,32 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, "1");
         assert_eq!(result[0].name().as_deref(), Some("alpha"));
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_service_mock("1"), get_service_mock("2")]])
+            .into_connection();
+
+        let services = list(
+            &db,
+            &ServiceListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("0".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(services.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""service"."id" >"#));
+        assert!(sql.contains("LIMIT"));
     }
 }

--- a/crates/config/src/api_key.rs
+++ b/crates/config/src/api_key.rs
@@ -20,6 +20,7 @@ use serde::Deserialize;
 use validator::Validate;
 
 use crate::common::{ProxyHeader, csv_ipnet, default_raft_driver};
+use crate::pagination::ListLimitConfig;
 
 /// API Key (SCIM ingress) provider configuration.
 #[derive(Debug, Deserialize, Clone, Validate)]
@@ -91,6 +92,10 @@ pub struct ApiKeyProvider {
     #[serde(default = "default_rate_limit_replenish_per_minute")]
     #[validate(range(min = 1))]
     pub rate_limit_replenish_per_minute: u32,
+
+    /// `GET /v4/api-keys` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 fn default_argon2_memory_kib() -> u32 {
@@ -139,6 +144,7 @@ impl Default for ApiKeyProvider {
             trusted_header: ProxyHeader::default(),
             rate_limit_burst_size: default_rate_limit_burst_size(),
             rate_limit_replenish_per_minute: default_rate_limit_replenish_per_minute(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -14,6 +14,7 @@
 use serde::Deserialize;
 
 use crate::common::default_sql_driver;
+use crate::pagination::ListLimitConfig;
 
 /// Catalog provider.
 #[derive(Debug, Deserialize, Clone)]
@@ -21,12 +22,17 @@ pub struct CatalogProvider {
     /// Catalog provider driver.
     #[serde(default = "default_sql_driver")]
     pub driver: String,
+
+    /// `GET /v3/services`, `/v3/regions`, `/v3/endpoints` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for CatalogProvider {
     fn default() -> Self {
         Self {
             driver: default_sql_driver(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/credential.rs
+++ b/crates/config/src/credential.rs
@@ -16,6 +16,7 @@ use serde::Deserialize;
 use std::path::PathBuf;
 
 use crate::common::default_sql_driver;
+use crate::pagination::ListLimitConfig;
 
 /// Credential provider.
 ///
@@ -41,6 +42,10 @@ pub struct CredentialProvider {
     /// Null Key).
     #[serde(default)]
     pub insecure_allow_null_key: bool,
+
+    /// `GET /v3/credentials` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 fn default_credential_key_repository() -> PathBuf {
@@ -53,6 +58,7 @@ impl Default for CredentialProvider {
             driver: default_sql_driver(),
             key_repository: default_credential_key_repository(),
             insecure_allow_null_key: false,
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -42,4 +42,14 @@ pub struct DefaultSection {
     /// Log output to standard error.
     #[serde(default)]
     pub use_stderr: bool,
+
+    /// Global default page size, used when a provider has no
+    /// `list_limit` of its own and the client omits `limit`. Mirrors
+    /// python-keystone's `[DEFAULT] list_limit`.
+    pub list_limit: Option<u64>,
+
+    /// Global absolute cap on `limit`, used when a provider has no
+    /// `max_list_limit` of its own. Mirrors python-keystone's
+    /// `[DEFAULT] max_db_limit`.
+    pub max_db_limit: Option<u64>,
 }

--- a/crates/config/src/identity.rs
+++ b/crates/config/src/identity.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 use crate::common::default_sql_driver;
+use crate::pagination::ListLimitConfig;
 
 /// Identity provider.
 #[derive(Debug, Deserialize, Clone)]
@@ -46,6 +47,10 @@ pub struct IdentityProvider {
     /// User options id to name mapping.
     #[serde(default = "default_user_options_mapping")]
     pub user_options_id_name_mapping: HashMap<String, String>,
+
+    /// `GET /v3/users` and `/v4/users` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for IdentityProvider {
@@ -58,6 +63,7 @@ impl Default for IdentityProvider {
             password_hashing_algorithm: PasswordHashingAlgo::Bcrypt,
             password_hash_rounds: None,
             user_options_id_name_mapping: default_user_options_mapping(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/k8s_auth.rs
+++ b/crates/config/src/k8s_auth.rs
@@ -14,6 +14,7 @@
 use serde::Deserialize;
 
 use crate::common::default_sql_driver;
+use crate::pagination::ListLimitConfig;
 
 /// K8s auth provider.
 #[derive(Debug, Deserialize, Clone)]
@@ -21,12 +22,17 @@ pub struct K8sAuthProvider {
     /// K8s auth provider backend.
     #[serde(default = "default_sql_driver")]
     pub driver: String,
+
+    /// `GET /v4/k8s_auth/instances` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for K8sAuthProvider {
     fn default() -> Self {
         Self {
             driver: default_sql_driver(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -88,6 +88,7 @@ mod local_emergency;
 mod mapping;
 mod oauth2;
 mod oslo_middleware;
+mod pagination;
 mod policy;
 mod rate_limit;
 mod resource;
@@ -129,6 +130,7 @@ pub use local_emergency::*;
 pub use mapping::*;
 pub use oauth2::*;
 pub use oslo_middleware::*;
+pub use pagination::*;
 pub use policy::*;
 pub use rate_limit::*;
 pub use resource::*;
@@ -472,6 +474,28 @@ impl Config {
             }
         }
         watched_paths
+    }
+
+    /// Resolve the effective page limit for a list request, following
+    /// python-keystone's `Hints.get_limit_with_default` precedence:
+    /// client-supplied `limit` → provider's `list_limit` → global
+    /// `[DEFAULT] list_limit` → provider's `max_list_limit` → global
+    /// `[DEFAULT] max_db_limit`. The client-supplied `limit` (if present) is
+    /// always clamped to whichever max applies.
+    pub fn resolve_list_limit(
+        &self,
+        provider_limit: &ListLimitConfig,
+        requested: Option<u64>,
+    ) -> Option<u64> {
+        let max = provider_limit.max_list_limit.or(self.default.max_db_limit);
+        let effective = requested
+            .or(provider_limit.list_limit)
+            .or(self.default.list_limit);
+        match (effective, max) {
+            (Some(effective), Some(max)) => Some(effective.min(max)),
+            (Some(effective), None) => Some(effective),
+            (None, max) => max,
+        }
     }
 }
 

--- a/crates/config/src/oauth2.rs
+++ b/crates/config/src/oauth2.rs
@@ -20,6 +20,8 @@
 use serde::Deserialize;
 use validator::Validate;
 
+use crate::pagination::ListLimitConfig;
+
 /// OAuth2 signing algorithm (ADR 0026 §3).
 ///
 /// This same value governs both outbound signing and inbound verification;
@@ -146,6 +148,10 @@ pub struct Oauth2Provider {
     #[serde(default = "default_device_code_poll_interval_seconds")]
     #[validate(range(min = 1))]
     pub device_code_poll_interval_seconds: u32,
+
+    /// `GET /v4/oauth2/{domain_id}/clients` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 fn default_signing_key_rotation_days() -> u32 {
@@ -222,6 +228,7 @@ impl Default for Oauth2Provider {
             pre_auth_session_lifetime_minutes: default_pre_auth_session_lifetime_minutes(),
             device_code_lifetime_minutes: default_device_code_lifetime_minutes(),
             device_code_poll_interval_seconds: default_device_code_poll_interval_seconds(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/pagination.rs
+++ b/crates/config/src/pagination.rs
@@ -1,0 +1,32 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Per-provider list-pagination limits, mirroring python-keystone's
+//! per-resource `list_limit` config plus a global `[DEFAULT] list_limit` /
+//! `max_db_limit` fallback (see `keystone.common.driver_hints.Hints`).
+use serde::Deserialize;
+
+/// Reusable per-provider pagination limit configuration.
+///
+/// Embedded as a field in each domain's provider config section (e.g.
+/// `IdentityProvider.list_limit`), rather than duplicated inline, so every
+/// domain gets the same two knobs.
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct ListLimitConfig {
+    /// Default page size applied when the client omits `limit`. Falls back
+    /// to the global `[DEFAULT] list_limit` when unset.
+    pub list_limit: Option<u64>,
+    /// Absolute cap a client-supplied `limit` is clamped to. Falls back to
+    /// the global `[DEFAULT] max_db_limit` when unset.
+    pub max_list_limit: Option<u64>,
+}

--- a/crates/config/src/resource.rs
+++ b/crates/config/src/resource.rs
@@ -14,6 +14,7 @@
 use serde::Deserialize;
 
 use crate::common::default_sql_driver;
+use crate::pagination::ListLimitConfig;
 
 /// Resource provider (domain, project).
 #[derive(Debug, Deserialize, Clone)]
@@ -21,12 +22,17 @@ pub struct ResourceProvider {
     /// Resource provider backend.
     #[serde(default = "default_sql_driver")]
     pub driver: String,
+
+    /// `GET /v3/projects` and `/v3/domains` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for ResourceProvider {
     fn default() -> Self {
         Self {
             driver: default_sql_driver(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/role.rs
+++ b/crates/config/src/role.rs
@@ -14,6 +14,7 @@
 use serde::Deserialize;
 
 use crate::common::default_sql_driver;
+use crate::pagination::ListLimitConfig;
 
 /// Role Provider.
 #[derive(Debug, Deserialize, Clone)]
@@ -21,12 +22,17 @@ pub struct RoleProvider {
     /// Role provider driver.
     #[serde(default = "default_sql_driver")]
     pub driver: String,
+
+    /// `GET /v3/roles` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for RoleProvider {
     fn default() -> Self {
         Self {
             driver: default_sql_driver(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/scim_realm.rs
+++ b/crates/config/src/scim_realm.rs
@@ -14,6 +14,7 @@
 use serde::Deserialize;
 
 use crate::common::default_raft_driver;
+use crate::pagination::ListLimitConfig;
 
 /// SCIM realm provider (ADR 0024).
 #[derive(Debug, Deserialize, Clone)]
@@ -21,12 +22,17 @@ pub struct ScimRealmProvider {
     /// SCIM realm provider driver.
     #[serde(default = "default_raft_driver")]
     pub driver: String,
+
+    /// `GET /v4/scim-realms` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for ScimRealmProvider {
     fn default() -> Self {
         Self {
             driver: default_raft_driver(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/token_restriction.rs
+++ b/crates/config/src/token_restriction.rs
@@ -17,6 +17,7 @@
 use serde::Deserialize;
 
 use crate::common::default_sql_driver;
+use crate::pagination::ListLimitConfig;
 
 /// Token restriction provider.
 #[derive(Debug, Deserialize, Clone)]
@@ -24,12 +25,17 @@ pub struct TokenRestrictionProvider {
     /// Token restriction driver.
     #[serde(default = "default_sql_driver")]
     pub driver: String,
+
+    /// `GET /v4/token/restrictions` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for TokenRestrictionProvider {
     fn default() -> Self {
         Self {
             driver: default_sql_driver(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/core-types/src/api_key/resource.rs
+++ b/crates/core-types/src/api_key/resource.rs
@@ -232,4 +232,7 @@ pub struct ApiClientResourceListParameters {
     /// Restrict to enabled/disabled keys.
     #[builder(default)]
     pub enabled: Option<bool>,
+
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }

--- a/crates/core-types/src/catalog/endpoint.rs
+++ b/crates/core-types/src/catalog/endpoint.rs
@@ -101,6 +101,10 @@ pub struct EndpointListParameters {
     /// Filters the response by a region ID.
     #[validate(length(max = 255))]
     pub region_id: Option<String>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }
 
 /// Fields that can be changed when updating an endpoint.

--- a/crates/core-types/src/catalog/region.rs
+++ b/crates/core-types/src/catalog/region.rs
@@ -70,6 +70,10 @@ pub struct RegionListParameters {
     /// Filters the response by a parent region ID.
     #[validate(length(max = 255))]
     pub parent_region_id: Option<String>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }
 
 /// Fields that can be changed when updating a region.

--- a/crates/core-types/src/catalog/service.rs
+++ b/crates/core-types/src/catalog/service.rs
@@ -88,6 +88,10 @@ pub struct ServiceListParameters {
     /// identity, image, network, or volume.
     #[validate(length(max = 255))]
     pub r#type: Option<String>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }
 
 /// Fields that can be changed when updating a service.

--- a/crates/core-types/src/credential/credential.rs
+++ b/crates/core-types/src/credential/credential.rs
@@ -130,4 +130,8 @@ pub struct CredentialListParameters {
     #[builder(default)]
     #[validate(length(max = 64))]
     pub user_id: Option<String>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }

--- a/crates/core-types/src/federation/identity_provider.rs
+++ b/crates/core-types/src/federation/identity_provider.rs
@@ -18,6 +18,7 @@ use secrecy::SecretString;
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::ListPagination;
 use crate::error::BuilderError;
 
 /// Identity provider resource.
@@ -207,14 +208,10 @@ pub struct IdentityProviderListParameters {
     /// in a single request.
     pub domain_ids: Option<std::collections::HashSet<Option<String>>>,
 
-    /// Limit number of entries on the single response page.
+    /// Pagination controls (limit/marker/page_reverse).
     #[builder(default)]
-    pub limit: Option<u64>,
+    pub pagination: ListPagination,
 
-    /// Page marker (id of the last entry on the previous page.
-    #[builder(default)]
-    pub marker: Option<String>,
-    ///
     /// Filters the response by IDP name.
     pub name: Option<String>,
 }

--- a/crates/core-types/src/identity/group.rs
+++ b/crates/core-types/src/identity/group.rs
@@ -66,6 +66,10 @@ pub struct GroupListParameters {
     /// Filter groups by the name attribute.
     #[builder(default)]
     pub name: Option<String>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }
 
 #[derive(Builder, Clone, Debug, Default, PartialEq)]

--- a/crates/core-types/src/identity/user.rs
+++ b/crates/core-types/src/identity/user.rs
@@ -309,6 +309,10 @@ pub struct UserListParameters {
     #[builder(default)]
     //#[serde(default, rename = "type")]
     pub user_type: Option<UserType>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }
 
 /// User type for filtering.

--- a/crates/core-types/src/k8s_auth/instance.rs
+++ b/crates/core-types/src/k8s_auth/instance.rs
@@ -120,6 +120,8 @@ pub struct K8sAuthInstanceListParameters {
     pub domain_id: Option<String>,
     /// Name.
     pub name: Option<String>,
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }
 
 pub enum K8sAuthInstanceFilter {

--- a/crates/core-types/src/lib.rs
+++ b/crates/core-types/src/lib.rs
@@ -17,6 +17,8 @@
 #![allow(clippy::module_inception)]
 #![deny(clippy::unwrap_used)]
 
+use serde::{Deserialize, Serialize};
+
 pub mod api_key;
 pub mod application_credential;
 pub mod assignment;
@@ -45,4 +47,22 @@ pub mod trust;
 /// Return `true` to be used as a positive default for the serde macros.
 pub fn default_true() -> bool {
     true
+}
+
+/// Shared pagination modifiers for `*ListParameters` structs.
+///
+/// Embedded as a named field (`pub pagination: ListPagination`) rather than
+/// duplicated per-domain, so every domain's list-parameters struct gets the
+/// same shape and can implement `HasPagination` with a one-line accessor.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct ListPagination {
+    /// Limit number of entries on the single response page.
+    pub limit: Option<u64>,
+    /// Page marker (id of the last entry of the previous page).
+    pub marker: Option<String>,
+    /// Fetch the page preceding `marker` instead of the page following it.
+    ///
+    /// Only meaningful for v4 endpoints; v3 handlers never read or forward
+    /// this field, keeping v3 forward-only and python-keystone compatible.
+    pub page_reverse: bool,
 }

--- a/crates/core-types/src/oauth2_client/resource.rs
+++ b/crates/core-types/src/oauth2_client/resource.rs
@@ -300,4 +300,7 @@ pub struct OAuth2ClientResourceListParameters {
     /// Restrict to enabled/disabled clients.
     #[builder(default)]
     pub enabled: Option<bool>,
+
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }

--- a/crates/core-types/src/resource/domain.rs
+++ b/crates/core-types/src/resource/domain.rs
@@ -113,4 +113,8 @@ pub struct DomainListParameters {
     #[builder(default)]
     #[validate(length(max = 255))]
     pub name: Option<String>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }

--- a/crates/core-types/src/resource/project.rs
+++ b/crates/core-types/src/resource/project.rs
@@ -169,4 +169,8 @@ pub struct ProjectListParameters {
     #[builder(default)]
     #[validate(length(max = 255))]
     pub name: Option<String>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }

--- a/crates/core-types/src/role/role.rs
+++ b/crates/core-types/src/role/role.rs
@@ -107,6 +107,10 @@ pub struct RoleListParameters {
     #[builder(default)]
     #[validate(length(min = 1, max = 255))]
     pub name: Option<String>,
+
+    /// Pagination controls (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }
 
 /// Role creation data.

--- a/crates/core-types/src/scim/resource.rs
+++ b/crates/core-types/src/scim/resource.rs
@@ -122,4 +122,7 @@ pub struct ScimRealmResourceListParameters {
     /// Restrict to enabled/disabled realms.
     #[builder(default)]
     pub enabled: Option<bool>,
+
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }

--- a/crates/core-types/src/token/restriction.rs
+++ b/crates/core-types/src/token/restriction.rs
@@ -111,4 +111,7 @@ pub struct TokenRestrictionListParameters {
     /// Project id.
     #[validate(length(min = 1, max = 64))]
     pub project_id: Option<String>,
+
+    #[builder(default)]
+    pub pagination: crate::ListPagination,
 }

--- a/crates/credential-driver-sql/src/credential/list.rs
+++ b/crates/credential-driver-sql/src/credential/list.rs
@@ -15,6 +15,7 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
+use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_config::Config;
 use openstack_keystone_core::credential::CredentialProviderError;
@@ -24,13 +25,16 @@ use openstack_keystone_core_types::credential::*;
 use crate::credential::get::to_plaintext;
 use crate::entity::{credential as db_credential, prelude::Credential as DbCredential};
 
-/// List credentials matching the given driver-level hints
-/// (`user_id`/`type`).
-pub async fn list(
-    cfg: &Config,
-    db: &DatabaseConnection,
+/// Prepare the paginated query for listing credentials.
+///
+/// # Parameters
+/// - `params`: The list parameters.
+///
+/// # Returns
+/// A `Result` containing a `Cursor` for the select model.
+fn get_list_query(
     params: &CredentialListParameters,
-) -> Result<Vec<Credential>, CredentialProviderError> {
+) -> Result<Cursor<SelectModel<db_credential::Model>>, CredentialProviderError> {
     let mut select = DbCredential::find();
     if let Some(user_id) = &params.user_id {
         select = select.filter(db_credential::Column::UserId.eq(user_id.as_str()));
@@ -39,7 +43,40 @@ pub async fn list(
         select = select.filter(db_credential::Column::Type.eq(r#type.as_str()));
     }
 
-    let models = select.all(db).await.context("listing credentials")?;
+    let mut cursor = select.cursor_by(db_credential::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
+}
+
+/// List credentials matching the given driver-level hints
+/// (`user_id`/`type`).
+pub async fn list(
+    cfg: &Config,
+    db: &DatabaseConnection,
+    params: &CredentialListParameters,
+) -> Result<Vec<Credential>, CredentialProviderError> {
+    let models = get_list_query(params)?
+        .all(db)
+        .await
+        .context("listing credentials")?;
 
     let mut result = Vec::with_capacity(models.len());
     for model in models {
@@ -61,6 +98,7 @@ pub async fn list_for_user<'a>(
         &CredentialListParameters {
             user_id: Some(user_id.to_string()),
             r#type: r#type.map(str::to_string),
+            ..Default::default()
         },
     )
     .await
@@ -147,6 +185,7 @@ mod tests {
         let params = CredentialListParameters {
             user_id: Some("user-1".into()),
             r#type: Some("totp".into()),
+            ..Default::default()
         };
         let results = list(&cfg, &db, &params).await.unwrap();
         assert_eq!(results.len(), 1);
@@ -168,5 +207,29 @@ mod tests {
         let results = list_for_user(&cfg, &db, "user-1", None).await.unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "cred-1");
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let key_dir = tempfile::tempdir().unwrap();
+        let cfg = test_config(key_dir.path());
+        let db = test_db().await;
+        FernetKeyRepository::new(key_dir.path().to_path_buf())
+            .setup()
+            .await
+            .unwrap();
+        insert_credential(&cfg, &db, "cred-1", "user-1", "totp", b"a").await;
+        insert_credential(&cfg, &db, "cred-2", "user-1", "totp", b"b").await;
+
+        let params = CredentialListParameters {
+            pagination: openstack_keystone_core_types::ListPagination {
+                limit: Some(1),
+                marker: Some("cred-0".into()),
+                page_reverse: false,
+            },
+            ..Default::default()
+        };
+        let results = list(&cfg, &db, &params).await.unwrap();
+        assert_eq!(results.len(), 2, "backend over-fetched limit+1 rows");
     }
 }

--- a/crates/federation-driver-sql/src/identity_provider/list.rs
+++ b/crates/federation-driver-sql/src/identity_provider/list.rs
@@ -56,11 +56,25 @@ fn get_list_query(
     }
 
     let mut cursor = select.cursor_by(db_federated_identity_provider::Column::Id);
-    if let Some(limit) = params.limit {
-        cursor.first(limit);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
     }
-    if let Some(marker) = &params.marker {
-        cursor.after(marker);
+    // Over-fetch by one row so the API layer can tell "there is a next/
+    // previous page" exactly, instead of guessing from `returned == limit`
+    // (which false-positives when the table has exactly `limit` rows left).
+    // `.last()` fetches in descending order but sea-orm returns the rows
+    // back in ascending order, so callers always see ascending IDs
+    // regardless of direction.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
     }
     Ok(cursor)
 }
@@ -91,6 +105,8 @@ mod tests {
     use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, sea_query::*};
     use std::collections::HashSet;
 
+    use openstack_keystone_core_types::ListPagination;
+
     use super::super::tests::get_idp_mock;
     use super::*;
 
@@ -104,6 +120,13 @@ mod tests {
         assert!(sql.contains("federated_identity_provider"));
         assert!(sql.ends_with(r#"FROM "federated_identity_provider""#));
     }
+
+    // Note: `Cursor`'s `.before()`/`.last()` (backward/page_reverse) state is
+    // applied internally at execution time, not exposed via
+    // `QueryOrder::query()` the way `.after()`/`.first()` are, so the
+    // filter/order/limit shape for `page_reverse` is verified against the
+    // executed query's bind parameters instead — see `test_list_page_reverse`
+    // below.
 
     #[tokio::test]
     async fn test_query_name() {
@@ -175,8 +198,11 @@ mod tests {
             &IdentityProviderListParameters {
                 name: Some("idp_name".into()),
                 domain_ids: Some(HashSet::from([Some("did".into())])),
-                limit: Some(1),
-                marker: Some("marker".into()),
+                pagination: ListPagination {
+                    limit: Some(1),
+                    marker: Some("marker".into()),
+                    page_reverse: false,
+                },
             },
         )
         .await
@@ -196,6 +222,42 @@ mod tests {
         assert!(sql.contains(r#""federated_identity_provider"."domain_id" IN"#));
         assert!(sql.contains(r#""federated_identity_provider"."id" >"#));
         assert!(sql.contains(r#"ORDER BY "federated_identity_provider"."id" ASC"#));
+        // limit=1 requested, but the query over-fetches by one row (2) so the
+        // API layer can detect "is there a next page" exactly (bind
+        // parameter value asserted in `test_query_overfetches_by_one` via
+        // the literal-SQL query builder).
+        assert!(sql.contains("LIMIT"));
+    }
+
+    #[tokio::test]
+    async fn test_list_page_reverse() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_idp_mock("1")]])
+            .into_connection();
+
+        let idps = list(
+            &db,
+            &IdentityProviderListParameters {
+                pagination: ListPagination {
+                    limit: Some(1),
+                    marker: Some("marker".into()),
+                    page_reverse: true,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(idps.len(), 1);
+
+        let txns = db.into_transaction_log();
+        assert_eq!(txns.len(), 1);
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""federated_identity_provider"."id" <"#));
+        assert!(
+            sql.contains(r#"ORDER BY "federated_identity_provider"."id" DESC"#),
+            "expected DESC fetch direction for page_reverse: {sql}"
+        );
         assert!(sql.contains("LIMIT"));
     }
 }

--- a/crates/identity-driver-sql/src/group/list.rs
+++ b/crates/identity-driver-sql/src/group/list.rs
@@ -15,12 +15,55 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
+use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::identity::IdentityProviderError;
 use openstack_keystone_core_types::identity::{Group, GroupListParameters};
 
 use crate::entity::{group, prelude::Group as DbGroup};
+
+/// Prepare the paginated query for listing groups.
+///
+/// # Parameters
+/// - `params`: The parameters to filter the group list.
+///
+/// # Returns
+/// A `Result` containing a `Cursor` for the select model.
+fn get_list_query(
+    params: &GroupListParameters,
+) -> Result<Cursor<SelectModel<group::Model>>, IdentityProviderError> {
+    let mut group_select = DbGroup::find();
+
+    if let Some(domain_id) = &params.domain_id {
+        group_select = group_select.filter(group::Column::DomainId.eq(domain_id));
+    }
+    if let Some(name) = &params.name {
+        group_select = group_select.filter(group::Column::Name.eq(name));
+    }
+
+    let mut cursor = group_select.cursor_by(group::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
+}
 
 /// Lists groups based on the provided parameters.
 ///
@@ -35,17 +78,7 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &GroupListParameters,
 ) -> Result<Vec<Group>, IdentityProviderError> {
-    // Prepare basic selects
-    let mut group_select = DbGroup::find();
-
-    if let Some(domain_id) = &params.domain_id {
-        group_select = group_select.filter(group::Column::DomainId.eq(domain_id));
-    }
-    if let Some(name) = &params.name {
-        group_select = group_select.filter(group::Column::Name.eq(name));
-    }
-
-    Ok(group_select
+    Ok(get_list_query(params)?
         .all(db)
         .await
         .context("listing groups")?
@@ -56,7 +89,7 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
     use serde_json::json;
 
     use openstack_keystone_core_types::identity::GroupListParametersBuilder;
@@ -65,6 +98,15 @@ mod tests {
 
     use super::*;
     use crate::group::tests::get_group_mock;
+
+    #[tokio::test]
+    async fn test_query_all() {
+        assert_eq!(
+            r#"SELECT "group"."id", "group"."domain_id", "group"."name", "group"."description", "group"."extra" FROM "group""#,
+            QueryOrder::query(&mut get_list_query(&GroupListParameters::default()).unwrap())
+                .to_string(PostgresQueryBuilder)
+        );
+    }
 
     #[tokio::test]
     async fn test_list() {
@@ -91,11 +133,37 @@ mod tests {
             db.into_transaction_log(),
             [Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                r#"SELECT "group"."id", "group"."domain_id", "group"."name", "group"."description", "group"."extra" FROM "group""#,
-                //["1".into(), 1u64.into()]
+                r#"SELECT "group"."id", "group"."domain_id", "group"."name", "group"."description", "group"."extra" FROM "group" ORDER BY "group"."id" ASC"#,
                 []
             ),]
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_group_mock("1"), get_group_mock("2")]])
+            .into_connection();
+
+        let groups = list(
+            &db,
+            &GroupListParametersBuilder::default()
+                .pagination(openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("0".into()),
+                    page_reverse: false,
+                })
+                .build()
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(groups.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""group"."id" >"#));
+        assert!(sql.contains("LIMIT"));
     }
 
     #[tokio::test]
@@ -122,7 +190,7 @@ mod tests {
             db.into_transaction_log(),
             [Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                r#"SELECT "group"."id", "group"."domain_id", "group"."name", "group"."description", "group"."extra" FROM "group" WHERE "group"."domain_id" = $1 AND "group"."name" = $2"#,
+                r#"SELECT "group"."id", "group"."domain_id", "group"."name", "group"."description", "group"."extra" FROM "group" WHERE "group"."domain_id" = $1 AND "group"."name" = $2 ORDER BY "group"."id" ASC"#,
                 ["d".into(), "n".into()]
             ),]
         );

--- a/crates/identity-driver-sql/src/user/list.rs
+++ b/crates/identity-driver-sql/src/user/list.rs
@@ -15,6 +15,7 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
+use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_config::Config;
 use openstack_keystone_core::error::DbContextExt;
@@ -35,6 +36,45 @@ use crate::local_user::MergeLocalUserData;
 use crate::nonlocal_user::MergeNonlocalUserData;
 use crate::password::MergePasswordData;
 use crate::user::MergeUserData;
+
+/// Prepare the paginated query for listing the main `user` rows.
+///
+/// # Parameters
+/// - `params`: The list parameters.
+///
+/// # Returns
+/// A `Result` containing a `Cursor` for the select model.
+fn get_user_list_query(
+    params: &UserListParameters,
+) -> Result<Cursor<SelectModel<db_user::Model>>, IdentityProviderError> {
+    let mut user_select = DbUser::find();
+
+    if let Some(domain_id) = &params.domain_id {
+        user_select = user_select.filter(db_user::Column::DomainId.eq(domain_id));
+    }
+
+    let mut cursor = user_select.cursor_by(db_user::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
+}
 
 /// List users.
 ///
@@ -58,14 +98,10 @@ pub async fn list(
     params: &UserListParameters,
 ) -> Result<Vec<UserResponse>, IdentityProviderError> {
     // Prepare basic selects
-    let mut user_select = DbUser::find();
     let mut local_user_select = LocalUser::find();
     let mut nonlocal_user_select = NonlocalUser::find();
     let mut federated_user_select = FederatedUser::find();
 
-    if let Some(domain_id) = &params.domain_id {
-        user_select = user_select.filter(db_user::Column::DomainId.eq(domain_id));
-    }
     if let Some(name) = &params.name {
         local_user_select = local_user_select.filter(db_local_user::Column::Name.eq(name));
         nonlocal_user_select = nonlocal_user_select.filter(db_nonlocal_user::Column::Name.eq(name));
@@ -74,7 +110,10 @@ pub async fn list(
     }
 
     // Fetch main `user` entries
-    let db_users: Vec<db_user::Model> = user_select.all(db).await.context("fetching users data")?;
+    let db_users: Vec<db_user::Model> = get_user_list_query(params)?
+        .all(db)
+        .await
+        .context("fetching users data")?;
     let count_of_users_selected = db_users.len();
 
     let user_type = params.user_type.unwrap_or(UserType::All);
@@ -175,6 +214,7 @@ mod tests {
     use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
 
     use openstack_keystone_config::Config;
+    use openstack_keystone_core_types::ListPagination;
 
     use super::*;
     use crate::entity::password as db_password;
@@ -219,7 +259,7 @@ mod tests {
         for (l,r) in db.into_transaction_log().iter().zip([
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user""#,
+                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user" ORDER BY "user"."id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
@@ -290,7 +330,7 @@ mod tests {
         for (l,r) in db.into_transaction_log().iter().zip([
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user""#,
+                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user" ORDER BY "user"."id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
@@ -317,7 +357,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_pagination_forward_over_fetches() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Simulates the backend over-fetching `limit + 1 == 2` rows.
+            .append_query_results([vec![get_user_mock("1"), get_user_mock("2")]])
+            .append_query_results([Vec::<crate::entity::user_option::Model>::new()])
+            .append_query_results([vec![get_local_user_mock("1"), get_local_user_mock("2")]])
+            .append_query_results([Vec::<db_password::Model>::new()])
+            .into_connection();
 
+        let config = Config::default();
+        let res = list(
+            &config,
+            &db,
+            &UserListParameters {
+                user_type: Some(UserType::Local),
+                pagination: ListPagination {
+                    limit: Some(1),
+                    marker: Some("m".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(res.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""user"."id" >"#));
+        assert!(sql.contains(r#"ORDER BY "user"."id" ASC"#));
+        assert!(sql.contains("LIMIT"));
+    }
+
+    #[tokio::test]
+    async fn test_list_page_reverse() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_user_mock("2"), get_user_mock("3")]])
+            .append_query_results([Vec::<crate::entity::user_option::Model>::new()])
+            .append_query_results([vec![get_local_user_mock("2"), get_local_user_mock("3")]])
+            .append_query_results([Vec::<db_password::Model>::new()])
+            .into_connection();
+
+        let config = Config::default();
+        let res = list(
+            &config,
+            &db,
+            &UserListParameters {
+                user_type: Some(UserType::Local),
+                pagination: ListPagination {
+                    limit: Some(1),
+                    marker: Some("m".into()),
+                    page_reverse: true,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(res.len(), 2);
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""user"."id" <"#));
+        assert!(
+            sql.contains(r#"ORDER BY "user"."id" DESC"#),
+            "expected DESC fetch direction for page_reverse: {sql}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_list_nonlocal_only() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![
@@ -352,7 +462,7 @@ mod tests {
         for (l,r) in db.into_transaction_log().iter().zip([
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user""#,
+                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user" ORDER BY "user"."id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
@@ -408,7 +518,7 @@ mod tests {
         for (l,r) in db.into_transaction_log().iter().zip([
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user""#,
+                    r#"SELECT "user"."created_at", "user"."default_project_id", "user"."domain_id", "user"."enabled", "user"."extra", "user"."id", "user"."last_active_at" FROM "user" ORDER BY "user"."id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(

--- a/crates/k8s-auth-driver-raft/src/lib.rs
+++ b/crates/k8s-auth-driver-raft/src/lib.rs
@@ -192,6 +192,25 @@ impl RaftBackend {
                 }
             }
         }
+
+        res.sort_by(|a, b| a.id.cmp(&b.id));
+        if let Some(marker) = &params.pagination.marker {
+            if params.pagination.page_reverse {
+                res.retain(|x| x.id.as_str() < marker.as_str());
+            } else {
+                res.retain(|x| x.id.as_str() > marker.as_str());
+            }
+        }
+        if let Some(limit) = params.pagination.limit {
+            let limit = (limit + 1) as usize;
+            if params.pagination.page_reverse {
+                if res.len() > limit {
+                    res = res.split_off(res.len() - limit);
+                }
+            } else {
+                res.truncate(limit);
+            }
+        }
         Ok(res)
     }
 
@@ -440,6 +459,7 @@ mod tests {
         let params = K8sAuthInstanceListParameters {
             domain_id: None,
             name: None,
+            ..Default::default()
         };
         let result = backend.list_auth_instances_impl(&storage, &params).await;
         assert!(result.is_ok());
@@ -463,6 +483,7 @@ mod tests {
         let params = K8sAuthInstanceListParameters {
             domain_id: Some("domain-1".to_string()),
             name: None,
+            ..Default::default()
         };
         let result = backend.list_auth_instances_impl(&storage, &params).await;
         assert!(result.is_ok());

--- a/crates/k8s-auth-driver-sql/src/instance/list.rs
+++ b/crates/k8s-auth-driver-sql/src/instance/list.rs
@@ -42,7 +42,27 @@ fn get_list_query(
         select = select.filter(kubernetes_auth_instance::Column::Name.eq(val));
     }
 
-    Ok(select.cursor_by(kubernetes_auth_instance::Column::Id))
+    let mut cursor = select.cursor_by(kubernetes_auth_instance::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
 }
 
 /// List K8s auth instances.
@@ -110,6 +130,36 @@ mod tests {
         )
         .to_string(PostgresQueryBuilder);
         assert!(query.contains("\"kubernetes_auth_instance\".\"domain_id\" = 'd1'"));
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![
+                get_k8s_auth_instance_mock("id1"),
+                get_k8s_auth_instance_mock("id2"),
+            ]])
+            .into_connection();
+
+        let instances = list(
+            &db,
+            &K8sAuthInstanceListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("id0".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(instances.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""kubernetes_auth_instance"."id" >"#));
+        assert!(sql.contains("LIMIT"));
     }
 
     #[tokio::test]

--- a/crates/keystone/src/api/common.rs
+++ b/crates/keystone/src/api/common.rs
@@ -15,10 +15,9 @@
 use std::net::SocketAddr;
 
 use axum::{extract::FromRequestParts, http::request::Parts};
-use serde::Serialize;
 use url::Url;
 
-use openstack_keystone_api_types::Link;
+use openstack_keystone_api_types::{Link, PaginationQuery};
 use openstack_keystone_config::Config;
 use openstack_keystone_core::net::public_ingress_peer_addr;
 use openstack_keystone_core_types::resource::Domain;
@@ -86,63 +85,172 @@ pub async fn get_domain<I: AsRef<str>, N: AsRef<str>>(
     }
 }
 
-/// Prepare the links for the paginated resource collection.
-pub fn build_pagination_links<T, Q>(
-    config: &Config,
-    data: &[T],
-    query: &Q,
-    collection_url: &str,
-) -> Result<Option<Vec<Link>>, KeystoneApiError>
-where
-    T: ResourceIdentifier,
-    Q: QueryParameterPagination + Clone + Serialize,
-{
-    Ok(match &query.get_limit() {
-        Some(limit) => {
-            if (data.len() as u64) >= *limit
-                && let Some(last_id) = data.last().map(|x| x.get_id())
-            {
-                let mut url = if let Some(pe) = &config.default.public_endpoint {
-                    pe.clone()
-                } else {
-                    Url::parse("http://localhost")?
-                };
-                url.set_path(collection_url);
-                let mut new_query = query.clone();
-
-                new_query.set_marker(last_id);
-                url.set_query(Some(&serde_urlencoded::to_string(&new_query)?));
-
-                let next_page_url = format!(
-                    "{}{}",
-                    url.path(),
-                    url.query().map(|q| format!("?{}", q)).unwrap_or_default()
-                );
-                Some(vec![Link {
-                    rel: String::from("next"),
-                    href: next_page_url,
-                }])
-            } else {
-                None
-            }
-        }
-        None => None,
-    })
-}
-
-/// Resource query parameters pagination extension trait.
-pub trait QueryParameterPagination {
-    /// Get the page limit.
-    fn get_limit(&self) -> Option<u64>;
-    /// Set the pagination marker.
-    fn set_marker(&mut self, marker: String) -> &mut Self;
-}
-
 /// Trait for the resource to expose the unique identifier that can be used for
 /// building the marker pagination.
 pub trait ResourceIdentifier {
     /// Get the unique resource identifier.
     fn get_id(&self) -> String;
+}
+
+/// Build a single pagination `Link`, pointing `collection_url` at a new
+/// `marker`/`page_reverse` combination derived from `query`.
+fn build_pagination_link(
+    config: &Config,
+    query: &PaginationQuery,
+    collection_url: &str,
+    rel: &str,
+    marker: String,
+    page_reverse: bool,
+) -> Result<Link, KeystoneApiError> {
+    let mut url = if let Some(pe) = &config.default.public_endpoint {
+        pe.clone()
+    } else {
+        Url::parse("http://localhost")?
+    };
+    url.set_path(collection_url);
+
+    let new_query = PaginationQuery {
+        limit: query.limit,
+        marker: Some(marker),
+        page_reverse,
+    };
+    url.set_query(Some(&serde_urlencoded::to_string(&new_query)?));
+
+    let href = format!(
+        "{}{}",
+        url.path(),
+        url.query().map(|q| format!("?{}", q)).unwrap_or_default()
+    );
+    Ok(Link {
+        rel: rel.to_string(),
+        href,
+    })
+}
+
+/// Paginate a forward-only (v3, python-keystone compatible) list response.
+///
+/// The backend is expected to have over-fetched by one row (`limit + 1`) so
+/// that "is there a next page" can be answered exactly instead of
+/// heuristically guessing from `returned_count >= limit` (which produces a
+/// false-positive `next` link when the table has exactly `limit` rows left).
+/// This trims the extra row off before returning the page.
+///
+/// Never emits a `previous` link — v3 stays forward-only to match real
+/// python-keystone behavior (its `previous` is always `null`).
+pub fn paginate_forward<T: ResourceIdentifier>(
+    config: &Config,
+    mut items: Vec<T>,
+    query: &PaginationQuery,
+    collection_url: &str,
+) -> Result<(Vec<T>, Option<Vec<Link>>), KeystoneApiError> {
+    let Some(limit) = query.limit else {
+        return Ok((items, None));
+    };
+
+    let has_next = items.len() as u64 > limit;
+    if has_next {
+        items.truncate(limit as usize);
+    }
+
+    let links = if has_next {
+        items
+            .last()
+            .map(|last| {
+                build_pagination_link(config, query, collection_url, "next", last.get_id(), false)
+            })
+            .transpose()?
+            .map(|link| vec![link])
+    } else {
+        None
+    };
+
+    Ok((items, links))
+}
+
+/// Paginate a bidirectional (v4) list response.
+///
+/// Same over-fetch/trim mechanism as [`paginate_forward`], but also builds a
+/// `previous` link. The backend is expected to fetch `limit + 1` rows in the
+/// direction implied by `query.page_reverse`:
+/// - forward (`page_reverse == false`): ascending, after `marker`. The extra
+///   row (if any) is trimmed off the tail and signals `next`.
+/// - backward (`page_reverse == true`): descending, before `marker`, then
+///   re-sorted ascending before being passed in here. The extra row (if any) is
+///   trimmed off the *head* and signals `previous`.
+///
+/// Going forward from a backward page is always possible by re-requesting
+/// the original `marker` with `page_reverse: false` — no extra lookup needed.
+pub fn paginate_bidirectional<T: ResourceIdentifier>(
+    config: &Config,
+    mut items: Vec<T>,
+    query: &PaginationQuery,
+    collection_url: &str,
+) -> Result<(Vec<T>, Option<Vec<Link>>), KeystoneApiError> {
+    let Some(limit) = query.limit else {
+        return Ok((items, None));
+    };
+
+    let mut links = Vec::new();
+
+    if query.page_reverse {
+        // We fetched backward; the truncation edge (if any) is at the head.
+        let has_previous = items.len() as u64 > limit;
+        if has_previous {
+            items = items.split_off(items.len() - limit as usize);
+        }
+        if has_previous && let Some(first) = items.first() {
+            links.push(build_pagination_link(
+                config,
+                query,
+                collection_url,
+                "previous",
+                first.get_id(),
+                true,
+            )?);
+        }
+        // The page you'd get by going forward from here is exactly the page
+        // reached by re-requesting the marker that got us here, forward.
+        if let Some(marker) = &query.marker {
+            links.push(build_pagination_link(
+                config,
+                query,
+                collection_url,
+                "next",
+                marker.clone(),
+                false,
+            )?);
+        }
+    } else {
+        let has_next = items.len() as u64 > limit;
+        if has_next {
+            items.truncate(limit as usize);
+        }
+        if has_next && let Some(last) = items.last() {
+            links.push(build_pagination_link(
+                config,
+                query,
+                collection_url,
+                "next",
+                last.get_id(),
+                false,
+            )?);
+        }
+        // Only offer `previous` once we've actually moved past the first page.
+        if query.marker.is_some()
+            && let Some(first) = items.first()
+        {
+            links.push(build_pagination_link(
+                config,
+                query,
+                collection_url,
+                "previous",
+                first.get_id(),
+                true,
+            )?);
+        }
+    }
+
+    Ok((items, if links.is_empty() { None } else { Some(links) }))
 }
 
 #[cfg(test)]
@@ -222,81 +330,89 @@ mod tests {
         pub id: String,
     }
 
-    /// Fake query params for pagination testing.
-    #[derive(Clone, Default, Serialize)]
-    struct FakeQueryParams {
-        pub marker: Option<String>,
-        pub limit: Option<u64>,
-    }
-
     impl ResourceIdentifier for FakeResource {
         fn get_id(&self) -> String {
             self.id.clone()
         }
     }
 
-    impl QueryParameterPagination for FakeQueryParams {
-        fn get_limit(&self) -> Option<u64> {
-            self.limit
-        }
+    fn fake_items(cnt: usize) -> Vec<FakeResource> {
+        Vec::from_iter((0..cnt).map(|x| FakeResource { id: x.to_string() }))
+    }
 
-        fn set_marker(&mut self, marker: String) -> &mut Self {
-            self.marker = Some(marker);
-            self
+    fn pq(limit: Option<u64>, marker: Option<&str>, page_reverse: bool) -> PaginationQuery {
+        PaginationQuery {
+            limit,
+            marker: marker.map(String::from),
+            page_reverse,
         }
     }
 
-    /// Parameterized pagination test
+    /// `cnt` simulates a backend that over-fetches by one row: passing
+    /// exactly `limit` items means "no more pages" (the false-positive case
+    /// this design fixes); passing `limit + 1` means "there is a next page".
     #[rstest]
-    #[case(5, FakeQueryParams::default(), None)]
-    #[case(5, FakeQueryParams{marker: Some("x".into()), limit: None}, None)]
-    #[case(5, FakeQueryParams{marker: Some("x".into()), limit: Some(6)}, None)]
-    #[case(5, FakeQueryParams{marker: Some("x".into()), limit: Some(5)}, Some(vec![
-        Link {
-            rel: "next".into(),
-            href: "/foo/bar?marker=4&limit=5".into()
-        }])
-    )]
-    #[case(5, FakeQueryParams{marker: Some("x".into()), limit: Some(3)}, Some(vec![
-        Link {
-            rel: "next".into(),
-            href: "/foo/bar?marker=4&limit=3".into()
-        }])
-    )]
-    #[case(5, FakeQueryParams{marker: Some("x".into()), limit: Some(1)}, Some(vec![
-        Link {
-            rel: "next".into(),
-            href: "/foo/bar?marker=4&limit=1".into()
-        }])
-    )]
-    #[case(5, FakeQueryParams{marker: Some("x".into()), limit: Some(0)}, Some(vec![
-        Link {
-            rel: "next".into(),
-            href: "/foo/bar?marker=4&limit=0".into()
-        }])
-    )]
-    #[case(0, FakeQueryParams{marker: Some("x".into()), limit: Some(6)}, None)]
-    #[case(0, FakeQueryParams{marker: None, limit: Some(6)}, None)]
-    #[case(5, FakeQueryParams{marker: None, limit: Some(5)}, Some(vec![
-        Link {
-            rel: "next".into(),
-            href: "/foo/bar?marker=4&limit=5".into()
-        }])
-    )]
-    fn test_pagination(
+    #[case(5, pq(None, Some("x"), false), 5, None)]
+    #[case(5, pq(Some(5), Some("x"), false), 5, None)] // exact count: no false-positive next
+    #[case(6, pq(Some(5), Some("x"), false), 5, Some(vec![
+        Link { rel: "next".into(), href: "/foo/bar?limit=5&marker=4".into() }
+    ]))]
+    #[case(4, pq(Some(3), Some("x"), false), 3, Some(vec![
+        Link { rel: "next".into(), href: "/foo/bar?limit=3&marker=2".into() }
+    ]))]
+    #[case(2, pq(Some(1), Some("x"), false), 1, Some(vec![
+        Link { rel: "next".into(), href: "/foo/bar?limit=1&marker=0".into() }
+    ]))]
+    #[case(1, pq(Some(0), Some("x"), false), 0, None)] // truncated to empty: no sensible marker
+    #[case(0, pq(Some(6), Some("x"), false), 0, None)]
+    #[case(0, pq(Some(6), None, false), 0, None)]
+    #[case(6, pq(Some(5), None, false), 5, Some(vec![
+        Link { rel: "next".into(), href: "/foo/bar?limit=5&marker=4".into() }
+    ]))]
+    fn test_paginate_forward(
         #[case] cnt: usize,
-        #[case] query: FakeQueryParams,
-        #[case] expected: Option<Vec<Link>>,
+        #[case] query: PaginationQuery,
+        #[case] expected_len: usize,
+        #[case] expected_links: Option<Vec<Link>>,
     ) {
-        assert_eq!(
-            build_pagination_links(
-                &Config::default(),
-                Vec::from_iter((0..cnt).map(|x| FakeResource { id: x.to_string() })).as_slice(),
-                &query,
-                "foo/bar",
-            )
-            .unwrap(),
-            expected
-        );
+        let (items, links) =
+            paginate_forward(&Config::default(), fake_items(cnt), &query, "foo/bar").unwrap();
+        assert_eq!(items.len(), expected_len);
+        assert_eq!(links, expected_links);
+    }
+
+    #[rstest]
+    // forward, more remaining, had a marker already (not first page): next + previous
+    #[case(6, pq(Some(5), Some("x"), false), 5, Some(vec![
+        Link { rel: "next".into(), href: "/foo/bar?limit=5&marker=4".into() },
+        Link { rel: "previous".into(), href: "/foo/bar?limit=5&marker=0&page_reverse=true".into() },
+    ]))]
+    // forward, more remaining, first page (no marker yet): next only
+    #[case(6, pq(Some(5), None, false), 5, Some(vec![
+        Link { rel: "next".into(), href: "/foo/bar?limit=5&marker=4".into() },
+    ]))]
+    // forward, exact count (no more), not first page: previous only
+    #[case(5, pq(Some(5), Some("x"), false), 5, Some(vec![
+        Link { rel: "previous".into(), href: "/foo/bar?limit=5&marker=0&page_reverse=true".into() },
+    ]))]
+    // backward, more before, has an anchor marker: previous + next (back to where we came from)
+    #[case(6, pq(Some(5), Some("m"), true), 5, Some(vec![
+        Link { rel: "previous".into(), href: "/foo/bar?limit=5&marker=1&page_reverse=true".into() },
+        Link { rel: "next".into(), href: "/foo/bar?limit=5&marker=m".into() },
+    ]))]
+    // backward, exact count (no more before): next only
+    #[case(5, pq(Some(5), Some("m"), true), 5, Some(vec![
+        Link { rel: "next".into(), href: "/foo/bar?limit=5&marker=m".into() },
+    ]))]
+    fn test_paginate_bidirectional(
+        #[case] cnt: usize,
+        #[case] query: PaginationQuery,
+        #[case] expected_len: usize,
+        #[case] expected_links: Option<Vec<Link>>,
+    ) {
+        let (items, links) =
+            paginate_bidirectional(&Config::default(), fake_items(cnt), &query, "foo/bar").unwrap();
+        assert_eq!(items.len(), expected_len);
+        assert_eq!(links, expected_links);
     }
 }

--- a/crates/keystone/src/api/v3/auth/project/list.rs
+++ b/crates/keystone/src/api/v3/auth/project/list.rs
@@ -95,6 +95,7 @@ pub(super) async fn list(
             } else {
                 vec![]
             },
+            links: None,
         }),
     )
         .into_response())

--- a/crates/keystone/src/api/v3/credential/list.rs
+++ b/crates/keystone/src/api/v3/credential/list.rs
@@ -14,14 +14,18 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{Credential, CredentialList, CredentialListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -34,10 +38,13 @@ use openstack_keystone_core::policy::PolicyError;
 /// hints, then every returned record is individually re-checked against
 /// `identity/credential/show` using *that record's own* `user_id`/
 /// `project_id` as the policy target, dropping any the caller may not read.
+/// Pagination is applied *after* this per-item filtering, over the
+/// already-policy-approved set, matching the over-fetch-by-one convention
+/// used everywhere else.
 #[utoipa::path(
     get,
     path = "/",
-    params(CredentialListParameters),
+    params(CredentialListParameters, PaginationQuery),
     description = "List credentials",
     responses(
         (status = OK, description = "List of credentials", body = CredentialList),
@@ -48,7 +55,9 @@ use openstack_keystone_core::policy::PolicyError;
 #[tracing::instrument(name = "api::credential_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<CredentialListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -61,12 +70,21 @@ pub(super) async fn list(
         )
         .await?;
 
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::credential::CredentialListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.credential.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let raw = state
         .provider
         .get_credential_provider()
         .list_credentials(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?;
 
@@ -88,7 +106,10 @@ pub(super) async fn list(
         }
     }
 
-    Ok((StatusCode::OK, Json(CredentialList { credentials })).into_response())
+    let (credentials, links) =
+        paginate_forward(&config, credentials, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(CredentialList { credentials, links })).into_response())
 }
 
 #[cfg(test)]
@@ -351,5 +372,115 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["own-project"]
         );
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_list_credentials()
+            .withf(|_, qp: &CredentialListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    CredentialBuilder::default()
+                        .id("1")
+                        .blob(r#"{"seed":"AAAA"}"#)
+                        .r#type("totp")
+                        .user_id("uid")
+                        .build()
+                        .unwrap(),
+                    CredentialBuilder::default()
+                        .id("2")
+                        .blob(r#"{"seed":"BBBB"}"#)
+                        .r#type("totp")
+                        .user_id("uid")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_credential(credential_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: CredentialList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.credentials.len(), 1);
+        assert_eq!(res.credentials[0].id, "1");
+        assert!(res.links.is_some());
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_list_credentials()
+            .withf(|_, qp: &CredentialListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    CredentialBuilder::default()
+                        .id("1")
+                        .blob(r#"{"seed":"AAAA"}"#)
+                        .r#type("totp")
+                        .user_id("uid")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_credential(credential_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: CredentialList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.credentials.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/credential/types.rs
+++ b/crates/keystone/src/api/v3/credential/types.rs
@@ -13,3 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use openstack_keystone_api_types::v3::credential::*;
+
+impl crate::api::common::ResourceIdentifier for Credential {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}

--- a/crates/keystone/src/api/v3/domain/list.rs
+++ b/crates/keystone/src/api/v3/domain/list.rs
@@ -15,15 +15,19 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 use validator::Validate;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{Domain, DomainList, DomainListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -32,7 +36,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(DomainListParameters),
+    params(DomainListParameters, PaginationQuery),
     description = "List domains",
     responses(
         (status = OK, description = "List of domains", body = DomainList),
@@ -43,7 +47,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::v3::domain_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<DomainListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     query.validate()?;
@@ -56,18 +62,31 @@ pub(super) async fn list(
             None,
         )
         .await?;
+
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::resource::DomainListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.resource.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let domains: Vec<Domain> = state
         .provider
         .get_resource_provider()
         .list_domains(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    Ok((StatusCode::OK, Json(DomainList { domains })).into_response())
+
+    let (domains, links) = paginate_forward(&config, domains, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(DomainList { domains, links })).into_response())
 }
 
 #[cfg(test)]
@@ -151,12 +170,7 @@ mod tests {
         let mut resource_mock = MockResourceProvider::default();
         resource_mock
             .expect_list_domains()
-            .withf(|_, qp: &DomainListParameters| {
-                DomainListParameters {
-                    name: Some("domain".into()),
-                    ..Default::default()
-                } == *qp
-            })
+            .withf(|_, qp: &DomainListParameters| qp.name == Some("domain".into()))
             .returning(|_, _| Ok(Vec::new()));
 
         let vsc = test_fixture_scoped();
@@ -228,5 +242,112 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_list_domains()
+            .withf(|_, qp: &DomainListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    openstack_keystone_core_types::resource::DomainBuilder::default()
+                        .id("1")
+                        .enabled(true)
+                        .name("domain1")
+                        .build()
+                        .unwrap(),
+                    openstack_keystone_core_types::resource::DomainBuilder::default()
+                        .id("2")
+                        .enabled(true)
+                        .name("domain2")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: DomainList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.domains.len(), 1);
+        assert_eq!(res.domains[0].id, "1");
+        assert!(res.links.is_some());
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_list_domains()
+            .withf(|_, qp: &DomainListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    openstack_keystone_core_types::resource::DomainBuilder::default()
+                        .id("1")
+                        .enabled(true)
+                        .name("domain1")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: DomainList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.domains.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/domain/types.rs
+++ b/crates/keystone/src/api/v3/domain/types.rs
@@ -14,3 +14,9 @@
 //! Domain API types.
 
 pub use openstack_keystone_api_types::v3::domain::*;
+
+impl crate::api::common::ResourceIdentifier for Domain {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}

--- a/crates/keystone/src/api/v3/endpoint/list.rs
+++ b/crates/keystone/src/api/v3/endpoint/list.rs
@@ -14,14 +14,18 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{Endpoint, EndpointList, EndpointListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -30,7 +34,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(EndpointListParameters),
+    params(EndpointListParameters, PaginationQuery),
     description = "List endpoints",
     responses(
         (status = OK, description = "List of endpoints", body = EndpointList),
@@ -41,7 +45,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::endpoint_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<EndpointListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -53,18 +59,32 @@ pub(super) async fn list(
             None,
         )
         .await?;
+
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::catalog::EndpointListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.catalog.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let endpoints: Vec<Endpoint> = state
         .provider
         .get_catalog_provider()
         .list_endpoints(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    Ok((StatusCode::OK, Json(EndpointList { endpoints })).into_response())
+
+    let (endpoints, links) =
+        paginate_forward(&config, endpoints, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(EndpointList { endpoints, links })).into_response())
 }
 
 #[cfg(test)]
@@ -154,11 +174,9 @@ mod tests {
         catalog_mock
             .expect_list_endpoints()
             .withf(|_, qp: &EndpointListParameters| {
-                EndpointListParameters {
-                    interface: Some("public".into()),
-                    service_id: Some("svc1".into()),
-                    region_id: Some("region1".into()),
-                } == *qp
+                qp.interface == Some("public".into())
+                    && qp.service_id == Some("svc1".into())
+                    && qp.region_id == Some("region1".into())
             })
             .returning(|_, _| Ok(Vec::new()));
 
@@ -207,5 +225,118 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_endpoints()
+            .withf(|_, qp: &EndpointListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    EndpointBuilder::default()
+                        .id("1")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                    EndpointBuilder::default()
+                        .id("2")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: EndpointList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.endpoints.len(), 1);
+        assert_eq!(res.endpoints[0].id, "1");
+        assert!(res.links.is_some());
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_endpoints()
+            .withf(|_, qp: &EndpointListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    EndpointBuilder::default()
+                        .id("1")
+                        .interface("public")
+                        .service_id("svc1")
+                        .url("https://example.com")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: EndpointList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.endpoints.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/endpoint/types.rs
+++ b/crates/keystone/src/api/v3/endpoint/types.rs
@@ -13,3 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use openstack_keystone_api_types::v3::endpoint::*;
+
+impl crate::api::common::ResourceIdentifier for Endpoint {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}

--- a/crates/keystone/src/api/v3/group/list.rs
+++ b/crates/keystone/src/api/v3/group/list.rs
@@ -13,15 +13,19 @@
 // SPDX-License-Identifier: Apache-2.0
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 use validator::Validate;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{Group, GroupList, GroupListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -30,7 +34,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(GroupListParameters),
+    params(GroupListParameters, PaginationQuery),
     responses(
         (status = OK, description = "List of groups", body = GroupList),
         (status = 500, description = "Internal error", example = json!(KeystoneApiError::InternalError(String::from("id = 1"))))
@@ -40,7 +44,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::group_list", level = "debug", skip(state))]
 pub async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<GroupListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     query.validate()?;
@@ -54,18 +60,30 @@ pub async fn list(
         )
         .await?;
 
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::identity::GroupListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.identity.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let groups: Vec<Group> = state
         .provider
         .get_identity_provider()
         .list_groups(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    Ok((StatusCode::OK, Json(GroupList { groups })).into_response())
+
+    let (groups, links) = paginate_forward(&config, groups, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(GroupList { groups, links })).into_response())
 }
 
 #[cfg(test)]
@@ -149,10 +167,7 @@ mod tests {
         identity_mock
             .expect_list_groups()
             .withf(|_, qp: &GroupListParameters| {
-                GroupListParameters {
-                    domain_id: Some("domain".into()),
-                    name: Some("name".into()),
-                } == *qp
+                qp.domain_id == Some("domain".into()) && qp.name == Some("name".into())
             })
             .returning(|_, _| Ok(Vec::new()));
 
@@ -230,5 +245,110 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_list_groups()
+            .withf(|_, qp: &GroupListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    Group {
+                        id: "1".into(),
+                        name: "a".into(),
+                        domain_id: "did".into(),
+                        ..Default::default()
+                    },
+                    Group {
+                        id: "2".into(),
+                        name: "b".into(),
+                        domain_id: "did".into(),
+                        ..Default::default()
+                    },
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: GroupList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.groups.len(), 1);
+        assert_eq!(res.groups[0].id, "1");
+        assert!(res.links.is_some());
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_list_groups()
+            .withf(|_, qp: &GroupListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![Group {
+                    id: "1".into(),
+                    name: "a".into(),
+                    domain_id: "did".into(),
+                    ..Default::default()
+                }])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: GroupList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.groups.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/group/types.rs
+++ b/crates/keystone/src/api/v3/group/types.rs
@@ -13,3 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use openstack_keystone_api_types::v3::group::*;
+
+impl crate::api::common::ResourceIdentifier for Group {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}

--- a/crates/keystone/src/api/v3/project/list.rs
+++ b/crates/keystone/src/api/v3/project/list.rs
@@ -15,15 +15,19 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 use validator::Validate;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{ProjectListParameters, ProjectShortList};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -32,7 +36,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(ProjectListParameters),
+    params(ProjectListParameters, PaginationQuery),
     description = "List projects",
     responses(
         (status = OK, description = "List of projects", body = ProjectShortList),
@@ -43,7 +47,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::v3::project_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<ProjectListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     query.validate()?;
@@ -56,18 +62,31 @@ pub(super) async fn list(
             None,
         )
         .await?;
+
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::resource::ProjectListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.resource.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let projects: Vec<super::types::ProjectShort> = state
         .provider
         .get_resource_provider()
         .list_projects(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    Ok((StatusCode::OK, Json(ProjectShortList { projects })).into_response())
+
+    let (projects, links) = paginate_forward(&config, projects, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(ProjectShortList { projects, links })).into_response())
 }
 
 #[cfg(test)]
@@ -153,12 +172,7 @@ mod tests {
         let mut resource_mock = MockResourceProvider::default();
         resource_mock
             .expect_list_projects()
-            .withf(|_, qp: &ProjectListParameters| {
-                ProjectListParameters {
-                    name: Some("project_name".into()),
-                    ..Default::default()
-                } == *qp
-            })
+            .withf(|_, qp: &ProjectListParameters| qp.name == Some("project_name".into()))
             .returning(|_, _| Ok(Vec::new()));
 
         let vsc = test_fixture_scoped();
@@ -229,5 +243,122 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_list_projects()
+            .withf(|_, qp: &ProjectListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    ProviderProject {
+                        domain_id: "did".into(),
+                        enabled: true,
+                        extra: std::collections::HashMap::new(),
+                        id: "p1".into(),
+                        name: "p1_name".into(),
+                        parent_id: None,
+                        is_domain: false,
+                        description: None,
+                    },
+                    ProviderProject {
+                        domain_id: "did".into(),
+                        enabled: true,
+                        extra: std::collections::HashMap::new(),
+                        id: "p2".into(),
+                        name: "p2_name".into(),
+                        parent_id: None,
+                        is_domain: false,
+                        description: None,
+                    },
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ProjectShortList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.projects.len(), 1);
+        assert_eq!(res.projects[0].id, "p1");
+        assert!(res.links.is_some());
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut resource_mock = MockResourceProvider::default();
+        resource_mock
+            .expect_list_projects()
+            .withf(|_, qp: &ProjectListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![ProviderProject {
+                    domain_id: "did".into(),
+                    enabled: true,
+                    extra: std::collections::HashMap::new(),
+                    id: "p1".into(),
+                    name: "p1_name".into(),
+                    parent_id: None,
+                    is_domain: false,
+                    description: None,
+                }])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_resource(resource_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ProjectShortList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.projects.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/project/types.rs
+++ b/crates/keystone/src/api/v3/project/types.rs
@@ -15,6 +15,12 @@
 
 pub use openstack_keystone_api_types::v3::project::*;
 
+impl crate::api::common::ResourceIdentifier for ProjectShort {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}
+
 //use crate::resource::types as provider_types;
 //
 //impl From<provider_types::Project> for ProjectShort {

--- a/crates/keystone/src/api/v3/region/list.rs
+++ b/crates/keystone/src/api/v3/region/list.rs
@@ -14,14 +14,18 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{Region, RegionList, RegionListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -30,7 +34,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(RegionListParameters),
+    params(RegionListParameters, PaginationQuery),
     description = "List regions",
     responses(
         (status = OK, description = "List of regions", body = RegionList),
@@ -41,7 +45,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::region_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<RegionListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -53,18 +59,31 @@ pub(super) async fn list(
             None,
         )
         .await?;
+
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::catalog::RegionListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.catalog.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let regions: Vec<Region> = state
         .provider
         .get_catalog_provider()
         .list_regions(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    Ok((StatusCode::OK, Json(RegionList { regions })).into_response())
+
+    let (regions, links) = paginate_forward(&config, regions, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(RegionList { regions, links })).into_response())
 }
 
 #[cfg(test)]
@@ -138,11 +157,7 @@ mod tests {
         let mut catalog_mock = MockCatalogProvider::default();
         catalog_mock
             .expect_list_regions()
-            .withf(|_, qp: &RegionListParameters| {
-                RegionListParameters {
-                    parent_region_id: Some("parent".into()),
-                } == *qp
-            })
+            .withf(|_, qp: &RegionListParameters| qp.parent_region_id == Some("parent".into()))
             .returning(|_, _| Ok(Vec::new()));
 
         let vsc = test_fixture_scoped();
@@ -190,5 +205,93 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_regions()
+            .withf(|_, qp: &RegionListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    RegionBuilder::default().id("1").build().unwrap(),
+                    RegionBuilder::default().id("2").build().unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RegionList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.regions.len(), 1);
+        assert_eq!(res.regions[0].id, "1");
+        assert!(res.links.is_some());
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_regions()
+            .withf(|_, qp: &RegionListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| Ok(vec![RegionBuilder::default().id("1").build().unwrap()]));
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RegionList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.regions.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/region/types.rs
+++ b/crates/keystone/src/api/v3/region/types.rs
@@ -13,3 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use openstack_keystone_api_types::v3::region::*;
+
+impl crate::api::common::ResourceIdentifier for Region {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}

--- a/crates/keystone/src/api/v3/role/list.rs
+++ b/crates/keystone/src/api/v3/role/list.rs
@@ -14,14 +14,18 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{Role, RoleList, RoleListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -30,7 +34,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(RoleListParameters),
+    params(RoleListParameters, PaginationQuery),
     description = "List roles",
     responses(
         (status = OK, description = "List of roles", body = RoleList),
@@ -41,7 +45,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::role_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<RoleListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -53,18 +59,30 @@ pub(super) async fn list(
             None,
         )
         .await?;
+
+    let config = state.config_manager.config.read().await;
+    let mut provider_params = openstack_keystone_core_types::role::RoleListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.role.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let roles: Vec<Role> = state
         .provider
         .get_role_provider()
         .list_roles(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    Ok((StatusCode::OK, Json(RoleList { roles })).into_response())
+
+    let (roles, links) = paginate_forward(&config, roles, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(RoleList { roles, links })).into_response())
 }
 
 #[cfg(test)]
@@ -140,10 +158,7 @@ mod tests {
         role_mock
             .expect_list_roles()
             .withf(|_, qp: &RoleListParameters| {
-                RoleListParameters {
-                    domain_id: Some(Some("domain".into())),
-                    name: Some("name".into()),
-                } == *qp
+                qp.domain_id == Some(Some("domain".into())) && qp.name == Some("name".into())
             })
             .returning(|_, _| Ok(Vec::new()));
 
@@ -188,5 +203,89 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_list_roles()
+            .withf(|_, qp: &RoleListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    RoleBuilder::default().id("1").name("a").build().unwrap(),
+                    RoleBuilder::default().id("2").name("b").build().unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state =
+            get_mocked_state(Provider::mocked_builder().mock_role(role_mock), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RoleList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.roles.len(), 1);
+        assert_eq!(res.roles[0].id, "1");
+        assert!(res.links.is_some());
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut role_mock = MockRoleProvider::default();
+        role_mock
+            .expect_list_roles()
+            .withf(|_, qp: &RoleListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    RoleBuilder::default().id("1").name("a").build().unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state =
+            get_mocked_state(Provider::mocked_builder().mock_role(role_mock), true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: RoleList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.roles.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/role/types.rs
+++ b/crates/keystone/src/api/v3/role/types.rs
@@ -20,6 +20,12 @@
 
 pub use openstack_keystone_api_types::v3::role::*;
 
+impl crate::api::common::ResourceIdentifier for Role {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}
+
 //use crate::role::types;
 
 //impl From<types::Role> for Role {

--- a/crates/keystone/src/api/v3/service/list.rs
+++ b/crates/keystone/src/api/v3/service/list.rs
@@ -14,14 +14,18 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{Service, ServiceList, ServiceListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -30,7 +34,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(ServiceListParameters),
+    params(ServiceListParameters, PaginationQuery),
     description = "List services",
     responses(
         (status = OK, description = "List of services", body = ServiceList),
@@ -41,7 +45,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::service_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<ServiceListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -53,18 +59,31 @@ pub(super) async fn list(
             None,
         )
         .await?;
+
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::catalog::ServiceListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.catalog.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let services: Vec<Service> = state
         .provider
         .get_catalog_provider()
         .list_services(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    Ok((StatusCode::OK, Json(ServiceList { services })).into_response())
+
+    let (services, links) = paginate_forward(&config, services, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(ServiceList { services, links })).into_response())
 }
 
 #[cfg(test)]
@@ -149,10 +168,7 @@ mod tests {
         catalog_mock
             .expect_list_services()
             .withf(|_, qp: &ServiceListParameters| {
-                ServiceListParameters {
-                    name: Some("name".into()),
-                    r#type: Some("identity".into()),
-                } == *qp
+                qp.name == Some("name".into()) && qp.r#type == Some("identity".into())
             })
             .returning(|_, _| Ok(Vec::new()));
 
@@ -201,5 +217,112 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_services()
+            .withf(|_, qp: &ServiceListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    ServiceBuilder::default()
+                        .id("1")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                    ServiceBuilder::default()
+                        .id("2")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ServiceList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.services.len(), 1);
+        assert_eq!(res.services[0].id, "1");
+        assert!(res.links.is_some());
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut catalog_mock = MockCatalogProvider::default();
+        catalog_mock
+            .expect_list_services()
+            .withf(|_, qp: &ServiceListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    ServiceBuilder::default()
+                        .id("1")
+                        .r#type("identity")
+                        .enabled(true)
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_catalog(catalog_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ServiceList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.services.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/service/types.rs
+++ b/crates/keystone/src/api/v3/service/types.rs
@@ -13,3 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use openstack_keystone_api_types::v3::service::*;
+
+impl crate::api::common::ResourceIdentifier for Service {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}

--- a/crates/keystone/src/api/v3/user/groups.rs
+++ b/crates/keystone/src/api/v3/user/groups.rs
@@ -78,7 +78,14 @@ pub(super) async fn groups(
                 .into_iter()
                 .map(Into::into)
                 .collect();
-            Ok((StatusCode::OK, Json(GroupList { groups })).into_response())
+            Ok((
+                StatusCode::OK,
+                Json(GroupList {
+                    groups,
+                    links: None,
+                }),
+            )
+                .into_response())
         }
         _ => Err(KeystoneApiError::NotFound {
             resource: "user".to_string(),

--- a/crates/keystone/src/api/v3/user/list.rs
+++ b/crates/keystone/src/api/v3/user/list.rs
@@ -14,15 +14,19 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 use validator::Validate;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{User, UserList, UserListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
@@ -31,7 +35,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(UserListParameters),
+    params(UserListParameters, PaginationQuery),
     description = "List users",
     responses(
         (status = OK, description = "List of users", body = UserList),
@@ -42,7 +46,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::user_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<UserListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     query.validate()?;
@@ -55,18 +61,32 @@ pub(super) async fn list(
             None,
         )
         .await?;
+
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::identity::UserListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        // v3 stays python-keystone compatible: forward-only, no page_reverse.
+        limit: config.resolve_list_limit(&config.identity.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
     let users: Vec<User> = state
         .provider
         .get_identity_provider()
         .list_users(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
-    Ok((StatusCode::OK, Json(UserList { users })).into_response())
+
+    let (users, links) = paginate_forward(&config, users, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(UserList { users, links })).into_response())
 }
 
 #[cfg(test)]
@@ -153,11 +173,7 @@ mod tests {
         identity_mock
             .expect_list_users()
             .withf(|_, qp: &UserListParameters| {
-                UserListParameters {
-                    domain_id: Some("domain".into()),
-                    name: Some("name".into()),
-                    ..Default::default()
-                } == *qp
+                qp.domain_id == Some("domain".into()) && qp.name == Some("name".into())
             })
             .returning(|_, _| Ok(Vec::new()));
 
@@ -231,5 +247,122 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed from the response body. v3
+    /// never emits a `previous` link.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_list_users()
+            .withf(|_, qp: &UserListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    UserResponseBuilder::default()
+                        .id("1")
+                        .domain_id("did")
+                        .enabled(true)
+                        .name("a")
+                        .build()
+                        .unwrap(),
+                    UserResponseBuilder::default()
+                        .id("2")
+                        .domain_id("did")
+                        .enabled(true)
+                        .name("b")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: UserList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.users.len(), 1);
+        assert_eq!(res.users[0].id, "1");
+        assert!(res.links.is_some());
+        assert_eq!(res.links.as_ref().unwrap().len(), 1);
+        assert_eq!(res.links.as_ref().unwrap()[0].rel, "next");
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced. This is the false-positive the
+    /// over-fetch design fixes vs the old `returned_count >= limit`
+    /// heuristic.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_list_users()
+            .withf(|_, qp: &UserListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    UserResponseBuilder::default()
+                        .id("1")
+                        .domain_id("did")
+                        .enabled(true)
+                        .name("a")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: UserList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.users.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/user/types.rs
+++ b/crates/keystone/src/api/v3/user/types.rs
@@ -14,6 +14,12 @@
 
 pub use openstack_keystone_api_types::v3::user::*;
 
+impl crate::api::common::ResourceIdentifier for User {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}
+
 //impl From<identity_types::UserOptions> for UserOptions {
 //    fn from(value: identity_types::UserOptions) -> Self {
 //        Self {

--- a/crates/keystone/src/api/v4/api_key/list.rs
+++ b/crates/keystone/src/api/v4/api_key/list.rs
@@ -15,17 +15,26 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 
+use openstack_keystone_api_types::PaginationQuery;
 use openstack_keystone_api_types::v4::api_key::{ApiKey, ApiKeyList, ApiKeyListParameters};
+use openstack_keystone_core_types::ListPagination;
 use openstack_keystone_core_types::api_key::ApiClientResourceListParameters;
 
 use crate::api::auth::Auth;
+use crate::api::common::{ResourceIdentifier, paginate_bidirectional};
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
+
+impl ResourceIdentifier for ApiKey {
+    fn get_id(&self) -> String {
+        self.client_id.clone()
+    }
+}
 
 /// List API Keys.
 ///
@@ -36,7 +45,7 @@ use crate::keystone::ServiceState;
     get,
     path = "/",
     operation_id = "/api_key:list",
-    params(ApiKeyListParameters),
+    params(ApiKeyListParameters, PaginationQuery),
     responses(
         (status = OK, description = "List of API Keys", body = ApiKeyList),
     ),
@@ -51,7 +60,9 @@ use crate::keystone::ServiceState;
 )]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<ApiKeyListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -64,7 +75,13 @@ pub(super) async fn list(
         )
         .await?;
 
-    let params: ApiClientResourceListParameters = query.into();
+    let config = state.config_manager.config.read().await;
+    let mut params: ApiClientResourceListParameters = query.into();
+    params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.api_key.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: pagination.page_reverse,
+    };
 
     let keys: Vec<ApiKey> = state
         .provider
@@ -75,7 +92,10 @@ pub(super) async fn list(
         .map(Into::into)
         .collect();
 
-    Ok((StatusCode::OK, Json(ApiKeyList { api_keys: keys })).into_response())
+    let (api_keys, links) =
+        paginate_bidirectional(&config, keys, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(ApiKeyList { api_keys, links })).into_response())
 }
 
 #[cfg(test)]
@@ -147,6 +167,102 @@ mod tests {
         let res: ApiKeyList = serde_json::from_slice(&body).unwrap();
         assert_eq!(res.api_keys.len(), 1);
         assert_eq!(res.api_keys[0].client_id, "client-1");
+    }
+
+    fn resource_with_client_id(client_id: &str) -> provider_types::ApiClientResource {
+        provider_types::ApiClientResource {
+            client_id: client_id.into(),
+            ..sample_resource_core()
+        }
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows), not the first
+    /// page (`marker` set): both `next` and `previous` links are produced,
+    /// and the extra row is trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_bidirectional_links() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list()
+            .withf(|_, qp: &provider_types::ApiClientResourceListParameters| {
+                qp.pagination.limit == Some(1) && qp.pagination.marker == Some("m".into())
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    resource_with_client_id("client-1"),
+                    resource_with_client_id("client-2"),
+                ])
+            });
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?domain_id=domain_id&limit=1&marker=m")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeyList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.api_keys.len(), 1);
+        assert_eq!(res.api_keys[0].client_id, "client-1");
+        let links = res.links.expect("expected next+previous links");
+        assert!(links.iter().any(|l| l.rel == "next"));
+        assert!(links.iter().any(|l| l.rel == "previous"));
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let vsc = test_fixture_scoped();
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockApiKeyProvider::default();
+        mock.expect_list()
+            .withf(|_, qp: &provider_types::ApiClientResourceListParameters| {
+                qp.pagination.limit == Some(1)
+            })
+            .returning(|_, _| Ok(vec![sample_resource_core()]));
+        provider = provider.mock_api_key(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?domain_id=domain_id&limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiKeyList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.api_keys.len(), 1);
+        assert_eq!(res.links, None);
     }
 
     #[tokio::test]

--- a/crates/keystone/src/api/v4/oauth2/clients/list.rs
+++ b/crates/keystone/src/api/v4/oauth2/clients/list.rs
@@ -15,20 +15,29 @@
 
 use axum::{
     Json,
-    extract::{Path, Query, State},
+    extract::{OriginalUri, Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 
+use openstack_keystone_api_types::PaginationQuery;
 use openstack_keystone_api_types::v4::oauth2_client::{
     OAuth2Client, OAuth2ClientList, OAuth2ClientListParameters,
 };
+use openstack_keystone_core_types::ListPagination;
 use openstack_keystone_core_types::oauth2_client::OAuth2ClientResourceListParameters;
 
 use crate::api::auth::Auth;
+use crate::api::common::{ResourceIdentifier, paginate_bidirectional};
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
+
+impl ResourceIdentifier for OAuth2Client {
+    fn get_id(&self) -> String {
+        self.provider_id.clone()
+    }
+}
 
 /// List OAuth2 clients for a domain.
 #[utoipa::path(
@@ -38,6 +47,7 @@ use openstack_keystone_core::auth::ExecutionContext;
     params(
         ("domain_id" = String, Path, description = "Domain ID"),
         OAuth2ClientListParameters,
+        PaginationQuery,
     ),
     responses(
         (status = OK, description = "List of OAuth2 clients", body = OAuth2ClientList),
@@ -53,8 +63,10 @@ use openstack_keystone_core::auth::ExecutionContext;
 )]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Path(domain_id): Path<String>,
     Query(query): Query<OAuth2ClientListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -67,9 +79,15 @@ pub(super) async fn list(
         )
         .await?;
 
+    let config = state.config_manager.config.read().await;
     let params = OAuth2ClientResourceListParameters {
         domain_id: domain_id.clone(),
         enabled: query.enabled,
+        pagination: ListPagination {
+            limit: config.resolve_list_limit(&config.oauth2.list_limit, pagination.limit),
+            marker: pagination.marker.clone(),
+            page_reverse: pagination.page_reverse,
+        },
     };
     let clients: Vec<OAuth2Client> = state
         .provider
@@ -80,11 +98,14 @@ pub(super) async fn list(
         .map(Into::into)
         .collect();
 
+    let (oauth2_clients, links) =
+        paginate_bidirectional(&config, clients, &pagination, original_url.path())?;
+
     Ok((
         StatusCode::OK,
         Json(OAuth2ClientList {
-            oauth2_clients: clients,
-            links: None,
+            oauth2_clients,
+            links,
         }),
     )
         .into_response())
@@ -159,6 +180,104 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let res: OAuth2ClientList = serde_json::from_slice(&body).unwrap();
         assert_eq!(res.oauth2_clients.len(), 1);
+    }
+
+    fn resource_with_provider_id(provider_id: &str) -> provider_types::OAuth2ClientResource {
+        provider_types::OAuth2ClientResource {
+            provider_id: provider_id.into(),
+            ..sample_resource()
+        }
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows), not the first
+    /// page (`marker` set): both `next` and `previous` links are produced,
+    /// and the extra row is trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_bidirectional_links() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_list()
+            .withf(
+                |_, qp: &provider_types::OAuth2ClientResourceListParameters| {
+                    qp.pagination.limit == Some(1) && qp.pagination.marker == Some("m".into())
+                },
+            )
+            .returning(|_, _| {
+                Ok(vec![
+                    resource_with_provider_id("provider-1"),
+                    resource_with_provider_id("provider-2"),
+                ])
+            });
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain_id/clients?limit=1&marker=m")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: OAuth2ClientList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.oauth2_clients.len(), 1);
+        assert_eq!(res.oauth2_clients[0].provider_id, "provider-1");
+        let links = res.links.expect("expected next+previous links");
+        assert!(links.iter().any(|l| l.rel == "next"));
+        assert!(links.iter().any(|l| l.rel == "previous"));
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockOauth2ClientProvider::default();
+        mock.expect_list()
+            .withf(
+                |_, qp: &provider_types::OAuth2ClientResourceListParameters| {
+                    qp.pagination.limit == Some(1)
+                },
+            )
+            .returning(|_, _| Ok(vec![sample_resource()]));
+        let provider = Provider::mocked_builder().mock_oauth2_client(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain_id/clients?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: OAuth2ClientList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.oauth2_clients.len(), 1);
+        assert_eq!(res.links, None);
     }
 
     #[tokio::test]

--- a/crates/keystone/src/api/v4/scim_realm/list.rs
+++ b/crates/keystone/src/api/v4/scim_realm/list.rs
@@ -15,26 +15,35 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 
+use openstack_keystone_api_types::PaginationQuery;
 use openstack_keystone_api_types::v4::scim_realm::{
     ScimRealm, ScimRealmList, ScimRealmListParameters,
 };
+use openstack_keystone_core_types::ListPagination;
 
 use crate::api::auth::Auth;
+use crate::api::common::{ResourceIdentifier, paginate_bidirectional};
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
+
+impl ResourceIdentifier for ScimRealm {
+    fn get_id(&self) -> String {
+        self.provider_id.clone()
+    }
+}
 
 /// List SCIM realms for a domain.
 #[utoipa::path(
     get,
     path = "/",
     operation_id = "/scim_realm:list",
-    params(ScimRealmListParameters),
+    params(ScimRealmListParameters, PaginationQuery),
     responses(
         (status = OK, description = "List of SCIM realms", body = ScimRealmList),
     ),
@@ -49,7 +58,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 )]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<ScimRealmListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -62,7 +73,15 @@ pub(super) async fn list(
         )
         .await?;
 
-    let params = query.into();
+    let config = state.config_manager.config.read().await;
+    let mut params: openstack_keystone_core_types::scim::ScimRealmResourceListParameters =
+        query.into();
+    params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.scim_realm.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: pagination.page_reverse,
+    };
+
     let realms: Vec<ScimRealm> = state
         .provider
         .get_scim_realm_provider()
@@ -72,14 +91,10 @@ pub(super) async fn list(
         .map(Into::into)
         .collect();
 
-    Ok((
-        StatusCode::OK,
-        Json(ScimRealmList {
-            scim_realms: realms,
-            links: None,
-        }),
-    )
-        .into_response())
+    let (scim_realms, links) =
+        paginate_bidirectional(&config, realms, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(ScimRealmList { scim_realms, links })).into_response())
 }
 
 #[cfg(test)]
@@ -144,6 +159,100 @@ mod tests {
         let res: ScimRealmList = serde_json::from_slice(&body).unwrap();
         assert_eq!(res.scim_realms.len(), 1);
         assert_eq!(res.scim_realms[0].provider_id, "provider-1");
+    }
+
+    fn realm_with_provider_id(provider_id: &str) -> provider_types::ScimRealmResource {
+        provider_types::ScimRealmResource {
+            provider_id: provider_id.into(),
+            ..sample_realm_core()
+        }
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows), not the first
+    /// page (`marker` set): both `next` and `previous` links are produced,
+    /// and the extra row is trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_bidirectional_links() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockScimRealmProvider::default();
+        mock.expect_list_realms()
+            .withf(|_, qp: &provider_types::ScimRealmResourceListParameters| {
+                qp.pagination.limit == Some(1) && qp.pagination.marker == Some("m".into())
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    realm_with_provider_id("provider-1"),
+                    realm_with_provider_id("provider-2"),
+                ])
+            });
+        let provider = Provider::mocked_builder().mock_scim_realm(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?domain_id=domain_id&limit=1&marker=m")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ScimRealmList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.scim_realms.len(), 1);
+        assert_eq!(res.scim_realms[0].provider_id, "provider-1");
+        let links = res.links.expect("expected next+previous links");
+        assert!(links.iter().any(|l| l.rel == "next"));
+        assert!(links.iter().any(|l| l.rel == "previous"));
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockScimRealmProvider::default();
+        mock.expect_list_realms()
+            .withf(|_, qp: &provider_types::ScimRealmResourceListParameters| {
+                qp.pagination.limit == Some(1)
+            })
+            .returning(|_, _| Ok(vec![sample_realm_core()]));
+        let provider = Provider::mocked_builder().mock_scim_realm(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?domain_id=domain_id&limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ScimRealmList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.scim_realms.len(), 1);
+        assert_eq!(res.links, None);
     }
 
     #[tokio::test]

--- a/crates/keystone/src/api/v4/token/restriction/list.rs
+++ b/crates/keystone/src/api/v4/token/restriction/list.rs
@@ -15,19 +15,28 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
 use openstack_keystone_core_types::token::TokenRestrictionListParameters as ProviderTokenRestrictionListParameters;
 
 use crate::api::auth::Auth;
+use crate::api::common::paginate_bidirectional;
 use crate::api::error::KeystoneApiError;
 use crate::api::v4::token::types::*;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
+
+impl crate::api::common::ResourceIdentifier for TokenRestriction {
+    fn get_id(&self) -> String {
+        self.id.clone()
+    }
+}
 
 /// List token restrictions.
 ///
@@ -38,7 +47,7 @@ use openstack_keystone_core::auth::ExecutionContext;
     get,
     path = "/",
     operation_id = "/token_restriction:list",
-    params(TokenRestrictionListParameters),
+    params(TokenRestrictionListParameters, PaginationQuery),
     responses(
         (status = OK, description = "List of token restrictions.", body = TokenRestrictionList),
         (status = 500, description = "Internal error.", example = json!(KeystoneApiError::InternalError(String::from("id = 1"))))
@@ -54,7 +63,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 )]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<TokenRestrictionListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -67,7 +78,13 @@ pub(super) async fn list(
         )
         .await?;
 
-    let provider_list_params: ProviderTokenRestrictionListParameters = query.into();
+    let config = state.config_manager.config.read().await;
+    let mut provider_list_params: ProviderTokenRestrictionListParameters = query.into();
+    provider_list_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.token_restriction.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: pagination.page_reverse,
+    };
 
     let token_restrictions: Vec<TokenRestriction> = state
         .provider
@@ -80,10 +97,19 @@ pub(super) async fn list(
         .into_iter()
         .map(Into::into)
         .collect();
+
+    let (restrictions, links) = paginate_bidirectional(
+        &config,
+        token_restrictions,
+        &pagination,
+        original_url.path(),
+    )?;
+
     Ok((
         StatusCode::OK,
         Json(TokenRestrictionList {
-            restrictions: token_restrictions,
+            restrictions,
+            links,
         }),
     )
         .into_response())
@@ -199,11 +225,9 @@ mod tests {
         token_mock
             .expect_list_token_restrictions()
             .withf(|_, qp: &provider_types::TokenRestrictionListParameters| {
-                provider_types::TokenRestrictionListParameters {
-                    domain_id: Some("did".into()),
-                    user_id: Some("uid".into()),
-                    project_id: Some("pid".into()),
-                } == *qp
+                qp.domain_id == Some("did".into())
+                    && qp.user_id == Some("uid".into())
+                    && qp.project_id == Some("pid".into())
             })
             .returning(|_, _| {
                 Ok(vec![provider_types::TokenRestriction {
@@ -255,6 +279,130 @@ mod tests {
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let _res: TokenRestrictionList = serde_json::from_slice(&body).unwrap();
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows), not the first
+    /// page (`marker` set): both `next` and `previous` links are produced,
+    /// and the extra row is trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_bidirectional_links() {
+        let vsc = test_fixture_scoped();
+        let mut token_mock = get_token_provider_mock_with_mocks();
+        token_mock
+            .expect_list_token_restrictions()
+            .withf(|_, qp: &provider_types::TokenRestrictionListParameters| {
+                qp.pagination.limit == Some(1) && qp.pagination.marker == Some("m".into())
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    provider_types::TokenRestriction {
+                        user_id: None,
+                        allow_renew: true,
+                        allow_rescope: true,
+                        id: "1".into(),
+                        domain_id: "did".into(),
+                        project_id: None,
+                        role_ids: vec![],
+                        roles: None,
+                    },
+                    provider_types::TokenRestriction {
+                        user_id: None,
+                        allow_renew: true,
+                        allow_rescope: true,
+                        id: "2".into(),
+                        domain_id: "did".into(),
+                        project_id: None,
+                        role_ids: vec![],
+                        roles: None,
+                    },
+                ])
+            });
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_token(token_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1&marker=m")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: TokenRestrictionList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.restrictions.len(), 1);
+        assert_eq!(res.restrictions[0].id, "1");
+        let links = res.links.expect("expected next+previous links");
+        assert!(links.iter().any(|l| l.rel == "next"));
+        assert!(links.iter().any(|l| l.rel == "previous"));
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let vsc = test_fixture_scoped();
+        let mut token_mock = get_token_provider_mock_with_mocks();
+        token_mock
+            .expect_list_token_restrictions()
+            .withf(|_, qp: &provider_types::TokenRestrictionListParameters| {
+                qp.pagination.limit == Some(1)
+            })
+            .returning(|_, _| {
+                Ok(vec![provider_types::TokenRestriction {
+                    user_id: None,
+                    allow_renew: true,
+                    allow_rescope: true,
+                    id: "1".into(),
+                    domain_id: "did".into(),
+                    project_id: None,
+                    role_ids: vec![],
+                    roles: None,
+                }])
+            });
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_token(token_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: TokenRestrictionList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.restrictions.len(), 1);
+        assert_eq!(res.links, None);
     }
 
     #[tokio::test]

--- a/crates/keystone/src/api/v4/user/groups.rs
+++ b/crates/keystone/src/api/v4/user/groups.rs
@@ -72,7 +72,14 @@ pub(super) async fn groups(
                 .map(Into::into)
                 .collect();
 
-            Ok((StatusCode::OK, Json(GroupList { groups })).into_response())
+            Ok((
+                StatusCode::OK,
+                Json(GroupList {
+                    groups,
+                    links: None,
+                }),
+            )
+                .into_response())
         }
         _ => Err(KeystoneApiError::NotFound {
             resource: "user".to_string(),

--- a/crates/keystone/src/api/v4/user/list.rs
+++ b/crates/keystone/src/api/v4/user/list.rs
@@ -15,15 +15,19 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 use validator::Validate;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use super::types::{User, UserList, UserListParameters};
 use crate::api::auth::Auth;
+use crate::api::common::paginate_bidirectional;
 use crate::api::error::KeystoneApiError;
 
 use crate::keystone::ServiceState;
@@ -33,7 +37,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/",
-    params(UserListParameters),
+    params(UserListParameters, PaginationQuery),
     description = "List users",
     responses(
         (status = OK, description = "List of users", body = UserList),
@@ -44,7 +48,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[tracing::instrument(name = "api::user_list", level = "debug", skip(state))]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<UserListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     query.validate()?;
@@ -59,19 +65,30 @@ pub(super) async fn list(
         )
         .await?;
 
+    let config = state.config_manager.config.read().await;
+    let mut provider_params =
+        openstack_keystone_core_types::identity::UserListParameters::from(query);
+    provider_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.identity.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: pagination.page_reverse,
+    };
+
     let users: Vec<User> = state
         .provider
         .get_identity_provider()
         .list_users(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.into(),
+            &provider_params,
         )
         .await?
         .into_iter()
         .map(Into::into)
         .collect();
 
-    Ok((StatusCode::OK, Json(UserList { users })).into_response())
+    let (users, links) = paginate_bidirectional(&config, users, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(UserList { users, links })).into_response())
 }
 
 #[cfg(test)]
@@ -159,11 +176,7 @@ mod tests {
         identity_mock
             .expect_list_users()
             .withf(|_, qp: &UserListParameters| {
-                UserListParameters {
-                    domain_id: Some("domain".into()),
-                    name: Some("name".into()),
-                    ..Default::default()
-                } == *qp
+                qp.domain_id == Some("domain".into()) && qp.name == Some("name".into())
             })
             .returning(|_, _| Ok(Vec::new()));
 
@@ -236,5 +249,124 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows), not the first
+    /// page (`marker` set): both `next` and `previous` links are produced,
+    /// and the extra row is trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_bidirectional_links() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_list_users()
+            .withf(|_, qp: &UserListParameters| {
+                qp.pagination.limit == Some(1) && qp.pagination.marker == Some("m".into())
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    UserResponseBuilder::default()
+                        .id("1")
+                        .domain_id("did")
+                        .enabled(true)
+                        .name("a")
+                        .build()
+                        .unwrap(),
+                    UserResponseBuilder::default()
+                        .id("2")
+                        .domain_id("did")
+                        .enabled(true)
+                        .name("b")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1&marker=m")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: UserList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.users.len(), 1);
+        assert_eq!(res.users[0].id, "1");
+        let links = res.links.expect("expected next+previous links");
+        assert!(links.iter().any(|l| l.rel == "next"));
+        assert!(links.iter().any(|l| l.rel == "previous"));
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced. This is the false-positive the
+    /// over-fetch design fixes vs the old `returned_count >= limit`
+    /// heuristic.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_list_users()
+            .withf(|_, qp: &UserListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    UserResponseBuilder::default()
+                        .id("1")
+                        .domain_id("did")
+                        .enabled(true)
+                        .name("a")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_identity(identity_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: UserList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.users.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/federation/api/identity_provider/list.rs
+++ b/crates/keystone/src/federation/api/identity_provider/list.rs
@@ -23,10 +23,12 @@ use serde_json::json;
 use std::collections::HashSet;
 use validator::Validate;
 
+use openstack_keystone_api_types::PaginationQuery;
 use openstack_keystone_api_types::federation::*;
+use openstack_keystone_core_types::ListPagination;
 use openstack_keystone_core_types::federation::IdentityProviderListParameters as ProviderIdentityProviderListParameters;
 
-use crate::api::{KeystoneApiError, auth::Auth, common::build_pagination_links};
+use crate::api::{KeystoneApiError, auth::Auth, common::paginate_bidirectional};
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
 
@@ -42,7 +44,7 @@ use openstack_keystone_core::auth::ExecutionContext;
     get,
     path = "/",
     operation_id = "/federation/identity_provider:list",
-    params(IdentityProviderListParameters),
+    params(IdentityProviderListParameters, PaginationQuery),
     responses(
         (status = OK, description = "List of identity providers", body = IdentityProviderList),
         (status = 500, description = "Internal error", example = json!(KeystoneApiError::InternalError(String::from("id = 1"))))
@@ -60,6 +62,7 @@ pub(super) async fn list(
     Auth(user_auth): Auth,
     OriginalUri(original_url): OriginalUri,
     Query(query): Query<IdentityProviderListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     query.validate()?;
@@ -95,6 +98,11 @@ pub(super) async fn list(
     };
     let mut provider_list_params = ProviderIdentityProviderListParameters::from(query.clone());
     provider_list_params.domain_ids = domain_ids;
+    provider_list_params.pagination = ListPagination {
+        limit: pagination.limit,
+        marker: pagination.marker.clone(),
+        page_reverse: pagination.page_reverse,
+    };
 
     let identity_providers: Vec<IdentityProvider> = state
         .provider
@@ -109,10 +117,10 @@ pub(super) async fn list(
         .collect();
 
     let config = state.config_manager.config.read().await;
-    let links = build_pagination_links(
+    let (identity_providers, links) = paginate_bidirectional(
         &config,
-        identity_providers.as_slice(),
-        &query,
+        identity_providers,
+        &pagination,
         original_url.path(),
     )?;
     Ok((
@@ -224,8 +232,11 @@ mod tests {
                 provider_types::IdentityProviderListParameters {
                     name: Some("name".into()),
                     domain_ids: Some(HashSet::from([Some("did".into())])),
-                    limit: Some(20),
-                    marker: None,
+                    pagination: ListPagination {
+                        limit: Some(20),
+                        marker: None,
+                        page_reverse: false,
+                    },
                 } == *qp
             })
             .returning(|_, _| {
@@ -275,8 +286,11 @@ mod tests {
                 provider_types::IdentityProviderListParameters {
                     name: Some("name".into()),
                     domain_ids: Some(HashSet::from([None, Some("domain_id".into())])),
-                    limit: Some(20),
-                    marker: None,
+                    pagination: ListPagination {
+                        limit: Some(20),
+                        marker: None,
+                        page_reverse: false,
+                    },
                 } == *qp
             })
             .returning(|_, _| {
@@ -329,8 +343,11 @@ mod tests {
                 provider_types::IdentityProviderListParameters {
                     name: Some("name".into()),
                     domain_ids: Some(HashSet::from([None, Some("domain_id".into())])),
-                    limit: Some(20),
-                    marker: None,
+                    pagination: ListPagination {
+                        limit: Some(20),
+                        marker: None,
+                        page_reverse: false,
+                    },
                 } == *qp
             })
             .returning(|_, _| {
@@ -373,6 +390,8 @@ mod tests {
         let _res: IdentityProviderList = serde_json::from_slice(&body).unwrap();
     }
 
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// must be produced, and the extra row trimmed from the response body.
     #[tokio::test]
     #[traced_test]
     async fn test_list_pagination_link() {
@@ -381,14 +400,87 @@ mod tests {
             .expect_list_identity_providers()
             .withf(|_, qp: &provider_types::IdentityProviderListParameters| {
                 provider_types::IdentityProviderListParameters {
-                    limit: Some(1),
                     domain_ids: Some(HashSet::from([None, Some("domain_id".into())])),
+                    pagination: ListPagination {
+                        limit: Some(1),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                } == *qp
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    provider_types::IdentityProvider {
+                        id: "id1".into(),
+                        name: "name".into(),
+                        domain_id: Some("did".into()),
+                        ..Default::default()
+                    },
+                    provider_types::IdentityProvider {
+                        id: "id2".into(),
+                        name: "name".into(),
+                        domain_id: Some("did".into()),
+                        ..Default::default()
+                    },
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_federation(federation_mock),
+            true,
+            Some(false),
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: IdentityProviderList = serde_json::from_slice(&body).unwrap();
+        assert!(res.links.is_some());
+        assert_eq!(res.identity_providers.len(), 1);
+        assert_eq!(res.identity_providers[0].id, "id1");
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced. This is the false-positive this
+    /// design fixes vs the old `returned_count >= limit` heuristic.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut federation_mock = MockFederationProvider::default();
+        federation_mock
+            .expect_list_identity_providers()
+            .withf(|_, qp: &provider_types::IdentityProviderListParameters| {
+                provider_types::IdentityProviderListParameters {
+                    domain_ids: Some(HashSet::from([None, Some("domain_id".into())])),
+                    pagination: ListPagination {
+                        limit: Some(1),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 } == *qp
             })
             .returning(|_, _| {
                 Ok(vec![provider_types::IdentityProvider {
-                    id: "id".into(),
+                    id: "id1".into(),
                     name: "name".into(),
                     domain_id: Some("did".into()),
                     ..Default::default()
@@ -424,6 +516,7 @@ mod tests {
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let res: IdentityProviderList = serde_json::from_slice(&body).unwrap();
-        assert!(res.links.is_some());
+        assert_eq!(res.links, None);
+        assert_eq!(res.identity_providers.len(), 1);
     }
 }

--- a/crates/keystone/src/federation/api/types/identity_provider.rs
+++ b/crates/keystone/src/federation/api/types/identity_provider.rs
@@ -14,21 +14,10 @@
 //! Federated identity provider types.
 use openstack_keystone_api_types::federation::*;
 
-use crate::api::common::{QueryParameterPagination, ResourceIdentifier};
+use crate::api::common::ResourceIdentifier;
 
 impl ResourceIdentifier for IdentityProvider {
     fn get_id(&self) -> String {
         self.id.clone()
-    }
-}
-
-impl QueryParameterPagination for IdentityProviderListParameters {
-    fn get_limit(&self) -> Option<u64> {
-        self.limit
-    }
-
-    fn set_marker(&mut self, marker: String) -> &mut Self {
-        self.marker = Some(marker);
-        self
     }
 }

--- a/crates/keystone/src/k8s_auth/api/instance/list.rs
+++ b/crates/keystone/src/k8s_auth/api/instance/list.rs
@@ -24,9 +24,12 @@ use validator::Validate;
 
 use openstack_keystone_core::auth::ExecutionContext;
 
+use openstack_keystone_api_types::PaginationQuery;
 use openstack_keystone_api_types::k8s_auth::*;
+use openstack_keystone_core_types::ListPagination;
 use openstack_keystone_core_types::k8s_auth as provider_types;
 
+use crate::api::common::paginate_bidirectional;
 use crate::api::{KeystoneApiError, auth::Auth};
 use crate::keystone::ServiceState;
 
@@ -35,7 +38,7 @@ use crate::keystone::ServiceState;
     get,
     path = "/",
     operation_id = "/k8s_auth/instance:list",
-    params(K8sAuthInstanceListParameters),
+    params(K8sAuthInstanceListParameters, PaginationQuery),
     responses(
         (status = OK, description = "List of instances", body = K8sAuthInstanceList),
         (status = 500, description = "Internal error", example = json!(KeystoneApiError::InternalError(String::from("id = 1"))))
@@ -53,6 +56,7 @@ pub(super) async fn list(
     Auth(user_auth): Auth,
     OriginalUri(original_url): OriginalUri,
     Query(query): Query<K8sAuthInstanceListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     query.validate()?;
@@ -78,8 +82,14 @@ pub(super) async fn list(
         // other domain
         query.domain_id.clone()
     };
+    let config = state.config_manager.config.read().await;
     let mut list_params = provider_types::K8sAuthInstanceListParameters::from(query.clone());
     list_params.domain_id = domain_id;
+    list_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.k8s_auth.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: pagination.page_reverse,
+    };
 
     let instances: Vec<K8sAuthInstance> = state
         .provider
@@ -93,18 +103,11 @@ pub(super) async fn list(
         .map(Into::into)
         .collect();
 
-    //let links = build_pagination_links(
-    //    &state.config,
-    //    identity_providers.as_slice(),
-    //    &query,
-    //    original_url.path(),
-    //)?;
+    let (instances, links) =
+        paginate_bidirectional(&config, instances, &pagination, original_url.path())?;
     Ok((
         StatusCode::OK,
-        Json(K8sAuthInstanceList {
-            instances,
-            links: None,
-        }),
+        Json(K8sAuthInstanceList { instances, links }),
     )
         .into_response())
 }
@@ -192,10 +195,7 @@ mod tests {
         let mut mock = MockK8sAuthProvider::default();
         mock.expect_list_auth_instances()
             .withf(|_, qp: &provider_types::K8sAuthInstanceListParameters| {
-                provider_types::K8sAuthInstanceListParameters {
-                    name: Some("name".into()),
-                    domain_id: Some("did".into()),
-                } == *qp
+                qp.name == Some("name".into()) && qp.domain_id == Some("did".into())
             })
             .returning(|_, _| {
                 Ok(vec![provider_types::K8sAuthInstance {
@@ -235,6 +235,123 @@ mod tests {
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let _res: K8sAuthInstanceList = serde_json::from_slice(&body).unwrap();
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows), not the first
+    /// page (`marker` set): both `next` and `previous` links are produced,
+    /// and the extra row is trimmed from the response body.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_list_pagination_bidirectional_links() {
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockK8sAuthProvider::default();
+        mock.expect_list_auth_instances()
+            .withf(|_, qp: &provider_types::K8sAuthInstanceListParameters| {
+                qp.pagination.limit == Some(1) && qp.pagination.marker == Some("m".into())
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    provider_types::K8sAuthInstance {
+                        ca_cert: None,
+                        disable_local_ca_jwt: false,
+                        domain_id: "did".into(),
+                        enabled: true,
+                        host: "http://host:post".into(),
+                        id: "1".into(),
+                        name: Some("a".into()),
+                    },
+                    provider_types::K8sAuthInstance {
+                        ca_cert: None,
+                        disable_local_ca_jwt: false,
+                        domain_id: "did".into(),
+                        enabled: true,
+                        host: "http://host:post".into(),
+                        id: "2".into(),
+                        name: Some("b".into()),
+                    },
+                ])
+            });
+        provider = provider.mock_k8s_auth(mock);
+        let vsc = test_fixture_scoped();
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1&marker=m")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: K8sAuthInstanceList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.instances.len(), 1);
+        assert_eq!(res.instances[0].id, "1");
+        let links = res.links.expect("expected next+previous links");
+        assert!(links.iter().any(|l| l.rel == "next"));
+        assert!(links.iter().any(|l| l.rel == "previous"));
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut provider = Provider::mocked_builder();
+        let mut mock = MockK8sAuthProvider::default();
+        mock.expect_list_auth_instances()
+            .withf(|_, qp: &provider_types::K8sAuthInstanceListParameters| {
+                qp.pagination.limit == Some(1)
+            })
+            .returning(|_, _| {
+                Ok(vec![provider_types::K8sAuthInstance {
+                    ca_cert: None,
+                    disable_local_ca_jwt: false,
+                    domain_id: "did".into(),
+                    enabled: true,
+                    host: "http://host:post".into(),
+                    id: "1".into(),
+                    name: Some("a".into()),
+                }])
+            });
+        provider = provider.mock_k8s_auth(mock);
+        let vsc = test_fixture_scoped();
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: K8sAuthInstanceList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.instances.len(), 1);
+        assert_eq!(res.links, None);
     }
 
     #[tokio::test]
@@ -291,10 +408,7 @@ mod tests {
         let mut mock = MockK8sAuthProvider::default();
         mock.expect_list_auth_instances()
             .withf(|_, qp: &provider_types::K8sAuthInstanceListParameters| {
-                provider_types::K8sAuthInstanceListParameters {
-                    name: Some("name".into()),
-                    domain_id: Some("domain_id".into()),
-                } == *qp
+                qp.name == Some("name".into()) && qp.domain_id == Some("domain_id".into())
             })
             .returning(|_, _| {
                 Ok(vec![provider_types::K8sAuthInstance {
@@ -345,10 +459,7 @@ mod tests {
         let mut mock = MockK8sAuthProvider::default();
         mock.expect_list_auth_instances()
             .withf(|_, qp: &provider_types::K8sAuthInstanceListParameters| {
-                provider_types::K8sAuthInstanceListParameters {
-                    name: Some("name".into()),
-                    domain_id: None,
-                } == *qp
+                qp.name == Some("name".into()) && qp.domain_id.is_none()
             })
             .returning(|_, _| {
                 Ok(vec![provider_types::K8sAuthInstance {

--- a/crates/oauth2-client-driver-raft/src/lib.rs
+++ b/crates/oauth2-client-driver-raft/src/lib.rs
@@ -261,6 +261,25 @@ impl RaftOauth2ClientBackend {
             }
             res.push(candidate);
         }
+
+        res.sort_by(|a, b| a.provider_id.cmp(&b.provider_id));
+        if let Some(marker) = &params.pagination.marker {
+            if params.pagination.page_reverse {
+                res.retain(|x| x.provider_id.as_str() < marker.as_str());
+            } else {
+                res.retain(|x| x.provider_id.as_str() > marker.as_str());
+            }
+        }
+        if let Some(limit) = params.pagination.limit {
+            let limit = (limit + 1) as usize;
+            if params.pagination.page_reverse {
+                if res.len() > limit {
+                    res = res.split_off(res.len() - limit);
+                }
+            } else {
+                res.truncate(limit);
+            }
+        }
         Ok(res)
     }
 
@@ -577,6 +596,7 @@ mod tests {
         let params = OAuth2ClientResourceListParameters {
             domain_id: "domain-1".to_string(),
             enabled: None,
+            ..Default::default()
         };
         let listed = backend.list_impl(&storage, &params).await.unwrap();
         assert_eq!(listed.len(), 2);

--- a/crates/resource-driver-sql/src/domain/list.rs
+++ b/crates/resource-driver-sql/src/domain/list.rs
@@ -48,7 +48,27 @@ fn get_list_query(
         select = select.filter(db_project::Column::Id.is_in(val));
     }
 
-    Ok(select.cursor_by(db_project::Column::Id))
+    let mut cursor = select.cursor_by(db_project::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
 }
 
 /// List domains.
@@ -117,6 +137,33 @@ mod tests {
         )
         .to_string(PostgresQueryBuilder);
         assert!(q.contains("\"project\".\"id\" IN ('"), "{}", q);
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_domain_mock("pid1"), get_domain_mock("pid2")]])
+            .into_connection();
+
+        let domains = list(
+            &db,
+            &DomainListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("pid0".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(domains.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""project"."id" >"#));
+        assert!(sql.contains("LIMIT"));
     }
 
     #[tokio::test]

--- a/crates/resource-driver-sql/src/project/list.rs
+++ b/crates/resource-driver-sql/src/project/list.rs
@@ -49,7 +49,27 @@ fn get_list_query(
         select = select.filter(db_project::Column::Id.is_in(val));
     }
 
-    Ok(select.cursor_by(db_project::Column::Id))
+    let mut cursor = select.cursor_by(db_project::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
 }
 
 /// List projects.
@@ -133,6 +153,38 @@ mod tests {
         )
         .to_string(PostgresQueryBuilder);
         assert!(q.contains("\"project\".\"id\" IN ('"), "{}", q);
+    }
+
+    // Note: `Cursor`'s `.after()`/`.before()`/`.first()`/`.last()` state is
+    // applied internally at execution time, not rendered by
+    // `QueryOrder::query()`, so marker/limit behavior is verified against
+    // the executed query's bind parameters below instead.
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_project_mock("pid1"), get_project_mock("pid2")]])
+            .into_connection();
+
+        let projects = list(
+            &db,
+            &ProjectListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("pid0".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(projects.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""project"."id" >"#));
+        assert!(sql.contains("LIMIT"));
     }
 
     #[tokio::test]

--- a/crates/role-driver-sql/src/role/list.rs
+++ b/crates/role-driver-sql/src/role/list.rs
@@ -15,6 +15,7 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
+use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::role::RoleProviderError;
@@ -22,6 +23,49 @@ use openstack_keystone_core_types::role::{Role, RoleListParameters};
 
 use crate::entity::{prelude::Role as DbRole, role as db_role};
 use crate::role::NULL_DOMAIN_ID;
+
+/// Prepare the paginated query for listing roles.
+///
+/// # Parameters
+/// - `params`: The list parameters.
+///
+/// # Returns
+/// A `Result` containing a `Cursor` for the select model.
+fn get_list_query(
+    params: &RoleListParameters,
+) -> Result<Cursor<SelectModel<db_role::Model>>, RoleProviderError> {
+    let mut select = DbRole::find();
+
+    if let Some(domain_id) = &params.domain_id {
+        select = select
+            .filter(db_role::Column::DomainId.eq(domain_id.as_ref().map_or(NULL_DOMAIN_ID, |x| x)));
+    }
+    if let Some(name) = &params.name {
+        select = select.filter(db_role::Column::Name.eq(name));
+    }
+
+    let mut cursor = select.cursor_by(db_role::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    Ok(cursor)
+}
 
 /// List roles.
 ///
@@ -35,33 +79,32 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &RoleListParameters,
 ) -> Result<Vec<Role>, RoleProviderError> {
-    let mut select = DbRole::find();
-
-    if let Some(domain_id) = &params.domain_id {
-        select = select
-            .filter(db_role::Column::DomainId.eq(domain_id.as_ref().map_or(NULL_DOMAIN_ID, |x| x)));
-    }
-    if let Some(name) = &params.name {
-        select = select.filter(db_role::Column::Name.eq(name));
-    }
-
-    let db_roles: Vec<db_role::Model> = select.all(db).await.context("listing roles")?;
-    let results: Result<Vec<Role>, _> = db_roles
+    Ok(get_list_query(params)?
+        .all(db)
+        .await
+        .context("listing roles")?
         .into_iter()
         .map(TryInto::<Role>::try_into)
-        .collect();
-
-    results
+        .collect::<Result<Vec<Role>, _>>()?)
 }
 
 #[cfg(test)]
 pub(super) mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
 
     use openstack_keystone_core_types::role::RoleBuilder;
 
     use super::*;
     use crate::role::tests::get_role_mock;
+
+    #[tokio::test]
+    async fn test_query_all() {
+        assert_eq!(
+            r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role""#,
+            QueryOrder::query(&mut get_list_query(&RoleListParameters::default()).unwrap())
+                .to_string(PostgresQueryBuilder)
+        );
+    }
 
     #[tokio::test]
     async fn test_list() {
@@ -86,7 +129,8 @@ pub(super) mod tests {
                 &db,
                 &RoleListParameters {
                     name: Some("foo".into()),
-                    domain_id: Some(Some("foo_domain".into()))
+                    domain_id: Some(Some("foo_domain".into())),
+                    ..Default::default()
                 }
             )
             .await
@@ -117,20 +161,47 @@ pub(super) mod tests {
             [
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role""#,
+                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" ORDER BY "role"."id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."domain_id" = $1 AND "role"."name" = $2"#,
+                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."domain_id" = $1 AND "role"."name" = $2 ORDER BY "role"."id" ASC"#,
                     ["foo_domain".into(), "foo".into()]
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."domain_id" = $1"#,
+                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."domain_id" = $1 ORDER BY "role"."id" ASC"#,
                     [NULL_DOMAIN_ID.into()]
                 ),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_role_mock("1", "a"), get_role_mock("2", "b")]])
+            .into_connection();
+
+        let roles = list(
+            &db,
+            &RoleListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("0".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(roles.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        let sql = &txns[0].statements()[0].sql;
+        assert!(sql.contains(r#""role"."id" >"#));
+        assert!(sql.contains("LIMIT"));
     }
 }

--- a/crates/scim-driver-raft/src/lib.rs
+++ b/crates/scim-driver-raft/src/lib.rs
@@ -216,6 +216,25 @@ impl RaftBackend {
             }
             res.push(candidate);
         }
+
+        res.sort_by(|a, b| a.provider_id.cmp(&b.provider_id));
+        if let Some(marker) = &params.pagination.marker {
+            if params.pagination.page_reverse {
+                res.retain(|x| x.provider_id.as_str() < marker.as_str());
+            } else {
+                res.retain(|x| x.provider_id.as_str() > marker.as_str());
+            }
+        }
+        if let Some(limit) = params.pagination.limit {
+            let limit = (limit + 1) as usize;
+            if params.pagination.page_reverse {
+                if res.len() > limit {
+                    res = res.split_off(res.len() - limit);
+                }
+            } else {
+                res.truncate(limit);
+            }
+        }
         Ok(res)
     }
 
@@ -856,6 +875,7 @@ mod tests {
         let params = ScimRealmResourceListParameters {
             domain_id: "domain-1".to_string(),
             enabled: None,
+            ..Default::default()
         };
         let listed = backend.list_impl(&storage, &params).await.unwrap();
         assert_eq!(listed.len(), 2);
@@ -877,6 +897,7 @@ mod tests {
         let params_enabled = ScimRealmResourceListParameters {
             domain_id: "domain-1".to_string(),
             enabled: Some(true),
+            ..Default::default()
         };
         let listed_enabled = backend.list_impl(&storage, &params_enabled).await.unwrap();
         assert_eq!(listed_enabled.len(), 1);

--- a/crates/token-restriction-driver-sql/src/list.rs
+++ b/crates/token-restriction-driver-sql/src/list.rs
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! List existing token restriction.
 
+use std::collections::HashMap;
+
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
 use sea_orm::query::*;
@@ -31,6 +33,12 @@ use crate::entity::{
 };
 
 /// List existing token restrictions.
+///
+/// `find_with_related` issues a single query with a `LEFT JOIN` against the
+/// role-association table, so a naive `.limit()` on it would cap joined rows,
+/// not distinct restrictions. Instead the marker/limit is applied to a first,
+/// join-free query over just the restriction ids; the joined role
+/// associations are then fetched only for that page.
 ///
 /// # Parameters
 /// - `db`: The database connection.
@@ -53,24 +61,60 @@ pub async fn list(
     if let Some(val) = &params.project_id {
         select = select.filter(token_restriction::Column::ProjectId.eq(val));
     }
+
+    let mut cursor = select.cursor_by(token_restriction::Column::Id);
+    if let Some(marker) = &params.pagination.marker {
+        if params.pagination.page_reverse {
+            cursor.before(marker);
+        } else {
+            cursor.after(marker);
+        }
+    }
+    // Over-fetch by one row so the API layer can tell "there is a
+    // next/previous page" exactly, instead of guessing from
+    // `returned == limit` (false-positives when exactly `limit` rows
+    // remain). `.last()` fetches in descending order but sea-orm returns
+    // rows back in ascending order.
+    if let Some(limit) = params.pagination.limit {
+        if params.pagination.page_reverse {
+            cursor.last(limit + 1);
+        } else {
+            cursor.first(limit + 1);
+        }
+    }
+    let page = cursor.all(db).await.context("listing token restrictions")?;
+    if page.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let order: HashMap<String, usize> = page
+        .iter()
+        .enumerate()
+        .map(|(i, model)| (model.id.clone(), i))
+        .collect();
+    let ids: Vec<String> = page.into_iter().map(|model| model.id).collect();
+
     let db_restrictions: Vec<(
         token_restriction::Model,
         Vec<token_restriction_role_association::Model>,
-    )> = select
+    )> = DbTokenRestriction::find()
+        .filter(token_restriction::Column::Id.is_in(ids))
         .find_with_related(DbTokenRestrictionRoleAssociation)
         .all(db)
         .await
-        .context("listing token restrictions")?;
+        .context("listing token restriction role associations")?;
 
-    Ok(db_restrictions
+    let mut result: Vec<TokenRestriction> = db_restrictions
         .into_iter()
         .map(TokenRestriction::from_model_with_ra)
-        .collect())
+        .collect();
+    result.sort_by_key(|r| order.get(&r.id).copied().unwrap_or(usize::MAX));
+    Ok(result)
 }
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase};
 
     use crate::entity::token_restriction_role_association;
 
@@ -101,8 +145,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_list() {
-        // Create MockDatabase with mock query results
+        // Create MockDatabase with mock query results: first the join-free
+        // marker/limit query, then the `find_with_related` join for that
+        // page's ids.
         let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![token_restriction::Model {
+                id: "id".to_string(),
+                domain_id: "did".to_string(),
+                user_id: Some("uid".to_string()),
+                project_id: Some("pid".to_string()),
+                allow_rescope: true,
+                allow_renew: true,
+            }]])
             .append_query_results([vec![
                 get_restriction_with_roles_mock("id", "rid1"),
                 get_restriction_with_roles_mock("id", "rid2"),
@@ -116,6 +170,7 @@ mod tests {
                     domain_id: Some("did".into()),
                     user_id: Some("uid".into()),
                     project_id: Some("pid".into()),
+                    ..Default::default()
                 },
             )
             .await
@@ -132,14 +187,66 @@ mod tests {
             }]
         );
 
-        // Checking transaction log
-        assert_eq!(
-            db.into_transaction_log(),
-            [Transaction::from_sql_and_values(
-                DatabaseBackend::Postgres,
-                r#"SELECT "token_restriction"."id" AS "A_id", "token_restriction"."domain_id" AS "A_domain_id", "token_restriction"."user_id" AS "A_user_id", "token_restriction"."allow_renew" AS "A_allow_renew", "token_restriction"."allow_rescope" AS "A_allow_rescope", "token_restriction"."project_id" AS "A_project_id", "token_restriction_role_association"."restriction_id" AS "B_restriction_id", "token_restriction_role_association"."role_id" AS "B_role_id" FROM "token_restriction" LEFT JOIN "token_restriction_role_association" ON "token_restriction"."id" = "token_restriction_role_association"."restriction_id" WHERE "token_restriction"."domain_id" = $1 AND "token_restriction"."user_id" = $2 AND "token_restriction"."project_id" = $3 ORDER BY "token_restriction"."id" ASC"#,
-                ["did".into(), "uid".into(), "pid".into()]
-            ),]
+        // Checking transaction log: a join-free marker/limit query, then the
+        // `find_with_related` join restricted to that page's ids.
+        let txns = db.into_transaction_log();
+        assert_eq!(txns.len(), 2);
+        assert!(
+            !txns[0].statements()[0]
+                .sql
+                .contains("token_restriction_role_association")
         );
+        assert!(
+            txns[1].statements()[0]
+                .sql
+                .contains("token_restriction_role_association")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_pagination_over_fetches_and_uses_marker() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![
+                token_restriction::Model {
+                    id: "id1".to_string(),
+                    domain_id: "did".to_string(),
+                    user_id: None,
+                    project_id: None,
+                    allow_rescope: true,
+                    allow_renew: true,
+                },
+                token_restriction::Model {
+                    id: "id2".to_string(),
+                    domain_id: "did".to_string(),
+                    user_id: None,
+                    project_id: None,
+                    allow_rescope: true,
+                    allow_renew: true,
+                },
+            ]])
+            .append_query_results([vec![
+                get_restriction_with_roles_mock("id1", "rid1"),
+                get_restriction_with_roles_mock("id2", "rid2"),
+            ]])
+            .into_connection();
+
+        let restrictions = list(
+            &db,
+            &TokenRestrictionListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    marker: Some("id0".into()),
+                    page_reverse: false,
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(restrictions.len(), 2, "backend over-fetched limit+1 rows");
+
+        let txns = db.into_transaction_log();
+        assert!(txns[0].statements()[0].sql.contains(r#""id" >"#));
+        assert!(txns[0].statements()[0].sql.contains("LIMIT"));
     }
 }

--- a/tests/integration/src/api_key/list.rs
+++ b/tests/integration/src/api_key/list.rs
@@ -43,6 +43,7 @@ async fn test_list_scoped_to_domain() -> Result<()> {
                 domain_id: domain_a.id.clone(),
                 provider_id: None,
                 enabled: None,
+                pagination: Default::default(),
             },
         )
         .await?;
@@ -73,6 +74,7 @@ async fn test_list_filters_by_provider_id() -> Result<()> {
                 domain_id: domain.id.clone(),
                 provider_id: Some("provider-a".to_string()),
                 enabled: None,
+                pagination: Default::default(),
             },
         )
         .await?;
@@ -108,6 +110,7 @@ async fn test_list_filters_by_enabled() -> Result<()> {
                 domain_id: domain.id.clone(),
                 provider_id: None,
                 enabled: Some(true),
+                pagination: Default::default(),
             },
         )
         .await?;

--- a/tests/integration/src/catalog/endpoint/list.rs
+++ b/tests/integration/src/catalog/endpoint/list.rs
@@ -98,6 +98,7 @@ async fn test_list_filter_by_interface() -> Result<()> {
                 interface: Some("public".to_string()),
                 service_id: Some(service.id.clone()),
                 region_id: None,
+                pagination: Default::default(),
             },
         )
         .await?;

--- a/tests/integration/src/catalog/region/list.rs
+++ b/tests/integration/src/catalog/region/list.rs
@@ -116,6 +116,7 @@ async fn test_list_filter_by_parent() -> Result<()> {
             &ExecutionContext::internal(&state),
             &RegionListParameters {
                 parent_region_id: Some("parent".to_string()),
+                pagination: Default::default(),
             },
         )
         .await?;

--- a/tests/integration/src/catalog/service/list.rs
+++ b/tests/integration/src/catalog/service/list.rs
@@ -71,6 +71,7 @@ async fn test_list_filter_by_type() -> Result<()> {
             &ServiceListParameters {
                 name: None,
                 r#type: Some("compute".to_string()),
+                pagination: Default::default(),
             },
         )
         .await?;

--- a/tests/integration/src/credential/list.rs
+++ b/tests/integration/src/credential/list.rs
@@ -72,6 +72,7 @@ async fn test_list_filters_by_user_and_type() -> Result<()> {
             &CredentialListParameters {
                 user_id: Some(user_a.id.clone()),
                 r#type: None,
+                pagination: Default::default(),
             },
         )
         .await?;
@@ -89,6 +90,7 @@ async fn test_list_filters_by_user_and_type() -> Result<()> {
             &CredentialListParameters {
                 user_id: Some(user_a.id.clone()),
                 r#type: Some("totp".into()),
+                pagination: Default::default(),
             },
         )
         .await?;


### PR DESCRIPTION
Land the shared pagination mechanism from issue #308: a reusable
PaginationQuery (api-types) and ListPagination (core-types) struct,
taken via a second independent Query extractor to avoid the
serde_urlencoded flatten trap on typed fields. Fix the false-positive
next-link bug in the already-shipped federation/identity_provider code
by over-fetching limit+1 rows and trimming, matching python-keystone's
own truncation approach. v3 stays forward-only (python-keystone
compatible); v4 gains real bidirectional paging via page_reverse.

Add per-provider list_limit/max_list_limit config with a global
[DEFAULT] fallback, mirroring python-keystone's Hints precedence chain.

Wire the User domain (v3 and v4) end-to-end as the reference
implementation for the remaining domains to follow.

Apply the shared pagination mechanism from the previous commit to four
more v3 domains (Project, Domain, Group, Role), following the exact
mechanical recipe: add a `pagination: ListPagination` field to each
core-types `*ListParameters` struct, apply the over-fetch-by-one-row
strategy in the SQL driver (with marker filter + ordering), add
`links: Option<Vec<Link>>` to the response envelope, implement
ResourceIdentifier for the resource type, and wire the handler to take
a second PaginationQuery extractor and call paginate_forward.

Project and Domain reuse resource-driver-sql's existing cursor_by
scaffolding; Group and Role add marker/limit filtering to their plain
Select queries directly. All four are v3-only (python-keystone
compatible, forward-only).

Extend the v3 pagination mechanism (over-fetch-by-one, config-driven
limits, next-link generation) to the remaining catalog domains and to
Credential, following the same recipe already applied to User,
Project, Domain, Group, and Role.

Service/Region/Endpoint share a new list_limit on CatalogProvider;
Credential gets its own since it is configured separately. Credential
needed one adaptation: pagination is applied to the SQL query before
the existing per-item policy re-check (ADR 0019 CVE-2019-19687), and
the next/previous link is built from the already-filtered result so
truncation never drops policy-approved records.

Wire K8sAuthInstance, ScimRealm, OAuth2Client, ApiKey, TokenRestriction
list endpoints

Continues the pagination rollout (issue #308) to five more v4-only
domains, all bidirectional (page_reverse/previous supported):

- K8sAuthInstance and TokenRestriction are SQL-backed and follow the
  established cursor_by()/marker/over-fetch recipe.
- ScimRealmResource, OAuth2ClientResource, and ApiClientResource are
  Raft-backed in-memory stores with no prior pagination support at
  all; marker/limit/page_reverse are now applied in-memory after the
  prefix scan, sorted by each resource's natural unique key
  (provider_id for the first two, client_id for API keys, since
  provider_id may repeat across keys).
- TokenRestriction's driver issues a join (`find_with_related`
  against the role-association table) that would otherwise limit
  joined rows instead of distinct restrictions; the marker/limit is
  now applied to a first, join-free id query, with the joined roles
  fetched only for that page and re-sorted to match.
- Added per-provider `list_limit`/`max_list_limit` config for each
  touched provider (k8s_auth, scim_realm, oauth2, api_key,
  token_restriction).

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
