### PR TITLE
chore(deps): Bump sea-orm and sea-orm-migration to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +269,165 @@ name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "arrow"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+
+[[package]]
+name = "arrow-select"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "askama"
@@ -2016,6 +2189,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,13 +2561,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2571,7 +2754,7 @@ dependencies = [
  "byteorder-lite",
  "byteview",
  "dashmap",
- "flume 0.12.0",
+ "flume",
  "log",
  "lsm-tree",
  "lz4_flex",
@@ -2592,21 +2775,12 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin",
-]
-
-[[package]]
-name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
+ "futures-core",
+ "futures-sink",
  "spin",
 ]
 
@@ -2978,6 +3152,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -2987,7 +3162,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -3002,8 +3177,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3025,15 +3198,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "hashlink"
@@ -3120,15 +3284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3483,14 +3638,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "inherent"
-version = "1.0.13"
+name = "indoc"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "rustversion",
 ]
 
 [[package]]
@@ -3883,6 +4036,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,10 +4120,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.13.0",
  "libc",
- "plain",
- "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -4096,12 +4303,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4352,6 +4559,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -6025,7 +6241,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -6343,12 +6559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6374,6 +6584,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -6911,15 +7131,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags 2.13.0",
 ]
@@ -7539,43 +7750,61 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "1.1.20"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957"
+checksum = "549c6d29a2e7a84e35c5dfbc06370a62c4d35f2328c31005267bec586b34f682"
 dependencies = [
  "async-stream",
  "async-trait",
  "bigdecimal",
  "chrono",
+ "derive-where",
  "derive_more",
  "futures-util",
+ "itertools 0.14.0",
  "log",
  "mac_address",
  "ouroboros",
  "pgvector",
  "rust_decimal",
+ "sea-orm-arrow",
  "sea-orm-macros",
  "sea-query",
- "sea-query-binder",
+ "sea-query-sqlx",
+ "sea-schema",
  "serde",
  "serde_json",
  "sqlx",
+ "sqlx-core",
  "strum",
  "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
  "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "sea-orm-arrow"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2eee8405f16c1f337fe3a83389361caea83c928d14dbd666a480407072c365"
+dependencies = [
+ "arrow",
+ "sea-query",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "sea-orm-cli"
-version = "1.1.20"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
+checksum = "3ec4b7c39c90efa92b8bb0b91ac7159684b9fa0d6371ce39bfab0a9793ce7394"
 dependencies = [
  "chrono",
  "glob",
+ "indoc",
  "regex",
  "sea-schema",
  "sqlx",
@@ -7587,11 +7816,13 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "1.1.20"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88"
+checksum = "b4cbb7ae053b9b37c919ea944a3bc52f7830a90c223f8a765c908293bca8f22d"
 dependencies = [
  "heck 0.5.0",
+ "itertools 0.14.0",
+ "pluralizer",
  "proc-macro2",
  "quote",
  "sea-bae",
@@ -7601,9 +7832,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-migration"
-version = "1.1.20"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
+checksum = "ef3576c5301b67ea7d2ce4515858d700066e51911c7d228a439c00ff258695c8"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -7615,13 +7846,11 @@ dependencies = [
 
 [[package]]
 name = "sea-query"
-version = "0.32.7"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+checksum = "8d190cfb3bcceb8a8d7d04dee5a0c77f60c7627979cdcb47fdcb8934f009badf"
 dependencies = [
- "bigdecimal",
  "chrono",
- "inherent",
  "ordered-float",
  "rust_decimal",
  "sea-query-derive",
@@ -7631,26 +7860,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-query-binder"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
-dependencies = [
- "bigdecimal",
- "chrono",
- "rust_decimal",
- "sea-query",
- "serde_json",
- "sqlx",
- "time",
- "uuid",
-]
-
-[[package]]
 name = "sea-query-derive"
-version = "0.4.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
 dependencies = [
  "darling 0.20.11",
  "heck 0.4.1",
@@ -7661,14 +7874,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-schema"
-version = "0.16.2"
+name = "sea-query-sqlx"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
+checksum = "4eaa419cdb9157da1361186b1959983eb2ea0dcb9a3c69dc45c449ecb2af8fef"
 dependencies = [
- "futures",
  "sea-query",
- "sea-query-binder",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3553c77dceed56e95bece9ea876c4dd67ca879ef51055a0b97a7bb89a8ae4fed"
+dependencies = [
+ "async-trait",
+ "sea-query",
+ "sea-query-sqlx",
  "sea-schema-derive",
  "sqlx",
 ]
@@ -8231,9 +8454,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -8244,13 +8467,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
- "bigdecimal",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -8260,13 +8483,12 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink 0.10.0",
+ "hashbrown 0.16.1",
+ "hashlink",
  "indexmap",
  "log",
  "memchr",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "rust_decimal",
  "serde",
@@ -8284,9 +8506,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8297,15 +8519,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck 0.5.0",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -8322,60 +8544,42 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
- "bigdecimal",
  "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "rust_decimal",
  "serde",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bigdecimal",
  "bitflags 2.13.0",
  "byteorder",
  "chrono",
@@ -8386,20 +8590,17 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "num-bigint",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -8412,13 +8613,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
- "flume 0.11.1",
+ "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -8428,7 +8630,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "time",
@@ -8483,9 +8684,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "subtle"
@@ -9779,12 +9980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10358,13 +10553,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "wiggle"
@@ -10529,15 +10720,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -10561,21 +10743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -10613,12 +10780,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -10631,12 +10792,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -10646,12 +10801,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10679,12 +10828,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -10694,12 +10837,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10715,12 +10852,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -10730,12 +10861,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10885,7 +11010,7 @@ checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink 0.11.1",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,8 +166,8 @@ rustls = { version = "0.23" }
 schemars = { version = "1.2" }
 scopeguard = "1.2.0"
 serial_test = { version = "3.2" }
-sea-orm = { version = "1.1", default-features = false }
-sea-orm-migration = { version = "1.1", default-features = false }
+sea-orm = { version = "2.0", default-features = false }
+sea-orm-migration = { version = "2.0", default-features = false }
 secrecy = { version = "0.10" }
 sha1 = { version = "0.11" }
 sha2 = "0.11"

--- a/crates/appcred-driver-sql/src/application_credential/create.rs
+++ b/crates/appcred-driver-sql/src/application_credential/create.rs
@@ -220,7 +220,7 @@ where
 #[cfg(test)]
 mod tests {
     use chrono::{Timelike, Utc};
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Statement, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, Statement, Transaction};
 
     use openstack_keystone_core_types::role::RoleRef;
 
@@ -283,10 +283,16 @@ mod tests {
                 db_application_credential::ActiveModel::try_from(sot.clone()).unwrap(),
                 1,
             )]])
-            .append_exec_results([MockExecResult {
-                rows_affected: 2,
-                ..Default::default()
-            }])
+            .append_query_results([vec![
+                db_application_credential_role::Model {
+                    application_credential_id: 1,
+                    role_id: "role_a".into(),
+                },
+                db_application_credential_role::Model {
+                    application_credential_id: 1,
+                    role_id: "role_b".into(),
+                },
+            ]])
             .append_query_results([Vec::<db_access_rule::Model>::new()])
             .append_query_results([vec![get_access_rule_mock("app_cred_rule_id1", Some(1))]])
             .append_query_results([vec![db_application_credential_access_rule::Model {

--- a/crates/appcred-driver-sql/src/application_credential/list.rs
+++ b/crates/appcred-driver-sql/src/application_credential/list.rs
@@ -174,17 +174,17 @@ mod tests {
             ),
             Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                r#"SELECT "application_credential_role"."application_credential_id", "application_credential_role"."role_id" FROM "application_credential_role" WHERE "application_credential_role"."application_credential_id" IN ($1, $2)"#,
+                r#"SELECT "application_credential_role"."application_credential_id", "application_credential_role"."role_id" FROM "application_credential_role" WHERE ("application_credential_role"."application_credential_id") IN (($1), ($2)) ORDER BY "application_credential_role"."application_credential_id" ASC, "application_credential_role"."role_id" ASC"#,
                 []
             ),
             Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                r#"SELECT "application_credential_access_rule"."application_credential_id", "application_credential_access_rule"."access_rule_id" FROM "application_credential_access_rule" WHERE "application_credential_access_rule"."application_credential_id" IN ($1, $2)"#,
+                r#"SELECT "application_credential_access_rule"."application_credential_id", "application_credential_access_rule"."access_rule_id" FROM "application_credential_access_rule" WHERE ("application_credential_access_rule"."application_credential_id") IN (($1), ($2))"#,
                 []
             ),
             Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                r#"SELECT "access_rule"."id", "access_rule"."service", "access_rule"."path", "access_rule"."method", "access_rule"."external_id", "access_rule"."user_id" FROM "access_rule" WHERE "access_rule"."id" IN ($1, $2)"#,
+                r#"SELECT "access_rule"."id", "access_rule"."service", "access_rule"."path", "access_rule"."method", "access_rule"."external_id", "access_rule"."user_id" FROM "access_rule" WHERE ("access_rule"."id") IN (($1), ($2)) ORDER BY "access_rule"."id" ASC"#,
                 []
             ),
         ]) {

--- a/crates/catalog-driver-sql/src/endpoint/list.rs
+++ b/crates/catalog-driver-sql/src/endpoint/list.rs
@@ -80,18 +80,18 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &EndpointListParameters,
 ) -> Result<Vec<Endpoint>, CatalogProviderError> {
-    Ok(get_list_query(params)?
+    get_list_query(params)?
         .all(db)
         .await
         .context("fetching endpoints")?
         .into_iter()
         .map(TryInto::<Endpoint>::try_into)
-        .collect::<Result<_, _>>()?)
+        .collect::<Result<_, _>>()
 }
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
 
     use super::super::tests::get_endpoint_mock;
     use super::*;
@@ -100,7 +100,7 @@ mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "endpoint"."id", "endpoint"."legacy_endpoint_id", "endpoint"."interface", "endpoint"."service_id", "endpoint"."url", "endpoint"."extra", "endpoint"."enabled", "endpoint"."region_id" FROM "endpoint""#,
-            QueryOrder::query(&mut get_list_query(&EndpointListParameters::default()).unwrap())
+            QuerySelect::query(&mut get_list_query(&EndpointListParameters::default()).unwrap())
                 .to_string(PostgresQueryBuilder)
         );
     }
@@ -108,7 +108,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_filters() {
         assert!(
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&EndpointListParameters {
                     interface: Some("public".into()),
                     service_id: Some("service_id".into()),

--- a/crates/catalog-driver-sql/src/region/list.rs
+++ b/crates/catalog-driver-sql/src/region/list.rs
@@ -74,18 +74,18 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &RegionListParameters,
 ) -> Result<Vec<Region>, CatalogProviderError> {
-    Ok(get_list_query(params)?
+    get_list_query(params)?
         .all(db)
         .await
         .context("fetching regions")?
         .into_iter()
         .map(TryInto::<Region>::try_into)
-        .collect::<Result<_, _>>()?)
+        .collect::<Result<_, _>>()
 }
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
     use serde_json::json;
 
     use super::super::tests::get_region_mock;
@@ -95,7 +95,7 @@ mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "region"."id", "region"."description", "region"."parent_region_id", "region"."extra" FROM "region""#,
-            QueryOrder::query(&mut get_list_query(&RegionListParameters::default()).unwrap())
+            QuerySelect::query(&mut get_list_query(&RegionListParameters::default()).unwrap())
                 .to_string(PostgresQueryBuilder)
         );
     }
@@ -103,7 +103,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_parent_region_id() {
         assert!(
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&RegionListParameters {
                     parent_region_id: Some("parent".into()),
                     ..Default::default()

--- a/crates/catalog-driver-sql/src/service/list.rs
+++ b/crates/catalog-driver-sql/src/service/list.rs
@@ -94,7 +94,7 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
     use serde_json::json;
 
     use super::super::tests::get_service_mock;
@@ -104,7 +104,7 @@ mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "service"."id", "service"."type", "service"."enabled", "service"."extra" FROM "service""#,
-            QueryOrder::query(&mut get_list_query(&ServiceListParameters::default()).unwrap())
+            QuerySelect::query(&mut get_list_query(&ServiceListParameters::default()).unwrap())
                 .to_string(PostgresQueryBuilder)
         );
     }
@@ -112,7 +112,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_type() {
         assert!(
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&ServiceListParameters {
                     r#type: Some("type".into()),
                     ..Default::default()

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -214,7 +214,7 @@ pub mod tests {
         Arc::new(
             Service::new(
                 ConfigManager::not_watched(Config::default()),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(policy_enforcer_mock),
                 AuditDispatcher::noop(),
@@ -291,7 +291,7 @@ pub mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(Config::default()),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(policy.clone()),
                 AuditDispatcher::noop(),

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -237,7 +237,7 @@ mod tests {
         let config = Config::default();
         let config_manager = ConfigManager::not_watched(config);
         let policy_enforcer = Arc::new(MockPolicy::default());
-        let db = sea_orm::DatabaseConnection::Disconnected;
+        let db = sea_orm::DatabaseConnection::default();
         let provider = Provider::mocked_builder()
             .mock_mapping(mapping_provider)
             .build()
@@ -362,7 +362,7 @@ mod tests {
 
         let state = Arc::new(Service {
             config_manager,
-            db: sea_orm::DatabaseConnection::Disconnected,
+            db: sea_orm::DatabaseConnection::default(),
             policy_enforcer: Arc::new(MockPolicy::default()),
             provider: Provider::mocked_builder()
                 .mock_mapping(mapping_mock)
@@ -475,7 +475,7 @@ mod tests {
             ..Default::default()
         };
         let config_manager = ConfigManager::not_watched(config);
-        let db = sea_orm::DatabaseConnection::Disconnected;
+        let db = sea_orm::DatabaseConnection::default();
         let provider = Provider::mocked_builder()
             .mock_mapping(mapping_mock)
             .build()
@@ -558,7 +558,7 @@ mod tests {
 
         let state = Arc::new(Service {
             config_manager,
-            db: sea_orm::DatabaseConnection::Disconnected,
+            db: sea_orm::DatabaseConnection::default(),
             policy_enforcer: Arc::new(MockPolicy::default()),
             provider: Provider::mocked_builder()
                 .mock_mapping(mapping_mock)
@@ -608,7 +608,7 @@ mod tests {
         let config = Config::default();
         let config_manager = ConfigManager::not_watched(config);
         let policy_enforcer = Arc::new(MockPolicy::default());
-        let db = sea_orm::DatabaseConnection::Disconnected;
+        let db = sea_orm::DatabaseConnection::default();
 
         let mut token_mock = MockTokenProvider::new();
         token_mock.expect_authorize_by_token().once().returning(
@@ -684,7 +684,7 @@ mod tests {
         let config = Config::default();
         let config_manager = ConfigManager::not_watched(config);
         let policy_enforcer = Arc::new(MockPolicy::default());
-        let db = sea_orm::DatabaseConnection::Disconnected;
+        let db = sea_orm::DatabaseConnection::default();
 
         let mut token_mock = MockTokenProvider::new();
         token_mock.expect_authorize_by_token().once().returning(

--- a/crates/core/src/auth_plugin.rs
+++ b/crates/core/src/auth_plugin.rs
@@ -1108,7 +1108,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 provider.build().unwrap(),
                 Arc::new(MockPolicy::default()),
                 audit_dispatcher,

--- a/crates/core/src/auth_plugin_auth.rs
+++ b/crates/core/src/auth_plugin_auth.rs
@@ -1008,7 +1008,7 @@ mod acceptance_tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 audit_dispatcher,
@@ -1530,7 +1530,7 @@ mod mapping_acceptance_tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 audit_dispatcher,
@@ -1773,7 +1773,7 @@ mod route_acceptance_tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 audit_dispatcher,
@@ -1849,7 +1849,7 @@ mod route_acceptance_tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 audit_dispatcher,

--- a/crates/core/src/auth_plugin_startup.rs
+++ b/crates/core/src/auth_plugin_startup.rs
@@ -147,7 +147,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 Provider::mocked_builder().build().unwrap(),
                 Arc::new(crate::policy::MockPolicy::default()),
                 audit_dispatcher,
@@ -205,7 +205,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 Provider::mocked_builder().build().unwrap(),
                 Arc::new(crate::policy::MockPolicy::default()),
                 audit_dispatcher,

--- a/crates/core/src/db.rs
+++ b/crates/core/src/db.rs
@@ -28,20 +28,15 @@ where
 {
     // Create types before the table
     for ttype in schema.create_enum_from_entity(entity) {
-        conn.execute(conn.get_database_backend().build(&ttype))
-            .await
-            .context("creating types")?;
+        conn.execute(&ttype).await.context("creating types")?;
     }
     // Create the table
-    conn.execute(
-        conn.get_database_backend()
-            .build(&schema.create_table_from_entity(entity)),
-    )
-    .await
-    .context("creating table")?;
+    conn.execute(&schema.create_table_from_entity(entity))
+        .await
+        .context("creating table")?;
     // Create related indexes
     for tidx in schema.create_index_from_entity(entity) {
-        conn.execute(conn.get_database_backend().build(&tidx))
+        conn.execute(&tidx)
             .await
             .context("creating table indexes")?;
     }
@@ -53,9 +48,7 @@ pub async fn create_index<C>(conn: &C, index: IndexCreateStatement) -> Result<()
 where
     C: ConnectionTrait,
 {
-    conn.execute(conn.get_database_backend().build(&index))
-        .await
-        .context("creating the index")?;
+    conn.execute(&index).await.context("creating the index")?;
     Ok(())
 }
 

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -30,7 +30,7 @@ pub async fn get_mocked_state(
     Arc::new(
         Service::new(
             ConfigManager::not_watched(config.unwrap_or_default()),
-            DatabaseConnection::Disconnected,
+            DatabaseConnection::default(),
             provider_builder
                 .unwrap_or(Provider::mocked_builder())
                 .build()

--- a/crates/credential-driver-sql/src/test_support.rs
+++ b/crates/credential-driver-sql/src/test_support.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # Test-only table creation
 
-use sea_orm::{ConnectionTrait, DatabaseConnection, Schema};
+use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::SqlDriver;
 use openstack_keystone_core::error::DatabaseError;

--- a/crates/federation-driver-sql/src/identity_provider/create.rs
+++ b/crates/federation-driver-sql/src/identity_provider/create.rs
@@ -15,7 +15,6 @@
 use sea_orm::DatabaseConnection;
 use sea_orm::TransactionTrait;
 use sea_orm::entity::*;
-use sea_orm::sea_query::OnConflict;
 use secrecy::ExposeSecret;
 use uuid::Uuid;
 
@@ -158,19 +157,17 @@ pub async fn create(
     .await
     .context("persisting v3 federation jwt protocol")?;
 
+    // `dummy` is a shared row referenced by every v3 protocol entry; it may
+    // already exist from a prior identity provider creation, so a conflict
+    // here means "nothing to do", not a failure. `on_conflict_do_nothing_on`
+    // (unlike `on_conflict(..).do_nothing_on(..)`) reports that outcome as
+    // `TryInsertResult::Conflicted` instead of `DbErr::RecordNotInserted`.
     db_old_mapping::Entity::insert(db_old_mapping::ActiveModel {
         id: Set("dummy".into()),
         rules: Set(Some("\"[]\"".into())),
         schema_version: Set("1.0".into()),
     })
-    .on_conflict(
-        OnConflict::column(db_old_mapping::Column::Id)
-            // Special handling for
-            // [mysql](https://docs.rs/sea-query/0.32.7/sea_query/query/struct.OnConflict.html#method.do_nothing_on)
-            .do_nothing_on([db_old_mapping::Column::Id])
-            .to_owned(),
-    )
-    .on_empty_do_nothing()
+    .on_conflict_do_nothing_on([db_old_mapping::Column::Id])
     .exec(&txn)
     .await
     .context("persisting v3 federation mapping")?;
@@ -184,7 +181,7 @@ pub async fn create(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+    use sea_orm::{DatabaseBackend, MockDatabase};
     use serde_json::json;
 
     use super::super::tests::{get_idp_mock, get_old_idp_mock, get_old_proto_mock};
@@ -202,10 +199,11 @@ mod tests {
             // 4. INSERT into federation_protocol (jwt)
             .append_query_results([vec![get_old_proto_mock("2")]])
             // 5. INSERT into mapping (on_conflict do_nothing)
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![db_old_mapping::Model {
+                id: "dummy".into(),
+                rules: Some("\"[]\"".into()),
+                schema_version: "1.0".into(),
+            }]])
             .into_connection();
 
         let req = IdentityProviderCreate {

--- a/crates/federation-driver-sql/src/identity_provider/list.rs
+++ b/crates/federation-driver-sql/src/identity_provider/list.rs
@@ -102,7 +102,7 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, sea_query::*};
     use std::collections::HashSet;
 
     use openstack_keystone_core_types::ListPagination;
@@ -112,7 +112,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_all() {
-        let sql = QueryOrder::query(
+        let sql = QuerySelect::query(
             &mut get_list_query(&IdentityProviderListParameters::default()).unwrap(),
         )
         .to_string(PostgresQueryBuilder);
@@ -123,7 +123,7 @@ mod tests {
 
     // Note: `Cursor`'s `.before()`/`.last()` (backward/page_reverse) state is
     // applied internally at execution time, not exposed via
-    // `QueryOrder::query()` the way `.after()`/`.first()` are, so the
+    // `QuerySelect::query()` the way `.after()`/`.first()` are, so the
     // filter/order/limit shape for `page_reverse` is verified against the
     // executed query's bind parameters instead — see `test_list_page_reverse`
     // below.
@@ -131,7 +131,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_name() {
         assert!(
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&IdentityProviderListParameters {
                     name: Some("idp_name".into()),
                     ..Default::default()
@@ -145,7 +145,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_domain_ids() {
-        let query = QueryOrder::query(
+        let query = QuerySelect::query(
             &mut get_list_query(&IdentityProviderListParameters {
                 domain_ids: Some(HashSet::from([Some("d1".into()), Some("d2".into()), None])),
                 ..Default::default()

--- a/crates/identity-driver-sql/src/group/list.rs
+++ b/crates/identity-driver-sql/src/group/list.rs
@@ -89,7 +89,7 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
     use serde_json::json;
 
     use openstack_keystone_core_types::identity::GroupListParametersBuilder;
@@ -103,7 +103,7 @@ mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "group"."id", "group"."domain_id", "group"."name", "group"."description", "group"."extra" FROM "group""#,
-            QueryOrder::query(&mut get_list_query(&GroupListParameters::default()).unwrap())
+            QuerySelect::query(&mut get_list_query(&GroupListParameters::default()).unwrap())
                 .to_string(PostgresQueryBuilder)
         );
     }

--- a/crates/identity-driver-sql/src/nonlocal_user/update.rs
+++ b/crates/identity-driver-sql/src/nonlocal_user/update.rs
@@ -85,7 +85,6 @@ mod tests {
             .append_exec_results([sea_orm::MockExecResult {
                 rows_affected: 1,
                 last_insert_id: 0,
-                ..Default::default()
             }])
             // 3. Insert new nonlocal user with updated name
             .append_query_results([vec![db_nonlocal_user::Model {

--- a/crates/identity-driver-sql/src/service_account/create.rs
+++ b/crates/identity-driver-sql/src/service_account/create.rs
@@ -122,7 +122,7 @@ pub async fn create(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Statement, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, Statement, Transaction};
 
     use super::*;
     use crate::entity::{nonlocal_user, user};
@@ -161,10 +161,11 @@ mod tests {
                 name: "sa_foo".into(),
                 user_id: "1".into(),
             }]])
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![crate::entity::user_option::Model {
+                user_id: "1".into(),
+                option_id: "ISSA".into(),
+                option_value: Some("true".into()),
+            }]])
             .into_connection();
 
         let now = Utc::now();

--- a/crates/identity-driver-sql/src/user/create.rs
+++ b/crates/identity-driver-sql/src/user/create.rs
@@ -215,7 +215,7 @@ pub async fn create(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
 
     use openstack_keystone_config::Config;
     use openstack_keystone_core_types::identity::{
@@ -364,10 +364,11 @@ mod tests {
         };
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_user_mock("1")]])
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![crate::entity::user_option::Model {
+                user_id: "1".into(),
+                option_id: "1001".into(),
+                option_value: Some("true".into()),
+            }]])
             .append_query_results([vec![get_federated_user_mock("1")]])
             .into_connection();
         let mut federation_data = FederationBuilder::default();
@@ -404,10 +405,11 @@ mod tests {
             // 1. Insert main user record
             .append_query_results([vec![get_user_mock("1")]])
             // 2. Insert user option (ignore_password_expiry)
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![crate::entity::user_option::Model {
+                user_id: "1".into(),
+                option_id: "1001".into(),
+                option_value: Some("true".into()),
+            }]])
             // 3. Insert local_user record
             .append_query_results([vec![get_local_user_mock("1")]])
             // 4. password::set_new_password with Vec::new() -> no expire, no delete just insert new
@@ -415,11 +417,6 @@ mod tests {
             .append_query_results([vec![get_password_mock(1)]])
             // 5. password::list after set_new_password
             .append_query_results([vec![get_password_mock(1)]])
-            // 6. Insert user option (ignore_password_expiry for user_options)
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
             .into_connection();
         let req = UserCreateBuilder::default()
             .default_project_id("dpid")

--- a/crates/identity-driver-sql/src/user/list.rs
+++ b/crates/identity-driver-sql/src/user/list.rs
@@ -264,7 +264,7 @@ mod tests {
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE "user_option"."user_id" IN ($1, $2, $3, $4)"#,
+                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE ("user_option"."user_id") IN (($1), ($2), ($3), ($4)) ORDER BY "user_option"."user_id" ASC, "user_option"."option_id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
@@ -279,7 +279,7 @@ mod tests {
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "federated_user"."id", "federated_user"."user_id", "federated_user"."idp_id", "federated_user"."protocol_id", "federated_user"."unique_id", "federated_user"."display_name" FROM "federated_user" WHERE "federated_user"."user_id" IN ($1, $2, $3, $4)"#,
+                    r#"SELECT "federated_user"."id", "federated_user"."user_id", "federated_user"."idp_id", "federated_user"."protocol_id", "federated_user"."unique_id", "federated_user"."display_name" FROM "federated_user" WHERE ("federated_user"."user_id") IN (($1), ($2), ($3), ($4))"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
@@ -335,7 +335,7 @@ mod tests {
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE "user_option"."user_id" IN ($1, $2, $3, $4)"#,
+                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE ("user_option"."user_id") IN (($1), ($2), ($3), ($4)) ORDER BY "user_option"."user_id" ASC, "user_option"."option_id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
@@ -467,7 +467,7 @@ mod tests {
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE "user_option"."user_id" IN ($1, $2, $3, $4)"#,
+                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE ("user_option"."user_id") IN (($1), ($2), ($3), ($4)) ORDER BY "user_option"."user_id" ASC, "user_option"."option_id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
@@ -523,12 +523,12 @@ mod tests {
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE "user_option"."user_id" IN ($1, $2, $3, $4)"#,
+                    r#"SELECT "user_option"."user_id", "user_option"."option_id", "user_option"."option_value" FROM "user_option" WHERE ("user_option"."user_id") IN (($1), ($2), ($3), ($4)) ORDER BY "user_option"."user_id" ASC, "user_option"."option_id" ASC"#,
                     []
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "federated_user"."id", "federated_user"."user_id", "federated_user"."idp_id", "federated_user"."protocol_id", "federated_user"."unique_id", "federated_user"."display_name" FROM "federated_user" WHERE "federated_user"."user_id" IN ($1, $2, $3, $4)"#,
+                    r#"SELECT "federated_user"."id", "federated_user"."user_id", "federated_user"."idp_id", "federated_user"."protocol_id", "federated_user"."unique_id", "federated_user"."display_name" FROM "federated_user" WHERE ("federated_user"."user_id") IN (($1), ($2), ($3), ($4))"#,
                     []
                 ),
             ]) {

--- a/crates/identity-driver-sql/src/user/update.rs
+++ b/crates/identity-driver-sql/src/user/update.rs
@@ -266,7 +266,6 @@ mod tests {
             .append_exec_results([MockExecResult {
                 rows_affected: 1,
                 last_insert_id: 0,
-                ..Default::default()
             }])
             // 6. nonlocal_user::update_name - insert new
             .append_query_results([vec![db_nonlocal_user::Model {

--- a/crates/identity-driver-sql/src/user_group/add.rs
+++ b/crates/identity-driver-sql/src/user_group/add.rs
@@ -76,7 +76,6 @@ where
             group_id: Set(g.as_ref().into()),
         }
     }))
-    .on_empty_do_nothing()
     .exec(db)
     .await
     .context("adding user to groups")?;
@@ -149,7 +148,6 @@ where
             last_verified: Set(last_verified),
         }
     }))
-    .on_empty_do_nothing()
     .exec(db)
     .await
     .context("adding user to groups with expiration")?;
@@ -160,7 +158,7 @@ where
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
 
     use super::*;
     use crate::user_group::tests::{
@@ -190,10 +188,11 @@ mod tests {
     async fn test_bulk() {
         // Create MockDatabase with mock query results
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![
+                get_user_group_membership_mock("u1", "g1"),
+                get_user_group_membership_mock("u1", "g2"),
+                get_user_group_membership_mock("u2", "g2"),
+            ]])
             .into_connection();
 
         add_users_to_groups(&db, vec![("u1", "g1"), ("u1", "g2"), ("u2", "g2")])
@@ -253,15 +252,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_expiring() {
+        let last_verified = Utc::now();
         // Create MockDatabase with mock query results
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![
+                get_expiring_user_group_membership_mock("u1", "g1", last_verified),
+                get_expiring_user_group_membership_mock("u1", "g2", last_verified),
+                get_expiring_user_group_membership_mock("u2", "g2", last_verified),
+            ]])
             .into_connection();
 
-        let last_verified = Utc::now();
         add_users_to_groups_expiring(
             &db,
             vec![("u1", "g1"), ("u1", "g2"), ("u2", "g2")],

--- a/crates/identity-driver-sql/src/user_group/set.rs
+++ b/crates/identity-driver-sql/src/user_group/set.rs
@@ -217,10 +217,10 @@ mod tests {
                 rows_affected: 1,
                 ..Default::default()
             }])
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![
+                get_user_group_membership_mock("u1", "g0"),
+                get_user_group_membership_mock("u1", "g5"),
+            ]])
             .into_connection();
 
         set_user_groups(&db, "u1", vec!["g2", "g4", "g5", "g0"])
@@ -259,10 +259,7 @@ mod tests {
                 get_user_group_membership_mock("u1", "g3"),
                 get_user_group_membership_mock("u1", "g4"),
             ]])
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![get_user_group_membership_mock("u1", "g5")]])
             .into_connection();
 
         set_user_groups(&db, "u1", vec!["g1", "g2", "g3", "g4", "g5"])
@@ -351,6 +348,7 @@ mod tests {
     #[tokio::test]
     async fn test_expiring_add_and_remove() {
         let expiry = Utc::now();
+        let last_verified = Utc::now();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![
                 get_expiring_user_group_membership_mock("u1", "g1", expiry),
@@ -362,16 +360,15 @@ mod tests {
                 rows_affected: 1,
                 ..Default::default()
             }])
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![
+                get_expiring_user_group_membership_mock("u1", "g0", last_verified),
+                get_expiring_user_group_membership_mock("u1", "g5", last_verified),
+            ]])
             .append_exec_results([MockExecResult {
                 rows_affected: 1,
                 ..Default::default()
             }])
             .into_connection();
-        let last_verified = Utc::now();
 
         set_user_groups_expiring(
             &db,
@@ -429,6 +426,7 @@ mod tests {
     #[tokio::test]
     async fn test_expiring_only_add() {
         let expiry = Utc::now();
+        let last_verified = Utc::now();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![
                 get_expiring_user_group_membership_mock("u1", "g1", expiry),
@@ -436,16 +434,16 @@ mod tests {
                 get_expiring_user_group_membership_mock("u1", "g3", expiry),
                 get_expiring_user_group_membership_mock("u1", "g4", expiry),
             ]])
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![get_expiring_user_group_membership_mock(
+                "u1",
+                "g5",
+                last_verified,
+            )]])
             .append_exec_results([MockExecResult {
                 rows_affected: 1,
                 ..Default::default()
             }])
             .into_connection();
-        let last_verified = Utc::now();
 
         set_user_groups_expiring(
             &db,

--- a/crates/identity-driver-sql/src/user_option/create.rs
+++ b/crates/identity-driver-sql/src/user_option/create.rs
@@ -58,7 +58,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
 
     use super::*;
 
@@ -71,10 +71,11 @@ mod tests {
     #[tokio::test]
     async fn test_create_issa() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![db_user_option::Model {
+                user_id: "1".into(),
+                option_id: "ISSA".into(),
+                option_value: Some("true".into()),
+            }]])
             .into_connection();
         create(
             &db,

--- a/crates/k8s-auth-driver-sql/src/instance/list.rs
+++ b/crates/k8s-auth-driver-sql/src/instance/list.rs
@@ -88,7 +88,7 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
 
     use super::super::tests::get_k8s_auth_instance_mock;
     use super::*;
@@ -97,7 +97,7 @@ mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "kubernetes_auth_instance"."ca_cert", "kubernetes_auth_instance"."disable_local_ca_jwt", "kubernetes_auth_instance"."domain_id", "kubernetes_auth_instance"."enabled", "kubernetes_auth_instance"."host", "kubernetes_auth_instance"."id", "kubernetes_auth_instance"."name" FROM "kubernetes_auth_instance""#,
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&K8sAuthInstanceListParameters::default()).unwrap()
             )
             .to_string(PostgresQueryBuilder)
@@ -107,7 +107,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_name() {
         assert!(
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&K8sAuthInstanceListParameters {
                     name: Some("name".into()),
                     ..Default::default()
@@ -121,7 +121,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_domain_id() {
-        let query = QueryOrder::query(
+        let query = QuerySelect::query(
             &mut get_list_query(&K8sAuthInstanceListParameters {
                 domain_id: Some("d1".into()),
                 ..Default::default()

--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -222,7 +222,7 @@ pub(crate) mod tests {
                 openstack_keystone_config::ConfigManager::not_watched(
                     openstack_keystone_config::Config::default(),
                 ),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 provider,
                 std::sync::Arc::new(enforcer),
                 openstack_keystone_audit::AuditDispatcher::noop(),

--- a/crates/keystone/src/api/v3/auth/token/common.rs
+++ b/crates/keystone/src/api/v3/auth/token/common.rs
@@ -660,7 +660,7 @@ mod route_dispatch_tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 audit_dispatcher,

--- a/crates/keystone/src/api/v3/auth/token/create.rs
+++ b/crates/keystone/src/api/v3/auth/token/create.rs
@@ -364,7 +364,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -523,7 +523,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -638,7 +638,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -750,7 +750,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -825,7 +825,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -891,7 +891,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -962,7 +962,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -1035,7 +1035,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -1106,7 +1106,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -1301,7 +1301,7 @@ mod auth_plugin_http_tests {
         let state: ServiceState = Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 audit_dispatcher,

--- a/crates/keystone/src/api/v4/auth_plugin/identity_link/mod.rs
+++ b/crates/keystone/src/api/v4/auth_plugin/identity_link/mod.rs
@@ -192,7 +192,7 @@ mod tests {
         Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(mock_policy(policy_allow)),
                 AuditDispatcher::noop(),

--- a/crates/keystone/src/api/v4/oauth2/device.rs
+++ b/crates/keystone/src/api/v4/oauth2/device.rs
@@ -626,7 +626,7 @@ mod tests {
         Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider.build().unwrap(),
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),

--- a/crates/keystone/src/api/v4/oauth2/device_authorization.rs
+++ b/crates/keystone/src/api/v4/oauth2/device_authorization.rs
@@ -372,7 +372,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),

--- a/crates/keystone/src/api/v4/oauth2/jwks.rs
+++ b/crates/keystone/src/api/v4/oauth2/jwks.rs
@@ -284,7 +284,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -370,7 +370,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),

--- a/crates/keystone/src/api/v4/oauth2/token.rs
+++ b/crates/keystone/src/api/v4/oauth2/token.rs
@@ -1620,7 +1620,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),
@@ -2017,7 +2017,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),

--- a/crates/keystone/src/api/v4/oauth2/well_known.rs
+++ b/crates/keystone/src/api/v4/oauth2/well_known.rs
@@ -291,7 +291,7 @@ mod tests {
         let state = Arc::new(
             Service::new(
                 ConfigManager::not_watched(config),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 provider,
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),

--- a/crates/keystone/src/api/v4/user/create.rs
+++ b/crates/keystone/src/api/v4/user/create.rs
@@ -163,7 +163,7 @@ mod tests {
             .build()?;
         let service = Service::new(
             ConfigManager::not_watched(Config::default()),
-            DatabaseConnection::Disconnected,
+            DatabaseConnection::default(),
             provider,
             Arc::new(policy_enforcer_mock),
             AuditDispatcher::noop(),

--- a/crates/keystone/src/api/v4/user/update.rs
+++ b/crates/keystone/src/api/v4/user/update.rs
@@ -204,7 +204,7 @@ mod tests {
             .build()?;
         let service = Service::new(
             ConfigManager::not_watched(Config::default()),
-            DatabaseConnection::Disconnected,
+            DatabaseConnection::default(),
             provider,
             Arc::new(policy_enforcer_mock),
             AuditDispatcher::noop(),

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -1497,7 +1497,7 @@ mod tests {
         Arc::new(
             Service::new(
                 ConfigManager::not_watched(cfg),
-                DatabaseConnection::Disconnected,
+                DatabaseConnection::default(),
                 Provider::mocked_builder().build().unwrap(),
                 Arc::new(MockPolicy::default()),
                 AuditDispatcher::noop(),

--- a/crates/oauth2-key-driver-raft/src/lib.rs
+++ b/crates/oauth2-key-driver-raft/src/lib.rs
@@ -1088,7 +1088,7 @@ mod tests {
         std::sync::Arc::new(
             openstack_keystone_core::keystone::Service::new(
                 openstack_keystone_config::ConfigManager::not_watched(config),
-                sea_orm::DatabaseConnection::Disconnected,
+                sea_orm::DatabaseConnection::default(),
                 openstack_keystone_core::provider::Provider::mocked_builder()
                     .build()
                     .unwrap(),

--- a/crates/resource-driver-sql/src/domain/list.rs
+++ b/crates/resource-driver-sql/src/domain/list.rs
@@ -94,7 +94,7 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
 
     use super::super::tests::*;
     use super::*;
@@ -103,7 +103,7 @@ mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "project"."id", "project"."name", "project"."extra", "project"."description", "project"."enabled", "project"."domain_id", "project"."parent_id", "project"."is_domain" FROM "project" WHERE "project"."is_domain" = TRUE AND "project"."id" <> '<<keystone.domain.root>>'"#,
-            QueryOrder::query(&mut get_list_query(&DomainListParameters::default()).unwrap())
+            QuerySelect::query(&mut get_list_query(&DomainListParameters::default()).unwrap())
                 .to_string(PostgresQueryBuilder)
         );
     }
@@ -111,7 +111,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_name() {
         assert!(
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&DomainListParameters {
                     name: Some("name".into()),
                     ..Default::default()
@@ -125,7 +125,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_ids() {
-        let q = QueryOrder::query(
+        let q = QuerySelect::query(
             &mut get_list_query(&DomainListParameters {
                 ids: Some(std::collections::HashSet::from([
                     "1".to_string(),

--- a/crates/resource-driver-sql/src/project/list.rs
+++ b/crates/resource-driver-sql/src/project/list.rs
@@ -95,7 +95,7 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
 
     use super::super::tests::*;
     use super::*;
@@ -104,7 +104,7 @@ mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "project"."id", "project"."name", "project"."extra", "project"."description", "project"."enabled", "project"."domain_id", "project"."parent_id", "project"."is_domain" FROM "project" WHERE "project"."is_domain" = FALSE"#,
-            QueryOrder::query(&mut get_list_query(&ProjectListParameters::default()).unwrap())
+            QuerySelect::query(&mut get_list_query(&ProjectListParameters::default()).unwrap())
                 .to_string(PostgresQueryBuilder)
         );
     }
@@ -112,7 +112,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_domain_id() {
         assert!(
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&ProjectListParameters {
                     domain_id: Some("did".into()),
                     ..Default::default()
@@ -127,7 +127,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_name() {
         assert!(
-            QueryOrder::query(
+            QuerySelect::query(
                 &mut get_list_query(&ProjectListParameters {
                     name: Some("name".into()),
                     ..Default::default()
@@ -141,7 +141,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_ids() {
-        let q = QueryOrder::query(
+        let q = QuerySelect::query(
             &mut get_list_query(&ProjectListParameters {
                 ids: Some(std::collections::HashSet::from([
                     "1".to_string(),
@@ -157,7 +157,7 @@ mod tests {
 
     // Note: `Cursor`'s `.after()`/`.before()`/`.first()`/`.last()` state is
     // applied internally at execution time, not rendered by
-    // `QueryOrder::query()`, so marker/limit behavior is verified against
+    // `QuerySelect::query()`, so marker/limit behavior is verified against
     // the executed query's bind parameters below instead.
 
     #[tokio::test]

--- a/crates/role-driver-sql/src/role/list.rs
+++ b/crates/role-driver-sql/src/role/list.rs
@@ -79,18 +79,18 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &RoleListParameters,
 ) -> Result<Vec<Role>, RoleProviderError> {
-    Ok(get_list_query(params)?
+    get_list_query(params)?
         .all(db)
         .await
         .context("listing roles")?
         .into_iter()
         .map(TryInto::<Role>::try_into)
-        .collect::<Result<Vec<Role>, _>>()?)
+        .collect::<Result<Vec<Role>, _>>()
 }
 
 #[cfg(test)]
 pub(super) mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
 
     use openstack_keystone_core_types::role::RoleBuilder;
 
@@ -101,7 +101,7 @@ pub(super) mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role""#,
-            QueryOrder::query(&mut get_list_query(&RoleListParameters::default()).unwrap())
+            QuerySelect::query(&mut get_list_query(&RoleListParameters::default()).unwrap())
                 .to_string(PostgresQueryBuilder)
         );
     }

--- a/crates/token-restriction-driver-sql/src/create.rs
+++ b/crates/token-restriction-driver-sql/src/create.rs
@@ -84,7 +84,7 @@ pub async fn create(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Statement, Transaction};
+    use sea_orm::{DatabaseBackend, MockDatabase, Statement, Transaction};
 
     use super::super::tests::get_restriction_mock;
     use super::*;
@@ -94,10 +94,16 @@ mod tests {
         // Create MockDatabase with mock query results
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_restriction_mock("1")]])
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![
+                token_restriction_role_association::Model {
+                    restriction_id: "1".into(),
+                    role_id: "r1".into(),
+                },
+                token_restriction_role_association::Model {
+                    restriction_id: "1".into(),
+                    role_id: "r2".into(),
+                },
+            ]])
             .into_connection();
 
         let req = TokenRestrictionCreate {

--- a/crates/token-restriction-driver-sql/src/update.rs
+++ b/crates/token-restriction-driver-sql/src/update.rs
@@ -104,7 +104,6 @@ pub async fn update<S: AsRef<str>>(
                         role_id: Set(r),
                     }
                 }))
-                .on_empty_do_nothing()
                 .exec(db)
                 .await
                 .context("Adding new token restriction roles")?;
@@ -158,10 +157,16 @@ mod tests {
                 BTreeMap::from([("role_id", Into::<Value>::into("rid1"))]).into_mock_row(),
                 BTreeMap::from([("role_id", Into::<Value>::into("rid2"))]).into_mock_row(),
             ]])
-            .append_exec_results([MockExecResult {
-                rows_affected: 1,
-                ..Default::default()
-            }])
+            .append_query_results([vec![
+                token_restriction_role_association::Model {
+                    restriction_id: "tr1".into(),
+                    role_id: "r1".into(),
+                },
+                token_restriction_role_association::Model {
+                    restriction_id: "tr1".into(),
+                    role_id: "r2".into(),
+                },
+            ]])
             .append_exec_results([MockExecResult {
                 rows_affected: 1,
                 ..Default::default()

--- a/crates/trust-driver-sql/src/trust/list.rs
+++ b/crates/trust-driver-sql/src/trust/list.rs
@@ -80,7 +80,7 @@ pub async fn list(
 
 #[cfg(test)]
 mod tests {
-    use sea_orm::{DatabaseBackend, MockDatabase, QueryOrder, Transaction, sea_query::*};
+    use sea_orm::{DatabaseBackend, MockDatabase, QuerySelect, Transaction, sea_query::*};
 
     use crate::entity::trust_role as db_trust_role;
     use crate::trust::tests::get_trust_mock;
@@ -91,7 +91,7 @@ mod tests {
     async fn test_query_all() {
         assert_eq!(
             r#"SELECT "trust"."id", "trust"."trustor_user_id", "trust"."trustee_user_id", "trust"."project_id", "trust"."impersonation", "trust"."deleted_at", "trust"."expires_at", "trust"."remaining_uses", "trust"."extra", "trust"."expires_at_int", "trust"."redelegated_trust_id", "trust"."redelegation_count" FROM "trust" WHERE "trust"."deleted_at" IS NULL"#,
-            QueryOrder::query(&mut get_list_query(&TrustListParameters::default()).unwrap())
+            QuerySelect::query(&mut get_list_query(&TrustListParameters::default()).unwrap())
                 .to_string(PostgresQueryBuilder)
         );
     }
@@ -99,7 +99,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_include_deleted() {
         assert!(
-            !QueryOrder::query(
+            !QuerySelect::query(
                 &mut get_list_query(&TrustListParameters {
                     include_deleted: Some(true),
                     ..Default::default()
@@ -148,7 +148,7 @@ mod tests {
                 ),
                 Transaction::from_sql_and_values(
                     DatabaseBackend::Postgres,
-                    r#"SELECT "trust_role"."trust_id", "trust_role"."role_id" FROM "trust_role" WHERE "trust_role"."trust_id" IN ($1)"#,
+                    r#"SELECT "trust_role"."trust_id", "trust_role"."role_id" FROM "trust_role" WHERE ("trust_role"."trust_id") IN (($1)) ORDER BY "trust_role"."trust_id" ASC, "trust_role"."role_id" ASC"#,
                     ["1".into()]
                 ),
             ]

--- a/crates/webauthn/src/driver/sql/state/create.rs
+++ b/crates/webauthn/src/driver/sql/state/create.rs
@@ -136,7 +136,7 @@ mod tests {
     }
 
     fn sv<S: Into<String>>(s: S) -> sea_orm::Value {
-        sea_orm::Value::String(Some(Box::new(s.into())))
+        sea_orm::Value::String(Some(s.into()))
     }
 
     // upsert is private; tests exercise it directly with arbitrary serializable

--- a/crates/webauthn/tests/common/mod.rs
+++ b/crates/webauthn/tests/common/mod.rs
@@ -169,7 +169,7 @@ pub async fn get_state(
         get_isolated_database().await?
     } else {
         cfg.webauthn.driver = "raft".to_string();
-        DatabaseConnection::Disconnected
+        DatabaseConnection::default()
     };
     let storage = Arc::new(openstack_keystone_distributed_storage::mock::MockStorage::default());
     let main_state = Arc::new(

--- a/tests/integration/src/federation.rs
+++ b/tests/integration/src/federation.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod identity_provider;
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use eyre::Result;
+
+use openstack_keystone::keystone::Service;
+use openstack_keystone::keystone::ServiceState;
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::federation::*;
+
+use crate::common::*;
+use crate::impl_deleter;
+
+impl_deleter!(
+    Service,
+    IdentityProvider,
+    get_federation_provider,
+    delete_identity_provider
+);
+
+pub async fn create_identity_provider(
+    state: &ServiceState,
+    data: IdentityProviderCreate,
+) -> Result<AsyncResourceGuard<IdentityProvider, ServiceState>> {
+    let res = state
+        .provider
+        .get_federation_provider()
+        .create_identity_provider(&ExecutionContext::internal(state), data)
+        .await
+        .unwrap();
+    Ok(AsyncResourceGuard::new(res, state.clone()))
+}

--- a/tests/integration/src/federation/identity_provider.rs
+++ b/tests/integration/src/federation/identity_provider.rs
@@ -1,0 +1,70 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Test identity provider creation.
+
+use eyre::Result;
+use tracing_test::traced_test;
+
+use openstack_keystone_core_types::federation::IdentityProviderCreate;
+
+use crate::common::get_state;
+use crate::create_domain;
+use crate::federation::create_identity_provider;
+
+/// Every identity provider creation also upserts a shared, table-global
+/// `mapping` row (id `dummy`) used by the legacy v3 federation protocol
+/// entries, via `INSERT ... ON CONFLICT (id) DO NOTHING`. The row is
+/// created by the first identity provider and every subsequent one must
+/// hit -- and tolerate -- that conflict instead of surfacing it as a
+/// creation failure.
+///
+/// Regression test for a bug where `on_conflict(..).do_nothing_on(..)`
+/// combined with sea-orm's `RETURNING`-based insert path turned "no rows
+/// returned because of the conflict" into a hard `DbErr::RecordNotInserted`,
+/// making every identity provider creation after the first one fail with a
+/// 500. Fixed by using `on_conflict_do_nothing_on`, whose `TryInsert::exec`
+/// maps that outcome to `TryInsertResult::Conflicted` instead of an error.
+#[traced_test]
+#[tokio::test]
+async fn test_create_second_identity_provider_does_not_fail_on_shared_legacy_row() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let first = create_identity_provider(
+        &state,
+        IdentityProviderCreate {
+            name: uuid::Uuid::new_v4().simple().to_string(),
+            domain_id: Some(domain.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    assert!(!first.id.is_empty());
+
+    // This is the call that used to 500 once the "dummy" mapping row
+    // already existed from the first creation above.
+    let second = create_identity_provider(
+        &state,
+        IdentityProviderCreate {
+            name: uuid::Uuid::new_v4().simple().to_string(),
+            domain_id: Some(domain.id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    assert!(!second.id.is_empty());
+    assert_ne!(first.id, second.id);
+
+    Ok(())
+}

--- a/tests/integration/src/integration.rs
+++ b/tests/integration/src/integration.rs
@@ -22,6 +22,7 @@ mod audit;
 mod catalog;
 mod common;
 mod credential;
+mod federation;
 mod identity;
 mod k8s_auth;
 mod mapping;


### PR DESCRIPTION
DatabaseConnection changed from enum to struct: replace
DatabaseConnection::Disconnected with DatabaseConnection::default().
ConnectionTrait::execute/query_one/query_all now take a
StatementBuilder reference directly instead of a pre-built Statement,
so callers no longer call .build() themselves. Cursor no longer
implements QueryOrder; tests switch to QuerySelect::query() to reach
the same underlying SelectStatement. Value::String no longer boxes
its inner String. Drop deprecated on_empty_do_nothing() calls, now a
no-op on empty input.

Update mocked SQL assertions in appcred-driver-sql: composite-key
inserts with an explicitly set primary key now go through the
RETURNING path on backends that support it, and IN clauses over
identity columns render as (col) IN ((v1), (v2)) with an explicit
ORDER BY from the loader.

Postgres auto-increment primary keys now codegen as
GENERATED BY DEFAULT AS IDENTITY instead of serial/bigserial
(sea-orm's postgres-use-serial-pk feature restores the old
behavior). Verified against a live Postgres instance: schema
creation and CRUD through the affected tables (application_credential,
access_rule) pass.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
