### PR TITLE
feat(server): Fold uri/request-id into access log message

### DIFF
--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -42,10 +42,10 @@ use tokio_util::sync::CancellationToken;
 use tower::util::MapRequestLayer;
 use tower::{Layer as _, ServiceBuilder};
 use tower_http::{
-    LatencyUnit, ServiceBuilderExt,
+    ServiceBuilderExt,
     normalize_path::NormalizePathLayer,
     request_id::{MakeRequestId, PropagateRequestIdLayer, RequestId, SetRequestIdLayer},
-    trace::{DefaultOnRequest, DefaultOnResponse, TraceLayer},
+    trace::{DefaultOnRequest, TraceLayer},
 };
 use tracing::{Level, debug, error, info, info_span, trace, warn};
 use tracing_appender::non_blocking::NonBlockingBuilder;
@@ -80,6 +80,7 @@ use openstack_keystone::resource::ResourceHook;
 use openstack_keystone::revoke::RevokeHook;
 use openstack_keystone::role::RoleHook;
 use openstack_keystone::scim;
+use openstack_keystone::server::access_log::log_request;
 use openstack_keystone::server::listener::{raft_grpc, spiffe_tls, spiffe_tls_uds};
 use openstack_keystone::server::proxy_headers;
 use openstack_keystone::server::request_cache;
@@ -834,12 +835,17 @@ async fn build_router(
                 // DEBUG (tower-http's own upstream default) instead of
                 // doubling every request's log volume at INFO.
                 .on_request(DefaultOnRequest::new().level(Level::DEBUG))
-                .on_response(
-                    DefaultOnResponse::new()
-                        .level(Level::INFO)
-                        .latency_unit(LatencyUnit::Micros),
-                ),
+                // Finish-of-request logging is done by `log_request` below
+                // instead of `DefaultOnResponse`, so the message text
+                // carries uri/request-id inline (see access_log module docs).
+                .on_response(()),
         )
+        // Logs one INFO line per request with method/uri/request-id/status/
+        // latency folded into the message text (not just span fields), so
+        // log collectors that only index MESSAGE (e.g. journald) can search
+        // on them. Must stay layered after TraceLayer so it runs inside the
+        // request span.
+        .layer(middleware::from_fn(log_request))
         // Compress responses
         .compression()
         .sensitive_response_headers(sensitive_headers)

--- a/crates/keystone/src/server.rs
+++ b/crates/keystone/src/server.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # Keystone server listeners
+pub mod access_log;
 pub mod listener;
 pub mod proxy_headers;
 pub mod request_cache;

--- a/crates/keystone/src/server/access_log.rs
+++ b/crates/keystone/src/server/access_log.rs
@@ -1,0 +1,61 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Access log middleware
+//!
+//! `tower_http::trace::DefaultOnResponse` logs a static "finished processing
+//! request" message and puts `uri`/`x_request_id`/etc. as separate `tracing`
+//! span fields. `tracing_subscriber::fmt` (stderr/file) flattens those fields
+//! into the rendered line, but `tracing_journald::Layer` stores them as
+//! distinct journal fields (`F_URI`, `F_X_REQUEST_ID`, ...) rather than
+//! folding them into `MESSAGE`. Log collectors that only index `MESSAGE`
+//! (e.g. journald-backed Graylog inputs) then can't search by URI or request
+//! id.
+//!
+//! This middleware must run inside the `TraceLayer` span (layered after
+//! it) so it replaces `TraceLayer`'s `on_response` and emits one line with
+//! method/uri/request id/status/latency baked directly into the message
+//! text, not just as structured fields.
+
+use std::time::Instant;
+
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+
+pub async fn log_request(req: Request, next: Next) -> Response {
+    let method = req.method().clone();
+    let uri = req.uri().path().to_string();
+    let request_id = req
+        .headers()
+        .get("x-openstack-request-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+        .unwrap_or_else(|| "-".to_owned());
+
+    let start = Instant::now();
+    let response = next.run(req).await;
+    let status = response.status();
+    let latency_us = start.elapsed().as_micros();
+
+    tracing::info!(
+        %method,
+        %uri,
+        %request_id,
+        %status,
+        latency_us,
+        "finished processing request: {method} {uri} id={request_id} status={status} latency_us={latency_us}"
+    );
+
+    response
+}


### PR DESCRIPTION
DefaultOnResponse logged a static "finished processing request"
message, with uri/x_request_id as separate tracing span fields.
tracing_subscriber::fmt (stderr/file) flattens those into the
rendered line, but tracing_journald stores them as distinct
journal fields instead of MESSAGE. Log collectors indexing only
MESSAGE (e.g. journald-backed Graylog inputs) couldn't search by
uri or request id.

log_request middleware replaces TraceLayer's on_response and
emits one line per request with method/uri/request-id/status/
latency baked into the message text.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
