### PR TITLE
feat: Auto-register backend drivers via inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,6 +4912,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "openstack-keystone-distributed-storage",
@@ -5000,6 +5001,7 @@ name = "openstack-keystone-auth-plugin-identity-driver-raft"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-distributed-storage",
  "tokio",
@@ -5288,6 +5290,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "eyre",
+ "inventory",
  "ldap3",
  "openstack-keystone-config",
  "openstack-keystone-core",
@@ -5427,6 +5430,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "openstack-keystone-distributed-storage",
@@ -5441,6 +5445,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "inventory",
  "openstack-keystone-audit",
  "openstack-keystone-config",
  "openstack-keystone-core",
@@ -5462,6 +5467,7 @@ name = "openstack-keystone-oauth2-session-driver-raft"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "openstack-keystone-distributed-storage",
@@ -5541,6 +5547,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "inventory",
  "openstack-keystone-core",
  "openstack-keystone-core-types",
  "openstack-keystone-distributed-storage",
@@ -5616,6 +5623,7 @@ dependencies = [
  "config",
  "criterion",
  "fernet",
+ "inventory",
  "itertools 0.15.0",
  "nix 0.31.3",
  "openstack-keystone-config",
@@ -5637,6 +5645,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "config",
+ "inventory",
  "jsonwebtoken",
  "openstack-keystone-config",
  "openstack-keystone-core",

--- a/crates/api-key-driver-raft/Cargo.toml
+++ b/crates/api-key-driver-raft/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, default-features = false, features = ["clock"] }
+inventory.workspace = true
 openstack-keystone-core.workspace = true
 openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage.workspace = true

--- a/crates/api-key-driver-raft/src/lib.rs
+++ b/crates/api-key-driver-raft/src/lib.rs
@@ -16,9 +16,12 @@
 use async_trait::async_trait;
 use chrono::Utc;
 
+use std::sync::Arc;
+
 use openstack_keystone_core::api_key::backend::ApiKeyBackend;
 use openstack_keystone_core::api_key::error::ApiKeyProviderError;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core_types::api_key::*;
 use openstack_keystone_distributed_storage::{
     Metadata, StorageApi, StoreDataEnvelope, StoreError, store_command::Mutation,
@@ -582,6 +585,16 @@ impl ApiKeyBackend for RaftBackend {
 /// members, keeping `inventory::submit!` sections visible at runtime.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn ApiKeyBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftBackend::default()) as Arc<dyn ApiKeyBackend>)
+        }),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/appcred-driver-sql/src/lib.rs
+++ b/crates/appcred-driver-sql/src/lib.rs
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone Application Credential SQL driver
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
 
@@ -20,6 +22,7 @@ use openstack_keystone_core::application_credential::{
     ApplicationCredentialProviderError, backend::ApplicationCredentialBackend,
 };
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
 };
@@ -43,6 +46,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn ApplicationCredentialBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn ApplicationCredentialBackend>)
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/assignment-driver-sql/src/lib.rs
+++ b/crates/assignment-driver-sql/src/lib.rs
@@ -14,6 +14,7 @@
 //! # Assignment driver to the OpenStack Keystone for the SQL database.
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
@@ -22,6 +23,7 @@ use openstack_keystone_core::assignment::{AssignmentProviderError, backend::Assi
 use openstack_keystone_core::db::create_table;
 use openstack_keystone_core::error::DatabaseError;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::{SqlDriver, SqlDriverRegistration};
 use openstack_keystone_core_types::assignment::*;
 
@@ -43,6 +45,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn AssignmentBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn AssignmentBackend>)
+        }),
+    }
 }
 
 impl SqlBackend {

--- a/crates/auth-plugin-identity-driver-raft/Cargo.toml
+++ b/crates/auth-plugin-identity-driver-raft/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-core.workspace = true
 openstack-keystone-distributed-storage.workspace = true
 tracing.workspace = true

--- a/crates/auth-plugin-identity-driver-raft/src/lib.rs
+++ b/crates/auth-plugin-identity-driver-raft/src/lib.rs
@@ -15,9 +15,12 @@
 //! index provider (ADR 0025 §4).
 use async_trait::async_trait;
 
+use std::sync::Arc;
+
 use openstack_keystone_core::auth_plugin_identity::backend::DynamicPluginIdentityBackend;
 use openstack_keystone_core::auth_plugin_identity::error::AuthPluginIdentityProviderError;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_distributed_storage::{
     Metadata, StorageApi, StoreError, store_command::Mutation,
 };
@@ -288,6 +291,16 @@ impl DynamicPluginIdentityBackend for RaftBackend {
 /// members, keeping `inventory::submit!` sections visible at runtime.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn DynamicPluginIdentityBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftBackend::default()) as Arc<dyn DynamicPluginIdentityBackend>)
+        }),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/catalog-driver-sql/src/lib.rs
+++ b/crates/catalog-driver-sql/src/lib.rs
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the catalog provider
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use sea_orm::entity::*;
 use sea_orm::query::*;
@@ -22,6 +24,7 @@ use openstack_keystone_core::catalog::CatalogProviderError;
 use openstack_keystone_core::catalog::backend::CatalogBackend;
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
 };
@@ -51,6 +54,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn CatalogBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn CatalogBackend>)
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/core/src/plugin_manager.rs
+++ b/crates/core/src/plugin_manager.rs
@@ -20,7 +20,12 @@
 //!
 //! The [PluginManagerApi] is responsible for picking the proper backend driver
 //! for the provider.
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+
+use openstack_keystone_config::Config;
 
 use crate::api_key::ApiKeyProviderError;
 use crate::api_key::backend::ApiKeyBackend;
@@ -66,6 +71,91 @@ use crate::token::backend::TokenBackend;
 use crate::token::backend::TokenRestrictionBackend;
 use crate::trust::TrustProviderError;
 use crate::trust::backend::TrustBackend;
+
+/// Future returned by a [`BackendRegistration::build`] constructor.
+pub type BuildFuture<B> = Pin<Box<dyn Future<Output = eyre::Result<Arc<B>>> + Send>>;
+
+/// A single driver's self-registration for backend kind `B` (e.g.
+/// `dyn IdentityBackend`), collected via `inventory` at link time.
+///
+/// Driver crates add themselves with `inventory::submit!` next to their
+/// backend implementation instead of `keystone::plugin_manager` calling
+/// out to them by name. See ADR-0018 for the linkage-anchor mechanism
+/// that keeps `submit!` sections from being stripped by the linker.
+pub struct BackendRegistration<B: ?Sized + 'static> {
+    /// Driver name this backend is registered under (e.g. `"sql"`,
+    /// `"raft"`, `"ldap"`).
+    pub name: &'static str,
+    /// Whether this driver should be built for the given configuration.
+    /// Always-on drivers (most `sql`/`raft` backends) use `|_| true`;
+    /// conditional drivers (e.g. `ldap`, `jws`) inspect `config`.
+    pub selected: fn(&Config) -> bool,
+    /// Constructs the backend. May perform real I/O (e.g. opening an
+    /// LDAP connection, loading signing keys) and fail.
+    pub build: fn(&Config) -> BuildFuture<B>,
+}
+
+/// Declares the `inventory` collection registry for one backend kind.
+///
+/// One invocation per `dyn XBackend` trait object type; must live in this
+/// crate since `inventory::collect!` defines the registry itself (driver
+/// crates only `inventory::submit!` into it).
+macro_rules! declare_backend_registry {
+    ($($ty:ty),+ $(,)?) => {
+        $(inventory::collect!(BackendRegistration<$ty>);)+
+    };
+}
+
+declare_backend_registry!(
+    dyn ApiKeyBackend,
+    dyn ApplicationCredentialBackend,
+    dyn AssignmentBackend,
+    dyn CatalogBackend,
+    dyn CredentialBackend,
+    dyn DynamicPluginIdentityBackend,
+    dyn FederationBackend,
+    dyn IdentityBackend,
+    dyn IdMappingBackend,
+    dyn MappingBackend,
+    dyn Oauth2ClientBackend,
+    dyn Oauth2KeyBackend,
+    dyn Oauth2SessionBackend,
+    dyn K8sAuthBackend,
+    dyn ResourceBackend,
+    dyn RevokeBackend,
+    dyn RoleBackend,
+    dyn ScimRealmBackend,
+    dyn ScimResourceBackend,
+    dyn TokenBackend,
+    dyn TokenRestrictionBackend,
+    dyn TrustBackend,
+);
+
+/// Builds and inserts every backend registered for kind `B` whose
+/// [`BackendRegistration::selected`] predicate accepts `config`.
+///
+/// # Errors
+/// - Propagates any error from a driver's `build` constructor.
+/// - Fails if two drivers of the same kind register under the same `name`
+///   (ambiguous selection at lookup time).
+pub async fn register_backends<B: ?Sized>(
+    config: &Config,
+    target: &mut HashMap<String, Arc<B>>,
+) -> eyre::Result<()>
+where
+    BackendRegistration<B>: inventory::Collect,
+{
+    for reg in inventory::iter::<BackendRegistration<B>> {
+        if (reg.selected)(config) {
+            if target.contains_key(reg.name) {
+                eyre::bail!("duplicate backend registration for driver \"{}\"", reg.name);
+            }
+            let backend = (reg.build)(config).await?;
+            target.insert(reg.name.to_string(), backend);
+        }
+    }
+    Ok(())
+}
 
 /// Plugin manager trait.
 pub trait PluginManagerApi {

--- a/crates/credential-driver-sql/src/lib.rs
+++ b/crates/credential-driver-sql/src/lib.rs
@@ -15,9 +15,13 @@
 //!
 //! Persists to the `credential` table.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
 
+use openstack_keystone_core::credential::backend::CredentialBackend;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
 };
@@ -51,6 +55,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn CredentialBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn CredentialBackend>)
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/federation-driver-sql/src/lib.rs
+++ b/crates/federation-driver-sql/src/lib.rs
@@ -43,12 +43,15 @@
 //! timestamp. The [`SqlBackend::cleanup`] method periodically removes expired
 //! records to prevent unbounded growth.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
 use sea_orm_migration::MigrationTrait;
 
 use openstack_keystone_core::federation::{FederationProviderError, backend::FederationBackend};
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
 };
@@ -78,6 +81,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn FederationBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn FederationBackend>)
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/identity-driver-ldap/Cargo.toml
+++ b/crates/identity-driver-ldap/Cargo.toml
@@ -14,6 +14,7 @@ exclude.workspace = true
 async-trait.workspace = true
 chrono = { workspace = true, features = ["now"] }
 eyre.workspace = true
+inventory.workspace = true
 ldap3.workspace = true
 openstack-keystone-config.workspace = true
 openstack-keystone-core.workspace = true

--- a/crates/identity-driver-ldap/src/lib.rs
+++ b/crates/identity-driver-ldap/src/lib.rs
@@ -24,11 +24,12 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use secrecy::SecretString;
 
-use openstack_keystone_config::LdapProvider;
+use openstack_keystone_config::{Config, LdapProvider};
 use openstack_keystone_core::auth::AuthenticationResult;
 use openstack_keystone_core::identity::IdentityProviderError;
 use openstack_keystone_core::identity::backend::IdentityBackend;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core_types::identity::*;
 
 mod authenticate;
@@ -110,6 +111,19 @@ impl LdapBackend {
 /// `PluginManager`.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn IdentityBackend> {
+        name: "ldap",
+        selected: |cfg: &Config| cfg.identity.driver == "ldap",
+        build: |cfg: &Config| {
+            let ldap_cfg = cfg.ldap.clone();
+            Box::pin(async move {
+                Ok(Arc::new(LdapBackend::new(&ldap_cfg).await?) as Arc<dyn IdentityBackend>)
+            })
+        },
+    }
+}
 
 #[async_trait]
 impl IdentityBackend for LdapBackend {

--- a/crates/identity-driver-sql/src/lib.rs
+++ b/crates/identity-driver-sql/src/lib.rs
@@ -13,6 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the identity provider
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -23,6 +24,7 @@ use openstack_keystone_core::auth::AuthenticationResult;
 use openstack_keystone_core::identity::IdentityProviderError;
 use openstack_keystone_core::identity::backend::IdentityBackend;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration,
     db::{create_index, create_table},
@@ -55,6 +57,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn IdentityBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn IdentityBackend>)
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/idmapping-driver-sql/src/lib.rs
+++ b/crates/idmapping-driver-sql/src/lib.rs
@@ -12,6 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the ID Mapping provider
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use sea_orm::{DatabaseConnection, Schema};
@@ -19,6 +21,7 @@ use sea_orm::{DatabaseConnection, Schema};
 use openstack_keystone_core::idmapping::IdMappingProviderError;
 use openstack_keystone_core::idmapping::backend::IdMappingBackend;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
 };
@@ -40,6 +43,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn IdMappingBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn IdMappingBackend>)
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/k8s-auth-driver-raft/src/lib.rs
+++ b/crates/k8s-auth-driver-raft/src/lib.rs
@@ -16,9 +16,12 @@ use std::collections::BTreeSet;
 
 use async_trait::async_trait;
 
+use std::sync::Arc;
+
 use openstack_keystone_core::k8s_auth::backend::K8sAuthBackend;
 use openstack_keystone_core::k8s_auth::error::K8sAuthProviderError;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core_types::k8s_auth::*;
 use openstack_keystone_distributed_storage::{
     Metadata, StorageApi, StoreDataEnvelope, StoreError, store_command::Mutation,
@@ -373,6 +376,16 @@ impl K8sAuthBackend for RaftBackend {
 /// members, keeping `inventory::submit!` sections visible at runtime.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn K8sAuthBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftBackend::default()) as Arc<dyn K8sAuthBackend>)
+        }),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/k8s-auth-driver-sql/src/lib.rs
+++ b/crates/k8s-auth-driver-sql/src/lib.rs
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the K8s auth provider
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
 use sea_orm_migration::MigrationTrait;
@@ -20,6 +22,7 @@ use sea_orm_migration::MigrationTrait;
 use openstack_keystone_core::k8s_auth::backend::K8sAuthBackend;
 use openstack_keystone_core::k8s_auth::error::K8sAuthProviderError;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
 };
@@ -33,6 +36,15 @@ pub mod migration;
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn K8sAuthBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn K8sAuthBackend>)
+        }),
+    }
 }
 
 /// Sql Database K8s auth backend.

--- a/crates/keystone/src/plugin_manager.rs
+++ b/crates/keystone/src/plugin_manager.rs
@@ -831,63 +831,15 @@ impl PluginManagerApi for PluginManager {
 }
 
 impl PluginManager {
-    /// Register default SQL drivers in the [PluginManager]
-    fn register_sql_drivers(&mut self) {
-        self.register_application_credential_backend(
-            "sql",
-            Arc::new(openstack_keystone_appcred_driver_sql::SqlBackend::default()),
-        );
-        self.register_assignment_backend(
-            "sql",
-            Arc::new(openstack_keystone_assignment_driver_sql::SqlBackend::default()),
-        );
-        self.register_catalog_backend(
-            "sql",
-            Arc::new(openstack_keystone_catalog_driver_sql::SqlBackend::default()),
-        );
-        self.register_credential_backend(
-            "sql",
-            Arc::new(openstack_keystone_credential_driver_sql::SqlBackend::default()),
-        );
-        self.register_federation_backend(
-            "sql",
-            Arc::new(openstack_keystone_federation_driver_sql::SqlBackend::default()),
-        );
-        self.register_identity_backend(
-            "sql",
-            Arc::new(openstack_keystone_identity_driver_sql::SqlBackend::default()),
-        );
-        self.register_idmapping_backend(
-            "sql",
-            Arc::new(openstack_keystone_idmapping_driver_sql::SqlBackend::default()),
-        );
-        self.register_k8s_auth_backend(
-            "sql",
-            Arc::new(openstack_keystone_k8s_auth_driver_sql::SqlBackend::default()),
-        );
-        self.register_resource_backend(
-            "sql",
-            Arc::new(openstack_keystone_resource_driver_sql::SqlBackend::default()),
-        );
-        self.register_revoke_backend(
-            "sql",
-            Arc::new(openstack_keystone_revoke_driver_sql::SqlBackend::default()),
-        );
-        self.register_role_backend(
-            "sql",
-            Arc::new(openstack_keystone_role_driver_sql::SqlBackend::default()),
-        );
-        self.register_token_restriction_backend(
-            "sql",
-            Arc::new(openstack_keystone_token_restriction_driver_sql::SqlBackend::default()),
-        );
-        self.register_trust_backend(
-            "sql",
-            Arc::new(openstack_keystone_trust_driver_sql::SqlBackend::default()),
-        );
-    }
-
     /// Initialize the [PluginManager] with the initialized [Config].
+    ///
+    /// Every backend kind is populated from the drivers that registered
+    /// themselves via `inventory::submit!` (see
+    /// `crates/core/src/plugin_manager.rs` and ADR-0018) — there is no
+    /// per-driver call site here. To add a new driver crate, add it as a
+    /// dependency of `keystone` (the `build.rs` linkage anchor picks it up
+    /// automatically) and have it `submit!` a `BackendRegistration` next to
+    /// its backend impl; nothing in this file needs to change.
     ///
     /// # Parameters
     /// * `config` - The configuration to use for initialization.
@@ -919,76 +871,28 @@ impl PluginManager {
             token_restriction_backends: HashMap::new(),
             trust_backends: HashMap::new(),
         };
-        slf.register_sql_drivers();
-        let mut fernet_token_provider =
-            openstack_keystone_token_driver_fernet::FernetTokenProvider::new(config.clone());
-        // Eagerly start the auto-refreshing key cache here, before the
-        // provider is erased behind `Arc<dyn TokenBackend>`: `decrypt`/
-        // `encrypt` are synchronous (called on every request) and require
-        // `load_keys` to have already run.
-        fernet_token_provider.load_keys().await?;
-        slf.register_token_backend("fernet", Arc::new(fernet_token_provider));
-        // Only load/register the JWS backend when actually selected: unlike
-        // Fernet (always eagerly loaded, ADR 0019), a `[jws_tokens]` key
-        // repository need not exist for a Fernet-only deployment, and
-        // eagerly requiring one would break every existing installation.
-        // When `[token] provider = jws` *is* selected, fail loudly here
-        // (ADR 0026 §10, Phase 0) rather than silently falling back to
-        // Fernet if the repository is empty or unloadable.
-        if config.token.provider == openstack_keystone_config::TokenProviderDriver::Jws {
-            let mut jws_token_provider =
-                openstack_keystone_token_driver_jws::JwsTokenProvider::new(config.clone());
-            jws_token_provider.load_keys().await?;
-            slf.register_token_backend("jws", Arc::new(jws_token_provider));
-        }
-        // Only construct the LDAP identity backend when actually selected:
-        // unlike the SQL backend (always eagerly registered above), this
-        // opens a real connection to an external directory server, which
-        // must not be attempted for a `driver = sql` deployment that never
-        // configured `[ldap]`. When `driver = "ldap"` *is* selected, fail
-        // loudly here (ADR-0027) rather than registering a backend that can
-        // never serve a request.
-        if config.identity.driver == "ldap" {
-            let ldap_backend =
-                openstack_keystone_identity_driver_ldap::LdapBackend::new(&config.ldap).await?;
-            slf.register_identity_backend("ldap", Arc::new(ldap_backend));
-        }
-        slf.register_k8s_auth_backend(
-            "raft",
-            Arc::new(openstack_keystone_k8s_auth_driver_raft::RaftBackend::default()),
-        );
-        slf.register_mapping_backend(
-            "raft",
-            Arc::new(openstack_keystone_mapping_driver_raft::RaftBackend::default()),
-        );
-        slf.register_oauth2_key_backend(
-            "raft",
-            Arc::new(openstack_keystone_oauth2_key_driver_raft::RaftOauth2KeyBackend::default()),
-        );
-        slf.register_oauth2_client_backend(
-            "raft",
-            Arc::new(
-                openstack_keystone_oauth2_client_driver_raft::RaftOauth2ClientBackend::default(),
-            ),
-        );
-        slf.register_oauth2_session_backend(
-            "raft",
-            Arc::new(
-                openstack_keystone_oauth2_session_driver_raft::RaftOauth2SessionBackend::default(),
-            ),
-        );
-        slf.register_api_key_backend(
-            "raft",
-            Arc::new(openstack_keystone_api_key_driver_raft::RaftBackend::default()),
-        );
-        let scim_raft_backend =
-            Arc::new(openstack_keystone_scim_driver_raft::RaftBackend::default());
-        slf.register_scim_realm_backend("raft", scim_raft_backend.clone());
-        slf.register_scim_resource_backend("raft", scim_raft_backend);
-        slf.register_auth_plugin_identity_backend(
-            "raft",
-            Arc::new(openstack_keystone_auth_plugin_identity_driver_raft::RaftBackend::default()),
-        );
+        register_backends(config, &mut slf.api_key_backends).await?;
+        register_backends(config, &mut slf.application_credential_backends).await?;
+        register_backends(config, &mut slf.assignment_backends).await?;
+        register_backends(config, &mut slf.catalog_backends).await?;
+        register_backends(config, &mut slf.credential_backends).await?;
+        register_backends(config, &mut slf.auth_plugin_identity_backends).await?;
+        register_backends(config, &mut slf.federation_backends).await?;
+        register_backends(config, &mut slf.identity_backends).await?;
+        register_backends(config, &mut slf.idmapping_backends).await?;
+        register_backends(config, &mut slf.mapping_backends).await?;
+        register_backends(config, &mut slf.oauth2_client_backends).await?;
+        register_backends(config, &mut slf.oauth2_key_backends).await?;
+        register_backends(config, &mut slf.oauth2_session_backends).await?;
+        register_backends(config, &mut slf.k8s_auth_backends).await?;
+        register_backends(config, &mut slf.resource_backends).await?;
+        register_backends(config, &mut slf.revoke_backends).await?;
+        register_backends(config, &mut slf.role_backends).await?;
+        register_backends(config, &mut slf.scim_realm_backends).await?;
+        register_backends(config, &mut slf.scim_resource_backends).await?;
+        register_backends(config, &mut slf.token_backends).await?;
+        register_backends(config, &mut slf.token_restriction_backends).await?;
+        register_backends(config, &mut slf.trust_backends).await?;
         Ok(slf)
     }
 }

--- a/crates/mapping-driver-raft/src/lib.rs
+++ b/crates/mapping-driver-raft/src/lib.rs
@@ -60,9 +60,12 @@ use std::collections::BTreeSet;
 
 use async_trait::async_trait;
 
+use std::sync::Arc;
+
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::mapping::backend::MappingBackend;
 use openstack_keystone_core::mapping::error::MappingProviderError;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core_types::mapping::*;
 use openstack_keystone_distributed_storage::{
     Metadata, StorageApi, StoreDataEnvelope, StoreError, store_command::Mutation,
@@ -1431,6 +1434,16 @@ impl MappingBackend for RaftBackend {
 /// members, keeping `inventory::submit!` sections visible at runtime.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn MappingBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftBackend::default()) as Arc<dyn MappingBackend>)
+        }),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/oauth2-client-driver-raft/Cargo.toml
+++ b/crates/oauth2-client-driver-raft/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, default-features = false, features = ["clock", "serde"] }
+inventory.workspace = true
 openstack-keystone-core.workspace = true
 openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage.workspace = true

--- a/crates/oauth2-client-driver-raft/src/lib.rs
+++ b/crates/oauth2-client-driver-raft/src/lib.rs
@@ -17,9 +17,12 @@ use async_trait::async_trait;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
+use std::sync::Arc;
+
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::oauth2_client::Oauth2ClientProviderError;
 use openstack_keystone_core::oauth2_client::backend::Oauth2ClientBackend;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core_types::oauth2_client::*;
 use openstack_keystone_distributed_storage::{
     ApiStoreError, Metadata, StorageApi, StoreDataEnvelope, StoreError, StoreResponse,
@@ -477,6 +480,16 @@ impl Oauth2ClientBackend for RaftOauth2ClientBackend {
 /// Linkage anchor -- see ADR-0018.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn Oauth2ClientBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftOauth2ClientBackend::default()) as Arc<dyn Oauth2ClientBackend>)
+        }),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/oauth2-key-driver-raft/Cargo.toml
+++ b/crates/oauth2-key-driver-raft/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, default-features = false, features = ["clock", "serde"] }
+inventory.workspace = true
 openstack-keystone-core.workspace = true
 openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage.workspace = true

--- a/crates/oauth2-key-driver-raft/src/lib.rs
+++ b/crates/oauth2-key-driver-raft/src/lib.rs
@@ -19,8 +19,11 @@ use async_trait::async_trait;
 use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 
+use std::sync::Arc;
+
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::oauth2_key::backend::Oauth2KeyBackend;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core_types::oauth2_key::{
     LocalEmergencyCandidateSummary, LocalEmergencyRotationInfo, Oauth2KeyProviderError,
     PendingRotationInfo,
@@ -1072,6 +1075,16 @@ impl Oauth2KeyBackend for RaftOauth2KeyBackend {
 /// Linkage anchor — see ADR-0018.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn Oauth2KeyBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftOauth2KeyBackend::default()) as Arc<dyn Oauth2KeyBackend>)
+        }),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/oauth2-session-driver-raft/Cargo.toml
+++ b/crates/oauth2-session-driver-raft/Cargo.toml
@@ -12,6 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+inventory.workspace = true
 openstack-keystone-core.workspace = true
 openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage.workspace = true

--- a/crates/oauth2-session-driver-raft/src/lib.rs
+++ b/crates/oauth2-session-driver-raft/src/lib.rs
@@ -30,9 +30,12 @@ use async_trait::async_trait;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+use std::sync::Arc;
+
 use openstack_keystone_core::keystone::ServiceState;
 use openstack_keystone_core::oauth2_session::Oauth2SessionProviderError;
 use openstack_keystone_core::oauth2_session::backend::Oauth2SessionBackend;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core_types::oauth2_session::*;
 use openstack_keystone_distributed_storage::{
     ApiStoreError as StoreError, Metadata, StorageApi, StoreDataEnvelope,
@@ -682,6 +685,16 @@ impl Oauth2SessionBackend for RaftOauth2SessionBackend {
 /// Linkage anchor — see ADR-0018.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn Oauth2SessionBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftOauth2SessionBackend::default()) as Arc<dyn Oauth2SessionBackend>)
+        }),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/resource-driver-sql/src/lib.rs
+++ b/crates/resource-driver-sql/src/lib.rs
@@ -13,10 +13,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the resource provider
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::resource::{ResourceProviderError, backend::ResourceBackend};
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
@@ -41,6 +44,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn ResourceBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn ResourceBackend>)
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/revoke-driver-sql/src/lib.rs
+++ b/crates/revoke-driver-sql/src/lib.rs
@@ -13,12 +13,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the revocation event provider
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::auth::ValidatedSecurityContext;
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::revoke::{RevokeProviderError, backend::RevokeBackend};
 use openstack_keystone_core::{
     SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
@@ -46,6 +49,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn RevokeBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn RevokeBackend>)
+        }),
+    }
 }
 
 impl From<db_revocation_event::Model> for RevocationEvent {

--- a/crates/role-driver-sql/src/lib.rs
+++ b/crates/role-driver-sql/src/lib.rs
@@ -13,12 +13,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the role provider
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::role::RoleProviderError;
 use openstack_keystone_core::role::backend::RoleBackend;
 use openstack_keystone_core::{
@@ -45,6 +47,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn RoleBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn RoleBackend>)
+        }),
+    }
 }
 
 /// Expand implied roles by resolving role inheritance and populating

--- a/crates/scim-driver-raft/Cargo.toml
+++ b/crates/scim-driver-raft/Cargo.toml
@@ -13,6 +13,7 @@ exclude.workspace = true
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, default-features = false, features = ["clock"] }
+inventory.workspace = true
 openstack-keystone-core.workspace = true
 openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage.workspace = true

--- a/crates/scim-driver-raft/src/lib.rs
+++ b/crates/scim-driver-raft/src/lib.rs
@@ -15,7 +15,10 @@
 use async_trait::async_trait;
 use chrono::Utc;
 
+use std::sync::Arc;
+
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::scim_realm::backend::ScimRealmBackend;
 use openstack_keystone_core::scim_realm::error::ScimRealmProviderError;
 use openstack_keystone_core::scim_resource::backend::ScimResourceBackend;
@@ -808,6 +811,26 @@ impl ScimResourceBackend for RaftBackend {
 /// members, keeping `inventory::submit!` sections visible at runtime.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn ScimRealmBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftBackend::default()) as Arc<dyn ScimRealmBackend>)
+        }),
+    }
+}
+
+inventory::submit! {
+    BackendRegistration::<dyn ScimResourceBackend> {
+        name: "raft",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(RaftBackend::default()) as Arc<dyn ScimResourceBackend>)
+        }),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/token-driver-fernet/Cargo.toml
+++ b/crates/token-driver-fernet/Cargo.toml
@@ -18,6 +18,7 @@ byteorder.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 fernet = { workspace = true, features = ["rustcrypto"] }
+inventory.workspace = true
 itertools.workspace = true
 openstack-keystone-config.workspace = true
 openstack-keystone-core.workspace = true

--- a/crates/token-driver-fernet/src/lib.rs
+++ b/crates/token-driver-fernet/src/lib.rs
@@ -34,6 +34,7 @@ use tracing::{trace, warn};
 use validator::Validate;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::token::{TokenProviderError, backend::TokenBackend};
 use openstack_keystone_core_types::token::*;
 //    application_credential::ApplicationCredentialPayload,
@@ -559,6 +560,23 @@ fn get_fernet_timestamp(payload: &str) -> Result<DateTime<Utc>, FernetDriverErro
 /// members, keeping `inventory::submit!` sections visible at runtime.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    // Always eagerly registered (ADR-0019): unlike jws, fernet keys are
+    // required for every deployment, so this driver is never conditional.
+    BackendRegistration::<dyn TokenBackend> {
+        name: "fernet",
+        selected: |_| true,
+        build: |cfg: &Config| Box::pin({
+            let cfg = cfg.clone();
+            async move {
+                let mut provider = FernetTokenProvider::new(cfg);
+                provider.load_keys().await?;
+                Ok(Arc::new(provider) as Arc<dyn TokenBackend>)
+            }
+        }),
+    }
+}
 
 #[cfg(feature = "bench_internals")]
 /// Conditionally expose the function when the 'bench_internals' feature is

--- a/crates/token-driver-jws/Cargo.toml
+++ b/crates/token-driver-jws/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace = true, features = ["now"] }
+inventory.workspace = true
 jsonwebtoken.workspace = true
 openstack-keystone-config.workspace = true
 openstack-keystone-core.workspace = true

--- a/crates/token-driver-jws/src/lib.rs
+++ b/crates/token-driver-jws/src/lib.rs
@@ -18,9 +18,11 @@
 //! roles, no catalog) — a token *format*, not the OP-issued
 //! `OpenStackAccessTokenClaims` later ADR 0026 phases introduce.
 use std::fmt;
+use std::sync::Arc;
 
 use jsonwebtoken::{Header, Validation, decode, encode};
-use openstack_keystone_config::Config;
+use openstack_keystone_config::{Config, TokenProviderDriver};
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::token::TokenProviderError;
 use openstack_keystone_core::token::backend::TokenBackend;
 use openstack_keystone_core_types::token::TokenPayload;
@@ -41,6 +43,24 @@ pub use openstack_keystone_key_repository::asymmetric::jwt_algorithm;
 /// members, keeping `inventory::submit!` sections visible at runtime.
 #[allow(dead_code)]
 pub fn anchor() {}
+
+inventory::submit! {
+    // Only registered when actually selected (ADR-0026 §10, Phase 0): unlike
+    // fernet, a `[jws_tokens]` key repository need not exist for a
+    // fernet-only deployment, so this driver must not be eagerly built.
+    BackendRegistration::<dyn TokenBackend> {
+        name: "jws",
+        selected: |cfg: &Config| cfg.token.provider == TokenProviderDriver::Jws,
+        build: |cfg: &Config| Box::pin({
+            let cfg = cfg.clone();
+            async move {
+                let mut provider = JwsTokenProvider::new(cfg);
+                provider.load_keys().await?;
+                Ok(Arc::new(provider) as Arc<dyn TokenBackend>)
+            }
+        }),
+    }
+}
 
 /// JWS token provider.
 pub struct JwsTokenProvider {

--- a/crates/token-restriction-driver-sql/src/lib.rs
+++ b/crates/token-restriction-driver-sql/src/lib.rs
@@ -12,11 +12,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the token restriction provider
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
 use sea_orm_migration::MigrationTrait;
 
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::token::TokenProviderError;
 use openstack_keystone_core::token::backend::TokenRestrictionBackend;
 use openstack_keystone_core::{
@@ -47,6 +50,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn TokenRestrictionBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn TokenRestrictionBackend>)
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/trust-driver-sql/src/lib.rs
+++ b/crates/trust-driver-sql/src/lib.rs
@@ -13,10 +13,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # OpenStack Keystone SQL driver for the Trust provider
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, Schema};
 
 use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
 use openstack_keystone_core::trust::TrustProviderError;
 use openstack_keystone_core::trust::backend::TrustBackend;
 use openstack_keystone_core::{
@@ -41,6 +44,15 @@ pub fn anchor() {}
 static PLUGIN: SqlBackend = SqlBackend {};
 inventory::submit! {
     SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn TrustBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn TrustBackend>)
+        }),
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
Replace the hand-maintained register_*_backend call sites in
plugin_manager.rs with inventory::submit! self-registration in each
driver crate, extending the linkage-anchor mechanism already built for
SqlDriverRegistration (ADR-0018). Adding a new driver crate no longer
requires editing plugin_manager.rs.

BackendRegistration<B> carries a name, a selected(&Config) predicate,
and an async build(&Config) constructor, so the mechanism uniformly
covers both always-on drivers (sql, raft) and conditional ones needing
real I/O (ldap, jws, fernet). Duplicate (kind, name) registration now
fails loudly at startup instead of silently overwriting.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
