### PR TITLE
feat: Add connection_debug to tune SQL query logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5091,6 +5091,7 @@ dependencies = [
  "http-serde",
  "httpmock",
  "ipnet",
+ "log",
  "notify",
  "regex",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ inventory = { version = "0.3" }
 ipnet = { version = "2" }
 itertools = { version = "0.15" }
 jsonwebtoken = { version = "11.0", features = ["rust_crypto"] }
+log = { version = "0.4" }
 ldap3 = { version = "0.12", default-features = false, features = ["tls-rustls-aws-lc-rs"] }
 mockall = { version = "0.15" }
 mockall_double = { version = "0.3" }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -18,6 +18,7 @@ eyre.workspace = true
 http.workspace = true
 http-serde = "2.1"
 ipnet = { workspace = true }
+log.workspace = true
 notify = "8.2"
 regex.workspace = true
 secrecy = { workspace = true, features = ["serde"] }

--- a/crates/config/src/database.rs
+++ b/crates/config/src/database.rs
@@ -19,9 +19,32 @@ use serde::Deserialize;
 pub struct DatabaseSection {
     /// Database URL.
     pub connection: SecretString,
+
+    /// SQL query logging verbosity, `0`-`100` (mirrors oslo_db's
+    /// `connection_debug`). `0` disables query logging (default); higher
+    /// values enable it at increasingly verbose tracing levels.
+    #[serde(default)]
+    pub connection_debug: u8,
 }
 
 impl DatabaseSection {
+    /// Whether SQL query logging should be enabled for the configured
+    /// `connection_debug` verbosity.
+    pub fn sqlx_logging_enabled(&self) -> bool {
+        self.connection_debug > 0
+    }
+
+    /// Tracing level to log SQL queries at for the configured
+    /// `connection_debug` verbosity.
+    pub fn sqlx_logging_level(&self) -> log::LevelFilter {
+        match self.connection_debug {
+            0 => log::LevelFilter::Off,
+            1..=33 => log::LevelFilter::Warn,
+            34..=66 => log::LevelFilter::Info,
+            _ => log::LevelFilter::Debug,
+        }
+    }
+
     pub fn get_connection(&self) -> SecretString {
         let val = self.connection.expose_secret();
         if let Some(slash_pos) = val.find("://") {
@@ -45,12 +68,14 @@ mod tests {
         // No driver suffix – no change
         let sot = DatabaseSection {
             connection: "mysql://u:p@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:p@h", sot.get_connection().expose_secret());
 
         // Driver suffix stripped
         let sot = DatabaseSection {
             connection: "mysql+driver://u:p@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:p@h", sot.get_connection().expose_secret());
     }
@@ -60,12 +85,14 @@ mod tests {
         // :// in password, driver stripped
         let sot = DatabaseSection {
             connection: "mysql+driver://u:p://x@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:p://x@h", sot.get_connection().expose_secret());
 
         // Multiple :// in password, driver stripped
         let sot = DatabaseSection {
             connection: "mysql+driver://u://x:p://y@h".into(),
+            ..Default::default()
         };
         assert_eq!(
             "mysql://u://x:p://y@h",
@@ -78,90 +105,105 @@ mod tests {
         // Single + in password, no driver – unchanged
         let sot = DatabaseSection {
             connection: "mysql://u:p+q@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:p+q@h", sot.get_connection().expose_secret());
 
         // Multiple + in password, no driver – unchanged
         let sot = DatabaseSection {
             connection: "mysql://u:a+b+c@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:a+b+c@h", sot.get_connection().expose_secret());
 
         // Only + as password, no driver – unchanged
         let sot = DatabaseSection {
             connection: "mysql://u:+@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:+@h", sot.get_connection().expose_secret());
 
         // + at end of password, no driver – unchanged
         let sot = DatabaseSection {
             connection: "mysql://u:pass+@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:pass+@h", sot.get_connection().expose_secret());
 
         // Driver suffix + single + in password
         let sot = DatabaseSection {
             connection: "mysql+driver://u:p+q@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:p+q@h", sot.get_connection().expose_secret());
 
         // Driver suffix + multiple + in password
         let sot = DatabaseSection {
             connection: "mysql+driver://u:a+b+c@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:a+b+c@h", sot.get_connection().expose_secret());
 
         // Driver suffix + only + as password
         let sot = DatabaseSection {
             connection: "mysql+driver://u:+@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:+@h", sot.get_connection().expose_secret());
 
         // Driver suffix + :// and + in password
         let sot = DatabaseSection {
             connection: "mysql+driver://u:p+q://r@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:p+q://r@h", sot.get_connection().expose_secret());
 
         // + in username and password, no driver
         let sot = DatabaseSection {
             connection: "mysql://u+v:p+w@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u+v:p+w@h", sot.get_connection().expose_secret());
 
         // Driver suffix + + in username and password
         let sot = DatabaseSection {
             connection: "mysql+driver://u+v:p+w@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u+v:p+w@h", sot.get_connection().expose_secret());
 
         // Empty password, no driver
         let sot = DatabaseSection {
             connection: "mysql://u:@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:@h", sot.get_connection().expose_secret());
 
         // Empty password, driver stripped
         let sot = DatabaseSection {
             connection: "mysql+driver://u:@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:@h", sot.get_connection().expose_secret());
 
         // No password, no driver
         let sot = DatabaseSection {
             connection: "mysql://u@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u@h", sot.get_connection().expose_secret());
 
         // No password, driver stripped
         let sot = DatabaseSection {
             connection: "mysql+driver://u@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u@h", sot.get_connection().expose_secret());
 
         // Special chars in password: @, /, ?, #
         let sot = DatabaseSection {
             connection: "mysql+driver://u:p@ss/w?_r#k@h".into(),
+            ..Default::default()
         };
         assert_eq!(
             "mysql://u:p@ss/w?_r#k@h",
@@ -171,6 +213,7 @@ mod tests {
         // % encoded + in password (literal %2B)
         let sot = DatabaseSection {
             connection: "mysql+driver://u:%2B@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:%2B@h", sot.get_connection().expose_secret());
     }
@@ -180,18 +223,21 @@ mod tests {
         // Multiple consecutive +
         let sot = DatabaseSection {
             connection: "mysql+driver+extra://u:p@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql://u:p@h", sot.get_connection().expose_secret());
 
         // No scheme separator – passthrough
         let sot = DatabaseSection {
             connection: "mysql+driver/u:p@h".into(),
+            ..Default::default()
         };
         assert_eq!("mysql+driver/u:p@h", sot.get_connection().expose_secret());
 
         // Empty connection
         let sot = DatabaseSection {
             connection: "".into(),
+            ..Default::default()
         };
         assert_eq!("", sot.get_connection().expose_secret());
     }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -211,8 +211,8 @@ async fn main() -> Result<(), Report> {
     let cloned_token = token.clone();
 
     let opt: ConnectOptions = ConnectOptions::new(cfg.database.get_connection().expose_secret())
-        // Prevent dumping the password in plaintext.
-        .sqlx_logging(false)
+        .sqlx_logging(cfg.database.sqlx_logging_enabled())
+        .sqlx_logging_level(cfg.database.sqlx_logging_level())
         .to_owned();
 
     debug!("Establishing the database connection...");

--- a/doc/src/configuration/options.md
+++ b/doc/src/configuration/options.md
@@ -10,7 +10,7 @@ the feature guide for constraints and safe production values.
 | Section | Options |
 | --- | --- |
 | `[DEFAULT]` | `debug`, `log_dir`, `public_endpoint`, `use_stderr`, `use_journal` |
-| `[database]` | `connection` |
+| `[database]` | `connection`, `connection_debug` |
 | `[interface_public]` | `tcp_address`, listener `type`, and listener-specific TLS/SPIFFE fields |
 | `[interface_internal]` | `tcp_address`, listener `type`, `trust_domains`, and TLS content/file fields |
 | `[interface_admin]` | `socket_path`, `trust_domains`, `peer_uid`, `peer_gid`, `admin_svid` |

--- a/tests/integration/src/identity/user/list.rs
+++ b/tests/integration/src/identity/user/list.rs
@@ -62,6 +62,93 @@ async fn test_list() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+#[traced_test]
+async fn test_list_mixed_user_types() -> Result<()> {
+    let (state, _tmp) = get_state_with_config(|_| {}).await?;
+    let domain = create_domain!(state)?;
+    let prov = state.provider.get_identity_provider();
+
+    prov.create_user(
+        &ExecutionContext::internal(&state),
+        UserCreateBuilder::default()
+            .name(format!("local-{}", Uuid::new_v4()))
+            .domain_id(domain.id.clone())
+            .enabled(true)
+            .password("foobar123")
+            .build()?,
+    )
+    .await?;
+
+    prov.create_user(
+        &ExecutionContext::internal(&state),
+        UserCreateBuilder::default()
+            .name(format!("nonlocal-{}", Uuid::new_v4()))
+            .domain_id(domain.id.clone())
+            .enabled(true)
+            .user_type(UserType::NonLocal)
+            .build()?,
+    )
+    .await?;
+
+    let fed = FederationBuilder::default()
+        .idp_id("idp_id")
+        .unique_id("uid")
+        .protocols(vec![FederationProtocol {
+            protocol_id: "oidc".into(),
+            unique_id: "uid".into(),
+        }])
+        .build()?;
+    prov.create_user(
+        &ExecutionContext::internal(&state),
+        UserCreateBuilder::default()
+            .name(format!("federated-{}", Uuid::new_v4()))
+            .domain_id(domain.id.clone())
+            .enabled(true)
+            .federated(vec![fed])
+            .build()?,
+    )
+    .await?;
+
+    let users: Vec<UserResponse> = prov
+        .list_users(
+            &ExecutionContext::internal(&state),
+            &UserListParameters {
+                domain_id: Some(domain.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?
+        .into_iter()
+        .collect();
+
+    let local_count = users
+        .iter()
+        .filter(|u| u.name.starts_with("local-"))
+        .count();
+    let nonlocal_count = users
+        .iter()
+        .filter(|u| u.name.starts_with("nonlocal-"))
+        .count();
+    let federated_count = users
+        .iter()
+        .filter(|u| u.name.starts_with("federated-"))
+        .count();
+
+    assert_eq!(
+        users.len(),
+        3,
+        "expected 3 users (local/nonlocal/federated), got {}: {:?}",
+        users.len(),
+        users.iter().map(|u| &u.name).collect::<Vec<_>>()
+    );
+    assert_eq!(local_count, 1, "local user missing");
+    assert_eq!(nonlocal_count, 1, "nonlocal user missing");
+    assert_eq!(federated_count, 1, "federated user missing");
+
+    Ok(())
+}
+
 /// Profile user-list performance with a configurable user count.
 ///
 /// # Design


### PR DESCRIPTION
Production binary hardcoded sqlx_logging(false), so live servers
had no way to enable query logging when diagnosing DB-layer bugs
(unlike oslo_db's connection_debug knob in Python Keystone).

- database.connection_debug (0-100, default 0) maps to sqlx logging
  on/off plus a tracing verbosity level (Off/Warn/Info/Debug)
- wire it into ConnectOptions in the keystone binary

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
