### PR TITLE
feat(pagination): Add pagination to remaining places

### DIFF
--- a/crates/api-types/src/v3/role_assignment.rs
+++ b/crates/api-types/src/v3/role_assignment.rs
@@ -16,6 +16,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "validate")]
 use validator::Validate;
 
+use crate::Link;
+
 /// Assignment.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(
@@ -133,6 +135,10 @@ pub struct AssignmentList {
     /// Collection of role assignment objects.
     #[cfg_attr(feature = "validate", validate(nested))]
     pub role_assignments: Vec<Assignment>,
+
+    /// Pagination links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
 }
 
 /// List role assignments query parameters.

--- a/crates/api-types/src/v4/mapping/ruleset.rs
+++ b/crates/api-types/src/v4/mapping/ruleset.rs
@@ -510,13 +510,6 @@ pub struct MappingRuleSetListParameters {
     /// Filter by enabled/disabled state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-    /// Limit number of entries per page.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub limit: Option<u64>,
-    /// Page marker (ID of the last entry on the previous page).
-    #[cfg_attr(feature = "validate", validate(length(max = 64)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub marker: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-types/src/v4/mapping/ruleset_conv.rs
+++ b/crates/api-types/src/v4/mapping/ruleset_conv.rs
@@ -368,8 +368,7 @@ impl From<api::MappingRuleSetListParameters> for core::MappingRuleSetListParamet
         Self {
             domain_id: value.domain_id,
             enabled: value.enabled,
-            limit: value.limit,
-            marker: value.marker,
+            pagination: Default::default(),
         }
     }
 }

--- a/crates/assignment-driver-sql/src/lib.rs
+++ b/crates/assignment-driver-sql/src/lib.rs
@@ -314,8 +314,35 @@ impl AssignmentBackend for SqlBackend {
         request.targets(targets);
         request.actors(actors);
         request.resolve_implied_roles(params.resolve_implied_roles);
-        self.list_assignments_for_multiple_actors_and_targets(state, &request.build()?)
-            .await
+        let mut assignments = self
+            .list_assignments_for_multiple_actors_and_targets(state, &request.build()?)
+            .await?;
+
+        // No SQL cursor is possible here: results are a union of two queries
+        // (regular + system assignments) plus in-memory implied-role
+        // expansion, so pagination is applied post-fetch over the fully
+        // materialized, expanded set - the same in-memory over-fetch pattern
+        // used by the Raft-backed domains.
+        assignments.sort_by(|a, b| a.pagination_marker().cmp(&b.pagination_marker()));
+        if let Some(marker) = &params.pagination.marker {
+            if params.pagination.page_reverse {
+                assignments.retain(|x| x.pagination_marker().as_str() < marker.as_str());
+            } else {
+                assignments.retain(|x| x.pagination_marker().as_str() > marker.as_str());
+            }
+        }
+        if let Some(limit) = params.pagination.limit {
+            let limit = (limit + 1) as usize;
+            if params.pagination.page_reverse {
+                if assignments.len() > limit {
+                    assignments = assignments.split_off(assignments.len() - limit);
+                }
+            } else {
+                assignments.truncate(limit);
+            }
+        }
+
+        Ok(assignments)
     }
 
     /// Revoke assignment grant.
@@ -700,5 +727,100 @@ mod tests {
             "in {:?}",
             res
         );
+    }
+
+    /// `list_assignments` cannot push a cursor into SQL (union of two
+    /// queries + in-memory implied-role expansion), so pagination is applied
+    /// post-fetch: sorted by the composite marker, over-fetching by one row
+    /// to let the caller detect a next page without a false positive.
+    #[tokio::test]
+    async fn test_list_assignments_pagination_over_fetches_and_uses_marker() {
+        use openstack_keystone_core_types::ListPagination;
+        use openstack_keystone_core_types::assignment::RoleAssignmentListParametersBuilder;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![
+                get_role_assignment_mock("1"),
+                get_role_assignment_mock("2"),
+                get_role_assignment_mock("3"),
+            ]])
+            .append_query_results([vec![] as Vec<entity::system_assignment::Model>])
+            .into_connection();
+
+        let provider = Provider::mocked_builder().build().unwrap();
+        let state = get_mock_state(db, provider).await;
+
+        let sot = SqlBackend {};
+        let res = sot
+            .list_assignments(
+                &state,
+                &RoleAssignmentListParametersBuilder::default()
+                    .group_id("scim-group")
+                    .pagination(ListPagination {
+                        limit: Some(1),
+                        marker: None,
+                        page_reverse: false,
+                    })
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Over-fetched by one (limit + 1): role "1" then "2", role "3" trimmed.
+        assert_eq!(2, res.len(), "{:?}", res);
+        assert_eq!("1", res[0].role_id);
+        assert_eq!("2", res[1].role_id);
+    }
+
+    #[tokio::test]
+    async fn test_list_assignments_pagination_marker_filters_prior_page() {
+        use openstack_keystone_core_types::ListPagination;
+        use openstack_keystone_core_types::assignment::RoleAssignmentListParametersBuilder;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![
+                get_role_assignment_mock("1"),
+                get_role_assignment_mock("2"),
+                get_role_assignment_mock("3"),
+            ]])
+            .append_query_results([vec![] as Vec<entity::system_assignment::Model>])
+            .into_connection();
+
+        let provider = Provider::mocked_builder().build().unwrap();
+        let state = get_mock_state(db, provider).await;
+
+        let marker = Assignment {
+            role_id: "1".into(),
+            role_name: None,
+            actor_id: "actor".into(),
+            target_id: "target".into(),
+            r#type: AssignmentType::UserProject,
+            inherited: false,
+            implied_via: None,
+        }
+        .pagination_marker();
+
+        let sot = SqlBackend {};
+        let res = sot
+            .list_assignments(
+                &state,
+                &RoleAssignmentListParametersBuilder::default()
+                    .group_id("scim-group")
+                    .pagination(ListPagination {
+                        limit: Some(5),
+                        marker: Some(marker),
+                        page_reverse: false,
+                    })
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Only rows sorting strictly after the marker's role "1" remain.
+        assert_eq!(2, res.len(), "{:?}", res);
+        assert_eq!("2", res[0].role_id);
+        assert_eq!("3", res[1].role_id);
     }
 }

--- a/crates/config/src/assignment.rs
+++ b/crates/config/src/assignment.rs
@@ -14,6 +14,7 @@
 use serde::Deserialize;
 
 use crate::common::default_sql_driver;
+use crate::pagination::ListLimitConfig;
 
 /// Assignment Provider.
 #[derive(Debug, Deserialize, Clone)]
@@ -21,12 +22,17 @@ pub struct AssignmentProvider {
     /// Assignment provider driver.
     #[serde(default = "default_sql_driver")]
     pub driver: String,
+
+    /// `GET /v3/role_assignments` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for AssignmentProvider {
     fn default() -> Self {
         Self {
             driver: default_sql_driver(),
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/config/src/mapping.rs
+++ b/crates/config/src/mapping.rs
@@ -15,6 +15,7 @@ use secrecy::SecretString;
 use serde::Deserialize;
 
 use crate::common::default_raft_driver;
+use crate::pagination::ListLimitConfig;
 
 /// Mapping provider.
 #[derive(Debug, Deserialize, Clone)]
@@ -33,6 +34,10 @@ pub struct MappingProvider {
     /// security posture.
     #[serde(default)]
     pub cluster_salt: Option<SecretString>,
+
+    /// `GET /v4/mapping/rulesets` pagination limits.
+    #[serde(default)]
+    pub list_limit: ListLimitConfig,
 }
 
 impl Default for MappingProvider {
@@ -40,6 +45,7 @@ impl Default for MappingProvider {
         Self {
             driver: default_raft_driver(),
             cluster_salt: None,
+            list_limit: ListLimitConfig::default(),
         }
     }
 }

--- a/crates/core-types/src/assignment/assignment.rs
+++ b/crates/core-types/src/assignment/assignment.rs
@@ -13,6 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    ListPagination,
     error::BuilderError,
     role::{RoleRef, RoleRefBuilder},
 };
@@ -53,6 +54,29 @@ pub struct Assignment {
     /// Assignment through the role inference rules.
     #[builder(default)]
     pub implied_via: Option<String>,
+}
+
+impl Assignment {
+    /// Build a stable, opaque marker string uniquely identifying this
+    /// assignment for cursor pagination.
+    ///
+    /// Assignments have no single `id` column: they are composite-keyed on
+    /// `(type, actor_id, target_id, role_id, inherited, implied_via)` — the
+    /// same tuple `resolve_implied_roles()` already uses for deduplication
+    /// (full struct equality). `implied_via` must be included because two
+    /// distinct prior roles can each imply the same `role_id` for the same
+    /// actor/target, producing two rows that would otherwise collide.
+    pub fn pagination_marker(&self) -> String {
+        format!(
+            "{}:{}:{}:{}:{}:{}",
+            self.r#type,
+            self.actor_id,
+            self.target_id,
+            self.role_id,
+            self.inherited,
+            self.implied_via.as_deref().unwrap_or("")
+        )
+    }
 }
 
 impl TryInto<RoleRef> for Assignment {
@@ -286,6 +310,10 @@ pub struct RoleAssignmentListParameters {
     /// are also included in the results.
     #[builder(default)]
     pub resolve_implied_roles: bool,
+
+    /// Pagination modifiers (limit/marker/page_reverse).
+    #[builder(default)]
+    pub pagination: ListPagination,
 }
 
 /// Querying effective role assignments for list of actors (typically user with

--- a/crates/core-types/src/mapping/ruleset.rs
+++ b/crates/core-types/src/mapping/ruleset.rs
@@ -18,6 +18,7 @@ use validator::Validate;
 
 use super::resolution::{DomainResolutionMode, IdentitySource};
 use super::rule::MappingRule;
+use crate::ListPagination;
 
 /// A complete mapping ruleset stored in the distributed store.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Validate)]
@@ -99,11 +100,8 @@ pub struct MappingRuleSetListParameters {
     /// Filter by enabled/disabled state.
     pub enabled: Option<bool>,
 
-    /// Limit number of entries per page.
-    pub limit: Option<u64>,
-
-    /// Page marker (ID of the last entry on the previous page).
-    pub marker: Option<String>,
+    /// Pagination parameters.
+    pub pagination: ListPagination,
 }
 
 impl From<MappingRuleSetCreate> for MappingRuleSet {

--- a/crates/keystone/src/api/v3/role_assignment/list.rs
+++ b/crates/keystone/src/api/v3/role_assignment/list.rs
@@ -14,13 +14,17 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 
+use openstack_keystone_api_types::PaginationQuery;
+use openstack_keystone_core_types::ListPagination;
+
 use crate::api::auth::Auth;
+use crate::api::common::paginate_forward;
 use crate::api::error::KeystoneApiError;
 use crate::api::v3::role_assignment::types::{
     Assignment, AssignmentList, RoleAssignmentListParameters,
@@ -32,7 +36,7 @@ use openstack_keystone_core::auth::ExecutionContext;
 #[utoipa::path(
     get,
     path = "/role_assignments",
-    params(RoleAssignmentListParameters),
+    params(RoleAssignmentListParameters, PaginationQuery),
     description = "List roles",
     responses(
         (status = OK, description = "List of role assignments", body = AssignmentList),
@@ -47,7 +51,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 )]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<RoleAssignmentListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     state
@@ -59,21 +65,37 @@ pub(super) async fn list(
             None,
         )
         .await?;
-    let assignments: Result<Vec<Assignment>, _> = state
+
+    let config = state.config_manager.config.read().await;
+    let mut provider_params: openstack_keystone_core_types::assignment::RoleAssignmentListParameters =
+        query.try_into()?;
+    provider_params.pagination = ListPagination {
+        // v3 stays python-keystone compatible: forward-only, no page_reverse.
+        limit: config.resolve_list_limit(&config.assignment.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: false,
+    };
+
+    let raw_assignments = state
         .provider
         .get_assignment_provider()
         .list_role_assignments(
             &ExecutionContext::from_auth(&state, &user_auth),
-            &query.try_into()?,
+            &provider_params,
         )
-        .await?
-        .into_iter()
-        .map(TryInto::try_into)
-        .collect();
+        .await?;
+
+    let (raw_assignments, links) =
+        paginate_forward(&config, raw_assignments, &pagination, original_url.path())?;
+
+    let assignments: Result<Vec<Assignment>, _> =
+        raw_assignments.into_iter().map(TryInto::try_into).collect();
+
     Ok((
         StatusCode::OK,
         Json(AssignmentList {
             role_assignments: assignments?,
+            links,
         }),
     )
         .into_response())
@@ -175,6 +197,7 @@ mod tests {
                     user_id: Some("user1".into()),
                     project_id: Some("project1".into()),
                     resolve_implied_roles: true,
+                    pagination: qp.pagination.clone(),
                     ..Default::default()
                 } == *qp
             })
@@ -198,6 +221,7 @@ mod tests {
                     user_id: Some("user2".into()),
                     domain_id: Some("domain2".into()),
                     resolve_implied_roles: true,
+                    pagination: qp.pagination.clone(),
                     ..Default::default()
                 } == *qp
             })
@@ -220,6 +244,7 @@ mod tests {
                     group_id: Some("group3".into()),
                     project_id: Some("project3".into()),
                     resolve_implied_roles: true,
+                    pagination: qp.pagination.clone(),
                     ..Default::default()
                 } == *qp
             })
@@ -291,5 +316,122 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link
+    /// is produced and the extra row trimmed. v3 never emits `previous`.
+    #[tokio::test]
+    async fn test_list_pagination_link() {
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, qp: &RoleAssignmentListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![
+                    Assignment {
+                        role_id: "1".into(),
+                        role_name: None,
+                        actor_id: "actor".into(),
+                        target_id: "target".into(),
+                        r#type: AssignmentType::UserProject,
+                        inherited: false,
+                        implied_via: None,
+                    },
+                    Assignment {
+                        role_id: "2".into(),
+                        role_name: None,
+                        actor_id: "actor".into(),
+                        target_id: "target".into(),
+                        r#type: AssignmentType::UserProject,
+                        inherited: false,
+                        implied_via: None,
+                    },
+                ])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_assignment(assignment_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/role_assignments?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiAssignmentList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.role_assignments.len(), 1);
+        assert!(res.links.is_some());
+        assert_eq!(res.links.as_ref().unwrap().len(), 1);
+        assert_eq!(res.links.as_ref().unwrap()[0].rel, "next");
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let mut assignment_mock = MockAssignmentProvider::default();
+        assignment_mock
+            .expect_list_role_assignments()
+            .withf(|_, qp: &RoleAssignmentListParameters| qp.pagination.limit == Some(1))
+            .returning(|_, _| {
+                Ok(vec![Assignment {
+                    role_id: "1".into(),
+                    role_name: None,
+                    actor_id: "actor".into(),
+                    target_id: "target".into(),
+                    r#type: AssignmentType::UserProject,
+                    inherited: false,
+                    implied_via: None,
+                }])
+            });
+
+        let vsc = test_fixture_scoped();
+        let state = get_mocked_state(
+            Provider::mocked_builder().mock_assignment(assignment_mock),
+            true,
+            None,
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/role_assignments?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: ApiAssignmentList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.role_assignments.len(), 1);
+        assert_eq!(res.links, None);
     }
 }

--- a/crates/keystone/src/api/v3/role_assignment/types.rs
+++ b/crates/keystone/src/api/v3/role_assignment/types.rs
@@ -14,6 +14,14 @@
 
 pub use openstack_keystone_api_types::v3::role_assignment::*;
 
+impl crate::api::common::ResourceIdentifier
+    for openstack_keystone_core_types::assignment::Assignment
+{
+    fn get_id(&self) -> String {
+        self.pagination_marker()
+    }
+}
+
 //use crate::api::error::KeystoneApiError;
 //use crate::assignment::types;
 //

--- a/crates/keystone/src/api/v4/mapping/ruleset/list.rs
+++ b/crates/keystone/src/api/v4/mapping/ruleset/list.rs
@@ -15,28 +15,37 @@
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{OriginalUri, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde_json::json;
 
+use openstack_keystone_api_types::PaginationQuery;
 use openstack_keystone_api_types::v4::mapping::{
     MappingRuleSet, MappingRuleSetList, MappingRuleSetListParameters,
 };
+use openstack_keystone_core_types::ListPagination;
 use openstack_keystone_core_types::mapping::MappingRuleSetListParameters as ProviderMappingRuleSetListParameters;
 
 use crate::api::auth::Auth;
+use crate::api::common::{ResourceIdentifier, paginate_bidirectional};
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 use openstack_keystone_core::auth::ExecutionContext;
+
+impl ResourceIdentifier for MappingRuleSet {
+    fn get_id(&self) -> String {
+        self.mapping_id.clone()
+    }
+}
 
 /// List mapping rulesets.
 #[utoipa::path(
     get,
     path = "/",
     operation_id = "/mapping_ruleset:list",
-    params(MappingRuleSetListParameters),
+    params(MappingRuleSetListParameters, PaginationQuery),
     responses(
         (status = OK, description = "List of rulesets", body = MappingRuleSetList),
     ),
@@ -51,7 +60,9 @@ use openstack_keystone_core::auth::ExecutionContext;
 )]
 pub(super) async fn list(
     Auth(user_auth): Auth,
+    OriginalUri(original_url): OriginalUri,
     Query(query): Query<MappingRuleSetListParameters>,
+    Query(pagination): Query<PaginationQuery>,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
     let res = state
@@ -64,6 +75,7 @@ pub(super) async fn list(
         )
         .await?;
 
+    let config = state.config_manager.config.read().await;
     let mut provider_list_params: ProviderMappingRuleSetListParameters = query.into();
 
     if provider_list_params.domain_id.is_none()
@@ -71,6 +83,11 @@ pub(super) async fn list(
     {
         provider_list_params.domain_id = user_auth.principal().domain_id();
     }
+    provider_list_params.pagination = ListPagination {
+        limit: config.resolve_list_limit(&config.mapping.list_limit, pagination.limit),
+        marker: pagination.marker.clone(),
+        page_reverse: pagination.page_reverse,
+    };
 
     let rulesets: Vec<MappingRuleSet> = state
         .provider
@@ -84,14 +101,10 @@ pub(super) async fn list(
         .map(Into::into)
         .collect();
 
-    Ok((
-        StatusCode::OK,
-        Json(MappingRuleSetList {
-            mappings: rulesets,
-            links: None,
-        }),
-    )
-        .into_response())
+    let (mappings, links) =
+        paginate_bidirectional(&config, rulesets, &pagination, original_url.path())?;
+
+    Ok((StatusCode::OK, Json(MappingRuleSetList { mappings, links })).into_response())
 }
 
 #[cfg(test)]
@@ -159,6 +172,100 @@ mod tests {
         let res: MappingRuleSetList = serde_json::from_slice(&body).unwrap();
         assert_eq!(res.mappings.len(), 1);
         assert_eq!(res.mappings[0].mapping_id, "test-ruleset");
+    }
+
+    fn ruleset_with_mapping_id(mapping_id: &str) -> provider_types::MappingRuleSet {
+        provider_types::MappingRuleSet {
+            mapping_id: mapping_id.into(),
+            ..sample_ruleset_core()
+        }
+    }
+
+    /// Backend over-fetched (returned `limit + 1 == 2` rows), not the first
+    /// page (`marker` set): both `next` and `previous` links are produced,
+    /// and the extra row is trimmed from the response body.
+    #[tokio::test]
+    async fn test_list_pagination_bidirectional_links() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockMappingProvider::default();
+        mock.expect_list_rulesets()
+            .withf(|_, qp: &provider_types::MappingRuleSetListParameters| {
+                qp.pagination.limit == Some(1) && qp.pagination.marker == Some("m".into())
+            })
+            .returning(|_, _| {
+                Ok(vec![
+                    ruleset_with_mapping_id("ruleset-1"),
+                    ruleset_with_mapping_id("ruleset-2"),
+                ])
+            });
+        let provider = Provider::mocked_builder().mock_mapping(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1&marker=m")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: MappingRuleSetList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.mappings.len(), 1);
+        assert_eq!(res.mappings[0].mapping_id, "ruleset-1");
+        let links = res.links.expect("expected next+previous links");
+        assert!(links.iter().any(|l| l.rel == "next"));
+        assert!(links.iter().any(|l| l.rel == "previous"));
+    }
+
+    /// Backend returned exactly `limit` rows (no over-fetched extra row): no
+    /// `next` link should be produced.
+    #[tokio::test]
+    async fn test_list_pagination_no_false_positive_next() {
+        let vsc = test_fixture_scoped();
+        let mut mock = MockMappingProvider::default();
+        mock.expect_list_rulesets()
+            .withf(|_, qp: &provider_types::MappingRuleSetListParameters| {
+                qp.pagination.limit == Some(1)
+            })
+            .returning(|_, _| Ok(vec![sample_ruleset_core()]));
+        let provider = Provider::mocked_builder().mock_mapping(mock);
+
+        let state = get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?limit=1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: MappingRuleSetList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(res.mappings.len(), 1);
+        assert_eq!(res.links, None);
     }
 
     #[tokio::test]

--- a/crates/mapping-driver-raft/src/lib.rs
+++ b/crates/mapping-driver-raft/src/lib.rs
@@ -625,6 +625,25 @@ impl RaftBackend {
                 }
             }
         }
+
+        res.sort_by(|a, b| a.mapping_id.cmp(&b.mapping_id));
+        if let Some(marker) = &params.pagination.marker {
+            if params.pagination.page_reverse {
+                res.retain(|x| x.mapping_id.as_str() < marker.as_str());
+            } else {
+                res.retain(|x| x.mapping_id.as_str() > marker.as_str());
+            }
+        }
+        if let Some(limit) = params.pagination.limit {
+            let limit = (limit + 1) as usize;
+            if params.pagination.page_reverse {
+                if res.len() > limit {
+                    res = res.split_off(res.len() - limit);
+                }
+            } else {
+                res.truncate(limit);
+            }
+        }
         Ok(res)
     }
 
@@ -1820,6 +1839,68 @@ mod tests {
         let result = backend.list_rulesets_impl(&storage, &params).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_rulesets_pagination_over_fetches_and_uses_marker() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .create_ruleset_impl(&storage, make_ruleset("rs-a", Some("domain-1"), true))
+            .await
+            .unwrap();
+        backend
+            .create_ruleset_impl(&storage, make_ruleset("rs-b", Some("domain-1"), true))
+            .await
+            .unwrap();
+        backend
+            .create_ruleset_impl(&storage, make_ruleset("rs-c", Some("domain-1"), true))
+            .await
+            .unwrap();
+        let params = MappingRuleSetListParameters {
+            pagination: openstack_keystone_core_types::ListPagination {
+                limit: Some(1),
+                marker: Some("rs-a".to_string()),
+                page_reverse: false,
+            },
+            ..MappingRuleSetListParameters::default()
+        };
+        let result = backend.list_rulesets_impl(&storage, &params).await.unwrap();
+        // limit+1 == 2 rows returned so the caller can detect a next page,
+        // and the marker excludes rs-a (already seen on the previous page).
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].mapping_id, "rs-b");
+        assert_eq!(result[1].mapping_id, "rs-c");
+    }
+
+    #[tokio::test]
+    async fn test_list_rulesets_pagination_reverse() {
+        let backend = RaftBackend::default();
+        let storage = MockStorage::default();
+        backend
+            .create_ruleset_impl(&storage, make_ruleset("rs-a", Some("domain-1"), true))
+            .await
+            .unwrap();
+        backend
+            .create_ruleset_impl(&storage, make_ruleset("rs-b", Some("domain-1"), true))
+            .await
+            .unwrap();
+        backend
+            .create_ruleset_impl(&storage, make_ruleset("rs-c", Some("domain-1"), true))
+            .await
+            .unwrap();
+        let params = MappingRuleSetListParameters {
+            pagination: openstack_keystone_core_types::ListPagination {
+                limit: Some(1),
+                marker: Some("rs-c".to_string()),
+                page_reverse: true,
+            },
+            ..MappingRuleSetListParameters::default()
+        };
+        let result = backend.list_rulesets_impl(&storage, &params).await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].mapping_id, "rs-a");
+        assert_eq!(result[1].mapping_id, "rs-b");
     }
 
     // ---------------------------------------------------------------------------

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -117,3 +117,4 @@
     - [OAuth2 / OIDC Provider](adr/0026-oauth2-oidc-provider.md)
     - [LDAP identity backend](adr/0027-ldap-identity-driver.md)
     - [Quorum-Bypass Emergency Operations](adr/0028-oauth2-quorum-bypass-emergency-rotation.md)
+    - [Generalized Pagination](adr/0029-pagination.md)

--- a/doc/src/adr/0029-pagination.md
+++ b/doc/src/adr/0029-pagination.md
@@ -1,0 +1,171 @@
+# 29. Generalized Marker Pagination for v3/v4 List Endpoints
+
+**Date:** 2026-07-24
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #308 asked for consistent, python-keystone-compatible pagination across
+all list endpoints. Two domains (federation `identity_provider`, ADR 0007)
+already had a first-cut implementation before this ADR, but it had real gaps:
+
+- **False-positive `next` link.** The original `build_pagination_links()`
+  inferred "more pages exist" purely from `data.len() >= limit`. If the table
+  had exactly `limit` rows left, it wrongly emitted a `next` link to an empty
+  page.
+- **No config-driven limit resolution.** Nothing mirrored python-keystone's
+  `Hints.get_limit_with_default` precedence chain (user limit → per-resource
+  default → global `list_limit` → absolute `max_db_limit`).
+- **Duplicated fields per domain.** The existing code hand-rolled
+  `limit`/`marker` fields directly on each domain's list-parameters struct
+  instead of a single shared, reusable pagination type.
+
+Real python-keystone (`keystone/common/driver_hints.py`, the `@truncated`
+decorator, `keystone/server/flask/common.py` `wrap_collection`) avoids the
+false-positive by always fetching `limit + 1` rows and trimming the extra one
+off before returning — that is the mechanism this design replicates. It's
+also worth noting real upstream `wrap_collection` hardcodes
+`links: {next, self, previous: null}` — `previous` is never computed, and
+there's no working `page_reverse` anywhere in current upstream. So
+byte-for-byte v3 compatibility (OSC, keystoneclient) only requires
+forward-marker paging with `previous` always absent/null. v4 is our own API,
+not constrained by OSC compatibility, so it gets real bidirectional paging.
+
+`serde_urlencoded` (what axum's `Query<T>` extractor uses) does not support
+`#[serde(flatten)]` on typed numeric fields — `limit: Option<u64>` flattened
+into an outer struct fails to deserialize `"limit=10"` with a type-coercion
+error, because flatten forces buffering through `serde::private::de::Content`,
+which loses string-to-number coercion. A single shared pagination struct is
+still achievable without flatten: axum allows a handler to take **two
+independent `Query<T>` extractors** against the same request — each runs its
+own `serde_urlencoded::from_str` over the full query string and silently
+ignores fields it doesn't declare. This is the mechanism used throughout.
+
+## Decision
+
+### Shared types
+
+- **`PaginationQuery`** (`crates/api-types/src/lib.rs`): `{ limit: Option<u64>,
+  marker: Option<String>, page_reverse: bool }`. Taken as a **second,
+  independent** `Query<PaginationQuery>` extractor in every v3 and v4 list
+  handler, alongside each domain's existing (unchanged) filter-only params
+  struct. v3 handlers accept `page_reverse` in the query string (harmless,
+  ignored) but never read or forward it — only v4 handlers wire it through.
+- **`ListPagination`** (`crates/core-types/src/lib.rs`): `{ limit: Option<u64>,
+  marker: Option<String>, page_reverse: bool }`. Embedded as a single named
+  field, `pub pagination: ListPagination`, on every domain's
+  `*ListParameters` struct — replacing what would otherwise be three
+  duplicated fields per domain.
+- **`ResourceIdentifier`** trait (`crates/keystone/src/api/common.rs`):
+  `fn get_id(&self) -> String`. Implemented once per domain, normally on the
+  API-facing response type (the type actually returned to the handler after
+  provider conversion). See "RoleAssignment" below for the one domain that
+  deviates from this.
+
+### Over-fetch-and-trim helpers (`crates/keystone/src/api/common.rs`)
+
+Two functions, both generic over `T: ResourceIdentifier`:
+
+- **`paginate_forward`** (v3): assumes the backend already returned up to
+  `limit + 1` rows in ascending order. If it got the extra row, trims it and
+  emits a `next` link built from the last remaining item's id; `previous` is
+  never emitted (matches upstream `wrap_collection`).
+- **`paginate_bidirectional`** (v4): same over-fetch/trim logic, but also
+  emits a real `previous` link whenever the request carried a `marker` at
+  all (i.e., this isn't the first page). Handles `page_reverse` by trimming
+  from the appropriate end.
+
+Both return `(trimmed_items, Option<Vec<Link>>)`; call sites replace the
+naive `Json(List { data, links: None })` construction with the trimmed vec
+plus the returned links.
+
+### Config: per-provider limits (`crates/config/src/pagination.rs`)
+
+```rust
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct ListLimitConfig {
+    pub list_limit: Option<u64>,
+    pub max_list_limit: Option<u64>,
+}
+```
+
+Embedded as `pub list_limit: ListLimitConfig` on each per-domain provider
+config struct (e.g. `CatalogProvider`, `AssignmentProvider`,
+`ScimRealmProvider`, `MappingProvider`). Resolution is
+`Config::resolve_list_limit(&self, provider_limit: &ListLimitConfig, requested:
+Option<u64>) -> Option<u64>`, called by the handler before invoking the
+provider: user-supplied `limit` → provider's `list_limit` → clamped to
+`max_list_limit` if set.
+
+### Backend responsibility: over-fetch by one
+
+Each backend is responsible for actually fetching `limit + 1` rows in
+marker/direction order — the API layer's `paginate_forward`/
+`paginate_bidirectional` only trims what it's given, it never re-queries.
+Two shapes of backend exist in this codebase:
+
+- **SQL-backed, single-cursor domains** (User, Project, Domain, Group, Role,
+  Service, Region, Endpoint, Credential, K8sAuthInstance,
+  TokenRestriction, federation `identity_provider`): the marker/limit filter
+  applies directly to the driving SQL query (`Column::Id.gt(marker)`,
+  `.order_by_asc(...)`, `.limit(effective_limit + 1)`; reversed comparison
+  and ordering when `page_reverse`).
+- **Raft-backed, in-memory domains** (ScimRealmResource, OAuth2ClientResource,
+  ApiClientResource, MappingRuleSet): there is no SQL cursor at all. The
+  backend fetches the full filtered candidate set, sorts it by a chosen
+  unique key, `retain()`s items strictly greater/less than the decoded
+  marker depending on `page_reverse`, then truncates (or `split_off`s, for
+  the reverse direction) to `limit + 1`.
+
+### RoleAssignment: the one deliberate deviation
+
+RoleAssignment's result set is a union of two SQL queries plus in-memory
+role-implication expansion (`resolve_implied_roles`); it cannot be paginated
+via a SQL cursor at all. It reuses the in-memory sort/retain/truncate pattern
+from the Raft-backed domains, but inside the **SQL** driver's outer
+`list_assignments` function, applied after the union and expansion are fully
+materialized.
+
+Assignment rows have no single `id` column, so pagination uses a synthetic
+composite marker:
+
+```
+format!("{type}:{actor_id}:{target_id}:{role_id}:{inherited}:{implied_via_or_empty}")
+```
+
+This deliberately matches the exact tuple `resolve_implied_roles()`'s
+`HashSet<Assignment>` already uses for full-struct-equality deduplication —
+chosen specifically because two different prior roles can each imply the
+same `role_id` for the same actor/target, producing rows that would
+otherwise collide without `implied_via` in the key.
+
+Because the API-facing `Assignment` response type lacks `inherited` and
+`implied_via`, `ResourceIdentifier` is implemented on the **core-types**
+`Assignment` instead (legal per Rust's orphan rule, since `ResourceIdentifier`
+is a local trait), and `paginate_forward` is called on the raw provider
+result **before** API conversion, rather than after as in every other
+domain.
+
+## Consequences
+
+- All 16 domains identified in the original rollout now share one
+  pagination mechanism: User, Project, Domain, Group, Role, federation
+  `identity_provider`, Service, Region, Endpoint, Credential,
+  K8sAuthInstance, ScimRealmResource, OAuth2ClientResource,
+  ApiClientResource, TokenRestriction, RoleAssignment, and mapping
+  `MappingRuleSet`.
+- `ServiceAccount` and `RevocationEvent` are out of scope: neither has a
+  list capability exposed over REST (ServiceAccount) or a public REST
+  endpoint at all (RevocationEvent, internal-only).
+- v3 responses never gain a `previous` link, matching upstream
+  python-keystone byte-for-byte; only v4 endpoints support
+  `page_reverse`/`previous`.
+- Every domain's list handler follows the same mechanical recipe, making it
+  straightforward for new domains to adopt: add `pagination: ListPagination`
+  to the core-types list-params struct, apply over-fetch-by-one in the
+  driver, implement `ResourceIdentifier`, add the second `PaginationQuery`
+  extractor plus `paginate_forward`/`paginate_bidirectional` in the handler,
+  add `list_limit: ListLimitConfig` to the provider's config struct.


### PR DESCRIPTION
RoleAssignment listing unions two SQL queries (regular and system
assignments) plus in-memory implied-role expansion, so no SQL cursor
can correspond to the final result's ordering or count. Pagination is
therefore applied in-memory over the fully materialized, expanded set,
mirroring the pattern already used for Raft-backed domains.

Assignments have no single id column: they are composite-keyed on
type/actor/target/role/inherited/implied_via, so a stable marker is
built from that tuple (matching the identity resolve_implied_roles
already uses for deduplication) and used to sort, filter by marker,
and over-fetch by one row for correct next-page detection.

Wire limit/marker/page_reverse into GET /v4/mapping/rulesets, the
last domain flagged as a follow-up in issue #308's pagination rollout.

list_rulesets_impl previously ignored limit/marker entirely despite
the core-types struct having had the fields since the first
pagination PR. Apply the same in-memory sort/marker-filter/over-fetch
pattern already used for the other Raft-backed domains (ScimRealm,
OAuth2Client, ApiClient), keyed on mapping_id since rulesets have no
other unique, orderable field.

Migrate MappingRuleSetListParameters from duplicated limit/marker
fields onto the shared ListPagination struct, matching every other
domain's convention. Add per-provider list_limit/max_list_limit
config for MappingProvider, and wire the v4 handler through the
shared PaginationQuery extractor and paginate_bidirectional helper
so it emits real next/previous links instead of hardcoding None.

Document the marker-based pagination mechanism landed across issue
the over-fetch-by-one-row + trim strategy that fixes the
false-positive next-link bug, per-provider list_limit config
resolution, the SQL-cursor vs in-memory-Raft backend patterns, and
the RoleAssignment domain's deliberate deviation (pagination applied
to the core-types type before API conversion, using a composite
marker since assignment rows have no single id column).

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
