### PR TITLE
fix: Respect X-Forwarded-Proto in version discovery

### DIFF
--- a/crates/keystone/src/api/common.rs
+++ b/crates/keystone/src/api/common.rs
@@ -26,6 +26,9 @@ use crate::api::KeystoneApiError;
 use crate::auth::ExecutionContext;
 use crate::keystone::ServiceState;
 
+// Canonical header name for proxy-forwarded protocol.
+const FORWARDED_PROTO: &str = "x-forwarded-proto";
+
 /// Raw TCP peer address for the public interface only.
 ///
 /// Internal/admin requests return `None` even when `ConnectInfo` is populated
@@ -40,6 +43,44 @@ impl<S: Send + Sync> FromRequestParts<S> for PeerAddr {
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         Ok(PeerAddr(public_ingress_peer_addr(&parts.extensions)))
     }
+}
+
+/// Resolve the public-facing base URL for constructing absolute links
+/// in API responses.
+///
+/// Fallback chain:
+/// 1. `public_endpoint` from config
+/// 2. `Host` header with protocol from `X-Forwarded-Proto` (defaults to `http`)
+/// 3. `http://localhost` as last resort
+pub async fn public_base_url(state: &ServiceState, headers: &axum::http::HeaderMap) -> String {
+    state
+        .config_manager
+        .config
+        .read()
+        .await
+        .default
+        .public_endpoint
+        .clone()
+        .map(|x| x.to_string())
+        .or_else(|| {
+            headers.get(axum::http::header::HOST).and_then(|host| {
+                host.to_str().ok().map(|h| {
+                    let proto = headers
+                        .get(FORWARDED_PROTO)
+                        .and_then(|h| h.to_str().ok())
+                        .filter(|v| matches!(*v, "http" | "https"))
+                        .unwrap_or("http");
+                    format!("{proto}://{h}")
+                })
+            })
+        })
+        .unwrap_or_else(|| "http://localhost".to_string())
+}
+
+/// Returns true when the request arrived over HTTPS as indicated by the
+/// `X-Forwarded-Proto` header being set to `https`.
+pub fn is_https(headers: &axum::http::HeaderMap) -> bool {
+    headers.get(FORWARDED_PROTO).and_then(|h| h.to_str().ok()) == Some("https")
 }
 
 /// Get the domain by ID or Name.
@@ -414,5 +455,51 @@ mod tests {
             paginate_bidirectional(&Config::default(), fake_items(cnt), &query, "foo/bar").unwrap();
         assert_eq!(items.len(), expected_len);
         assert_eq!(links, expected_links);
+    }
+
+    #[rstest]
+    #[case("https", true)]
+    #[case("http", false)]
+    #[case("gre", false)]
+    fn test_is_https(#[case] header_value: &str, #[case] expected: bool) {
+        let mut headers = axum::http::HeaderMap::new();
+        if let Ok(hv) = header_value.parse::<axum::http::HeaderValue>() {
+            let _ = headers.insert(FORWARDED_PROTO, hv);
+        }
+        assert_eq!(is_https(&headers), expected);
+    }
+
+    #[rstest]
+    #[case(None, None, "http://localhost")]
+    #[case(Some("api.example.com"), None, "http://api.example.com")]
+    #[case(Some("api.example.com"), Some("https"), "https://api.example.com")]
+    #[case(Some("api.example.com"), Some("http"), "http://api.example.com")]
+    #[case(
+        Some("api.example.com:5000"),
+        Some("https"),
+        "https://api.example.com:5000"
+    )]
+    #[case(Some("api.example.com"), Some("gre"), "http://api.example.com")] // invalid proto falls back to http
+    #[tokio::test]
+    async fn test_public_base_url_from_headers(
+        #[case] host: Option<&str>,
+        #[case] forwarded_proto: Option<&str>,
+        #[case] expected: &str,
+    ) {
+        let mut headers = axum::http::HeaderMap::new();
+        if let Some(h) = host {
+            if let Ok(hv) = h.parse::<axum::http::HeaderValue>() {
+                let _ = headers.insert(axum::http::header::HOST, hv);
+            }
+        }
+        if let Some(p) = forwarded_proto {
+            if let Ok(pv) = p.parse::<axum::http::HeaderValue>() {
+                let _ = headers.insert(FORWARDED_PROTO, pv);
+            }
+        }
+        // get_mocked_state uses Config::default()
+        // which has public_endpoint == None, so the fallback to Host header applies.
+        let state = get_mocked_state(Provider::mocked_builder(), false, None).await;
+        assert_eq!(public_base_url(&state, &headers).await, expected);
     }
 }

--- a/crates/keystone/src/api/mod.rs
+++ b/crates/keystone/src/api/mod.rs
@@ -18,7 +18,7 @@
 use axum::{
     Json,
     extract::State,
-    http::{HeaderMap, StatusCode, header},
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
 use utoipa::{
@@ -96,22 +96,7 @@ async fn version(
     headers: HeaderMap,
     State(state): State<ServiceState>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
-    let host = state
-        .config_manager
-        .config
-        .read()
-        .await
-        .default
-        .public_endpoint
-        .clone()
-        .map(|x| x.to_string())
-        .or_else(|| {
-            headers
-                .get(header::HOST)
-                .and_then(|header| header.to_str().map(|val| format!("http://{val}")).ok())
-        })
-        .unwrap_or_else(|| "http://localhost".to_string());
-
+    let host = crate::api::common::public_base_url(&state, &headers).await;
     let res = Versions {
         versions: Values {
             values: vec![

--- a/crates/keystone/src/api/v3/mod.rs
+++ b/crates/keystone/src/api/v3/mod.rs
@@ -17,12 +17,13 @@
 use axum::{
     Json,
     extract::{OriginalUri, Request, State},
-    http::{HeaderMap, StatusCode, header},
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
 use utoipa::OpenApi;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+use crate::api::common::public_base_url;
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 
@@ -87,21 +88,7 @@ async fn version(
     State(state): State<ServiceState>,
     _req: Request,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
-    let host = state
-        .config_manager
-        .config
-        .read()
-        .await
-        .default
-        .public_endpoint
-        .clone()
-        .map(|x| x.to_string())
-        .or_else(|| {
-            headers
-                .get(header::HOST)
-                .and_then(|header| header.to_str().map(|val| format!("http://{val}")).ok())
-        })
-        .unwrap_or_else(|| "http://localhost".to_string());
+    let host = public_base_url(&state, &headers).await;
     let link = Link {
         rel: "self".into(),
         href: format!("{}{}", host, uri.path()),

--- a/crates/keystone/src/api/v4/mod.rs
+++ b/crates/keystone/src/api/v4/mod.rs
@@ -17,12 +17,13 @@
 use axum::{
     Json,
     extract::{OriginalUri, Request, State},
-    http::{HeaderMap, StatusCode, header},
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
 use utoipa::OpenApi;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+use crate::api::common::public_base_url;
 use crate::api::error::KeystoneApiError;
 use crate::federation::api as federation;
 use crate::k8s_auth::api as k8s_auth;
@@ -93,21 +94,7 @@ async fn version(
     State(state): State<ServiceState>,
     _req: Request,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
-    let host = state
-        .config_manager
-        .config
-        .read()
-        .await
-        .default
-        .public_endpoint
-        .clone()
-        .map(|x| x.to_string())
-        .or_else(|| {
-            headers
-                .get(header::HOST)
-                .and_then(|header| header.to_str().map(|val| format!("http://{val}")).ok())
-        })
-        .unwrap_or_else(|| "http://localhost".to_string());
+    let host = public_base_url(&state, &headers).await;
     let link = Link {
         rel: "self".into(),
         href: format!("{}{}", host, uri.path()),

--- a/crates/keystone/src/api/v4/oauth2/authorize.rs
+++ b/crates/keystone/src/api/v4/oauth2/authorize.rs
@@ -145,10 +145,7 @@ fn verify_csrf_token(session: &PreAuthSession, presented: &str) -> bool {
 }
 
 fn is_https(headers: &HeaderMap) -> bool {
-    headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
-        == Some("https")
+    crate::api::common::is_https(headers)
 }
 
 fn session_cookie(session_id: String, secure: bool) -> Cookie<'static> {

--- a/crates/keystone/src/api/v4/oauth2/device.rs
+++ b/crates/keystone/src/api/v4/oauth2/device.rs
@@ -102,10 +102,7 @@ fn verify_csrf_token(grant: &DeviceCodeGrant, presented: &str) -> bool {
 }
 
 fn is_https(headers: &HeaderMap) -> bool {
-    headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
-        == Some("https")
+    crate::api::common::is_https(headers)
 }
 
 fn device_cookie(device_code: String, secure: bool) -> Cookie<'static> {

--- a/crates/keystone/src/api/v4/oauth2/well_known.rs
+++ b/crates/keystone/src/api/v4/oauth2/well_known.rs
@@ -35,23 +35,12 @@ use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
 
 pub(super) async fn base_url(state: &ServiceState, headers: &HeaderMap) -> String {
-    // Mirrors the fallback chain used by `api::v4::version`:
-    // `public_endpoint` -> `Host` header -> `http://localhost`.
-    state
-        .config_manager
-        .config
-        .read()
+    // Mirrors the fallback chain used by `api::common::public_base_url`:
+    // `public_endpoint` -> `Host` header + `X-Forwarded-Proto` -> `http://localhost`.
+    crate::api::common::public_base_url(state, headers)
         .await
-        .default
-        .public_endpoint
-        .clone()
-        .map(|x| x.to_string().trim_end_matches('/').to_owned())
-        .or_else(|| {
-            headers
-                .get(axum::http::header::HOST)
-                .and_then(|header| header.to_str().map(|val| format!("http://{val}")).ok())
-        })
-        .unwrap_or_else(|| "http://localhost".to_string())
+        .trim_end_matches('/')
+        .to_owned()
 }
 
 /// Publish the OIDC discovery document for a domain.


### PR DESCRIPTION
When public_endpoint is not configured, the version discovery endpoints
(root /, /v3, /v4) always returned http:// URLs even when the request
arrived over HTTPS behind a reverse proxy. This caused clients following
the self-links to be redirected from HTTPS to HTTP.

Introduce shared public_base_url() and is_https() helpers in api/common
that respect the X-Forwarded-Proto header (matching existing usage in
authorize.rs and device.rs) and refactor all version discovery and OIDC
well-known handlers to use the centralized logic.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
