### PR TITLE
feat: Add immutable option for project, domain, and role

### DIFF
--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -204,6 +204,7 @@ impl From<RoleProviderError> for KeystoneApiError {
             },
             ref err @ RoleProviderError::Conflict(..) => Self::Conflict(err.to_string()),
             ref err @ RoleProviderError::Validation { .. } => Self::BadRequest(err.to_string()),
+            err @ RoleProviderError::Immutable(..) => Self::forbidden(err),
             other => Self::InternalError(other.to_string()),
         }
     }
@@ -316,6 +317,7 @@ impl From<ResourceProviderError> for KeystoneApiError {
                 identifier: x,
             },
             ResourceProviderError::InvalidProjectDomain(x) => Self::BadRequest(x),
+            err @ ResourceProviderError::Immutable(..) => Self::forbidden(err),
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/api-types/src/v3/domain.rs
+++ b/crates/api-types/src/v3/domain.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::Link;
+pub use crate::v3::project::ProjectOptions;
 
 /// Short domain representation.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -79,6 +80,14 @@ pub struct Domain {
     /// The domain name.
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
     pub name: String,
+
+    /// The resource options for the domain. A domain is a project with
+    /// `is_domain = true` and shares its resource options, hence the shared
+    /// `ProjectOptions` type.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<ProjectOptions>,
 }
 
 /// New domain data.
@@ -120,6 +129,14 @@ pub struct DomainCreate {
     /// The domain name.
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
     pub name: String,
+
+    /// The resource options for the domain. A domain is a project with
+    /// `is_domain = true` and shares its resource options, hence the shared
+    /// `ProjectOptions` type.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<ProjectOptions>,
 }
 
 /// Complete response with the domain data.
@@ -174,6 +191,14 @@ pub struct DomainUpdate {
     #[cfg_attr(feature = "builder", builder(default))]
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
     pub name: Option<String>,
+
+    /// The resource options for the domain. A domain is a project with
+    /// `is_domain = true` and shares its resource options, hence the shared
+    /// `ProjectOptions` type.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<ProjectOptions>,
 }
 
 /// Domain update request.

--- a/crates/api-types/src/v3/domain_conv.rs
+++ b/crates/api-types/src/v3/domain_conv.rs
@@ -41,12 +41,14 @@ impl From<&provider_types::Domain> for api_types::DomainShort {
 
 impl From<provider_types::Domain> for api_types::Domain {
     fn from(value: provider_types::Domain) -> Self {
+        let opts: api_types::ProjectOptions = value.options.into();
         Self {
             description: value.description,
             enabled: value.enabled,
             extra: value.extra,
             id: value.id,
             name: value.name,
+            options: opts.immutable.is_some().then_some(opts),
         }
     }
 }
@@ -59,6 +61,7 @@ impl From<api_types::DomainCreate> for provider_types::DomainCreate {
             extra: value.extra,
             id: value.id,
             name: value.name,
+            options: value.options.map(Into::into),
         }
     }
 }
@@ -71,6 +74,7 @@ impl From<api_types::DomainUpdateRequest> for provider_types::DomainUpdate {
             enabled: domain.enabled,
             extra: domain.extra,
             name: domain.name,
+            options: domain.options.map(Into::into),
         }
     }
 }

--- a/crates/api-types/src/v3/project.rs
+++ b/crates/api-types/src/v3/project.rs
@@ -98,10 +98,38 @@ pub struct Project {
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
     pub name: String,
 
+    /// The resource options for the project. Available resource options are
+    /// documented in `ProjectOptions`.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<ProjectOptions>,
+
     /// The ID of the parent for the project.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 64)))]
     pub parent_id: Option<String>,
+}
+
+/// Project resource options.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct ProjectOptions {
+    /// When `true`, the project cannot be updated or deleted until an
+    /// administrator explicitly sets this back to `false`. Also used for
+    /// domains, which persist through the same underlying project.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub immutable: Option<bool>,
 }
 
 /// New project data.
@@ -160,7 +188,13 @@ pub struct ProjectCreate {
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
     pub name: String,
 
-    // TODO: add options
+    /// The resource options for the project. Available resource options are
+    /// documented in `ProjectOptions`.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<ProjectOptions>,
+
     /// The ID of the parent of the project.
     ///
     /// If specified on project creation, this places the project within a
@@ -246,6 +280,13 @@ pub struct ProjectUpdate {
     #[cfg_attr(feature = "builder", builder(default))]
     #[cfg_attr(feature = "validate", validate(length(min = 1, max = 255)))]
     pub name: Option<String>,
+
+    /// The resource options for the project. Available resource options are
+    /// documented in `ProjectOptions`.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<ProjectOptions>,
 }
 
 /// Project update request.

--- a/crates/api-types/src/v3/project_conv.rs
+++ b/crates/api-types/src/v3/project_conv.rs
@@ -19,6 +19,22 @@ use openstack_keystone_core_types::resource as provider_types;
 
 use crate::v3::project as api_types;
 
+impl From<provider_types::ProjectOptions> for api_types::ProjectOptions {
+    fn from(value: provider_types::ProjectOptions) -> Self {
+        Self {
+            immutable: value.immutable,
+        }
+    }
+}
+
+impl From<api_types::ProjectOptions> for provider_types::ProjectOptions {
+    fn from(value: api_types::ProjectOptions) -> Self {
+        Self {
+            immutable: value.immutable,
+        }
+    }
+}
+
 impl From<provider_types::Project> for api_types::ProjectShort {
     fn from(value: provider_types::Project) -> Self {
         Self {
@@ -43,6 +59,7 @@ impl From<&provider_types::Project> for api_types::ProjectShort {
 
 impl From<provider_types::Project> for api_types::Project {
     fn from(value: provider_types::Project) -> Self {
+        let opts: api_types::ProjectOptions = value.options.into();
         Self {
             description: value.description,
             domain_id: value.domain_id,
@@ -51,6 +68,7 @@ impl From<provider_types::Project> for api_types::Project {
             id: value.id,
             is_domain: value.is_domain,
             name: value.name,
+            options: opts.immutable.is_some().then_some(opts),
             parent_id: value.parent_id,
         }
     }
@@ -66,6 +84,7 @@ impl From<api_types::ProjectCreate> for provider_types::ProjectCreate {
             id: None,
             is_domain: value.is_domain,
             name: value.name,
+            options: value.options.map(Into::into),
             parent_id: value.parent_id,
         }
     }
@@ -79,6 +98,7 @@ impl From<api_types::ProjectUpdateRequest> for provider_types::ProjectUpdate {
             enabled: project.enabled,
             extra: project.extra,
             name: project.name,
+            options: project.options.map(Into::into),
         }
     }
 }

--- a/crates/api-types/src/v3/role.rs
+++ b/crates/api-types/src/v3/role.rs
@@ -44,6 +44,32 @@ pub struct Role {
     #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+
+    /// The resource options for the role. Available resource options are
+    /// documented in `RoleOptions`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<RoleOptions>,
+}
+
+/// Role resource options.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "builder",
+    derive(derive_builder::Builder),
+    builder(
+        build_fn(error = "crate::error::BuilderError"),
+        setter(strip_option, into)
+    )
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "validate", derive(validator::Validate))]
+pub struct RoleOptions {
+    /// When `true`, the role cannot be updated or deleted until an
+    /// administrator explicitly sets this back to `false`.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub immutable: Option<bool>,
 }
 
 /// The role reference data.
@@ -194,6 +220,13 @@ pub struct RoleCreate {
     #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+
+    /// The resource options for the role. Available resource options are
+    /// documented in `RoleOptions`.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<RoleOptions>,
 }
 
 /// New role creation request.
@@ -234,6 +267,13 @@ pub struct RoleUpdate {
     #[cfg_attr(feature = "openapi", schema(inline, additional_properties))]
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+
+    /// The resource options for the role. Available resource options are
+    /// documented in `RoleOptions`.
+    #[cfg_attr(feature = "builder", builder(default))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validate", validate(nested))]
+    pub options: Option<RoleOptions>,
 }
 
 /// Role update request.

--- a/crates/api-types/src/v3/role_conv.rs
+++ b/crates/api-types/src/v3/role_conv.rs
@@ -16,14 +16,32 @@ use openstack_keystone_core_types::role as provider_types;
 
 use crate::v3::role as api_types;
 
+impl From<provider_types::RoleOptions> for api_types::RoleOptions {
+    fn from(value: provider_types::RoleOptions) -> Self {
+        Self {
+            immutable: value.immutable,
+        }
+    }
+}
+
+impl From<api_types::RoleOptions> for provider_types::RoleOptions {
+    fn from(value: api_types::RoleOptions) -> Self {
+        Self {
+            immutable: value.immutable,
+        }
+    }
+}
+
 impl From<provider_types::Role> for api_types::Role {
     fn from(value: provider_types::Role) -> Self {
+        let opts: api_types::RoleOptions = value.options.into();
         Self {
             id: value.id,
             domain_id: value.domain_id,
             name: value.name,
             description: value.description,
             extra: value.extra,
+            options: opts.immutable.is_some().then_some(opts),
         }
     }
 }
@@ -65,6 +83,7 @@ impl From<api_types::RoleCreateRequest> for provider_types::RoleCreate {
             extra: value.role.extra,
             id: None,
             name: value.role.name,
+            options: value.role.options.map(Into::into),
         }
     }
 }
@@ -76,6 +95,7 @@ impl From<api_types::RoleUpdateRequest> for provider_types::RoleUpdate {
             description: role.description.map(Some),
             extra: role.extra,
             name: role.name,
+            options: role.options.map(Into::into),
         }
     }
 }

--- a/crates/cli-manage/src/bootstrap.rs
+++ b/crates/cli-manage/src/bootstrap.rs
@@ -720,6 +720,7 @@ mod tests {
             domain_id: None,
             description: None,
             extra: HashMap::new(),
+            options: None,
         }
     }
 
@@ -733,6 +734,7 @@ mod tests {
             description: None,
             is_domain: false,
             extra: HashMap::new(),
+            options: None,
         }
     }
 

--- a/crates/core-types/src/auth/tests.rs
+++ b/crates/core-types/src/auth/tests.rs
@@ -76,6 +76,7 @@ fn make_project() -> Project {
         is_domain: false,
         parent_id: None,
         extra: HashMap::new(),
+        options: Default::default(),
     }
 }
 
@@ -106,6 +107,7 @@ fn make_domain() -> Domain {
         enabled: true,
         description: None,
         extra: HashMap::new(),
+        options: Default::default(),
     }
 }
 
@@ -116,6 +118,7 @@ fn make_disabled_domain() -> Domain {
         enabled: false,
         description: None,
         extra: HashMap::new(),
+        options: Default::default(),
     }
 }
 
@@ -332,6 +335,7 @@ fn make_trust_with_roles(roles: Option<Vec<RoleRef>>) -> SecurityContext {
                     is_domain: false,
                     parent_id: None,
                     extra: HashMap::new(),
+                    options: Default::default(),
                 },
                 project_domain: make_domain(),
             })),

--- a/crates/core-types/src/resource/domain.rs
+++ b/crates/core-types/src/resource/domain.rs
@@ -20,6 +20,7 @@ use serde_json::Value;
 use validator::Validate;
 
 use crate::error::BuilderError;
+use crate::resource::project::ProjectOptions;
 
 /// Domain data.
 #[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
@@ -46,6 +47,13 @@ pub struct Domain {
     #[builder(default)]
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+
+    /// The resource options for the domain. A domain is a project row with
+    /// `is_domain = true` and shares the `project_option` table, hence the
+    /// shared [`ProjectOptions`](crate::resource::ProjectOptions) type.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: ProjectOptions,
 }
 
 /// New domain data.
@@ -74,6 +82,11 @@ pub struct DomainCreate {
     /// Additional domain properties.
     #[builder(default)]
     pub extra: HashMap<String, Value>,
+
+    /// The resource options for the domain.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: Option<ProjectOptions>,
 }
 
 /// Domain update data.
@@ -98,6 +111,12 @@ pub struct DomainUpdate {
     /// existing `extra` before persisting; an empty map means unchanged.
     #[builder(default)]
     pub extra: HashMap<String, Value>,
+
+    /// The resource options for the domain. `None` means unchanged; a field
+    /// left `None` within `Some(ProjectOptions { .. })` also means unchanged.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: Option<ProjectOptions>,
 }
 
 /// Domain listing parameters.

--- a/crates/core-types/src/resource/error.rs
+++ b/crates/core-types/src/resource/error.rs
@@ -41,6 +41,13 @@ pub enum ResourceProviderError {
     #[error("invalid project domain: {0}")]
     InvalidProjectDomain(String),
 
+    /// The resource has `options.immutable == true` and the requested update
+    /// does not itself clear that flag, or the request is a delete (which can
+    /// never clear it). Mirrors Python Keystone's `ResourceUpdateForbidden` /
+    /// `ResourceDeleteForbidden`.
+    #[error("resource {0} is immutable")]
+    Immutable(String),
+
     /// OAuth2 signing key provider error, surfaced when provisioning a
     /// domain's initial signing keypair synchronously on domain creation
     /// (ADR 0026 §3, "Domain creation").

--- a/crates/core-types/src/resource/project.rs
+++ b/crates/core-types/src/resource/project.rs
@@ -60,6 +60,11 @@ pub struct Project {
     #[validate(length(min = 1, max = 255))]
     pub name: String,
 
+    /// The resource options for the project.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: ProjectOptions,
+
     /// The ID of the parent for the project.
     #[builder(default)]
     #[validate(length(min = 1, max = 64))]
@@ -109,7 +114,11 @@ pub struct ProjectCreate {
     #[validate(length(min = 1, max = 255))]
     pub name: String,
 
-    // TODO: add options
+    /// The resource options for the project.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: Option<ProjectOptions>,
+
     /// The ID of the parent of the project.
     ///
     /// If specified on project creation, this places the project within a
@@ -149,6 +158,27 @@ pub struct ProjectUpdate {
     /// existing `extra` before persisting; an empty map means unchanged.
     #[builder(default)]
     pub extra: HashMap<String, Value>,
+
+    /// The resource options for the project. `None` means unchanged; a field
+    /// left `None` within `Some(ProjectOptions { .. })` also means unchanged.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: Option<ProjectOptions>,
+}
+
+/// Resource options for a project.
+///
+/// Also used for domains: a domain is a project row with `is_domain = true`
+/// and persists its options through the same `project_option` table,
+/// mirroring Python Keystone's shared resource_options registry for both.
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct ProjectOptions {
+    /// When `true`, the resource cannot be updated or deleted until an
+    /// administrator explicitly sets this back to `false` -- which may
+    /// happen in the same request that changes other fields.
+    pub immutable: Option<bool>,
 }
 
 /// Project listing parameters.

--- a/crates/core-types/src/role/error.rs
+++ b/crates/core-types/src/role/error.rs
@@ -25,6 +25,13 @@ pub enum RoleProviderError {
     #[error("backend driver error: {0}")]
     Driver(String),
 
+    /// The role has `options.immutable == true` and the requested update
+    /// does not itself clear that flag, or the request is a delete (which can
+    /// never clear it). Mirrors Python Keystone's `ResourceUpdateForbidden` /
+    /// `ResourceDeleteForbidden`.
+    #[error("role {0} is immutable")]
+    Immutable(String),
+
     /// Role imply not found.
     #[error("role implication {0} not found")]
     RoleImplyNotFound(String),

--- a/crates/core-types/src/role/role.rs
+++ b/crates/core-types/src/role/role.rs
@@ -47,6 +47,22 @@ pub struct Role {
     /// The role name.
     #[validate(length(min = 1, max = 255))]
     pub name: String,
+
+    /// The resource options for the role.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: RoleOptions,
+}
+
+/// Resource options for a role.
+#[derive(Builder, Clone, Debug, Default, PartialEq, Serialize, Validate)]
+#[builder(build_fn(error = "BuilderError"))]
+#[builder(setter(strip_option, into))]
+pub struct RoleOptions {
+    /// When `true`, the role cannot be updated or deleted until an
+    /// administrator explicitly sets this back to `false` -- which may
+    /// happen in the same request that changes other fields.
+    pub immutable: Option<bool>,
 }
 
 /// Short role representation (reference).
@@ -140,6 +156,11 @@ pub struct RoleCreate {
     /// The role name.
     #[validate(length(min = 1, max = 255))]
     pub name: String,
+
+    /// The resource options for the role.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: Option<RoleOptions>,
 }
 
 /// Role update data.
@@ -160,6 +181,12 @@ pub struct RoleUpdate {
     /// existing `extra` before persisting; an empty map means unchanged.
     #[builder(default)]
     pub extra: HashMap<String, Value>,
+
+    /// The resource options for the role. `None` means unchanged; a field
+    /// left `None` within `Some(RoleOptions { .. })` also means unchanged.
+    #[builder(default)]
+    #[validate(nested)]
+    pub options: Option<RoleOptions>,
 }
 
 /// Role inference (imply) data.

--- a/crates/core/src/api/api_key_auth.rs
+++ b/crates/core/src/api/api_key_auth.rs
@@ -529,6 +529,7 @@ mod tests {
             description: None,
             enabled: true,
             extra: Default::default(),
+            options: Default::default(),
         }));
         assert!(is_domain_scoped(&vsc, "domain-1"));
     }
@@ -541,6 +542,7 @@ mod tests {
             description: None,
             enabled: true,
             extra: Default::default(),
+            options: Default::default(),
         }));
         assert!(!is_domain_scoped(&vsc, "domain-2"));
     }
@@ -557,6 +559,7 @@ mod tests {
                 is_domain: false,
                 parent_id: None,
                 extra: Default::default(),
+                options: Default::default(),
             },
             project_domain: Domain {
                 id: "domain-1".to_string(),
@@ -564,6 +567,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             },
         });
         assert!(!is_domain_scoped(&vsc, "domain-1"));

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -357,6 +357,7 @@ mod tests {
                 description: None,
                 domain_id: None,
                 extra: Default::default(),
+                options: Default::default(),
             }])
         });
 
@@ -553,6 +554,7 @@ mod tests {
                 description: None,
                 domain_id: None,
                 extra: Default::default(),
+                options: Default::default(),
             }])
         });
 

--- a/crates/core/src/auth/tests.rs
+++ b/crates/core/src/auth/tests.rs
@@ -60,6 +60,7 @@ fn make_user_identity(user_id: impl Into<String>) -> PrincipalInfo {
             enabled: true,
             name: "default".to_string(),
             extra: HashMap::new(),
+            options: Default::default(),
         }),
         user_groups: Vec::new(),
     };
@@ -79,6 +80,7 @@ fn make_project(pid: impl Into<String>) -> Project {
         is_domain: false,
         parent_id: None,
         extra: HashMap::new(),
+        options: Default::default(),
     }
 }
 
@@ -91,6 +93,7 @@ fn make_project_scope(pid: impl Into<String>) -> ScopeInfo {
             enabled: true,
             name: "default".to_string(),
             extra: HashMap::new(),
+            options: Default::default(),
         },
     }
 }
@@ -102,6 +105,7 @@ fn make_domain_scope(did: impl Into<String>) -> ScopeInfo {
         enabled: true,
         name: "default".to_string(),
         extra: HashMap::new(),
+        options: Default::default(),
     })
 }
 
@@ -133,6 +137,7 @@ fn make_trust_scope(
             enabled: true,
             name: "default".to_string(),
             extra: HashMap::new(),
+            options: Default::default(),
         },
     }))
 }
@@ -174,6 +179,7 @@ fn disabled_domain_scope(did: impl Into<String>) -> ScopeInfo {
         enabled: false,
         name: "disabled".to_string(),
         extra: HashMap::new(),
+        options: Default::default(),
     })
 }
 
@@ -188,6 +194,7 @@ fn disabled_project_scope(pid: impl Into<String>) -> ScopeInfo {
             is_domain: false,
             parent_id: None,
             extra: HashMap::new(),
+            options: Default::default(),
         },
         project_domain: openstack_keystone_core_types::resource::Domain {
             id: "d1".to_string(),
@@ -195,6 +202,7 @@ fn disabled_project_scope(pid: impl Into<String>) -> ScopeInfo {
             enabled: true,
             name: "default".to_string(),
             extra: HashMap::new(),
+            options: Default::default(),
         },
     }
 }
@@ -210,6 +218,7 @@ fn disabled_project_domain_scope(pid: impl Into<String>) -> ScopeInfo {
             is_domain: false,
             parent_id: None,
             extra: HashMap::new(),
+            options: Default::default(),
         },
         project_domain: openstack_keystone_core_types::resource::Domain {
             id: "d1".to_string(),
@@ -217,6 +226,7 @@ fn disabled_project_domain_scope(pid: impl Into<String>) -> ScopeInfo {
             enabled: false,
             name: "disabled".to_string(),
             extra: HashMap::new(),
+            options: Default::default(),
         },
     }
 }
@@ -251,6 +261,7 @@ fn disabled_trust_scope(
             is_domain: false,
             parent_id: None,
             extra: HashMap::new(),
+            options: Default::default(),
         },
         project_domain: openstack_keystone_core_types::resource::Domain {
             id: "d1".to_string(),
@@ -258,6 +269,7 @@ fn disabled_trust_scope(
             enabled: true,
             name: "default".to_string(),
             extra: HashMap::new(),
+            options: Default::default(),
         },
     }))
 }
@@ -292,6 +304,7 @@ fn disabled_trust_project_domain_scope(
             is_domain: false,
             parent_id: None,
             extra: HashMap::new(),
+            options: Default::default(),
         },
         project_domain: openstack_keystone_core_types::resource::Domain {
             id: "d1".to_string(),
@@ -299,6 +312,7 @@ fn disabled_trust_project_domain_scope(
             enabled: false,
             name: "disabled".to_string(),
             extra: HashMap::new(),
+            options: Default::default(),
         },
     }))
 }
@@ -2742,6 +2756,7 @@ async fn test_new_for_scope_delegated_roles_never_exceed_delegation_matrix() {
             enabled: true,
             name: "default".to_string(),
             extra: HashMap::new(),
+            options: Default::default(),
         },
     }));
     let authz = AuthzInfoBuilder::default()

--- a/crates/core/src/mapping/service.rs
+++ b/crates/core/src/mapping/service.rs
@@ -108,6 +108,7 @@ fn derive_authz_info(authorizations: &[Authorization]) -> Option<AuthzInfo> {
                 parent_id: None,
                 domain_id: project_domain_id.clone(),
                 extra: Default::default(),
+                options: Default::default(),
             };
             let domain = Domain {
                 id: project_domain_id.clone(),
@@ -115,6 +116,7 @@ fn derive_authz_info(authorizations: &[Authorization]) -> Option<AuthzInfo> {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             };
             (
                 ScopeInfo::Project {
@@ -131,6 +133,7 @@ fn derive_authz_info(authorizations: &[Authorization]) -> Option<AuthzInfo> {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             };
             (ScopeInfo::Domain(domain), roles.clone())
         }
@@ -283,6 +286,7 @@ impl MappingService {
                     enabled: true,
                     name: String::new(),
                     extra: HashMap::new(),
+                    options: Default::default(),
                 })
                 .build()
                 .map_err(Box::new)?

--- a/crates/core/src/resource/service.rs
+++ b/crates/core/src/resource/service.rs
@@ -119,6 +119,49 @@ impl ResourceService {
             parent_id.to_string(),
         ))
     }
+
+    /// Reject the operation when the project is currently immutable and the
+    /// request does not itself clear the flag.
+    ///
+    /// Mirrors Python Keystone: a resource with `options.immutable == true`
+    /// rejects update/delete unless the update explicitly sets
+    /// `immutable: false` in the same request. Pass `new_options: None` for
+    /// delete, which can never clear the flag. When the project does not
+    /// exist, this is a no-op -- the caller's own lookup surfaces
+    /// `ProjectNotFound`.
+    async fn check_project_mutable<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        project_id: &'a str,
+        new_options: Option<&ProjectOptions>,
+    ) -> Result<(), ResourceProviderError> {
+        if let Some(current) = self.get_project(ctx, project_id).await?
+            && current.options.immutable == Some(true)
+            && new_options.and_then(|o| o.immutable) != Some(false)
+        {
+            return Err(ResourceProviderError::Immutable(project_id.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Reject the operation when the domain is currently immutable and the
+    /// request does not itself clear the flag. See
+    /// [`check_project_mutable`](Self::check_project_mutable) -- a domain is
+    /// a project row with `is_domain = true` sharing the same semantics.
+    async fn check_domain_mutable<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+        new_options: Option<&ProjectOptions>,
+    ) -> Result<(), ResourceProviderError> {
+        if let Some(current) = self.get_domain(ctx, domain_id).await?
+            && current.options.immutable == Some(true)
+            && new_options.and_then(|o| o.immutable) != Some(false)
+        {
+            return Err(ResourceProviderError::Immutable(domain_id.to_string()));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -303,6 +346,8 @@ impl ResourceApi for ResourceService {
         domain: DomainUpdate,
     ) -> Result<Domain, ResourceProviderError> {
         domain.validate()?;
+        self.check_domain_mutable(ctx, domain_id, domain.options.as_ref())
+            .await?;
         let domain = if let Some(vsc) = ctx.ctx() {
             let backend_driver = &self.backend_driver;
             let state = ctx.state();
@@ -356,6 +401,8 @@ impl ResourceApi for ResourceService {
         project: ProjectUpdate,
     ) -> Result<Project, ResourceProviderError> {
         project.validate()?;
+        self.check_project_mutable(ctx, project_id, project.options.as_ref())
+            .await?;
         let project = if let Some(vsc) = ctx.ctx() {
             let backend_driver = &self.backend_driver;
             let state = ctx.state();
@@ -406,6 +453,7 @@ impl ResourceApi for ResourceService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), ResourceProviderError> {
+        self.check_domain_mutable(ctx, id, None).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -449,6 +497,7 @@ impl ResourceApi for ResourceService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), ResourceProviderError> {
+        self.check_project_mutable(ctx, id, None).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -704,6 +753,7 @@ mod tests {
                     enabled: true,
                     description: None,
                     extra: Default::default(),
+                    options: Default::default(),
                 },
             )
             .await
@@ -751,6 +801,7 @@ mod tests {
                     enabled: true,
                     description: None,
                     extra: Default::default(),
+                    options: Default::default(),
                 },
             )
             .await
@@ -779,6 +830,10 @@ mod tests {
         .await;
         let mut backend = MockResourceBackend::default();
         backend
+            .expect_get_project()
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(None));
+        backend
             .expect_delete_project()
             .withf(|_, id: &'_ str| id == "pid")
             .returning(|_, _| Ok(()));
@@ -804,6 +859,7 @@ mod tests {
             is_domain: false,
             name: "pname".into(),
             parent_id: None,
+            options: Default::default(),
         }
     }
 
@@ -999,5 +1055,170 @@ mod tests {
             err,
             ResourceProviderError::InvalidProjectDomain(_)
         ));
+    }
+
+    fn make_immutable_project(id: &str, domain_id: &str) -> Project {
+        let mut project = make_project(id, domain_id);
+        project.options.immutable = Some(true);
+        project
+    }
+
+    fn make_immutable_domain(id: &str) -> openstack_keystone_core_types::resource::Domain {
+        let mut domain = make_domain(id);
+        domain.options.immutable = Some(true);
+        domain
+    }
+
+    #[tokio::test]
+    async fn test_update_project_blocked_when_immutable() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project()
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(make_immutable_project("pid", "did"))));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let err = provider
+            .update_project(
+                &ExecutionContext::internal(&state),
+                "pid",
+                ProjectUpdate {
+                    name: Some("new_name".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ResourceProviderError::Immutable(id) if id == "pid"));
+    }
+
+    #[tokio::test]
+    async fn test_update_project_allowed_when_clearing_immutable() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project()
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(make_immutable_project("pid", "did"))));
+        backend
+            .expect_update_project()
+            .withf(|_, id: &'_ str, _| id == "pid")
+            .returning(|_, _, _| Ok(make_project("pid", "did")));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let result = provider
+            .update_project(
+                &ExecutionContext::internal(&state),
+                "pid",
+                ProjectUpdate {
+                    options: Some(openstack_keystone_core_types::resource::ProjectOptions {
+                        immutable: Some(false),
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "clearing immutable in the same request must be allowed: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_project_blocked_when_immutable() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project()
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(make_immutable_project("pid", "did"))));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let err = provider
+            .delete_project(&ExecutionContext::internal(&state), "pid")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ResourceProviderError::Immutable(id) if id == "pid"));
+    }
+
+    #[tokio::test]
+    async fn test_update_domain_blocked_when_immutable() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_domain()
+            .withf(|_, id: &'_ str| id == "did")
+            .returning(|_, _| Ok(Some(make_immutable_domain("did"))));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let err = provider
+            .update_domain(
+                &ExecutionContext::internal(&state),
+                "did",
+                DomainUpdate {
+                    name: Some("new_name".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ResourceProviderError::Immutable(id) if id == "did"));
+    }
+
+    #[tokio::test]
+    async fn test_delete_domain_blocked_when_immutable() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_domain()
+            .withf(|_, id: &'_ str| id == "did")
+            .returning(|_, _| Ok(Some(make_immutable_domain("did"))));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let err = provider
+            .delete_domain(&ExecutionContext::internal(&state), "did")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ResourceProviderError::Immutable(id) if id == "did"));
+    }
+
+    #[tokio::test]
+    async fn test_update_project_not_immutable_proceeds() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project()
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(make_project("pid", "did"))));
+        backend
+            .expect_update_project()
+            .withf(|_, id: &'_ str, _| id == "pid")
+            .returning(|_, _, _| Ok(make_project("pid", "did")));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let result = provider
+            .update_project(
+                &ExecutionContext::internal(&state),
+                "pid",
+                ProjectUpdate {
+                    name: Some("new_name".into()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/core/src/role/service.rs
+++ b/crates/core/src/role/service.rs
@@ -46,6 +46,29 @@ impl RoleService {
             .clone();
         Ok(Self { backend_driver })
     }
+
+    /// Reject the operation when the role is currently immutable and the
+    /// request does not itself clear the flag.
+    ///
+    /// Mirrors Python Keystone: a resource with `options.immutable == true`
+    /// rejects update/delete unless the update explicitly sets
+    /// `immutable: false` in the same request. Pass `new_options: None` for
+    /// delete, which can never clear the flag. When the role does not exist,
+    /// this is a no-op -- the caller's own lookup surfaces `RoleNotFound`.
+    async fn check_role_mutable<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        role_id: &'a str,
+        new_options: Option<&RoleOptions>,
+    ) -> Result<(), RoleProviderError> {
+        if let Some(current) = self.get_role(ctx, role_id).await?
+            && current.options.immutable == Some(true)
+            && new_options.and_then(|o| o.immutable) != Some(false)
+        {
+            return Err(RoleProviderError::Immutable(role_id.to_string()));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -191,6 +214,8 @@ impl RoleApi for RoleService {
         role: RoleUpdate,
     ) -> Result<Role, RoleProviderError> {
         role.validate()?;
+        self.check_role_mutable(ctx, role_id, role.options.as_ref())
+            .await?;
         let role = if let Some(vsc) = ctx.ctx() {
             let backend_driver = &self.backend_driver;
             let state = ctx.state();
@@ -237,6 +262,7 @@ impl RoleApi for RoleService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<(), RoleProviderError> {
+        self.check_role_mutable(ctx, id, None).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -408,5 +434,129 @@ impl RoleApi for RoleService {
     ) -> Result<Vec<Role>, RoleProviderError> {
         params.validate()?;
         self.backend_driver.list_roles(ctx.state(), params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::auth::ExecutionContext;
+    use crate::provider::Provider;
+    use crate::role::backend::MockRoleBackend;
+    use crate::tests::get_mocked_state;
+
+    fn make_role(id: &str, name: &str) -> Role {
+        RoleBuilder::default().id(id).name(name).build().unwrap()
+    }
+
+    fn make_immutable_role(id: &str, name: &str) -> Role {
+        let mut role = make_role(id, name);
+        role.options.immutable = Some(true);
+        role
+    }
+
+    #[tokio::test]
+    async fn test_update_role_blocked_when_immutable() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_get_role()
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(Some(make_immutable_role("rid", "admin"))));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let err = provider
+            .update_role(
+                &ExecutionContext::internal(&state),
+                "rid",
+                RoleUpdate {
+                    name: Some("new_name".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RoleProviderError::Immutable(id) if id == "rid"));
+    }
+
+    #[tokio::test]
+    async fn test_update_role_allowed_when_clearing_immutable() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_get_role()
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(Some(make_immutable_role("rid", "admin"))));
+        backend
+            .expect_update_role()
+            .withf(|_, id: &'_ str, _| id == "rid")
+            .returning(|_, _, _| Ok(make_role("rid", "admin")));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let result = provider
+            .update_role(
+                &ExecutionContext::internal(&state),
+                "rid",
+                RoleUpdate {
+                    options: Some(RoleOptions {
+                        immutable: Some(false),
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "clearing immutable in the same request must be allowed: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_role_blocked_when_immutable() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_get_role()
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(Some(make_immutable_role("rid", "admin"))));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let err = provider
+            .delete_role(&ExecutionContext::internal(&state), "rid")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RoleProviderError::Immutable(id) if id == "rid"));
+    }
+
+    #[tokio::test]
+    async fn test_delete_role_not_immutable_proceeds() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_get_role()
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(Some(make_role("rid", "admin"))));
+        backend
+            .expect_delete_role()
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(()));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        assert!(
+            provider
+                .delete_role(&ExecutionContext::internal(&state), "rid")
+                .await
+                .is_ok()
+        );
     }
 }

--- a/crates/keystone/src/api/v3/auth/project/list.rs
+++ b/crates/keystone/src/api/v3/auth/project/list.rs
@@ -187,6 +187,7 @@ mod tests {
                         name: "p1_name".into(),
                         parent_id: None,
                         is_domain: false,
+                        options: Default::default(),
                     },
                     ProviderProject {
                         description: None,
@@ -197,6 +198,7 @@ mod tests {
                         name: "p2_name".into(),
                         parent_id: None,
                         is_domain: false,
+                        options: Default::default(),
                     },
                 ])
             });

--- a/crates/keystone/src/api/v3/domain/create.rs
+++ b/crates/keystone/src/api/v3/domain/create.rs
@@ -109,6 +109,7 @@ mod tests {
                 extra: std::collections::HashMap::new(),
                 id: "did".into(),
                 name: "domain_name".into(),
+                options: Default::default(),
             })
         });
 
@@ -150,6 +151,7 @@ mod tests {
                 extra: std::collections::HashMap::new(),
                 id: "did".into(),
                 name: "domain_name".into(),
+                options: Default::default(),
             },
             res.domain,
         );

--- a/crates/keystone/src/api/v3/project/create.rs
+++ b/crates/keystone/src/api/v3/project/create.rs
@@ -112,6 +112,7 @@ mod tests {
                 is_domain: false,
                 name: "project_name".into(),
                 parent_id: Some("ppid".into()),
+                options: Default::default(),
             })
         });
 
@@ -160,6 +161,7 @@ mod tests {
                 is_domain: false,
                 name: "project_name".into(),
                 parent_id: Some("ppid".into()),
+                options: Default::default(),
             },
             res.project,
         );

--- a/crates/keystone/src/api/v3/project/list.rs
+++ b/crates/keystone/src/api/v3/project/list.rs
@@ -125,6 +125,7 @@ mod tests {
                     name: "p1_name".into(),
                     parent_id: None,
                     is_domain: false,
+                    options: Default::default(),
                 }])
             });
 
@@ -264,6 +265,7 @@ mod tests {
                         parent_id: None,
                         is_domain: false,
                         description: None,
+                        options: Default::default(),
                     },
                     ProviderProject {
                         domain_id: "did".into(),
@@ -274,6 +276,7 @@ mod tests {
                         parent_id: None,
                         is_domain: false,
                         description: None,
+                        options: Default::default(),
                     },
                 ])
             });
@@ -328,6 +331,7 @@ mod tests {
                     parent_id: None,
                     is_domain: false,
                     description: None,
+                    options: Default::default(),
                 }])
             });
 

--- a/crates/keystone/src/api/v3/project/show.rs
+++ b/crates/keystone/src/api/v3/project/show.rs
@@ -169,6 +169,7 @@ mod tests {
                 is_domain: false,
                 name: "project_name".into(),
                 parent_id: None,
+                options: Default::default(),
             },
             res.project,
         );

--- a/crates/keystone/src/api/v3/role/create.rs
+++ b/crates/keystone/src/api/v3/role/create.rs
@@ -156,6 +156,7 @@ mod tests {
                 domain_id: Some("domain1".into()),
                 description: Some("A new role".into()),
                 extra: std::collections::HashMap::new(),
+                options: Default::default(),
             },
             res.role,
         );

--- a/crates/keystone/src/api/v3/role/list.rs
+++ b/crates/keystone/src/api/v3/role/list.rs
@@ -146,7 +146,8 @@ mod tests {
                 name: "2".into(),
                 extra: std::collections::HashMap::new(),
                 description: None,
-                domain_id: None
+                domain_id: None,
+                options: Default::default(),
             }],
             res.roles
         );

--- a/crates/keystone/src/api/v4/oauth2/token.rs
+++ b/crates/keystone/src/api/v4/oauth2/token.rs
@@ -1350,6 +1350,7 @@ mod tests {
                             description: None,
                             enabled: true,
                             extra: Default::default(),
+                            options: Default::default(),
                         },
                     ))
                     .roles(vec![RoleRef {
@@ -1568,6 +1569,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
         });
 

--- a/crates/keystone/src/k8s_auth/api/auth.rs
+++ b/crates/keystone/src/k8s_auth/api/auth.rs
@@ -210,6 +210,7 @@ fn derive_scope_from_authorizations(
                     description: None,
                     enabled: true,
                     extra: Default::default(),
+                    options: Default::default(),
                 };
                 let project = Project {
                     id: project_id.clone(),
@@ -220,6 +221,7 @@ fn derive_scope_from_authorizations(
                     is_domain: false,
                     parent_id: None,
                     extra: Default::default(),
+                    options: Default::default(),
                 };
                 Ok(ScopeInfo::Project {
                     project,
@@ -233,6 +235,7 @@ fn derive_scope_from_authorizations(
                     description: None,
                     enabled: true,
                     extra: Default::default(),
+                    options: Default::default(),
                 };
                 Ok(ScopeInfo::Domain(domain))
             }

--- a/crates/keystone/src/scim/group/create.rs
+++ b/crates/keystone/src/scim/group/create.rs
@@ -200,6 +200,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/group/delete.rs
+++ b/crates/keystone/src/scim/group/delete.rs
@@ -139,6 +139,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/group/list.rs
+++ b/crates/keystone/src/scim/group/list.rs
@@ -162,6 +162,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/group/patch.rs
+++ b/crates/keystone/src/scim/group/patch.rs
@@ -295,6 +295,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/group/show.rs
+++ b/crates/keystone/src/scim/group/show.rs
@@ -145,6 +145,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/group/update.rs
+++ b/crates/keystone/src/scim/group/update.rs
@@ -222,6 +222,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/user/create.rs
+++ b/crates/keystone/src/scim/user/create.rs
@@ -188,6 +188,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/user/delete.rs
+++ b/crates/keystone/src/scim/user/delete.rs
@@ -157,6 +157,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/user/list.rs
+++ b/crates/keystone/src/scim/user/list.rs
@@ -152,6 +152,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/user/patch.rs
+++ b/crates/keystone/src/scim/user/patch.rs
@@ -246,6 +246,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/user/show.rs
+++ b/crates/keystone/src/scim/user/show.rs
@@ -134,6 +134,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/keystone/src/scim/user/update.rs
+++ b/crates/keystone/src/scim/user/update.rs
@@ -166,6 +166,7 @@ mod tests {
                 description: None,
                 enabled: true,
                 extra: Default::default(),
+                options: Default::default(),
             }))
             .build()
             .unwrap();

--- a/crates/resource-driver-sql/src/domain/create.rs
+++ b/crates/resource-driver-sql/src/domain/create.rs
@@ -33,11 +33,15 @@ pub async fn create<C>(db: &C, domain: DomainCreate) -> Result<Domain, ResourceP
 where
     C: ConnectionTrait,
 {
-    TryInto::<db_project::ActiveModel>::try_into(domain)?
+    let options = domain.options.clone().unwrap_or_default();
+    let mut created: Domain = TryInto::<db_project::ActiveModel>::try_into(domain)?
         .insert(db)
         .await
         .context("persisting new domain data")?
-        .try_into()
+        .try_into()?;
+    crate::project_option::upsert(db, created.id.clone(), &options).await?;
+    created.options = options;
+    Ok(created)
 }
 
 #[cfg(test)]
@@ -60,6 +64,7 @@ mod tests {
             extra: std::collections::HashMap::new(),
             id: Some("1".into()),
             name: "name".into(),
+            options: None,
         };
 
         assert_eq!(

--- a/crates/resource-driver-sql/src/domain/get.rs
+++ b/crates/resource-driver-sql/src/domain/get.rs
@@ -60,13 +60,19 @@ pub async fn get_domain_by_id<I: AsRef<str>>(
     db: &DatabaseConnection,
     domain_id: I,
 ) -> Result<Option<Domain>, ResourceProviderError> {
-    DbProject::find_by_id(domain_id.as_ref())
+    let entry = DbProject::find_by_id(domain_id.as_ref())
         .filter(db_project::Column::IsDomain.eq(true))
         .one(db)
         .await
-        .context("fetching domain by id")?
-        .map(TryInto::try_into)
-        .transpose()
+        .context("fetching domain by id")?;
+    match entry {
+        Some(model) => {
+            let mut domain: Domain = model.try_into()?;
+            domain.options = crate::project_option::list_by_project_id(db, &domain.id).await?;
+            Ok(Some(domain))
+        }
+        None => Ok(None),
+    }
 }
 
 /// Get a domain by its name.
@@ -85,12 +91,18 @@ pub async fn get_domain_by_name<N: AsRef<str>>(
         .filter(db_project::Column::IsDomain.eq(true))
         .filter(db_project::Column::Name.eq(domain_name.as_ref()));
 
-    domain_select
+    let entry = domain_select
         .one(db)
         .await
-        .context("fetching domain by name")?
-        .map(TryInto::try_into)
-        .transpose()
+        .context("fetching domain by name")?;
+    match entry {
+        Some(model) => {
+            let mut domain: Domain = model.try_into()?;
+            domain.options = crate::project_option::list_by_project_id(db, &domain.id).await?;
+            Ok(Some(domain))
+        }
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]
@@ -105,6 +117,7 @@ mod tests {
     async fn test_get_by_name() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_domain_mock("1")]])
+            .append_query_results([Vec::<crate::entity::project_option::Model>::new()])
             .into_connection();
 
         assert_eq!(
@@ -115,12 +128,12 @@ mod tests {
             get_domain_mock("1").try_into().unwrap()
         );
         assert_eq!(
-            db.into_transaction_log(),
-            [Transaction::from_sql_and_values(
+            db.into_transaction_log()[0],
+            Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"SELECT "project"."id", "project"."name", "project"."extra", "project"."description", "project"."enabled", "project"."domain_id", "project"."parent_id", "project"."is_domain" FROM "project" WHERE "project"."is_domain" = $1 AND "project"."name" = $2 LIMIT $3"#,
                 [true.into(), "name".into(), 1u64.into()]
-            ),]
+            ),
         );
     }
 
@@ -128,6 +141,7 @@ mod tests {
     async fn test_get_by_id() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_domain_mock("1")]])
+            .append_query_results([Vec::<crate::entity::project_option::Model>::new()])
             .into_connection();
 
         assert_eq!(
@@ -138,13 +152,28 @@ mod tests {
             get_domain_mock("1").try_into().unwrap()
         );
         assert_eq!(
-            db.into_transaction_log(),
-            [Transaction::from_sql_and_values(
+            db.into_transaction_log()[0],
+            Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"SELECT "project"."id", "project"."name", "project"."extra", "project"."description", "project"."enabled", "project"."domain_id", "project"."parent_id", "project"."is_domain" FROM "project" WHERE "project"."id" = $1 AND "project"."is_domain" = $2 LIMIT $3"#,
                 ["1".into(), true.into(), 1u64.into()]
-            ),]
+            ),
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_by_id_merges_options() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_domain_mock("1")]])
+            .append_query_results([vec![crate::entity::project_option::Model {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let domain = get_domain_by_id(&db, "1").await.unwrap().unwrap();
+        assert_eq!(domain.options.immutable, Some(true));
     }
 
     #[tokio::test]

--- a/crates/resource-driver-sql/src/domain/list.rs
+++ b/crates/resource-driver-sql/src/domain/list.rs
@@ -19,10 +19,13 @@ use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::resource::ResourceProviderError;
-use openstack_keystone_core_types::resource::{Domain, DomainListParameters};
+use openstack_keystone_core_types::resource::{Domain, DomainListParameters, ProjectOptions};
 
 use crate::domain::NULL_DOMAIN_ID;
-use crate::entity::{prelude::Project as DbProject, project as db_project};
+use crate::entity::{
+    prelude::{Project as DbProject, ProjectOption},
+    project as db_project,
+};
 
 /// Prepare the paginated query for listing domains.
 ///
@@ -83,12 +86,22 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &DomainListParameters,
 ) -> Result<Vec<Domain>, ResourceProviderError> {
-    get_list_query(params)?
+    let rows = get_list_query(params)?
         .all(db)
         .await
-        .context("listing domains")?
-        .into_iter()
-        .map(TryInto::try_into)
+        .context("listing domains")?;
+    let options = rows
+        .load_many(ProjectOption, db)
+        .await
+        .context("fetching options of the listed domains")?;
+
+    rows.into_iter()
+        .zip(options)
+        .map(|(row, opts)| {
+            let mut domain: Domain = row.try_into()?;
+            domain.options = ProjectOptions::from_iter(opts);
+            Ok(domain)
+        })
         .collect()
 }
 
@@ -143,6 +156,7 @@ mod tests {
     async fn test_list_pagination_over_fetches_and_uses_marker() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_domain_mock("pid1"), get_domain_mock("pid2")]])
+            .append_query_results([Vec::<crate::entity::project_option::Model>::new()])
             .into_connection();
 
         let domains = list(
@@ -170,6 +184,7 @@ mod tests {
     async fn test_list() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_domain_mock("pid1")]])
+            .append_query_results([Vec::<crate::entity::project_option::Model>::new()])
             .into_connection();
 
         assert_eq!(
@@ -180,16 +195,32 @@ mod tests {
                 extra: std::collections::HashMap::new(),
                 id: "pid1".into(),
                 name: "name".into(),
+                options: Default::default(),
             }]
         );
 
         assert_eq!(
-            db.into_transaction_log(),
-            [Transaction::from_sql_and_values(
+            db.into_transaction_log()[0],
+            Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"SELECT "project"."id", "project"."name", "project"."extra", "project"."description", "project"."enabled", "project"."domain_id", "project"."parent_id", "project"."is_domain" FROM "project" WHERE "project"."is_domain" = $1 AND "project"."id" <> $2 ORDER BY "project"."id" ASC"#,
                 [true.into(), NULL_DOMAIN_ID.into()]
-            ),]
+            ),
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_merges_options() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_domain_mock("pid1")]])
+            .append_query_results([vec![crate::entity::project_option::Model {
+                project_id: "pid1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let domains = list(&db, &DomainListParameters::default()).await.unwrap();
+        assert_eq!(domains[0].options.immutable, Some(true));
     }
 }

--- a/crates/resource-driver-sql/src/domain/update.rs
+++ b/crates/resource-driver-sql/src/domain/update.rs
@@ -65,11 +65,18 @@ where
         update_model.extra = Set(Some(serde_json::to_string(&domain.extra)?));
     }
 
-    update_model
+    let mut updated: Domain = update_model
         .update(db)
         .await
         .context("updating domain")?
-        .try_into()
+        .try_into()?;
+
+    if let Some(opts) = domain.options {
+        crate::project_option::upsert(db, domain_id, &opts).await?;
+    }
+    updated.options = crate::project_option::list_by_project_id(db, domain_id).await?;
+
+    Ok(updated)
 }
 
 #[cfg(test)]
@@ -83,6 +90,7 @@ mod tests {
     async fn test_update() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_domain_mock("1")], vec![get_domain_mock("1")]])
+            .append_query_results([Vec::<crate::entity::project_option::Model>::new()])
             .into_connection();
 
         let req = DomainUpdate {
@@ -90,6 +98,7 @@ mod tests {
             enabled: Some(false),
             description: None,
             extra: Default::default(),
+            options: None,
         };
         let result = update(&db, "1", req).await.unwrap();
         assert_eq!(result, get_domain_mock("1").try_into().unwrap());
@@ -106,11 +115,43 @@ mod tests {
             enabled: None,
             description: None,
             extra: Default::default(),
+            options: None,
         };
         let result = update(&db, "missing", req).await;
         assert!(matches!(
             result,
             Err(ResourceProviderError::DomainNotFound(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn test_update_sets_immutable_option() {
+        use openstack_keystone_core_types::resource::ProjectOptions;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_domain_mock("1")], vec![get_domain_mock("1")]])
+            .append_query_results([vec![crate::entity::project_option::Model {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .append_query_results([vec![crate::entity::project_option::Model {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let req = DomainUpdate {
+            name: None,
+            enabled: None,
+            description: None,
+            extra: Default::default(),
+            options: Some(ProjectOptions {
+                immutable: Some(true),
+            }),
+        };
+        let result = update(&db, "1", req).await.unwrap();
+        assert_eq!(result.options.immutable, Some(true));
     }
 }

--- a/crates/resource-driver-sql/src/lib.rs
+++ b/crates/resource-driver-sql/src/lib.rs
@@ -26,6 +26,7 @@ use openstack_keystone_core_types::resource::*;
 mod domain;
 pub mod entity;
 mod project;
+mod project_option;
 
 #[derive(Default)]
 pub struct SqlBackend {}
@@ -315,6 +316,7 @@ impl SqlDriver for SqlBackend {
                     enabled: false,
                     id: Some(domain::NULL_DOMAIN_ID.into()),
                     name: domain::NULL_DOMAIN_ID.into(),
+                    options: None,
                 },
             )
             .await

--- a/crates/resource-driver-sql/src/project/create.rs
+++ b/crates/resource-driver-sql/src/project/create.rs
@@ -20,6 +20,7 @@ use openstack_keystone_core::resource::ResourceProviderError;
 use openstack_keystone_core_types::resource::{Project, ProjectCreate};
 
 use crate::entity::project as db_project;
+use crate::project_option;
 
 /// Create a new project.
 ///
@@ -33,11 +34,15 @@ pub async fn create<C>(db: &C, project: ProjectCreate) -> Result<Project, Resour
 where
     C: ConnectionTrait,
 {
-    TryInto::<db_project::ActiveModel>::try_into(project)?
+    let options = project.options.clone().unwrap_or_default();
+    let mut created: Project = TryInto::<db_project::ActiveModel>::try_into(project)?
         .insert(db)
         .await
         .context("persisting new project data")?
-        .try_into()
+        .try_into()?;
+    project_option::upsert(db, created.id.clone(), &options).await?;
+    created.options = options;
+    Ok(created)
 }
 
 #[cfg(test)]
@@ -62,6 +67,7 @@ mod tests {
             id: Some("1".into()),
             is_domain: false,
             name: "project_name".into(),
+            options: None,
             parent_id: Some("parent_id".into()),
         };
 
@@ -87,5 +93,36 @@ mod tests {
                 ]
             ),]
         );
+    }
+
+    #[tokio::test]
+    async fn test_create_with_immutable_option() {
+        use openstack_keystone_core_types::resource::ProjectOptions;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_project_mock("1")]])
+            .append_query_results([vec![crate::entity::project_option::Model {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let req = ProjectCreate {
+            description: None,
+            domain_id: Some("foo_domain".into()),
+            enabled: true,
+            extra: std::collections::HashMap::new(),
+            id: Some("1".into()),
+            is_domain: false,
+            name: "project_name".into(),
+            options: Some(ProjectOptions {
+                immutable: Some(true),
+            }),
+            parent_id: None,
+        };
+
+        let created = create(&db, req).await.unwrap();
+        assert_eq!(created.options.immutable, Some(true));
     }
 }

--- a/crates/resource-driver-sql/src/project/get.rs
+++ b/crates/resource-driver-sql/src/project/get.rs
@@ -42,7 +42,14 @@ pub async fn get_project<I: AsRef<str>>(
         .one(db)
         .await
         .context("fetching project by id")?;
-    project_entry.map(TryInto::try_into).transpose()
+    match project_entry {
+        Some(model) => {
+            let mut project: Project = model.try_into()?;
+            project.options = crate::project_option::list_by_project_id(db, &project.id).await?;
+            Ok(Some(project))
+        }
+        None => Ok(None),
+    }
 }
 
 /// Get a project by its name and domain ID.
@@ -69,5 +76,45 @@ pub async fn get_project_by_name<N: AsRef<str>, D: AsRef<str>>(
         .one(db)
         .await
         .context("fetching project by name and domain")?;
-    project_entry.map(TryInto::try_into).transpose()
+    match project_entry {
+        Some(model) => {
+            let mut project: Project = model.try_into()?;
+            project.options = crate::project_option::list_by_project_id(db, &project.id).await?;
+            Ok(Some(project))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    use super::*;
+    use crate::entity::project_option;
+    use crate::project::tests::get_project_mock;
+
+    #[tokio::test]
+    async fn test_get_project_merges_options() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_project_mock("1")]])
+            .append_query_results([vec![project_option::Model {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let project = get_project(&db, "1").await.unwrap().unwrap();
+        assert_eq!(project.options.immutable, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_get_project_not_found() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<db_project::Model>::new()])
+            .into_connection();
+
+        assert!(get_project(&db, "missing").await.unwrap().is_none());
+    }
 }

--- a/crates/resource-driver-sql/src/project/list.rs
+++ b/crates/resource-driver-sql/src/project/list.rs
@@ -19,9 +19,12 @@ use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::resource::ResourceProviderError;
-use openstack_keystone_core_types::resource::{Project, ProjectListParameters};
+use openstack_keystone_core_types::resource::{Project, ProjectListParameters, ProjectOptions};
 
-use crate::entity::{prelude::Project as DbProject, project as db_project};
+use crate::entity::{
+    prelude::{Project as DbProject, ProjectOption},
+    project as db_project,
+};
 
 /// Prepare the paginated query for listing projects.
 ///
@@ -84,12 +87,22 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &ProjectListParameters,
 ) -> Result<Vec<Project>, ResourceProviderError> {
-    get_list_query(params)?
+    let rows = get_list_query(params)?
         .all(db)
         .await
-        .context("listing projects")?
-        .into_iter()
-        .map(TryInto::try_into)
+        .context("listing projects")?;
+    let options = rows
+        .load_many(ProjectOption, db)
+        .await
+        .context("fetching options of the listed projects")?;
+
+    rows.into_iter()
+        .zip(options)
+        .map(|(row, opts)| {
+            let mut project: Project = row.try_into()?;
+            project.options = ProjectOptions::from_iter(opts);
+            Ok(project)
+        })
         .collect()
 }
 
@@ -164,6 +177,7 @@ mod tests {
     async fn test_list_pagination_over_fetches_and_uses_marker() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_project_mock("pid1"), get_project_mock("pid2")]])
+            .append_query_results([Vec::<crate::entity::project_option::Model>::new()])
             .into_connection();
 
         let projects = list(
@@ -191,6 +205,7 @@ mod tests {
     async fn test_list() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_project_mock("pid1")]])
+            .append_query_results([Vec::<crate::entity::project_option::Model>::new()])
             .into_connection();
 
         assert_eq!(
@@ -203,17 +218,33 @@ mod tests {
                 id: "pid1".into(),
                 is_domain: false,
                 name: "name".into(),
+                options: Default::default(),
                 parent_id: None,
             }]
         );
 
         assert_eq!(
-            db.into_transaction_log(),
-            [Transaction::from_sql_and_values(
+            db.into_transaction_log()[0],
+            Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"SELECT "project"."id", "project"."name", "project"."extra", "project"."description", "project"."enabled", "project"."domain_id", "project"."parent_id", "project"."is_domain" FROM "project" WHERE "project"."is_domain" = $1 ORDER BY "project"."id" ASC"#,
                 [false.into()]
-            ),]
+            ),
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_merges_options() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_project_mock("pid1")]])
+            .append_query_results([vec![crate::entity::project_option::Model {
+                project_id: "pid1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let projects = list(&db, &ProjectListParameters::default()).await.unwrap();
+        assert_eq!(projects[0].options.immutable, Some(true));
     }
 }

--- a/crates/resource-driver-sql/src/project/tree.rs
+++ b/crates/resource-driver-sql/src/project/tree.rs
@@ -102,6 +102,7 @@ mod tests {
                     description: Some("description".into()),
                     extra: std::collections::HashMap::new(),
                     is_domain: false,
+                    options: Default::default(),
                 },
                 Project {
                     id: "1".into(),
@@ -112,6 +113,7 @@ mod tests {
                     description: Some("description".into()),
                     extra: std::collections::HashMap::new(),
                     is_domain: false,
+                    options: Default::default(),
                 },
                 Project {
                     id: "domain_id".into(),
@@ -122,6 +124,7 @@ mod tests {
                     description: Some("description".into()),
                     extra: std::collections::HashMap::new(),
                     is_domain: false,
+                    options: Default::default(),
                 }
             ]
         );

--- a/crates/resource-driver-sql/src/project/update.rs
+++ b/crates/resource-driver-sql/src/project/update.rs
@@ -65,11 +65,18 @@ where
         update_model.extra = Set(Some(serde_json::to_string(&project.extra)?));
     }
 
-    update_model
+    let mut updated: Project = update_model
         .update(db)
         .await
         .context("updating project")?
-        .try_into()
+        .try_into()?;
+
+    if let Some(opts) = project.options {
+        crate::project_option::upsert(db, project_id, &opts).await?;
+    }
+    updated.options = crate::project_option::list_by_project_id(db, project_id).await?;
+
+    Ok(updated)
 }
 
 #[cfg(test)]
@@ -83,6 +90,7 @@ mod tests {
     async fn test_update() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_project_mock("1")], vec![get_project_mock("1")]])
+            .append_query_results([Vec::<crate::entity::project_option::Model>::new()])
             .into_connection();
 
         let req = ProjectUpdate {
@@ -90,6 +98,7 @@ mod tests {
             enabled: Some(false),
             description: None,
             extra: Default::default(),
+            options: None,
         };
         let result = update(&db, "1", req).await.unwrap();
         assert_eq!(result, get_project_mock("1").try_into().unwrap());
@@ -106,11 +115,43 @@ mod tests {
             enabled: None,
             description: None,
             extra: Default::default(),
+            options: None,
         };
         let result = update(&db, "missing", req).await;
         assert!(matches!(
             result,
             Err(ResourceProviderError::ProjectNotFound(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn test_update_sets_immutable_option() {
+        use openstack_keystone_core_types::resource::ProjectOptions;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_project_mock("1")], vec![get_project_mock("1")]])
+            .append_query_results([vec![crate::entity::project_option::Model {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .append_query_results([vec![crate::entity::project_option::Model {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let req = ProjectUpdate {
+            name: None,
+            enabled: None,
+            description: None,
+            extra: Default::default(),
+            options: Some(ProjectOptions {
+                immutable: Some(true),
+            }),
+        };
+        let result = update(&db, "1", req).await.unwrap();
+        assert_eq!(result.options.immutable, Some(true));
     }
 }

--- a/crates/resource-driver-sql/src/project_option.rs
+++ b/crates/resource-driver-sql/src/project_option.rs
@@ -1,0 +1,114 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use openstack_keystone_core_types::resource::ProjectOptions;
+
+use crate::entity::project_option;
+
+mod list;
+mod upsert;
+
+pub use list::list_by_project_id;
+pub use upsert::upsert;
+
+impl FromIterator<project_option::Model> for ProjectOptions {
+    fn from_iter<I: IntoIterator<Item = project_option::Model>>(iter: I) -> Self {
+        let mut project_opts: ProjectOptions = ProjectOptions::default();
+        for opt in iter.into_iter() {
+            if let ("IMMU", Some(val)) = (opt.option_id.as_str(), opt.option_value) {
+                project_opts.immutable = val.parse().ok();
+            }
+        }
+        project_opts
+    }
+}
+
+pub trait ProjectOptionIntoModelIterator {
+    fn to_model_iter<P: Into<String>>(
+        &self,
+        project_id: P,
+    ) -> impl IntoIterator<Item = project_option::Model>;
+}
+
+impl ProjectOptionIntoModelIterator for ProjectOptions {
+    /// Convert project options to a model iterator.
+    ///
+    /// # Parameters
+    /// - `project_id`: The project (or domain) ID.
+    ///
+    /// # Returns
+    /// An iterator of project option models.
+    fn to_model_iter<P: Into<String>>(
+        &self,
+        project_id: P,
+    ) -> impl IntoIterator<Item = project_option::Model> {
+        let mut res: Vec<project_option::Model> = Vec::new();
+        let pid = project_id.into();
+        if let Some(val) = &self.immutable {
+            res.push(project_option::Model {
+                project_id: pid.clone(),
+                option_id: "IMMU".into(),
+                option_value: Some(val.to_string()),
+            });
+        }
+        res
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::entity::project_option;
+
+    impl Default for project_option::Model {
+        fn default() -> Self {
+            Self {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_from_rows_empty() {
+        assert_eq!(
+            ProjectOptions::from_iter(Vec::<project_option::Model>::new()),
+            ProjectOptions::default()
+        );
+    }
+
+    #[test]
+    fn test_to_model_iter_immutable() {
+        let sot = ProjectOptions {
+            immutable: Some(true),
+        };
+        let rows = vec![project_option::Model {
+            project_id: "pid".into(),
+            option_id: "IMMU".into(),
+            option_value: Some("true".into()),
+        }];
+        assert_eq!(
+            sot.to_model_iter("pid").into_iter().collect::<Vec<_>>(),
+            rows
+        );
+        assert_eq!(sot, ProjectOptions::from_iter(rows));
+    }
+
+    #[test]
+    fn test_to_model_iter_unset() {
+        let sot = ProjectOptions::default();
+        assert!(sot.to_model_iter("pid").into_iter().next().is_none());
+    }
+}

--- a/crates/resource-driver-sql/src/project_option/list.rs
+++ b/crates/resource-driver-sql/src/project_option/list.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::ConnectionTrait;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::resource::ResourceProviderError;
+use openstack_keystone_core_types::resource::ProjectOptions;
+
+use crate::entity::{prelude::ProjectOption as DbProjectOption, project_option};
+
+/// List options of a project (or domain) by its ID.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `project_id`: The project (or domain) ID.
+///
+/// # Returns
+/// A `Result` containing `ProjectOptions` if successful, or an `Error`.
+#[tracing::instrument(skip_all)]
+pub async fn list_by_project_id<C, S>(
+    db: &C,
+    project_id: S,
+) -> Result<ProjectOptions, ResourceProviderError>
+where
+    C: ConnectionTrait,
+    S: AsRef<str>,
+{
+    Ok(ProjectOptions::from_iter(
+        DbProjectOption::find()
+            .filter(project_option::Column::ProjectId.eq(project_id.as_ref()))
+            .all(db)
+            .await
+            .context("fetching options of the project")?,
+    ))
+}

--- a/crates/resource-driver-sql/src/project_option/upsert.rs
+++ b/crates/resource-driver-sql/src/project_option/upsert.rs
@@ -1,0 +1,113 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::ConnectionTrait;
+use sea_orm::entity::*;
+use sea_orm::sea_query::OnConflict;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::resource::ResourceProviderError;
+use openstack_keystone_core_types::resource::ProjectOptions;
+
+use crate::entity::prelude::ProjectOption as DbProjectOption;
+use crate::entity::project_option as db_project_option;
+use crate::project_option::ProjectOptionIntoModelIterator;
+
+/// Upsert project (or domain) options.
+///
+/// Used both on creation (no existing rows can conflict) and on update
+/// (a previously-set option is overwritten in place), so the same conflict
+/// resolution path serves both callers.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `project_id`: The project (or domain) ID.
+/// - `opts`: The resource options to persist.
+///
+/// # Returns
+/// A `Result` containing `()` if successful, or an `Error`.
+#[tracing::instrument(skip_all)]
+pub async fn upsert<C, P>(
+    db: &C,
+    project_id: P,
+    opts: &ProjectOptions,
+) -> Result<(), ResourceProviderError>
+where
+    C: ConnectionTrait,
+    P: Into<String>,
+{
+    let rows: Vec<db_project_option::ActiveModel> = opts
+        .to_model_iter(project_id)
+        .into_iter()
+        .map(Into::<db_project_option::ActiveModel>::into)
+        .collect();
+    if !rows.is_empty() {
+        DbProjectOption::insert_many(rows)
+            .on_conflict(
+                OnConflict::columns([
+                    db_project_option::Column::ProjectId,
+                    db_project_option::Column::OptionId,
+                ])
+                .update_column(db_project_option::Column::OptionValue)
+                .to_owned(),
+            )
+            .exec(db)
+            .await
+            .context("upserting project options")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_upsert_empty_is_noop() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        upsert(&db, "1", &ProjectOptions::default()).await.unwrap();
+        assert_eq!(db.into_transaction_log(), []);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_immutable() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![db_project_option::Model {
+                project_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+        upsert(
+            &db,
+            "1",
+            &ProjectOptions {
+                immutable: Some(true),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"INSERT INTO "project_option" ("project_id", "option_id", "option_value") VALUES ($1, $2, $3) ON CONFLICT ("project_id", "option_id") DO UPDATE SET "option_value" = "excluded"."option_value" RETURNING "project_id", "option_id""#,
+                ["1".into(), "IMMU".into(), "true".into()]
+            ),]
+        );
+    }
+}

--- a/crates/role-driver-sql/src/lib.rs
+++ b/crates/role-driver-sql/src/lib.rs
@@ -29,6 +29,7 @@ use openstack_keystone_core_types::role::*;
 pub mod entity;
 mod implied_role;
 mod role;
+mod role_option;
 //mod role_imply;
 
 #[derive(Default)]
@@ -392,6 +393,7 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([Vec::<MockRow>::new()])
             .append_query_results([vec![get_role_mock("r1", "admin")]])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
 
         let mut roles = vec![RoleRef {
@@ -413,6 +415,7 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![mock_flat_imply("r1", "admin", "r2", "reader")]])
             .append_query_results([vec![get_role_mock("r1", "admin")]])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
 
         let mut roles = vec![RoleRef {
@@ -440,6 +443,7 @@ mod tests {
                 mock_flat_imply("r2", "member", "r3", "reader"),
             ]])
             .append_query_results([vec![get_role_mock("r1", "admin")]])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
 
         let mut roles = vec![RoleRef {
@@ -501,6 +505,7 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![mock_flat_imply("r2", "member", "r3", "reader")]])
             .append_query_results([vec![get_role_mock("r1", "admin")]])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
 
         let mut roles = vec![RoleRef {
@@ -521,6 +526,7 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([Vec::<MockRow>::new()])
             .append_query_results([vec![mock_role_with_domain("r1", "admin", "<<null>>")]])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
 
         let mut roles = vec![RoleRef {
@@ -541,6 +547,7 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![mock_flat_imply("r1", "admin", "r3", "viewer")]])
             .append_query_results([vec![get_role_mock("r1", "admin")]])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
 
         let mut roles = vec![

--- a/crates/role-driver-sql/src/role/create.rs
+++ b/crates/role-driver-sql/src/role/create.rs
@@ -30,11 +30,15 @@ use crate::entity::role as db_role;
 /// # Returns
 /// A `Result` containing the created `Role`, or an `Error`.
 pub async fn create(db: &DatabaseConnection, role: RoleCreate) -> Result<Role, RoleProviderError> {
-    TryInto::<db_role::ActiveModel>::try_into(role)?
+    let options = role.options.clone().unwrap_or_default();
+    let mut created: Role = TryInto::<db_role::ActiveModel>::try_into(role)?
         .insert(db)
         .await
         .context("creating role")?
-        .try_into()
+        .try_into()?;
+    crate::role_option::upsert(db, created.id.clone(), &options).await?;
+    created.options = options;
+    Ok(created)
 }
 
 #[cfg(test)]
@@ -64,6 +68,7 @@ mod tests {
             domain_id: Some("default".to_string()),
             description: Some("A role for testing".to_string()),
             extra: HashMap::from([("key".into(), json!("value"))]),
+            options: None,
         };
 
         let created = create(&db, role_create).await.unwrap();
@@ -94,6 +99,7 @@ mod tests {
             domain_id: None, // ← No domain
             description: None,
             extra: HashMap::new(),
+            options: None,
         };
 
         let created = create(&db, role_create).await.unwrap();
@@ -125,6 +131,7 @@ mod tests {
                 ("custom".into(), json!("data")),
                 ("count".into(), json!(42)),
             ]),
+            options: None,
         };
 
         let created = create(&db, role_create).await.unwrap();
@@ -132,5 +139,39 @@ mod tests {
         assert_eq!(created.name, "Role With Extra");
         assert_eq!(*created.extra.get("custom").unwrap(), json!("data"));
         assert_eq!(*created.extra.get("count").unwrap(), json!(42));
+    }
+
+    #[tokio::test]
+    async fn test_create_with_immutable_option() {
+        use openstack_keystone_core_types::role::RoleOptions;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![db_role::Model {
+                id: "role-1".into(),
+                domain_id: "default".into(),
+                name: "admin".into(),
+                description: None,
+                extra: None,
+            }]])
+            .append_query_results([vec![crate::entity::role_option::Model {
+                role_id: "role-1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let role_create = RoleCreate {
+            id: Some("role-1".to_string()),
+            name: "admin".to_string(),
+            domain_id: Some("default".to_string()),
+            description: None,
+            extra: HashMap::new(),
+            options: Some(RoleOptions {
+                immutable: Some(true),
+            }),
+        };
+
+        let created = create(&db, role_create).await.unwrap();
+        assert_eq!(created.options.immutable, Some(true));
     }
 }

--- a/crates/role-driver-sql/src/role/get.rs
+++ b/crates/role-driver-sql/src/role/get.rs
@@ -36,7 +36,14 @@ pub async fn get<I: AsRef<str>>(
     let role_select = DbRole::find_by_id(id.as_ref());
 
     let entry: Option<db_role::Model> = role_select.one(db).await.context("fetching role by id")?;
-    entry.map(TryInto::try_into).transpose()
+    match entry {
+        Some(model) => {
+            let mut role: Role = model.try_into()?;
+            role.options = crate::role_option::list_by_role_id(db, &role.id).await?;
+            Ok(Some(role))
+        }
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]
@@ -56,6 +63,7 @@ pub(super) mod tests {
                 // First query result - select user itself
                 vec![get_role_mock("1", "foo")],
             ])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
         assert_eq!(
             get(&db, "1").await.unwrap().unwrap(),
@@ -69,12 +77,27 @@ pub(super) mod tests {
 
         // Checking transaction log
         assert_eq!(
-            db.into_transaction_log(),
-            [Transaction::from_sql_and_values(
+            db.into_transaction_log()[0],
+            Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."id" = $1 LIMIT $2"#,
                 ["1".into(), 1u64.into()]
-            ),]
+            ),
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_merges_options() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_role_mock("1", "foo")]])
+            .append_query_results([vec![crate::entity::role_option::Model {
+                role_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let role = get(&db, "1").await.unwrap().unwrap();
+        assert_eq!(role.options.immutable, Some(true));
     }
 }

--- a/crates/role-driver-sql/src/role/list.rs
+++ b/crates/role-driver-sql/src/role/list.rs
@@ -19,9 +19,12 @@ use sea_orm::{Cursor, SelectModel};
 
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::role::RoleProviderError;
-use openstack_keystone_core_types::role::{Role, RoleListParameters};
+use openstack_keystone_core_types::role::{Role, RoleListParameters, RoleOptions};
 
-use crate::entity::{prelude::Role as DbRole, role as db_role};
+use crate::entity::{
+    prelude::{Role as DbRole, RoleOption},
+    role as db_role,
+};
 use crate::role::NULL_DOMAIN_ID;
 
 /// Prepare the paginated query for listing roles.
@@ -79,13 +82,23 @@ pub async fn list(
     db: &DatabaseConnection,
     params: &RoleListParameters,
 ) -> Result<Vec<Role>, RoleProviderError> {
-    get_list_query(params)?
+    let rows = get_list_query(params)?
         .all(db)
         .await
-        .context("listing roles")?
-        .into_iter()
-        .map(TryInto::<Role>::try_into)
-        .collect::<Result<Vec<Role>, _>>()
+        .context("listing roles")?;
+    let options = rows
+        .load_many(RoleOption, db)
+        .await
+        .context("fetching options of the listed roles")?;
+
+    rows.into_iter()
+        .zip(options)
+        .map(|(row, opts)| {
+            let mut role: Role = row.try_into()?;
+            role.options = RoleOptions::from_iter(opts);
+            Ok(role)
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -114,14 +127,17 @@ pub(super) mod tests {
                 // First query result - select user itself
                 vec![get_role_mock("1", "foo")],
             ])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .append_query_results([
                 // First query result - select user itself
                 vec![get_role_mock("1", "foo")],
             ])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .append_query_results([
                 // First query result - select user itself
                 vec![get_role_mock("1", "foo")],
             ])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
         assert!(list(&db, &RoleListParameters::default()).await.is_ok());
         assert_eq!(
@@ -155,26 +171,33 @@ pub(super) mod tests {
         .await
         .unwrap();
 
-        // Checking transaction log
+        // Checking transaction log (indices 0, 2, 4 are the main "role"
+        // queries; the interleaved odd indices are the `load_many` options
+        // lookups)
+        let log = db.into_transaction_log();
         assert_eq!(
-            db.into_transaction_log(),
-            [
-                Transaction::from_sql_and_values(
-                    DatabaseBackend::Postgres,
-                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" ORDER BY "role"."id" ASC"#,
-                    []
-                ),
-                Transaction::from_sql_and_values(
-                    DatabaseBackend::Postgres,
-                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."domain_id" = $1 AND "role"."name" = $2 ORDER BY "role"."id" ASC"#,
-                    ["foo_domain".into(), "foo".into()]
-                ),
-                Transaction::from_sql_and_values(
-                    DatabaseBackend::Postgres,
-                    r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."domain_id" = $1 ORDER BY "role"."id" ASC"#,
-                    [NULL_DOMAIN_ID.into()]
-                ),
-            ]
+            log[0],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" ORDER BY "role"."id" ASC"#,
+                []
+            ),
+        );
+        assert_eq!(
+            log[2],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."domain_id" = $1 AND "role"."name" = $2 ORDER BY "role"."id" ASC"#,
+                ["foo_domain".into(), "foo".into()]
+            ),
+        );
+        assert_eq!(
+            log[4],
+            Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "role"."id", "role"."name", "role"."extra", "role"."domain_id", "role"."description" FROM "role" WHERE "role"."domain_id" = $1 ORDER BY "role"."id" ASC"#,
+                [NULL_DOMAIN_ID.into()]
+            ),
         );
     }
 
@@ -182,6 +205,7 @@ pub(super) mod tests {
     async fn test_list_pagination_over_fetches_and_uses_marker() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![get_role_mock("1", "a"), get_role_mock("2", "b")]])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
 
         let roles = list(
@@ -203,5 +227,20 @@ pub(super) mod tests {
         let sql = &txns[0].statements()[0].sql;
         assert!(sql.contains(r#""role"."id" >"#));
         assert!(sql.contains("LIMIT"));
+    }
+
+    #[tokio::test]
+    async fn test_list_merges_options() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![get_role_mock("1", "foo")]])
+            .append_query_results([vec![crate::entity::role_option::Model {
+                role_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let roles = list(&db, &RoleListParameters::default()).await.unwrap();
+        assert_eq!(roles[0].options.immutable, Some(true));
     }
 }

--- a/crates/role-driver-sql/src/role/update.rs
+++ b/crates/role-driver-sql/src/role/update.rs
@@ -56,11 +56,18 @@ where
         update_model.extra = Set(Some(serde_json::to_string(&role.extra)?));
     }
 
-    update_model
+    let mut updated: Role = update_model
         .update(db)
         .await
         .context("updating role")?
-        .try_into()
+        .try_into()?;
+
+    if let Some(opts) = role.options {
+        crate::role_option::upsert(db, role_id, &opts).await?;
+    }
+    updated.options = crate::role_option::list_by_role_id(db, role_id).await?;
+
+    Ok(updated)
 }
 
 #[cfg(test)]
@@ -77,12 +84,14 @@ mod tests {
                 vec![get_role_mock("1", "foo")],
                 vec![get_role_mock("1", "new_name")],
             ])
+            .append_query_results([Vec::<crate::entity::role_option::Model>::new()])
             .into_connection();
 
         let req = RoleUpdate {
             name: Some("new_name".into()),
             description: None,
             extra: Default::default(),
+            options: None,
         };
         let result = update(&db, "1", req).await.unwrap();
         assert_eq!(result, get_role_mock("1", "new_name").try_into().unwrap());
@@ -98,8 +107,42 @@ mod tests {
             name: Some("new_name".into()),
             description: None,
             extra: Default::default(),
+            options: None,
         };
         let result = update(&db, "missing", req).await;
         assert!(matches!(result, Err(RoleProviderError::RoleNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_update_sets_immutable_option() {
+        use openstack_keystone_core_types::role::RoleOptions;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([
+                vec![get_role_mock("1", "foo")],
+                vec![get_role_mock("1", "foo")],
+            ])
+            .append_query_results([vec![crate::entity::role_option::Model {
+                role_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .append_query_results([vec![crate::entity::role_option::Model {
+                role_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+
+        let req = RoleUpdate {
+            name: None,
+            description: None,
+            extra: Default::default(),
+            options: Some(RoleOptions {
+                immutable: Some(true),
+            }),
+        };
+        let result = update(&db, "1", req).await.unwrap();
+        assert_eq!(result.options.immutable, Some(true));
     }
 }

--- a/crates/role-driver-sql/src/role_option.rs
+++ b/crates/role-driver-sql/src/role_option.rs
@@ -1,0 +1,114 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use openstack_keystone_core_types::role::RoleOptions;
+
+use crate::entity::role_option;
+
+mod list;
+mod upsert;
+
+pub use list::list_by_role_id;
+pub use upsert::upsert;
+
+impl FromIterator<role_option::Model> for RoleOptions {
+    fn from_iter<I: IntoIterator<Item = role_option::Model>>(iter: I) -> Self {
+        let mut role_opts: RoleOptions = RoleOptions::default();
+        for opt in iter.into_iter() {
+            if let ("IMMU", Some(val)) = (opt.option_id.as_str(), opt.option_value) {
+                role_opts.immutable = val.parse().ok();
+            }
+        }
+        role_opts
+    }
+}
+
+pub trait RoleOptionIntoModelIterator {
+    fn to_model_iter<R: Into<String>>(
+        &self,
+        role_id: R,
+    ) -> impl IntoIterator<Item = role_option::Model>;
+}
+
+impl RoleOptionIntoModelIterator for RoleOptions {
+    /// Convert role options to a model iterator.
+    ///
+    /// # Parameters
+    /// - `role_id`: The role ID.
+    ///
+    /// # Returns
+    /// An iterator of role option models.
+    fn to_model_iter<R: Into<String>>(
+        &self,
+        role_id: R,
+    ) -> impl IntoIterator<Item = role_option::Model> {
+        let mut res: Vec<role_option::Model> = Vec::new();
+        let rid = role_id.into();
+        if let Some(val) = &self.immutable {
+            res.push(role_option::Model {
+                role_id: rid.clone(),
+                option_id: "IMMU".into(),
+                option_value: Some(val.to_string()),
+            });
+        }
+        res
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::entity::role_option;
+
+    impl Default for role_option::Model {
+        fn default() -> Self {
+            Self {
+                role_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_from_rows_empty() {
+        assert_eq!(
+            RoleOptions::from_iter(Vec::<role_option::Model>::new()),
+            RoleOptions::default()
+        );
+    }
+
+    #[test]
+    fn test_to_model_iter_immutable() {
+        let sot = RoleOptions {
+            immutable: Some(true),
+        };
+        let rows = vec![role_option::Model {
+            role_id: "rid".into(),
+            option_id: "IMMU".into(),
+            option_value: Some("true".into()),
+        }];
+        assert_eq!(
+            sot.to_model_iter("rid").into_iter().collect::<Vec<_>>(),
+            rows
+        );
+        assert_eq!(sot, RoleOptions::from_iter(rows));
+    }
+
+    #[test]
+    fn test_to_model_iter_unset() {
+        let sot = RoleOptions::default();
+        assert!(sot.to_model_iter("rid").into_iter().next().is_none());
+    }
+}

--- a/crates/role-driver-sql/src/role_option/list.rs
+++ b/crates/role-driver-sql/src/role_option/list.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::ConnectionTrait;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::role::RoleProviderError;
+use openstack_keystone_core_types::role::RoleOptions;
+
+use crate::entity::{prelude::RoleOption as DbRoleOption, role_option};
+
+/// List options of a role by its ID.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `role_id`: The role ID.
+///
+/// # Returns
+/// A `Result` containing `RoleOptions` if successful, or an `Error`.
+#[tracing::instrument(skip_all)]
+pub async fn list_by_role_id<C, S>(db: &C, role_id: S) -> Result<RoleOptions, RoleProviderError>
+where
+    C: ConnectionTrait,
+    S: AsRef<str>,
+{
+    Ok(RoleOptions::from_iter(
+        DbRoleOption::find()
+            .filter(role_option::Column::RoleId.eq(role_id.as_ref()))
+            .all(db)
+            .await
+            .context("fetching options of the role")?,
+    ))
+}

--- a/crates/role-driver-sql/src/role_option/upsert.rs
+++ b/crates/role-driver-sql/src/role_option/upsert.rs
@@ -1,0 +1,109 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sea_orm::ConnectionTrait;
+use sea_orm::entity::*;
+use sea_orm::sea_query::OnConflict;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core::role::RoleProviderError;
+use openstack_keystone_core_types::role::RoleOptions;
+
+use crate::entity::prelude::RoleOption as DbRoleOption;
+use crate::entity::role_option as db_role_option;
+use crate::role_option::RoleOptionIntoModelIterator;
+
+/// Upsert role options.
+///
+/// Used both on creation (no existing rows can conflict) and on update
+/// (a previously-set option is overwritten in place), so the same conflict
+/// resolution path serves both callers.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `role_id`: The role ID.
+/// - `opts`: The resource options to persist.
+///
+/// # Returns
+/// A `Result` containing `()` if successful, or an `Error`.
+#[tracing::instrument(skip_all)]
+pub async fn upsert<C, R>(db: &C, role_id: R, opts: &RoleOptions) -> Result<(), RoleProviderError>
+where
+    C: ConnectionTrait,
+    R: Into<String>,
+{
+    let rows: Vec<db_role_option::ActiveModel> = opts
+        .to_model_iter(role_id)
+        .into_iter()
+        .map(Into::<db_role_option::ActiveModel>::into)
+        .collect();
+    if !rows.is_empty() {
+        DbRoleOption::insert_many(rows)
+            .on_conflict(
+                OnConflict::columns([
+                    db_role_option::Column::RoleId,
+                    db_role_option::Column::OptionId,
+                ])
+                .update_column(db_role_option::Column::OptionValue)
+                .to_owned(),
+            )
+            .exec(db)
+            .await
+            .context("upserting role options")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_upsert_empty_is_noop() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        upsert(&db, "1", &RoleOptions::default()).await.unwrap();
+        assert_eq!(db.into_transaction_log(), []);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_immutable() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![db_role_option::Model {
+                role_id: "1".into(),
+                option_id: "IMMU".into(),
+                option_value: Some("true".into()),
+            }]])
+            .into_connection();
+        upsert(
+            &db,
+            "1",
+            &RoleOptions {
+                immutable: Some(true),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"INSERT INTO "role_option" ("role_id", "option_id", "option_value") VALUES ($1, $2, $3) ON CONFLICT ("role_id", "option_id") DO UPDATE SET "option_value" = "excluded"."option_value" RETURNING "role_id", "option_id""#,
+                ["1".into(), "IMMU".into(), "true".into()]
+            ),]
+        );
+    }
+}

--- a/tests/api/tests/api_v3/resource/domain.rs
+++ b/tests/api/tests/api_v3/resource/domain.rs
@@ -17,6 +17,7 @@ use eyre::Result;
 use uuid::Uuid;
 
 use openstack_keystone_api_types::v3::domain::*;
+use openstack_keystone_api_types::v3::project::ProjectOptionsBuilder;
 use openstack_sdk::AsyncOpenStack;
 
 use test_api::guard::ResourceGuard;
@@ -81,6 +82,104 @@ async fn test_domain_list() -> Result<()> {
         "domain list should contain the created domain"
     );
     assert_eq!(domains[0].id, domain.id);
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_domain_create_immutable_option() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
+    let domain = create_domain(
+        &test_client,
+        DomainCreateBuilder::default()
+            .name(Uuid::new_v4().to_string())
+            .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+    assert_eq!(
+        domain.options.as_ref().and_then(|o| o.immutable),
+        Some(true)
+    );
+
+    let shown = get_domain(&test_client, &domain.id)
+        .await?
+        .expect("domain must be found");
+    assert_eq!(shown.options.as_ref().and_then(|o| o.immutable), Some(true));
+
+    // Clear immutable so the guard-driven cleanup does not fail.
+    update_domain(
+        &test_client,
+        &domain.id,
+        DomainUpdateBuilder::default()
+            .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_domain_update_blocked_when_immutable() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
+    let domain = create_domain(
+        &test_client,
+        DomainCreateBuilder::default()
+            .name(Uuid::new_v4().to_string())
+            .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+
+    let result = update_domain(
+        &test_client,
+        &domain.id,
+        DomainUpdateBuilder::default()
+            .name("updated_name")
+            .build()?,
+    )
+    .await;
+    assert!(result.is_err(), "update of an immutable domain is rejected");
+
+    update_domain(
+        &test_client,
+        &domain.id,
+        DomainUpdateBuilder::default()
+            .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_domain_delete_blocked_when_immutable() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
+    let domain = create_domain(
+        &test_client,
+        DomainCreateBuilder::default()
+            .name(Uuid::new_v4().to_string())
+            .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+
+    let result = delete_domain(&test_client, &domain.id).await;
+    assert!(result.is_err(), "delete of an immutable domain is rejected");
+
+    update_domain(
+        &test_client,
+        &domain.id,
+        DomainUpdateBuilder::default()
+            .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+
     domain.delete().await?;
     Ok(())
 }

--- a/tests/api/tests/api_v3/resource/project.rs
+++ b/tests/api/tests/api_v3/resource/project.rs
@@ -97,6 +97,117 @@ async fn test_project_list() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_project_create_immutable_option() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
+    let domain = create_test_domain(&test_client).await?;
+    let project = create_project(
+        &test_client,
+        ProjectCreateBuilder::default()
+            .name(Uuid::new_v4().to_string())
+            .domain_id(domain.id.clone())
+            .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+    assert_eq!(
+        project.options.as_ref().and_then(|o| o.immutable),
+        Some(true)
+    );
+
+    let shown = get_project(&test_client, &project.id).await?;
+    assert_eq!(shown.options.as_ref().and_then(|o| o.immutable), Some(true));
+
+    // Clear immutable so the guard-driven cleanup does not fail.
+    update_project(
+        &test_client,
+        &project.id,
+        ProjectUpdateBuilder::default()
+            .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+
+    project.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_project_update_blocked_when_immutable() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
+    let domain = create_test_domain(&test_client).await?;
+    let project = create_project(
+        &test_client,
+        ProjectCreateBuilder::default()
+            .name(Uuid::new_v4().to_string())
+            .domain_id(domain.id.clone())
+            .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+
+    let result = update_project(
+        &test_client,
+        &project.id,
+        ProjectUpdateBuilder::default()
+            .name("updated_name")
+            .build()?,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "update of an immutable project is rejected"
+    );
+
+    update_project(
+        &test_client,
+        &project.id,
+        ProjectUpdateBuilder::default()
+            .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+
+    project.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_project_delete_blocked_when_immutable() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
+    let domain = create_test_domain(&test_client).await?;
+    let project = create_project(
+        &test_client,
+        ProjectCreateBuilder::default()
+            .name(Uuid::new_v4().to_string())
+            .domain_id(domain.id.clone())
+            .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+
+    let result = delete_project(&test_client, &project.id).await;
+    assert!(
+        result.is_err(),
+        "delete of an immutable project is rejected"
+    );
+
+    update_project(
+        &test_client,
+        &project.id,
+        ProjectUpdateBuilder::default()
+            .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+
+    project.delete().await?;
+    domain.delete().await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_project_update() -> Result<()> {
     let test_client = Arc::new(AsyncOpenStack::new(&get_system_scope_config()?).await?);
     let domain = create_test_domain(&test_client).await?;

--- a/tests/api/tests/api_v3/role/create.rs
+++ b/tests/api/tests/api_v3/role/create.rs
@@ -35,3 +35,31 @@ async fn test_create() -> Result<()> {
     .await?;
     Ok(())
 }
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_with_immutable_option() -> Result<()> {
+    let test_client = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = uuid::Uuid::new_v4().to_string();
+    let role: Role = create_role(
+        &test_client,
+        RoleCreateBuilder::default()
+            .name(name)
+            .options(RoleOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+    assert_eq!(role.options.as_ref().and_then(|o| o.immutable), Some(true));
+
+    // Clear immutable so the resource can be deleted.
+    update_role(
+        &test_client,
+        &role.id,
+        RoleUpdateBuilder::default()
+            .options(RoleOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+    delete_role(&test_client, &role.id).await?;
+    Ok(())
+}

--- a/tests/api/tests/api_v3/role/delete.rs
+++ b/tests/api/tests/api_v3/role/delete.rs
@@ -38,3 +38,33 @@ async fn test_delete() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[traced_test]
+async fn test_delete_blocked_when_immutable() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("role_{}", Uuid::new_v4().simple());
+    let role: Role = create_role(
+        &tc,
+        RoleCreateBuilder::default()
+            .name(name)
+            .options(RoleOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+
+    let result = delete_role(&tc, &role.id).await;
+    assert!(result.is_err(), "delete of an immutable role is rejected");
+
+    update_role(
+        &tc,
+        &role.id,
+        RoleUpdateBuilder::default()
+            .options(RoleOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+    delete_role(&tc, &role.id).await?;
+
+    Ok(())
+}

--- a/tests/api/tests/api_v3/role/update.rs
+++ b/tests/api/tests/api_v3/role/update.rs
@@ -46,3 +46,38 @@ async fn test_update() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[traced_test]
+async fn test_update_blocked_when_immutable() -> Result<()> {
+    let tc = Arc::new(AsyncOpenStack::new(&CloudConfig::from_env()?).await?);
+    let name = format!("role_{}", Uuid::new_v4().simple());
+    let role: Role = create_role(
+        &tc,
+        RoleCreateBuilder::default()
+            .name(name)
+            .options(RoleOptionsBuilder::default().immutable(true).build()?)
+            .build()?,
+    )
+    .await?;
+
+    let result = update_role(
+        &tc,
+        &role.id,
+        RoleUpdateBuilder::default().name("updated_name").build()?,
+    )
+    .await;
+    assert!(result.is_err(), "update of an immutable role is rejected");
+
+    update_role(
+        &tc,
+        &role.id,
+        RoleUpdateBuilder::default()
+            .options(RoleOptionsBuilder::default().immutable(false).build()?)
+            .build()?,
+    )
+    .await?;
+    delete_role(&tc, &role.id).await?;
+
+    Ok(())
+}

--- a/tests/integration/src/resource/domain/create.rs
+++ b/tests/integration/src/resource/domain/create.rs
@@ -17,7 +17,9 @@ use eyre::Result;
 use tracing_test::traced_test;
 
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core_types::resource::DomainCreateBuilder;
+use openstack_keystone_core_types::resource::{
+    DomainCreateBuilder, DomainUpdateBuilder, ProjectOptionsBuilder,
+};
 
 use crate::common::get_state;
 
@@ -36,6 +38,49 @@ async fn test_create() -> Result<()> {
 
     assert_eq!(name, domain.name);
     assert!(domain.enabled);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_with_immutable_option() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+
+    let domain = state
+        .provider
+        .get_resource_provider()
+        .create_domain(
+            &ExecutionContext::internal(&state),
+            DomainCreateBuilder::default()
+                .name(uuid::Uuid::new_v4().simple().to_string())
+                .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    assert_eq!(domain.options.immutable, Some(true));
+
+    let fetched = state
+        .provider
+        .get_resource_provider()
+        .get_domain(&ExecutionContext::internal(&state), &domain.id)
+        .await?
+        .expect("domain should be there");
+    assert_eq!(fetched.options.immutable, Some(true));
+
+    // Clear immutable so the guard-driven cleanup does not fail.
+    state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
+
     Ok(())
 }
 

--- a/tests/integration/src/resource/domain/delete.rs
+++ b/tests/integration/src/resource/domain/delete.rs
@@ -19,12 +19,66 @@ use tracing_test::traced_test;
 use crate::common::get_state;
 use crate::create_domain;
 use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::resource::{DomainUpdateBuilder, ProjectOptionsBuilder};
 
 #[traced_test]
 #[tokio::test]
 async fn test_delete() -> Result<()> {
     let (state, _tmp) = get_state().await?;
     let domain = create_domain!(state)?;
+
+    state
+        .provider
+        .get_resource_provider()
+        .delete_domain(&ExecutionContext::internal(&state), &domain.id)
+        .await?;
+    assert!(
+        state
+            .provider
+            .get_resource_provider()
+            .get_domain(&ExecutionContext::internal(&state), &domain.id)
+            .await?
+            .is_none()
+    );
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_delete_blocked_when_immutable() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .delete_domain(&ExecutionContext::internal(&state), &domain.id)
+        .await;
+    assert!(result.is_err(), "delete of an immutable domain is rejected");
+
+    state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
 
     state
         .provider

--- a/tests/integration/src/resource/domain/update.rs
+++ b/tests/integration/src/resource/domain/update.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core_types::resource::DomainUpdateBuilder;
+use openstack_keystone_core_types::resource::{DomainUpdateBuilder, ProjectOptionsBuilder};
 
 use crate::common::get_state;
 use crate::create_domain;
@@ -52,6 +52,89 @@ async fn test_update() -> Result<()> {
         .expect("domain should still exist");
     assert_eq!(fetched.name, "updated_name");
     assert!(!fetched.enabled);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_blocked_when_immutable() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .name("updated_name")
+                .build()?,
+        )
+        .await;
+    assert!(result.is_err(), "update of an immutable domain is rejected");
+
+    state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_allowed_when_clearing_immutable() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    let updated = state
+        .provider
+        .get_resource_provider()
+        .update_domain(
+            &ExecutionContext::internal(&state),
+            &domain.id,
+            DomainUpdateBuilder::default()
+                .name("updated_name")
+                .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
+
+    assert_eq!(updated.name, "updated_name");
+    assert_eq!(updated.options.immutable, Some(false));
 
     Ok(())
 }

--- a/tests/integration/src/resource/project/create.rs
+++ b/tests/integration/src/resource/project/create.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core_types::resource::ProjectCreateBuilder;
+use openstack_keystone_core_types::resource::{ProjectCreateBuilder, ProjectOptionsBuilder};
 
 use crate::common::get_state;
 use crate::create_domain;
@@ -33,6 +33,51 @@ async fn test_create() -> Result<()> {
     assert!(!project.name.is_empty());
     assert_eq!(project.domain_id, domain.id);
     assert!(project.enabled);
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_create_with_immutable_option() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+
+    let project = state
+        .provider
+        .get_resource_provider()
+        .create_project(
+            &ExecutionContext::internal(&state),
+            ProjectCreateBuilder::default()
+                .name(uuid::Uuid::new_v4().simple().to_string())
+                .domain_id(domain.id.clone())
+                .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    assert_eq!(project.options.immutable, Some(true));
+
+    let fetched = state
+        .provider
+        .get_resource_provider()
+        .get_project(&ExecutionContext::internal(&state), &project.id)
+        .await?
+        .expect("project should be there");
+    assert_eq!(fetched.options.immutable, Some(true));
+
+    // Clear immutable so the guard-driven cleanup does not fail.
+    state
+        .provider
+        .get_resource_provider()
+        .update_project(
+            &ExecutionContext::internal(&state),
+            &project.id,
+            openstack_keystone_core_types::resource::ProjectUpdateBuilder::default()
+                .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
+
     Ok(())
 }
 

--- a/tests/integration/src/resource/project/update.rs
+++ b/tests/integration/src/resource/project/update.rs
@@ -17,7 +17,9 @@ use eyre::Result;
 use tracing_test::traced_test;
 
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core_types::resource::ProjectUpdateBuilder;
+use openstack_keystone_core_types::resource::{
+    ProjectCreateBuilder, ProjectOptionsBuilder, ProjectUpdateBuilder,
+};
 
 use crate::common::get_state;
 use crate::{create_domain, create_project};
@@ -53,6 +55,93 @@ async fn test_update() -> Result<()> {
         .expect("project should still exist");
     assert_eq!(fetched.name, "updated_name");
     assert!(!fetched.enabled);
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_blocked_when_immutable() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = state
+        .provider
+        .get_resource_provider()
+        .create_project(
+            &ExecutionContext::internal(&state),
+            ProjectCreateBuilder::default()
+                .name(uuid::Uuid::new_v4().simple().to_string())
+                .domain_id(domain.id.clone())
+                .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    let result = state
+        .provider
+        .get_resource_provider()
+        .update_project(
+            &ExecutionContext::internal(&state),
+            &project.id,
+            ProjectUpdateBuilder::default()
+                .name("updated_name")
+                .build()?,
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "update of an immutable project is rejected"
+    );
+
+    // Clear immutable so the guard-driven cleanup does not fail.
+    state
+        .provider
+        .get_resource_provider()
+        .update_project(
+            &ExecutionContext::internal(&state),
+            &project.id,
+            ProjectUpdateBuilder::default()
+                .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_allowed_when_clearing_immutable() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = state
+        .provider
+        .get_resource_provider()
+        .create_project(
+            &ExecutionContext::internal(&state),
+            ProjectCreateBuilder::default()
+                .name(uuid::Uuid::new_v4().simple().to_string())
+                .domain_id(domain.id.clone())
+                .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    let updated = state
+        .provider
+        .get_resource_provider()
+        .update_project(
+            &ExecutionContext::internal(&state),
+            &project.id,
+            ProjectUpdateBuilder::default()
+                .name("updated_name")
+                .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
+
+    assert_eq!(updated.name, "updated_name");
+    assert_eq!(updated.options.immutable, Some(false));
 
     Ok(())
 }

--- a/tests/integration/src/role.rs
+++ b/tests/integration/src/role.rs
@@ -26,6 +26,7 @@ use crate::common::*;
 use crate::impl_deleter;
 
 mod create;
+mod delete;
 mod imply_rules;
 mod list;
 mod update;

--- a/tests/integration/src/role/create.rs
+++ b/tests/integration/src/role/create.rs
@@ -16,6 +16,11 @@
 use eyre::Result;
 use uuid::Uuid;
 
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::role::{
+    RoleCreateBuilder, RoleOptionsBuilder, RoleUpdateBuilder,
+};
+
 use crate::common::get_state;
 use crate::create_role;
 
@@ -26,6 +31,49 @@ async fn test_create() -> Result<()> {
     let role = create_role!(state, name.clone())?;
 
     assert_eq!(name, role.name);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_create_with_immutable_option() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let name = Uuid::new_v4().to_string();
+
+    let role = state
+        .provider
+        .get_role_provider()
+        .create_role(
+            &ExecutionContext::internal(&state),
+            RoleCreateBuilder::default()
+                .name(name)
+                .options(RoleOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    assert_eq!(role.options.immutable, Some(true));
+
+    let fetched = state
+        .provider
+        .get_role_provider()
+        .get_role(&ExecutionContext::internal(&state), &role.id)
+        .await?
+        .expect("role should be there");
+    assert_eq!(fetched.options.immutable, Some(true));
+
+    // Clear immutable so the guard-driven cleanup does not fail.
+    state
+        .provider
+        .get_role_provider()
+        .update_role(
+            &ExecutionContext::internal(&state),
+            &role.id,
+            RoleUpdateBuilder::default()
+                .options(RoleOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
 
     Ok(())
 }

--- a/tests/integration/src/role/delete.rs
+++ b/tests/integration/src/role/delete.rs
@@ -11,36 +11,33 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Test project delete.
+//! Test role delete.
 
 use eyre::Result;
 use tracing_test::traced_test;
 
-use crate::common::get_state;
-use crate::create_domain;
-use crate::create_project;
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core_types::resource::{
-    ProjectCreateBuilder, ProjectOptionsBuilder, ProjectUpdateBuilder,
-};
+use openstack_keystone_core_types::role::{RoleOptionsBuilder, RoleUpdateBuilder};
+
+use crate::common::get_state;
+use crate::create_role;
 
 #[traced_test]
 #[tokio::test]
 async fn test_delete() -> Result<()> {
     let (state, _tmp) = get_state().await?;
-    let domain = create_domain!(state)?;
-    let project = create_project!(state, domain.id.clone())?;
+    let role = create_role!(state)?;
 
     state
         .provider
-        .get_resource_provider()
-        .delete_project(&ExecutionContext::internal(&state), &project.id)
+        .get_role_provider()
+        .delete_role(&ExecutionContext::internal(&state), &role.id)
         .await?;
     assert!(
         state
             .provider
-            .get_resource_provider()
-            .get_project(&ExecutionContext::internal(&state), &project.id)
+            .get_role_provider()
+            .get_role(&ExecutionContext::internal(&state), &role.id)
             .await?
             .is_none()
     );
@@ -51,52 +48,49 @@ async fn test_delete() -> Result<()> {
 #[tokio::test]
 async fn test_delete_blocked_when_immutable() -> Result<()> {
     let (state, _tmp) = get_state().await?;
-    let domain = create_domain!(state)?;
-    let project = state
+    let role = create_role!(state)?;
+
+    state
         .provider
-        .get_resource_provider()
-        .create_project(
+        .get_role_provider()
+        .update_role(
             &ExecutionContext::internal(&state),
-            ProjectCreateBuilder::default()
-                .name(uuid::Uuid::new_v4().simple().to_string())
-                .domain_id(domain.id.clone())
-                .options(ProjectOptionsBuilder::default().immutable(true).build()?)
+            &role.id,
+            RoleUpdateBuilder::default()
+                .options(RoleOptionsBuilder::default().immutable(true).build()?)
                 .build()?,
         )
         .await?;
 
     let result = state
         .provider
-        .get_resource_provider()
-        .delete_project(&ExecutionContext::internal(&state), &project.id)
+        .get_role_provider()
+        .delete_role(&ExecutionContext::internal(&state), &role.id)
         .await;
-    assert!(
-        result.is_err(),
-        "delete of an immutable project is rejected"
-    );
+    assert!(result.is_err(), "delete of an immutable role is rejected");
 
     state
         .provider
-        .get_resource_provider()
-        .update_project(
+        .get_role_provider()
+        .update_role(
             &ExecutionContext::internal(&state),
-            &project.id,
-            ProjectUpdateBuilder::default()
-                .options(ProjectOptionsBuilder::default().immutable(false).build()?)
+            &role.id,
+            RoleUpdateBuilder::default()
+                .options(RoleOptionsBuilder::default().immutable(false).build()?)
                 .build()?,
         )
         .await?;
 
     state
         .provider
-        .get_resource_provider()
-        .delete_project(&ExecutionContext::internal(&state), &project.id)
+        .get_role_provider()
+        .delete_role(&ExecutionContext::internal(&state), &role.id)
         .await?;
     assert!(
         state
             .provider
-            .get_resource_provider()
-            .get_project(&ExecutionContext::internal(&state), &project.id)
+            .get_role_provider()
+            .get_role(&ExecutionContext::internal(&state), &role.id)
             .await?
             .is_none()
     );

--- a/tests/integration/src/role/update.rs
+++ b/tests/integration/src/role/update.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use tracing_test::traced_test;
 
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core_types::role::RoleUpdateBuilder;
+use openstack_keystone_core_types::role::{RoleOptionsBuilder, RoleUpdateBuilder};
 
 use crate::common::get_state;
 use crate::create_role;
@@ -47,6 +47,87 @@ async fn test_update() -> Result<()> {
         .await?
         .expect("role should still exist");
     assert_eq!(fetched.name, "updated_name");
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_blocked_when_immutable() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let role = create_role!(state)?;
+
+    state
+        .provider
+        .get_role_provider()
+        .update_role(
+            &ExecutionContext::internal(&state),
+            &role.id,
+            RoleUpdateBuilder::default()
+                .options(RoleOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    let result = state
+        .provider
+        .get_role_provider()
+        .update_role(
+            &ExecutionContext::internal(&state),
+            &role.id,
+            RoleUpdateBuilder::default().name("updated_name").build()?,
+        )
+        .await;
+    assert!(result.is_err(), "update of an immutable role is rejected");
+
+    state
+        .provider
+        .get_role_provider()
+        .update_role(
+            &ExecutionContext::internal(&state),
+            &role.id,
+            RoleUpdateBuilder::default()
+                .options(RoleOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[traced_test]
+#[tokio::test]
+async fn test_update_allowed_when_clearing_immutable() -> Result<()> {
+    let (state, _tmp) = get_state().await?;
+    let role = create_role!(state)?;
+
+    state
+        .provider
+        .get_role_provider()
+        .update_role(
+            &ExecutionContext::internal(&state),
+            &role.id,
+            RoleUpdateBuilder::default()
+                .options(RoleOptionsBuilder::default().immutable(true).build()?)
+                .build()?,
+        )
+        .await?;
+
+    let updated = state
+        .provider
+        .get_role_provider()
+        .update_role(
+            &ExecutionContext::internal(&state),
+            &role.id,
+            RoleUpdateBuilder::default()
+                .name("updated_name")
+                .options(RoleOptionsBuilder::default().immutable(false).build()?)
+                .build()?,
+        )
+        .await?;
+
+    assert_eq!(updated.name, "updated_name");
+    assert_eq!(updated.options.immutable, Some(false));
 
     Ok(())
 }


### PR DESCRIPTION
Python Keystone's resource_options framework registers an `immutable`
option (id 0000) on project, domain, and role, blocking update/delete
unless a request explicitly clears it. This was previously unwired
here: the project_option/role_option DB tables existed but nothing
above the entity layer used them.

Adds ProjectOptions/RoleOptions core types, persists them through the
existing tables, exposes `options.immutable` on the v3 project, domain,
and role APIs, and enforces the block in the resource/role services
before update or delete, surfacing a 403 Forbidden.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
