### PR TITLE
feat: Add per-request cache framework (ADR 0030)

### DIFF
--- a/crates/core/src/identity/service.rs
+++ b/crates/core/src/identity/service.rs
@@ -34,7 +34,13 @@ use crate::auth::{
 use crate::events::AuditDispatchError;
 use crate::identity::{IdentityApi, IdentityProviderError, backend::IdentityBackend};
 use crate::plugin_manager::PluginManagerApi;
+use crate::request_cache::{cache_get, cache_remove, cache_set};
 use crate::resource::error::ResourceProviderError;
+
+/// Request-cache namespace for [`UserResponse`] lookups by `user_id`.
+const USER_CACHE_NS: &str = "identity.user";
+/// Request-cache namespace for [`Group`] lookups by `group_id`.
+const GROUP_CACHE_NS: &str = "identity.group";
 
 /// Identity provider.
 pub struct IdentityService {
@@ -719,6 +725,7 @@ impl IdentityApi for IdentityService {
                 .await;
         }
 
+        cache_remove(GROUP_CACHE_NS, group_id);
         Ok(())
     }
 
@@ -782,6 +789,7 @@ impl IdentityApi for IdentityService {
                 .await;
         }
 
+        cache_remove(USER_CACHE_NS, user_id);
         Ok(())
     }
 
@@ -819,14 +827,18 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Option<UserResponse>, IdentityProviderError> {
+        if let Some(user) = cache_get::<UserResponse>(USER_CACHE_NS, user_id) {
+            return Ok(Some(user));
+        }
         let user = self.backend_driver.get_user(ctx.state(), user_id).await?;
-        if self.caching
-            && let Some(user) = &user
-        {
-            self.user_id_domain_id_cache
-                .write()
-                .await
-                .insert(user_id.to_string(), user.domain_id.clone());
+        if let Some(user) = &user {
+            if self.caching {
+                self.user_id_domain_id_cache
+                    .write()
+                    .await
+                    .insert(user_id.to_string(), user.domain_id.clone());
+            }
+            cache_set(USER_CACHE_NS, user_id, user.clone());
         }
         Ok(user)
     }
@@ -941,7 +953,14 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         group_id: &'a str,
     ) -> Result<Option<Group>, IdentityProviderError> {
-        self.backend_driver.get_group(ctx.state(), group_id).await
+        if let Some(group) = cache_get::<Group>(GROUP_CACHE_NS, group_id) {
+            return Ok(Some(group));
+        }
+        let group = self.backend_driver.get_group(ctx.state(), group_id).await?;
+        if let Some(group) = &group {
+            cache_set(GROUP_CACHE_NS, group_id, group.clone());
+        }
+        Ok(group)
     }
 
     /// List groups a user is a member of.
@@ -1037,6 +1056,7 @@ impl IdentityApi for IdentityService {
             group
         };
 
+        cache_set(GROUP_CACHE_NS, group_id, group.clone());
         Ok(group)
     }
 
@@ -1344,6 +1364,7 @@ impl IdentityApi for IdentityService {
             user
         };
 
+        cache_set(USER_CACHE_NS, user_id, user.clone());
         Ok(user)
     }
 
@@ -1395,6 +1416,7 @@ impl IdentityApi for IdentityService {
                 ))
                 .await;
         }
+        cache_remove(USER_CACHE_NS, user_id);
         Ok(())
     }
 
@@ -2357,5 +2379,280 @@ mod tests {
                 .is_ok(),
             "no password on update should skip validation"
         );
+    }
+
+    // --- Per-request cache (ADR 0030) -------------------------------------
+
+    use openstack_keystone_core_types::identity::{GroupBuilder, GroupUpdate};
+
+    fn make_user(id: &str) -> UserResponse {
+        UserResponseBuilder::default()
+            .id(id)
+            .domain_id("did")
+            .enabled(true)
+            .name(format!("{id}-name"))
+            .build()
+            .unwrap()
+    }
+
+    fn make_group(id: &str) -> Group {
+        GroupBuilder::default()
+            .id(id)
+            .domain_id("did")
+            .name(format!("{id}-name"))
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_get_user_hits_backend_once_across_repeated_calls() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_user()
+            .times(1)
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(Some(make_user("uid"))));
+        let provider = IdentityService::from_driver(backend);
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            let first = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
+            let second = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
+            assert_eq!(first, second);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_user_not_cached_outside_request_scope() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_user()
+            .times(2)
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(Some(make_user("uid"))));
+        let provider = IdentityService::from_driver(backend);
+
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_user(&ctx, "uid").await.unwrap();
+        provider.get_user(&ctx, "uid").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_user_refreshes_cache_instead_of_refetching() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_user()
+            .times(1)
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(Some(make_user("uid"))));
+        backend
+            .expect_update_user()
+            .withf(|_, uid: &'_ str, _| uid == "uid")
+            .returning(|_, _, update| {
+                let mut u = make_user("uid");
+                if let Some(name) = update.name {
+                    u.name = name;
+                }
+                Ok(u)
+            });
+        let provider = IdentityService::from_driver(backend);
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_user(&ctx, "uid").await.unwrap();
+
+            let updated = provider
+                .update_user(
+                    &ctx,
+                    "uid",
+                    UserUpdateBuilder::default()
+                        .name("renamed".to_string())
+                        .build()
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(updated.name, "renamed");
+
+            let refetched = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
+            assert_eq!(refetched.name, "renamed");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_user_invalidates_cache() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_delete_credentials_for_user()
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_credential(credential_mock)),
+        )
+        .await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_user()
+            .times(2)
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(Some(make_user("uid"))));
+        backend
+            .expect_delete_user()
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(()));
+        let provider = IdentityService::from_driver(backend);
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_user(&ctx, "uid").await.unwrap();
+            provider.delete_user(&ctx, "uid").await.unwrap();
+            provider.get_user(&ctx, "uid").await.unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_update_user_password_invalidates_cache() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_user()
+            .times(2)
+            .withf(|_, uid: &'_ str| uid == "uid")
+            .returning(|_, _| Ok(Some(make_user("uid"))));
+        backend
+            .expect_update_user_password()
+            .withf(|_, uid: &'_ str, _, _| uid == "uid")
+            .returning(|_, _, _, _| Ok(()));
+        let provider = IdentityService::from_driver(backend);
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_user(&ctx, "uid").await.unwrap();
+            provider
+                .update_user_password(
+                    &ctx,
+                    "uid",
+                    SecretString::from("orig".to_string()),
+                    SecretString::from("newpassword".to_string()),
+                )
+                .await
+                .unwrap();
+            // `update_user_password` doesn't return a fresh `UserResponse`
+            // to refresh the cache with -- the cached entry must instead be
+            // invalidated so `password_expires_at` isn't served stale.
+            provider.get_user(&ctx, "uid").await.unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_group_hits_backend_once_across_repeated_calls() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_group()
+            .times(1)
+            .withf(|_, gid: &'_ str| gid == "gid")
+            .returning(|_, _| Ok(Some(make_group("gid"))));
+        let provider = IdentityService::from_driver(backend);
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            let first = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
+            let second = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
+            assert_eq!(first, second);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_group_not_cached_outside_request_scope() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_group()
+            .times(2)
+            .withf(|_, gid: &'_ str| gid == "gid")
+            .returning(|_, _| Ok(Some(make_group("gid"))));
+        let provider = IdentityService::from_driver(backend);
+
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_group(&ctx, "gid").await.unwrap();
+        provider.get_group(&ctx, "gid").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_group_refreshes_cache_instead_of_refetching() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_group()
+            .times(1)
+            .withf(|_, gid: &'_ str| gid == "gid")
+            .returning(|_, _| Ok(Some(make_group("gid"))));
+        backend
+            .expect_update_group()
+            .withf(|_, gid: &'_ str, _| gid == "gid")
+            .returning(|_, _, update| {
+                let mut g = make_group("gid");
+                if let Some(name) = update.name {
+                    g.name = name;
+                }
+                Ok(g)
+            });
+        let provider = IdentityService::from_driver(backend);
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_group(&ctx, "gid").await.unwrap();
+
+            let updated = provider
+                .update_group(
+                    &ctx,
+                    "gid",
+                    GroupUpdate {
+                        name: Some("renamed".into()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(updated.name, "renamed");
+
+            let refetched = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
+            assert_eq!(refetched.name, "renamed");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_group_invalidates_cache() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdentityBackend::default();
+        backend
+            .expect_get_group()
+            .times(2)
+            .withf(|_, gid: &'_ str| gid == "gid")
+            .returning(|_, _| Ok(Some(make_group("gid"))));
+        backend
+            .expect_delete_group()
+            .withf(|_, gid: &'_ str| gid == "gid")
+            .returning(|_, _| Ok(()));
+        let provider = IdentityService::from_driver(backend);
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_group(&ctx, "gid").await.unwrap();
+            provider.delete_group(&ctx, "gid").await.unwrap();
+            provider.get_group(&ctx, "gid").await.unwrap();
+        })
+        .await;
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -108,6 +108,7 @@ pub mod plugin_manager;
 pub mod policy;
 pub mod provider;
 pub mod rate_limit;
+pub mod request_cache;
 pub mod resource;
 pub mod revoke;
 pub mod role;

--- a/crates/core/src/request_cache.rs
+++ b/crates/core/src/request_cache.rs
@@ -1,0 +1,184 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Per-Request Cache
+//!
+//! Request-scoped cache backed by `tokio::task_local!` (see ADR 0030).
+//! Callers establish the scope once per request (the Axum middleware in
+//! `crates/keystone` does this); provider code anywhere on that task can
+//! then read/write it via [`cache_get`]/[`cache_set`] without threading a
+//! new parameter through provider trait signatures.
+//!
+//! Outside an established scope (unit tests calling provider methods
+//! directly, CLI tooling, background jobs) [`cache_get`] always returns
+//! `None` and [`cache_set`] is a silent no-op — the same defensive style
+//! already used by the `EMIT_CRITICAL_RECURSION` task_local in
+//! `crate::events`.
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::future::Future;
+
+tokio::task_local! {
+    /// Per-request cache. Established once per incoming request; absent
+    /// outside a request scope.
+    static REQUEST_CACHE: RequestCache;
+}
+
+type CacheKey = (&'static str, String);
+type CacheEntries = RefCell<HashMap<CacheKey, Box<dyn Any + Send>>>;
+
+/// Request-scoped cache of arbitrary, `Send` values keyed by
+/// `(namespace, id)`.
+///
+/// Not `Sync` and does not need to be: it is only ever accessed from the
+/// single task it is scoped to, never concurrently.
+#[derive(Default)]
+pub struct RequestCache {
+    entries: CacheEntries,
+}
+
+impl RequestCache {
+    /// Runs `fut` with a fresh, empty [`RequestCache`] established as the
+    /// current task's request cache for its duration.
+    pub async fn scope<F: Future>(fut: F) -> F::Output {
+        REQUEST_CACHE.scope(RequestCache::default(), fut).await
+    }
+
+    fn get<T: Clone + 'static>(&self, namespace: &'static str, id: &str) -> Option<T> {
+        self.entries
+            .borrow()
+            .get(&(namespace, id.to_string()))
+            .and_then(|v| v.downcast_ref::<T>())
+            .cloned()
+    }
+
+    fn set<T: Send + 'static>(&self, namespace: &'static str, id: &str, value: T) {
+        self.entries
+            .borrow_mut()
+            .insert((namespace, id.to_string()), Box::new(value));
+    }
+
+    fn remove(&self, namespace: &'static str, id: &str) {
+        self.entries
+            .borrow_mut()
+            .remove(&(namespace, id.to_string()));
+    }
+}
+
+/// Reads `id` from the current request's cache under `namespace`.
+///
+/// Returns `None` both on a cache miss and when called outside an
+/// established request scope.
+pub fn cache_get<T: Clone + 'static>(namespace: &'static str, id: &str) -> Option<T> {
+    REQUEST_CACHE
+        .try_with(|cache| cache.get(namespace, id))
+        .ok()
+        .flatten()
+}
+
+/// Writes `value` into the current request's cache under `namespace`/`id`.
+///
+/// Silently does nothing when called outside an established request scope.
+pub fn cache_set<T: Send + 'static>(namespace: &'static str, id: &str, value: T) {
+    let _ = REQUEST_CACHE.try_with(|cache| cache.set(namespace, id, value));
+}
+
+/// Removes `id` from the current request's cache under `namespace`, if
+/// present.
+///
+/// Call after a mutation (update/delete) so a later read in the same
+/// request doesn't observe a stale cached value. Silently does nothing
+/// when called outside an established request scope.
+pub fn cache_remove(namespace: &'static str, id: &str) {
+    let _ = REQUEST_CACHE.try_with(|cache| cache.remove(namespace, id));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_set_within_scope() {
+        RequestCache::scope(async {
+            assert_eq!(cache_get::<String>("ns", "k"), None);
+            cache_set("ns", "k", "value".to_string());
+            assert_eq!(cache_get::<String>("ns", "k"), Some("value".to_string()));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_outside_scope_is_noop() {
+        cache_set("ns", "k", "value".to_string());
+        assert_eq!(cache_get::<String>("ns", "k"), None);
+    }
+
+    #[tokio::test]
+    async fn test_namespace_isolation() {
+        RequestCache::scope(async {
+            cache_set("ns_a", "k", 1u64);
+            cache_set("ns_b", "k", 2u64);
+            assert_eq!(cache_get::<u64>("ns_a", "k"), Some(1));
+            assert_eq!(cache_get::<u64>("ns_b", "k"), Some(2));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_type_mismatch_is_miss() {
+        RequestCache::scope(async {
+            cache_set("ns", "k", 1u64);
+            assert_eq!(cache_get::<String>("ns", "k"), None);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_clears_entry() {
+        RequestCache::scope(async {
+            cache_set("ns", "k", "value".to_string());
+            cache_remove("ns", "k");
+            assert_eq!(cache_get::<String>("ns", "k"), None);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_missing_key_is_noop() {
+        RequestCache::scope(async {
+            cache_remove("ns", "missing");
+            assert_eq!(cache_get::<String>("ns", "missing"), None);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_outside_scope_is_noop() {
+        cache_remove("ns", "k");
+    }
+
+    #[tokio::test]
+    async fn test_scope_does_not_leak_to_new_scope() {
+        RequestCache::scope(async {
+            cache_set("ns", "k", "value".to_string());
+        })
+        .await;
+
+        RequestCache::scope(async {
+            assert_eq!(cache_get::<String>("ns", "k"), None);
+        })
+        .await;
+    }
+}

--- a/crates/core/src/resource/service.rs
+++ b/crates/core/src/resource/service.rs
@@ -24,7 +24,23 @@ use openstack_keystone_core_types::resource::*;
 use crate::auth::{ExecutionContext, scope_domain_id};
 use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
+use crate::request_cache::{cache_get, cache_remove, cache_set};
 use crate::resource::{ResourceApi, ResourceProviderError, backend::ResourceBackend};
+
+/// Request-cache namespace for [`Domain`] lookups by `domain_id`.
+const DOMAIN_CACHE_NS: &str = "resource.domain";
+/// Request-cache namespace for [`Project`] lookups by `project_id`.
+const PROJECT_CACHE_NS: &str = "resource.project";
+/// Request-cache namespace for a project's ancestor chain
+/// (`Vec<Project>`) by `project_id`. Safe to cache because `parent_id` is
+/// immutable after creation (`ProjectUpdate` has no `parent_id` field), so
+/// the ancestor *chain* for a given project never changes -- only the
+/// individual ancestor `Project` rows within it could go stale if one of
+/// them is updated later in the same request. That's the same accepted,
+/// request-scoped staleness window as ADR 0030's "known, accepted race";
+/// this cache is not reverse-indexed by ancestor id to invalidate on their
+/// updates too, since that's real complexity for a risk this narrow.
+const PROJECT_PARENTS_CACHE_NS: &str = "resource.project_parents";
 
 pub struct ResourceService {
     backend_driver: Arc<dyn ResourceBackend>,
@@ -381,6 +397,7 @@ impl ResourceApi for ResourceService {
             domain
         };
 
+        cache_set(DOMAIN_CACHE_NS, domain_id, domain.clone());
         Ok(domain)
     }
 
@@ -436,6 +453,7 @@ impl ResourceApi for ResourceService {
             project
         };
 
+        cache_set(PROJECT_CACHE_NS, project_id, project.clone());
         Ok(project)
     }
 
@@ -480,6 +498,7 @@ impl ResourceApi for ResourceService {
                 .await;
         }
 
+        cache_remove(DOMAIN_CACHE_NS, id);
         Ok(())
     }
 
@@ -535,6 +554,8 @@ impl ResourceApi for ResourceService {
                 .await;
         }
 
+        cache_remove(PROJECT_CACHE_NS, id);
+        cache_remove(PROJECT_PARENTS_CACHE_NS, id);
         Ok(())
     }
 
@@ -552,7 +573,17 @@ impl ResourceApi for ResourceService {
         ctx: &ExecutionContext<'a>,
         domain_id: &'a str,
     ) -> Result<Option<Domain>, ResourceProviderError> {
-        self.backend_driver.get_domain(ctx.state(), domain_id).await
+        if let Some(domain) = cache_get::<Domain>(DOMAIN_CACHE_NS, domain_id) {
+            return Ok(Some(domain));
+        }
+        let domain = self
+            .backend_driver
+            .get_domain(ctx.state(), domain_id)
+            .await?;
+        if let Some(domain) = &domain {
+            cache_set(DOMAIN_CACHE_NS, domain_id, domain.clone());
+        }
+        Ok(domain)
     }
 
     /// Get a single project.
@@ -569,9 +600,17 @@ impl ResourceApi for ResourceService {
         ctx: &ExecutionContext<'a>,
         project_id: &'a str,
     ) -> Result<Option<Project>, ResourceProviderError> {
-        self.backend_driver
+        if let Some(project) = cache_get::<Project>(PROJECT_CACHE_NS, project_id) {
+            return Ok(Some(project));
+        }
+        let project = self
+            .backend_driver
             .get_project(ctx.state(), project_id)
-            .await
+            .await?;
+        if let Some(project) = &project {
+            cache_set(PROJECT_CACHE_NS, project_id, project.clone());
+        }
+        Ok(project)
     }
 
     /// Get a single project by name and domain ID.
@@ -609,9 +648,17 @@ impl ResourceApi for ResourceService {
         ctx: &ExecutionContext<'a>,
         project_id: &'a str,
     ) -> Result<Option<Vec<Project>>, ResourceProviderError> {
-        self.backend_driver
+        if let Some(parents) = cache_get::<Vec<Project>>(PROJECT_PARENTS_CACHE_NS, project_id) {
+            return Ok(Some(parents));
+        }
+        let parents = self
+            .backend_driver
             .get_project_parents(ctx.state(), project_id)
-            .await
+            .await?;
+        if let Some(parents) = &parents {
+            cache_set(PROJECT_PARENTS_CACHE_NS, project_id, parents.clone());
+        }
+        Ok(parents)
     }
 
     /// Find a single domain by its name.
@@ -1220,5 +1267,355 @@ mod tests {
             )
             .await;
         assert!(result.is_ok());
+    }
+
+    // --- Per-request cache (ADR 0030) -------------------------------------
+
+    #[tokio::test]
+    async fn test_get_domain_hits_backend_once_across_repeated_calls() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_domain()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "did")
+            .returning(|_, _| Ok(Some(make_domain("did"))));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            let first = provider.get_domain(&ctx, "did").await.unwrap().unwrap();
+            let second = provider.get_domain(&ctx, "did").await.unwrap().unwrap();
+            assert_eq!(first, second);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_domain_not_cached_outside_request_scope() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_domain()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "did")
+            .returning(|_, _| Ok(Some(make_domain("did"))));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_domain(&ctx, "did").await.unwrap();
+        // No `RequestCache::scope` established (mirrors CLI/background-job
+        // call paths) -- each call must hit the backend.
+        provider.get_domain(&ctx, "did").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_project_hits_backend_once_across_repeated_calls() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(make_project("pid", "did"))));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            let first = provider.get_project(&ctx, "pid").await.unwrap().unwrap();
+            let second = provider.get_project(&ctx, "pid").await.unwrap().unwrap();
+            assert_eq!(first, second);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_update_domain_refreshes_cache_instead_of_refetching() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        // Only the very first `get_domain` (populating the cache) and the
+        // one inside `check_domain_mutable` before it's cached should ever
+        // reach the backend -- exactly once total.
+        backend
+            .expect_get_domain()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "did")
+            .returning(|_, _| Ok(Some(make_domain("did"))));
+        backend
+            .expect_update_domain()
+            .withf(|_, id: &'_ str, _| id == "did")
+            .returning(|_, _, update| {
+                let mut d = make_domain("did");
+                if let Some(name) = update.name {
+                    d.name = name;
+                }
+                Ok(d)
+            });
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_domain(&ctx, "did").await.unwrap();
+
+            let updated = provider
+                .update_domain(
+                    &ctx,
+                    "did",
+                    DomainUpdate {
+                        name: Some("renamed".into()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(updated.name, "renamed");
+
+            let refetched = provider.get_domain(&ctx, "did").await.unwrap().unwrap();
+            assert_eq!(refetched.name, "renamed");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_domain_invalidates_cache() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        // Populated once by the initial `get_domain`, hit from cache inside
+        // `check_domain_mutable`, then re-fetched from the backend after
+        // deletion invalidates the cache entry.
+        backend
+            .expect_get_domain()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "did")
+            .returning(|_, _| Ok(Some(make_domain("did"))));
+        backend
+            .expect_delete_domain()
+            .withf(|_, id: &'_ str| id == "did")
+            .returning(|_, _| Ok(()));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_domain(&ctx, "did").await.unwrap();
+            provider.delete_domain(&ctx, "did").await.unwrap();
+            // Cache entry was removed by the delete -- this call must reach
+            // the backend again rather than serve the deleted domain.
+            provider.get_domain(&ctx, "did").await.unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_update_project_refreshes_cache_instead_of_refetching() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(make_project("pid", "did"))));
+        backend
+            .expect_update_project()
+            .withf(|_, id: &'_ str, _| id == "pid")
+            .returning(|_, _, update| {
+                let mut p = make_project("pid", "did");
+                if let Some(name) = update.name {
+                    p.name = name;
+                }
+                Ok(p)
+            });
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_project(&ctx, "pid").await.unwrap();
+
+            let updated = provider
+                .update_project(
+                    &ctx,
+                    "pid",
+                    ProjectUpdate {
+                        name: Some("renamed".into()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(updated.name, "renamed");
+
+            let refetched = provider.get_project(&ctx, "pid").await.unwrap().unwrap();
+            assert_eq!(refetched.name, "renamed");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_project_invalidates_cache() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_delete_credentials_for_project()
+            .withf(|_, pid: &'_ str| pid == "pid")
+            .returning(|_, _| Ok(()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_credential(credential_mock)),
+        )
+        .await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(make_project("pid", "did"))));
+        backend
+            .expect_delete_project()
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(()));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_project(&ctx, "pid").await.unwrap();
+            provider.delete_project(&ctx, "pid").await.unwrap();
+            provider.get_project(&ctx, "pid").await.unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_project_parents_hits_backend_once_across_repeated_calls() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project_parents()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(vec![make_project("parent", "did")])));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            let first = provider
+                .get_project_parents(&ctx, "pid")
+                .await
+                .unwrap()
+                .unwrap();
+            let second = provider
+                .get_project_parents(&ctx, "pid")
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(first, second);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_project_parents_not_cached_outside_request_scope() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project_parents()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(vec![make_project("parent", "did")])));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_project_parents(&ctx, "pid").await.unwrap();
+        provider.get_project_parents(&ctx, "pid").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_project_parents_none_is_not_cached() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project_parents()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(None));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            assert!(
+                provider
+                    .get_project_parents(&ctx, "pid")
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+            // A `None` result (project not found) must not be cached as
+            // "no parents" -- it should keep hitting the backend.
+            assert!(
+                provider
+                    .get_project_parents(&ctx, "pid")
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_project_invalidates_parents_cache() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_delete_credentials_for_project()
+            .withf(|_, pid: &'_ str| pid == "pid")
+            .returning(|_, _| Ok(()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_credential(credential_mock)),
+        )
+        .await;
+        let mut backend = MockResourceBackend::default();
+        backend
+            .expect_get_project_parents()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(Some(vec![make_project("parent", "did")])));
+        backend
+            .expect_get_project()
+            .returning(|_, _| Ok(Some(make_project("pid", "did"))));
+        backend
+            .expect_delete_project()
+            .withf(|_, id: &'_ str| id == "pid")
+            .returning(|_, _| Ok(()));
+        let provider = ResourceService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_project_parents(&ctx, "pid").await.unwrap();
+            provider.delete_project(&ctx, "pid").await.unwrap();
+            // Cache entry was removed by the delete -- this call must reach
+            // the backend again.
+            provider.get_project_parents(&ctx, "pid").await.unwrap();
+        })
+        .await;
     }
 }

--- a/crates/core/src/role/service.rs
+++ b/crates/core/src/role/service.rs
@@ -25,7 +25,28 @@ use openstack_keystone_core_types::role::*;
 use crate::auth::ExecutionContext;
 use crate::events::AuditDispatchError;
 use crate::plugin_manager::PluginManagerApi;
+use crate::request_cache::{cache_get, cache_remove, cache_set};
 use crate::role::{RoleApi, RoleProviderError, backend::RoleBackend};
+
+/// Request-cache namespace for [`Role`] lookups by `role_id`.
+const ROLE_CACHE_NS: &str = "role.role";
+/// Request-cache namespace for a prior role's direct imply rules
+/// (`Vec<RoleImply>`) by `prior_role_id`. The primary consumer is
+/// `assignment-driver-sql`'s `SqlBackend::resolve_implied_roles`, whose BFS
+/// over the imply graph calls `list_role_imply_rules_by_prior` once per
+/// unique role encountered -- caching here helps when
+/// `resolve_implied_roles`/`expand_implied_roles` runs more than once
+/// within the same request (e.g. listing assignments for several
+/// actor/target pairs that share roles).
+///
+/// Entries are only invalidated by their own `prior_role_id` (on
+/// `delete_role`/`create_role_imply_rule`/`delete_role_imply_rule`), not by
+/// scanning for it appearing as an *implied* role in someone else's cached
+/// list. If role B is deleted while some other prior role A's rule list
+/// (containing `A -> B`) is already cached, that stale entry survives until
+/// the request ends -- same accepted, request-scoped staleness window as
+/// `resource::service::PROJECT_PARENTS_CACHE_NS`'s ancestor-update case.
+const ROLE_IMPLY_BY_PRIOR_CACHE_NS: &str = "role.imply_by_prior";
 
 pub struct RoleService {
     backend_driver: Arc<dyn RoleBackend>,
@@ -181,6 +202,7 @@ impl RoleApi for RoleService {
             rule
         };
 
+        cache_remove(ROLE_IMPLY_BY_PRIOR_CACHE_NS, prior_role_id);
         Ok(rule)
     }
 
@@ -249,6 +271,7 @@ impl RoleApi for RoleService {
             role
         };
 
+        cache_set(ROLE_CACHE_NS, role_id, role.clone());
         Ok(role)
     }
 
@@ -289,6 +312,8 @@ impl RoleApi for RoleService {
                 .await;
         }
 
+        cache_remove(ROLE_CACHE_NS, id);
+        cache_remove(ROLE_IMPLY_BY_PRIOR_CACHE_NS, id);
         Ok(())
     }
 
@@ -340,6 +365,7 @@ impl RoleApi for RoleService {
                 .await;
         }
 
+        cache_remove(ROLE_IMPLY_BY_PRIOR_CACHE_NS, prior_role_id);
         Ok(())
     }
 
@@ -376,7 +402,14 @@ impl RoleApi for RoleService {
         ctx: &ExecutionContext<'a>,
         id: &'a str,
     ) -> Result<Option<Role>, RoleProviderError> {
-        self.backend_driver.get_role(ctx.state(), id).await
+        if let Some(role) = cache_get::<Role>(ROLE_CACHE_NS, id) {
+            return Ok(Some(role));
+        }
+        let role = self.backend_driver.get_role(ctx.state(), id).await?;
+        if let Some(role) = &role {
+            cache_set(ROLE_CACHE_NS, id, role.clone());
+        }
+        Ok(role)
     }
 
     /// Get a role imply rule.
@@ -417,9 +450,17 @@ impl RoleApi for RoleService {
         ctx: &ExecutionContext<'a>,
         prior_role_id: &'a str,
     ) -> Result<Vec<RoleImply>, RoleProviderError> {
-        self.backend_driver
+        if let Some(rules) =
+            cache_get::<Vec<RoleImply>>(ROLE_IMPLY_BY_PRIOR_CACHE_NS, prior_role_id)
+        {
+            return Ok(rules);
+        }
+        let rules = self
+            .backend_driver
             .list_role_imply_rules_by_prior(ctx.state(), prior_role_id)
-            .await
+            .await?;
+        cache_set(ROLE_IMPLY_BY_PRIOR_CACHE_NS, prior_role_id, rules.clone());
+        Ok(rules)
     }
 
     /// List roles.
@@ -558,5 +599,291 @@ mod tests {
                 .await
                 .is_ok()
         );
+    }
+
+    // --- Per-request cache (ADR 0030) -------------------------------------
+
+    fn make_role_ref(id: &str) -> RoleRef {
+        RoleRefBuilder::default().id(id).build().unwrap()
+    }
+
+    fn make_imply(prior: &str, implied: &str) -> RoleImply {
+        RoleImplyBuilder::default()
+            .prior_role(make_role_ref(prior))
+            .implied_role(make_role_ref(implied))
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_get_role_hits_backend_once_across_repeated_calls() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_get_role()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(Some(make_role("rid", "admin"))));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            let first = provider.get_role(&ctx, "rid").await.unwrap().unwrap();
+            let second = provider.get_role(&ctx, "rid").await.unwrap().unwrap();
+            assert_eq!(first, second);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_role_not_cached_outside_request_scope() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_get_role()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(Some(make_role("rid", "admin"))));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_role(&ctx, "rid").await.unwrap();
+        provider.get_role(&ctx, "rid").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_role_refreshes_cache_instead_of_refetching() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_get_role()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(Some(make_role("rid", "admin"))));
+        backend
+            .expect_update_role()
+            .withf(|_, id: &'_ str, _| id == "rid")
+            .returning(|_, _, update| {
+                let mut r = make_role("rid", "admin");
+                if let Some(name) = update.name {
+                    r.name = name;
+                }
+                Ok(r)
+            });
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_role(&ctx, "rid").await.unwrap();
+
+            let updated = provider
+                .update_role(
+                    &ctx,
+                    "rid",
+                    RoleUpdate {
+                        name: Some("renamed".into()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(updated.name, "renamed");
+
+            let refetched = provider.get_role(&ctx, "rid").await.unwrap().unwrap();
+            assert_eq!(refetched.name, "renamed");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_role_invalidates_cache() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_get_role()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(Some(make_role("rid", "admin"))));
+        backend
+            .expect_delete_role()
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(()));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider.get_role(&ctx, "rid").await.unwrap();
+            provider.delete_role(&ctx, "rid").await.unwrap();
+            provider.get_role(&ctx, "rid").await.unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_list_role_imply_rules_by_prior_hits_backend_once_across_repeated_calls() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_list_role_imply_rules_by_prior()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(vec![make_imply("rid", "implied")]));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            let first = provider
+                .list_role_imply_rules_by_prior(&ctx, "rid")
+                .await
+                .unwrap();
+            let second = provider
+                .list_role_imply_rules_by_prior(&ctx, "rid")
+                .await
+                .unwrap();
+            assert_eq!(first, second);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_list_role_imply_rules_by_prior_caches_empty_result() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_list_role_imply_rules_by_prior()
+            .times(1)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(vec![]));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            assert!(
+                provider
+                    .list_role_imply_rules_by_prior(&ctx, "rid")
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+            // A leaf role with no imply rules is itself a stable answer --
+            // must not force a second backend call.
+            assert!(
+                provider
+                    .list_role_imply_rules_by_prior(&ctx, "rid")
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_list_role_imply_rules_by_prior_not_cached_outside_request_scope() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_list_role_imply_rules_by_prior()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(vec![make_imply("rid", "implied")]));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        let ctx = ExecutionContext::internal(&state);
+        provider
+            .list_role_imply_rules_by_prior(&ctx, "rid")
+            .await
+            .unwrap();
+        provider
+            .list_role_imply_rules_by_prior(&ctx, "rid")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_role_imply_rule_invalidates_by_prior_cache() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_list_role_imply_rules_by_prior()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(vec![make_imply("rid", "implied")]));
+        backend
+            .expect_create_role_imply_rule()
+            .withf(|_, prior: &'_ str, implied: &'_ str| prior == "rid" && implied == "new-implied")
+            .returning(|_, prior, implied| Ok(make_imply(prior, implied)));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider
+                .list_role_imply_rules_by_prior(&ctx, "rid")
+                .await
+                .unwrap();
+            provider
+                .create_role_imply_rule(&ctx, "rid", "new-implied")
+                .await
+                .unwrap();
+            // Cache entry for "rid" was invalidated by the create -- this
+            // call must reach the backend again rather than serve the
+            // stale pre-create list.
+            provider
+                .list_role_imply_rules_by_prior(&ctx, "rid")
+                .await
+                .unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_role_imply_rule_invalidates_by_prior_cache() {
+        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut backend = MockRoleBackend::default();
+        backend
+            .expect_list_role_imply_rules_by_prior()
+            .times(2)
+            .withf(|_, id: &'_ str| id == "rid")
+            .returning(|_, _| Ok(vec![make_imply("rid", "implied")]));
+        backend
+            .expect_delete_role_imply_rule()
+            .withf(|_, prior: &'_ str, implied: &'_ str| prior == "rid" && implied == "implied")
+            .returning(|_, _, _| Ok(()));
+        let provider = RoleService {
+            backend_driver: Arc::new(backend),
+        };
+
+        crate::request_cache::RequestCache::scope(async {
+            let ctx = ExecutionContext::internal(&state);
+            provider
+                .list_role_imply_rules_by_prior(&ctx, "rid")
+                .await
+                .unwrap();
+            provider
+                .delete_role_imply_rule(&ctx, "rid", "implied")
+                .await
+                .unwrap();
+            provider
+                .list_role_imply_rules_by_prior(&ctx, "rid")
+                .await
+                .unwrap();
+        })
+        .await;
     }
 }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -27,6 +27,7 @@ use axum::{
     Router, ServiceExt,
     extract::{ConnectInfo, DefaultBodyLimit, State},
     http::{self, HeaderName, Request, StatusCode, header},
+    middleware,
     response::IntoResponse,
 };
 use clap::{Parser, ValueEnum};
@@ -81,6 +82,7 @@ use openstack_keystone::role::RoleHook;
 use openstack_keystone::scim;
 use openstack_keystone::server::listener::{raft_grpc, spiffe_tls, spiffe_tls_uds};
 use openstack_keystone::server::proxy_headers;
+use openstack_keystone::server::request_cache;
 use openstack_keystone::token::TokenHook;
 use openstack_keystone::trust::TrustHook;
 use openstack_keystone::webauthn;
@@ -794,6 +796,10 @@ async fn build_router(
             OpenStackRequestId::default(),
         ))
         //.layer(PropagateRequestIdLayer::new(x_request_id))
+        // Establish the per-request cache scope (ADR 0030) before any
+        // handler runs, so provider code anywhere on this request's task
+        // can reach it via `openstack_keystone_core::request_cache`.
+        .layer(middleware::from_fn(request_cache::with_request_cache))
         .sensitive_request_headers(sensitive_headers.clone())
         .layer(DefaultBodyLimit::max(DEFAULT_BODY_LIMIT))
         .layer(

--- a/crates/keystone/src/server.rs
+++ b/crates/keystone/src/server.rs
@@ -14,3 +14,4 @@
 //! # Keystone server listeners
 pub mod listener;
 pub mod proxy_headers;
+pub mod request_cache;

--- a/crates/keystone/src/server/request_cache.rs
+++ b/crates/keystone/src/server/request_cache.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Per-request cache scope middleware
+//!
+//! Establishes the [`openstack_keystone_core::request_cache::RequestCache`]
+//! task_local for the duration of each request (see ADR 0030), so provider
+//! code anywhere on the request's task can read/write it without a new
+//! parameter threaded through every call site. Must be layered onto every
+//! independent router entry point (the main router and the SCIM router),
+//! since each is its own top-level `Router` and therefore its own set of
+//! request tasks.
+
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use openstack_keystone_core::request_cache::RequestCache;
+
+/// Axum middleware that runs the rest of the request inside a fresh,
+/// request-scoped [`RequestCache`].
+pub async fn with_request_cache(req: Request, next: Next) -> Response {
+    RequestCache::scope(next.run(req)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Router;
+    use axum::body::Body;
+    use axum::routing::get;
+    use tower::ServiceExt as _;
+
+    use super::*;
+    use openstack_keystone_core::request_cache::{cache_get, cache_set};
+
+    async fn handler() -> String {
+        assert_eq!(cache_get::<String>("ns", "k"), None);
+        cache_set("ns", "k", "value".to_string());
+        cache_get::<String>("ns", "k").unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn test_scope_established_per_request() {
+        let app = Router::new()
+            .route("/echo", get(handler))
+            .layer(axum::middleware::from_fn(with_request_cache));
+
+        for _ in 0..2 {
+            let resp = app
+                .clone()
+                .oneshot(Request::builder().uri("/echo").body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            assert_eq!(&body[..], b"value");
+        }
+    }
+}

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -118,3 +118,4 @@
     - [LDAP identity backend](adr/0027-ldap-identity-driver.md)
     - [Quorum-Bypass Emergency Operations](adr/0028-oauth2-quorum-bypass-emergency-rotation.md)
     - [Generalized Pagination](adr/0029-pagination.md)
+    - [Per-Request Cache via tokio::task_local!](adr/0030-per-request-cache.md)

--- a/doc/src/adr/0030-per-request-cache.md
+++ b/doc/src/adr/0030-per-request-cache.md
@@ -1,0 +1,242 @@
+# 30. Per-Request Cache via `tokio::task_local!`
+
+**Date:** 2026-07-28
+
+## Status
+
+Proposed
+
+## Context
+
+Several sessions of query-log analysis found the same shape of bug repeatedly: a
+single incoming request re-fetches the same row more than once because two
+independent code paths, invoked within the same request, each do their own
+lookup with no way to know the other already ran. Two concrete instances fixed
+ad hoc so far:
+
+- Token validation fetched the token's domain twice — once to validate scope,
+  once to build the response — because the two call sites had no shared state
+  between them.
+- `identity-driver-sql` fetched a user's **entire password history** on every
+  display/auth path (`GET /users/:id`, `GET /users`, password auth), even though
+  every consumer only ever reads the newest row (`merge_passwords_data` always
+  calls `.next()` on the iterator it's given). That one was fixed by pushing
+  `ORDER BY ... DESC LIMIT 1` / `DISTINCT ON` down into SQL rather than by
+  caching, because the DB can answer "give me only the newest row" directly — no
+  caching involved, just asking for less data. This ADR does not change that
+  fix.
+
+Both were fixed individually because there was no general mechanism. This ADR is
+about the _next_ one: a request-scoped cache so redundant lookups within a
+single request (e.g., two provider calls in the same handler both resolving the
+same `domain_id`, or a nested provider call re-fetching a `project` its caller
+already loaded) stop needing a bespoke fix each time.
+
+### Why not extend the existing process-lifetime cache pattern
+
+`crates/core/src/identity/service.rs` already has a cache:
+`user_id_domain_id_cache: RwLock<HashMap<String, String>>`, config-gated by
+`identity.caching`, manually invalidated on user delete and domain reassignment.
+That pattern works because the cached fact (`user_id` → `domain_id`) is close to
+immutable for the life of the process. Most candidate lookups for a per-request
+cache (a `project` row, a `domain` row, resolved role assignments) are _not_
+immutable — they can be mutated by a concurrent request a moment later. A
+process-lifetime cache for those would need real invalidation plumbing
+(bus/event-driven cache busting) to avoid serving stale data to a _different_
+request after a write. A cache whose scope is exactly one request sidesteps that
+entirely: it is populated from reads made within the request, discarded when the
+request ends, and never observed by any other request, so there is no
+invalidation problem to solve at all — correctness is automatic, not maintained
+by hand.
+
+### Why not thread an explicit cache parameter through every call
+
+`ExecutionContext<'a>` (`crates/core/src/auth.rs:548`) is the object passed by
+reference into every provider trait method
+(`crates/core/src/identity/provider_api.rs` and the equivalent `provider_api.rs`
+in every other domain crate). It looks like the natural place to hang a cache
+field. It isn't, in practice: handlers routinely construct a **fresh**
+`ExecutionContext::from_auth(&state, &user_auth)` inline at each call site
+rather than building one and reusing it — e.g.
+`crates/keystone/src/federation/api/identity_provider/update.rs` constructs two
+separate `ExecutionContext`s in the same handler function. Adding a cache field
+to the struct would only dedupe lookups made through the _same_
+`ExecutionContext` instance, missing exactly the multi-call-site case this ADR
+exists to fix, unless every handler in the codebase were first refactored to
+build one `ExecutionContext` per request and thread `&ctx` through every call —
+a much larger, invasive change than the caching mechanism itself warrants.
+
+### Why `tokio::task_local!` is the right shape here
+
+A per-request cache needs to be reachable from deep inside provider/backend code
+(`crates/core/src/identity/service.rs`, `crates/identity-driver-sql/src/lib.rs`,
+...) without adding a parameter to every trait method across every domain.
+`tokio::task_local!` gives exactly that: state that travels implicitly with the
+currently-executing async task, readable from any function running on that task
+without being passed explicitly, and automatically gone once the task's scope
+ends. This is not a new idea in this codebase —
+`crates/core/src/events.rs:117-125` already uses `tokio::task_local!` for
+`EMIT_CRITICAL_RECURSION`, a reentrancy guard for
+`EventDispatcher::emit_critical`, with exactly the defensive access pattern
+(`try_with(...).unwrap_or(default)`) this ADR reuses: code running outside any
+established scope (tests, CLI tooling, background jobs) just sees "no cache,"
+not a panic or an error.
+
+Axum's per-request execution unit **is** a single tokio task (the handler's
+future, spawned once per accepted connection/request), so "task-scoped" and
+"request-scoped" coincide exactly here — there is no separate request
+abstraction to scope against.
+
+### No new dependency
+
+`tokio` is already a workspace dependency (`Cargo.toml:185`,
+`tokio = { version = "1.52", default-features = false }`) and
+`task_local!`/`LocalKey::scope`/`LocalKey::try_with` are part of `tokio`'s core
+API surface with no additional feature flag required — proven by the existing
+`crates/core/src/events.rs` usage compiling and running today under the same
+`default-features = false` configuration. `moka`, `lru`, and `once_cell` are not
+present in the workspace and are not needed. `dashmap` and `arc-swap` are
+already workspace dependencies but are unnecessary here: the cache is exclusive
+to a single task by construction (never accessed concurrently), so a plain
+`RefCell` needs no interior synchronization — using `dashmap` would only be
+paying for concurrency control this design never needs.
+
+## Decision
+
+### New module: `crates/core/src/request_cache.rs`
+
+```rust
+tokio::task_local! {
+    /// Per-request cache. Established once per incoming request by Axum
+    /// middleware; absent outside a request scope (tests, CLI tooling,
+    /// background jobs), in which case reads/writes are silent no-ops.
+    static REQUEST_CACHE: RequestCache;
+}
+
+#[derive(Default)]
+pub struct RequestCache {
+    entries: RefCell<HashMap<(&'static str, String), Box<dyn Any + Send>>>,
+}
+```
+
+- Keyed by `(namespace, id)` — `namespace` is a `&'static str` literal owned by
+  the calling module (e.g. `"resource.domain"`, `"resource.project"`), `id` is
+  the lookup key (e.g. a `domain_id`). Namespacing avoids collisions between
+  domains caching under the same raw id string.
+- Values are `Box<dyn Any + Send>`, downcast by the typed accessor below. `Send`
+  (not `Send + Sync`) is required and sufficient: nothing needs `Sync` because
+  access is never concurrent — the cache belongs to exactly one task — but the
+  _task itself_ must remain `Send` for Axum's multi-thread runtime to move it
+  between worker threads at `.await` points, which requires every value the task
+  owns, including task-local storage, to be `Send`.
+- `RefCell`, not `RwLock`/`Mutex`: no async code holds a borrow across an
+  `.await` point (get and insert are both synchronous, bracketing any async
+  fetch — see below), and there is never concurrent access to fight over, so an
+  async-aware lock would be pure overhead.
+
+### Accessor API
+
+```rust
+impl RequestCache {
+    pub fn get<T: Clone + 'static>(&self, namespace: &'static str, id: &str) -> Option<T> { ... }
+    pub fn set<T: Send + 'static>(&self, namespace: &'static str, id: &str, value: T) { ... }
+}
+
+/// Reads from the current request's cache, if any. Outside a request scope
+/// (no `task_local` established), always returns `None`.
+pub fn cache_get<T: Clone + 'static>(namespace: &'static str, id: &str) -> Option<T> {
+    REQUEST_CACHE.try_with(|c| c.get(namespace, id)).ok().flatten()
+}
+
+/// Writes into the current request's cache, if any. Outside a request scope,
+/// silently does nothing.
+pub fn cache_set<T: Send + 'static>(namespace: &'static str, id: &str, value: T) {
+    let _ = REQUEST_CACHE.try_with(|c| c.set(namespace, id, value));
+}
+```
+
+Call-site pattern (e.g. resolving a `domain` inside a provider method):
+
+```rust
+if let Some(domain) = cache_get::<DomainResponse>("resource.domain", domain_id) {
+    return Ok(Some(domain));
+}
+let domain = self.backend_driver.get_domain(ctx.state(), domain_id).await?;
+if let Some(d) = &domain {
+    cache_set("resource.domain", domain_id, d.clone());
+}
+Ok(domain)
+```
+
+The cache check and the cache write are both synchronous and bracket the
+`.await` — no borrow is ever held across an await point, satisfying `RefCell`'s
+requirements without needing an async lock.
+
+**Known, accepted race**: two concurrent lookups for the same key that both miss
+will both hit the backend and both write — the second write just overwrites the
+first with an equal value. This is intentionally not guarded with an
+in-flight-request de-dup (e.g. a `HashMap<Key, oneshot::Receiver>` pattern) —
+that adds real complexity for a benefit that only matters if the _same_ request
+independently kicks off two concurrent fetches of the _same_ key, which existing
+call sites don't do (the duplicate-fetch bugs this ADR targets are sequential,
+not concurrent, within a request).
+
+### Middleware: establish the scope once per request
+
+New `axum::middleware::from_fn` layer, added next to the existing
+`proxy_headers` layer (`crates/keystone/src/server/proxy_headers.rs:116-120`) in
+the `ServiceBuilder` chain built by `build_router`
+(`crates/keystone/src/bin/keystone.rs:781`):
+
+```rust
+async fn with_request_cache(req: Request, next: Next) -> Response {
+    REQUEST_CACHE.scope(RequestCache::default(), next.run(req)).await
+}
+```
+
+Added to both entry points that build an Axum `Router` independently: the main
+router in `build_router` and the SCIM router (`crates/keystone/src/scim.rs:70`,
+nested at `/SCIM/v2`), since the SCIM router is constructed separately and would
+otherwise never establish the scope.
+
+### Provider-layer usage
+
+`cache_get`/`cache_set` are called from the domain provider layer
+(`crates/core/src/identity/service.rs` and equivalent `service.rs` files in
+`resource`, `assignment`, etc.) — the same layer that already hosts the
+process-lifetime `user_id_domain_id_cache` — not from the `*-driver-sql` backend
+crates, which stay backend-agnostic and untouched. This is opt-in per call site:
+only lookups that are (a) read multiple times within a plausible single request
+and (b) not already the cheapest possible query (recall the password fix:
+sometimes the right answer is "ask the DB for less," not "cache more") get wired
+up. There is no blanket "cache every provider read" policy — that would risk
+masking future N+1 patterns instead of surfacing them.
+
+## Consequences
+
+- Redundant same-request lookups (repeated `domain`/`project`/similar reads
+  across independent call sites within one request) can be eliminated by adding
+  a `cache_get`/`cache_set` pair at the provider layer, with no changes to trait
+  signatures, no threading a new parameter through `ExecutionContext` or any
+  `provider_api.rs`, and no per-crate dependency changes.
+- No invalidation logic is needed anywhere: the cache is torn down automatically
+  when the request's task completes (`REQUEST_CACHE.scope` ends), so a write
+  made by request A can never be observed by request B. This is strictly simpler
+  than the existing `user_id_domain_id_cache`, which requires manual
+  invalidation on every mutating call that touches its cached facts.
+- Code outside a request scope (unit tests calling provider methods directly,
+  CLI tooling, background jobs, `ExecutionContext::internal` paths not reached
+  via Axum) sees `cache_get` always return `None` and `cache_set` as a no-op —
+  correct by construction, not by an explicit feature flag, so no test setup
+  changes are required for the bulk of the existing test suite. Tests that
+  specifically want to exercise cache behavior must wrap the call under test in
+  `REQUEST_CACHE.scope(...)`.
+- The mechanism only helps deduplicate reads _within_ one request; it does
+  nothing for the "fetch too much data" class of problem (the password-list
+  fix). Both remain valid, complementary tools — engineers should default to
+  "can the query ask for less" first, and reach for the per-request cache only
+  when the same data is genuinely re-derived from scratch more than once inside
+  one request.
+- Adds one new module (`crates/core/src/request_cache.rs`) and one new
+  middleware layer registered in two places (`build_router`,
+  `crates/keystone/src/scim.rs`). No new workspace dependency.


### PR DESCRIPTION
Query-log analysis kept finding the same class of bug: two
independent call sites in one request each re-fetch the same row
because nothing tells the second one the first already ran. Adds a
tokio::task_local-scoped cache (crates/core/src/request_cache.rs),
following the existing EMIT_CRITICAL_RECURSION pattern in
crate::events, established once per HTTP request via a new Axum
middleware layer. No invalidation logic needed anywhere: the cache
dies with the request's task, so a write from one request can never
leak into another. No new workspace dependency.

Wires the ADR 0030 request cache into the resource, role, and
identity provider layers:

- resource: get_domain, get_project, get_project_parents
- role: get_role, list_role_imply_rules_by_prior (backs the
  assignment-driver-sql BFS role-imply resolution)
- identity: get_user, get_group

Each cached read is refreshed on its own update and invalidated on
its own delete. list_role_imply_rules_by_prior also caches empty
results (a leaf role's "no imply rules" is a stable answer), and
update_user_password invalidates get_user's entry since it changes
password_expires_at without returning a fresh UserResponse to
refresh with.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
