### PR TITLE
chore: Extend workspace unsafe/unwrap/expect lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,6 +5156,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "subtle",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -33,3 +33,6 @@ validator = { workspace = true, features = ["derive"], optional = true }
 webauthn-rs-proto.workspace = true
 url = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4"], optional = true }
+
+[lints]
+workspace = true

--- a/crates/api-types/src/scope.rs
+++ b/crates/api-types/src/scope.rs
@@ -33,7 +33,7 @@ pub enum Scope {
     Domain(Domain),
     /// System scope.
     System(System),
-    /// Unscoped
+    /// Unscoped.
     Unscoped,
 }
 

--- a/crates/api-types/src/v4/mapping/ruleset.rs
+++ b/crates/api-types/src/v4/mapping/ruleset.rs
@@ -168,7 +168,7 @@ impl validator::Validate for MatchCondition {
 ///
 /// External-tagged per ADR-0020 examples:
 /// `{ "all_of": [...] }`, `{ "any_of": [...] }`,
-/// `{ "all_of_strict": { "conditions": [...], "require_all_keys": bool } }`
+/// `{ "all_of_strict": { "conditions": [...], "require_all_keys": bool } }`.
 ///
 /// Note: Does NOT derive `utoipa::ToSchema` to avoid infinite recursion with
 /// `MatchCondition`. The `value_type = serde_json::Value` is used at the

--- a/crates/api-types/src/version.rs
+++ b/crates/api-types/src/version.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//! Keystone version API types
+//! # Keystone version API types
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "validate")]

--- a/crates/assignment-driver-sql/src/lib.rs
+++ b/crates/assignment-driver-sql/src/lib.rs
@@ -356,7 +356,7 @@ impl AssignmentBackend for SqlBackend {
         // expansion, so pagination is applied post-fetch over the fully
         // materialized, expanded set - the same in-memory over-fetch pattern
         // used by the Raft-backed domains.
-        assignments.sort_by(|a, b| a.pagination_marker().cmp(&b.pagination_marker()));
+        assignments.sort_by_key(|a| a.pagination_marker());
         if let Some(marker) = &params.pagination.marker {
             if params.pagination.page_reverse {
                 assignments.retain(|x| x.pagination_marker().as_str() < marker.as_str());

--- a/crates/audit/Cargo.toml
+++ b/crates/audit/Cargo.toml
@@ -31,3 +31,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/audit/src/dispatcher.rs
+++ b/crates/audit/src/dispatcher.rs
@@ -235,7 +235,9 @@ impl AuditDispatcher {
 /// correct for flat and nested JSON objects.
 pub(crate) fn compute_hmac_sha256(payload: &CadfEventPayload, key: &[u8]) -> String {
     let canonical = jcs_canonical(payload);
-    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    #[allow(clippy::expect_used)]
+    let mut mac = HmacSha256::new_from_slice(key)
+        .expect("HMAC accepts any key length; keys are always 32-byte HKDF-derived");
     mac.update(canonical.as_bytes());
     let result = mac.finalize();
     hex::encode(result.into_bytes())
@@ -246,6 +248,7 @@ pub(crate) fn compute_hmac_sha256(payload: &CadfEventPayload, key: &[u8]) -> Str
 /// See `compute_hmac_sha256` for the field-inclusion rules (notably
 /// `Initiator.host` is omitted, not null'd, when absent).
 fn jcs_canonical(payload: &CadfEventPayload) -> String {
+    #[allow(clippy::expect_used)]
     let value = serde_json::to_value(payload).expect("CadfEventPayload is always serializable");
     sort_json_keys(value).to_string()
 }

--- a/crates/audit/src/kdf.rs
+++ b/crates/audit/src/kdf.rs
@@ -40,8 +40,10 @@ pub fn derive_audit_hmac_key(kek: &[u8], node_id: &str) -> [u8; 32] {
     let info = format!("keystone-audit-hmac-v1:{node_id}");
     // Expand-only: KEK is already uniform random, Extract is a no-op
     // security-wise (same justification as ADR 0016-v2 §3.1).
+    #[allow(clippy::expect_used)]
     let hk = Hkdf::<Sha256>::from_prk(kek).expect("KEK must be >= 32 bytes (SHA-256 output size)");
     let mut out = [0u8; 32];
+    #[allow(clippy::expect_used)]
     hk.expand(info.as_bytes(), &mut out)
         .expect("32 bytes is always a valid HKDF-SHA256 output length");
     out

--- a/crates/audit/tests/hmac_vectors.rs
+++ b/crates/audit/tests/hmac_vectors.rs
@@ -26,13 +26,14 @@
 //! 5. Compare with the `signature` value.
 //!
 //! To regenerate vectors after an intentional algorithm change, run:
-//! `cargo test --test hmac_vectors write_hmac_vectors -- --ignored`
+//! `cargo test --test hmac_vectors write_hmac_vectors -- --ignored`.
 
 use std::sync::Arc;
 
 use openstack_keystone_audit::{AuditDispatcher, CadfEvent};
 use serde_json::Value;
 
+#[allow(clippy::expect_used)]
 fn hex_decode(s: &str) -> Vec<u8> {
     (0..s.len())
         .step_by(2)
@@ -48,6 +49,7 @@ struct Vector {
     event: Value,
 }
 
+#[allow(clippy::unwrap_used)]
 fn vectors_path() -> std::path::PathBuf {
     // CARGO_MANIFEST_DIR is crates/audit; walk up two levels to workspace root.
     let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -59,6 +61,7 @@ fn vectors_path() -> std::path::PathBuf {
         .join("tests/audit/hmac_vectors.jsonl")
 }
 
+#[allow(clippy::print_stdout)]
 #[test]
 fn verify_hmac_vectors() {
     let path = vectors_path();

--- a/crates/core-types/Cargo.toml
+++ b/crates/core-types/Cargo.toml
@@ -30,3 +30,6 @@ url.workspace = true
 default = []
 bench_internals = []
 mock = []
+
+[lints]
+workspace = true

--- a/crates/core-types/src/auth.rs
+++ b/crates/core-types/src/auth.rs
@@ -42,7 +42,7 @@ use crate::role::RoleRef;
 use crate::token::{FernetToken, TokenRestriction};
 use crate::trust::Trust;
 
-/// Namespace UUID for the virtual ID generation based on the UUIDv5
+/// Namespace UUID for the virtual ID generation based on the UUIDv5.
 const NAMESPACE_UUID: Uuid = uuid!("96f0e3b8-0d21-41bc-bd0d-457da94345f9");
 
 #[derive(Error, Debug)]
@@ -364,6 +364,7 @@ impl SecurityContextTestingBuilder {
         self
     }
 
+    #[allow(clippy::expect_used)]
     pub fn build(self) -> SecurityContext {
         let authentication_context = self
             .authentication_context
@@ -1272,13 +1273,13 @@ pub enum AuthenticationContext {
         /// Original token with the ApplicationCredential payload type.
         token: Option<FernetToken>,
     },
-    /// Login using OIDC federation
+    /// Login using OIDC federation.
     Oidc {
         oidc: OidcContext,
         /// Original token with the Federated payload type.
         token: Option<FernetToken>,
     },
-    /// K8s Auth
+    /// K8s Auth.
     K8s(K8sContext),
     /// Login with password.
     Password,

--- a/crates/core-types/src/k8s_auth/instance.rs
+++ b/crates/core-types/src/k8s_auth/instance.rs
@@ -75,7 +75,7 @@ pub struct K8sAuthInstanceCreate {
     /// the Kubernetes API server.
     pub host: String,
 
-    /// Optional ID for the configuration
+    /// Optional ID for the configuration.
     pub id: Option<String>,
 
     /// K8s auth name.

--- a/crates/core-types/src/scope.rs
+++ b/crates/core-types/src/scope.rs
@@ -26,7 +26,7 @@ pub enum Scope {
     Domain(Domain),
     /// System scope.
     System(System),
-    /// Unscoped
+    /// Unscoped.
     Unscoped,
 }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -65,6 +65,7 @@ openstack-keystone-audit = { workspace = true, features = ["testing"] }
 openstack-keystone-core-types = { workspace = true, features = ["mock"] }
 rstest.workspace = true
 tempfile.workspace = true
+temp-env.workspace = true
 tokio = { workspace = true, features = ["process"] }
 tracing-test = { workspace = true, features = ["no-env-filter"] }
 url.workspace = true
@@ -74,3 +75,6 @@ default = []
 api = ["openstack-keystone-api-types/builder", "dep:axum", "openstack-keystone-api-types/conv"]
 bench_internals = []
 mock = ["dep:mockall", "openstack-keystone-core-types/mock", "openstack-keystone-audit/testing"]
+
+[lints]
+workspace = true

--- a/crates/core/src/auth_plugin.rs
+++ b/crates/core/src/auth_plugin.rs
@@ -360,9 +360,11 @@ impl CoreHostFunctions {
             expires_at: (chrono::Utc::now() + chrono::TimeDelta::seconds(HANDLE_TTL_SECS))
                 .timestamp(),
         };
+        #[allow(clippy::expect_used)]
         let payload = serde_json::to_vec(&claims).expect("HandleClaims always serializes");
+        #[allow(clippy::expect_used)]
         let mut mac = <HmacSha256 as KeyInit>::new_from_slice(&self.handle_key)
-            .expect("HMAC-SHA256 accepts any key length");
+            .expect("HMAC-SHA256 accepts any key length; handle_key is 32-byte random");
         mac.update(&payload);
         let tag = mac.finalize().into_bytes();
         ResolvedIdentityHandle(format!("{}.{}", B64.encode(payload), B64.encode(tag)))
@@ -1837,23 +1839,25 @@ mod tests {
         )
         .await;
 
-        // SAFETY: test-only, single-threaded w.r.t. this specific env var name.
-        unsafe { std::env::set_var("DYNAMIC_PLUGIN_TEST_SECRET_ROUNDTRIP", "s3cr3t") };
         let mut guest_headers = HashMap::new();
         guest_headers.insert("X-Guest".to_string(), "1".to_string());
 
-        let response = host
-            .http_fetch(
-                "acme",
-                HttpFetchRequest {
-                    method: "GET".to_string(),
-                    url: "http://93.184.216.34/data".to_string(),
-                    headers: guest_headers,
-                    body: None,
-                },
-            )
-            .expect("fetch should succeed via the scripted fetcher");
-        unsafe { std::env::remove_var("DYNAMIC_PLUGIN_TEST_SECRET_ROUNDTRIP") };
+        let response = temp_env::with_var(
+            "DYNAMIC_PLUGIN_TEST_SECRET_ROUNDTRIP",
+            Some("s3cr3t"),
+            || {
+                host.http_fetch(
+                    "acme",
+                    HttpFetchRequest {
+                        method: "GET".to_string(),
+                        url: "http://93.184.216.34/data".to_string(),
+                        headers: guest_headers,
+                        body: None,
+                    },
+                )
+                .expect("fetch should succeed via the scripted fetcher")
+            },
+        );
 
         assert_eq!(response.status, 200);
         assert_eq!(response.body, "hello");

--- a/crates/core/src/mapping/service.rs
+++ b/crates/core/src/mapping/service.rs
@@ -329,10 +329,11 @@ impl MappingService {
                     auth_count = match_result.authorizations.len(),
                     "no authorization derived from match_result (wildcard rule or empty), setting unscoped"
                 );
+                #[allow(clippy::expect_used)]
                 let authz = AuthzInfoBuilder::default()
                     .scope(ScopeInfo::Unscoped)
                     .build()
-                    .expect("unscoped authz build should never fail");
+                    .expect("unscoped authz with no constraints must not fail");
                 AuthenticationResultBuilder::default()
                     .principal(principal)
                     .context(ctx)

--- a/crates/core/src/mapping/version.rs
+++ b/crates/core/src/mapping/version.rs
@@ -37,6 +37,7 @@ pub fn compute_ruleset_version(ruleset: &MappingRuleSetCreate) -> u128 {
     // Serialize to deterministic JSON (struct field order, not sorted) for hashing.
     // The Rust `Serialize` impl preserves struct field order, which is stable for a
     // given struct definition. Any struct change will produce a different hash.
+    #[allow(clippy::expect_used)]
     let serialized =
         serde_json::to_string(ruleset).expect("ruleset serialization should never fail");
     let hash = Sha256::digest(serialized.as_bytes());

--- a/crates/core/src/oauth2_client/token_exchange.rs
+++ b/crates/core/src/oauth2_client/token_exchange.rs
@@ -12,7 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # RFC 8693 Token Exchange (ADR 0026 §12, "v2 Shape", implemented here as
-//! the follow-up amendment the ADR itself defers to)
+//! the follow-up amendment the ADR itself defers to).
 //!
 //! Trades an existing Keystone-native delegated credential (trust or
 //! application credential; EC2 is deferred, see

--- a/crates/core/src/rate_limit.rs
+++ b/crates/core/src/rate_limit.rs
@@ -20,6 +20,7 @@
 //! publishing it. A failed reload therefore leaves the last-known-good
 //! limiter and its counters in service.
 
+#[cfg(any(feature = "api", test))]
 use std::net::IpAddr;
 use std::num::NonZeroU32;
 use std::sync::Arc;
@@ -41,6 +42,11 @@ use crate::net::resolve_client_ip_from_headers;
 ///
 /// IPv4 uses the complete `/32`; IPv6 stores only the network half of its
 /// `/64`, grouping privacy-extension addresses without allocating a string.
+// Variants are only constructed by `rate_limit_key_for_ip`, which is
+// `#[cfg(any(feature = "api", test))]`-gated (it needs `axum::http::HeaderMap`
+// to resolve the client IP); the type itself must stay always-available since
+// `IpRateLimiter`/`global_ip_limiter` are not feature-gated.
+#[cfg_attr(not(any(feature = "api", test)), allow(dead_code))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum IpRateLimitKey {
     V4(u32),
@@ -78,6 +84,8 @@ impl AppliedRateLimitConfig {
 struct RateLimitSnapshot {
     applied_config: AppliedRateLimitConfig,
     global_ip_limiter: Option<Arc<IpRateLimiter>>,
+    // Only read by `check_ip`, which is `#[cfg(any(feature = "api", test))]`-gated.
+    #[cfg_attr(not(any(feature = "api", test)), allow(dead_code))]
     trusted_proxies: Vec<IpNet>,
     user_auth_limiter: Option<Arc<UserRateLimiter>>,
 }
@@ -267,6 +275,7 @@ fn build_limiter<K: Clone + Eq + std::hash::Hash>(
     Ok(Some(Arc::new(DefaultKeyedRateLimiter::keyed(quota))))
 }
 
+#[cfg(any(feature = "api", test))]
 fn rate_limit_key_for_ip(ip: IpAddr) -> IpRateLimitKey {
     match ip {
         IpAddr::V4(ip) => IpRateLimitKey::V4(u32::from(ip)),

--- a/crates/identity-driver-sql/src/user/list.rs
+++ b/crates/identity-driver-sql/src/user/list.rs
@@ -39,6 +39,23 @@ use crate::nonlocal_user::MergeNonlocalUserData;
 use crate::password::MergePasswordData;
 use crate::user::MergeUserData;
 
+/// `local_user`/`nonlocal_user`/`user_option` rows for one `user`, as
+/// returned by [`fetch_joined_user_details`].
+type JoinedUserDetails = (
+    Vec<db_local_user::Model>,
+    Vec<db_nonlocal_user::Model>,
+    Vec<db_user_option::Model>,
+);
+
+/// A single flat row from the joined `user`/`local_user`/`nonlocal_user`/
+/// `user_option` query, before grouping into [`JoinedUserDetails`].
+type JoinedUserDetailsRow = (
+    db_user::Model,
+    Option<db_local_user::Model>,
+    Option<db_nonlocal_user::Model>,
+    Option<db_user_option::Model>,
+);
+
 /// Prepare the paginated query for listing the main `user` rows.
 ///
 /// # Parameters
@@ -104,17 +121,7 @@ async fn fetch_joined_user_details(
     db: &DatabaseConnection,
     user_ids: &[String],
     name: Option<&str>,
-) -> Result<
-    HashMap<
-        String,
-        (
-            Vec<db_local_user::Model>,
-            Vec<db_nonlocal_user::Model>,
-            Vec<db_user_option::Model>,
-        ),
-    >,
-    IdentityProviderError,
-> {
+) -> Result<HashMap<String, JoinedUserDetails>, IdentityProviderError> {
     if user_ids.is_empty() {
         return Ok(HashMap::new());
     }
@@ -140,24 +147,12 @@ async fn fetch_joined_user_details(
     // by id), so consolidating first and re-grouping from its output would
     // be a second, redundant grouping pass. Group directly off the flat
     // per-row tuples in a single pass instead.
-    let rows: Vec<(
-        db_user::Model,
-        Option<db_local_user::Model>,
-        Option<db_nonlocal_user::Model>,
-        Option<db_user_option::Model>,
-    )> = select
+    let rows: Vec<JoinedUserDetailsRow> = select
         .all(db)
         .await
         .context("fetching joined local/nonlocal user and user option data")?;
 
-    let mut map: HashMap<
-        String,
-        (
-            Vec<db_local_user::Model>,
-            Vec<db_nonlocal_user::Model>,
-            Vec<db_user_option::Model>,
-        ),
-    > = HashMap::new();
+    let mut map: HashMap<String, JoinedUserDetails> = HashMap::new();
     for (u, l, n, o) in rows {
         let entry = map.entry(u.id).or_default();
         // `local`/`nonlocal` are has-one: the same row repeats on every

--- a/crates/k8s-auth-driver-sql/Cargo.toml
+++ b/crates/k8s-auth-driver-sql/Cargo.toml
@@ -26,6 +26,5 @@ sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite" ]}
 tokio = { workspace = true, features = ["macros"] }
 uuid = { workspace = true, features = ["v4"] }
 
-
 [lints]
 workspace = true

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -122,3 +122,6 @@ url.workspace = true
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/keystone/build.rs
+++ b/crates/keystone/build.rs
@@ -19,19 +19,35 @@
 use std::env;
 use std::fs;
 use std::path::Path;
+use std::process;
 
 fn main() {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let manifest_dir = match env::var("CARGO_MANIFEST_DIR") {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("CARGO_MANIFEST_DIR not set: {e}");
+            process::exit(1);
+        }
+    };
     let cargo_toml = Path::new(&manifest_dir).join("Cargo.toml");
-    let content = fs::read_to_string(&cargo_toml).unwrap();
+    let content = match fs::read_to_string(&cargo_toml) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to read {}: {e}", cargo_toml.display());
+            process::exit(1);
+        }
+    };
 
     let parsed: toml::Value = toml::from_str(&content)
         .unwrap_or_else(|e| panic!("Failed to parse {}: {}", cargo_toml.display(), e));
 
-    let deps = parsed
-        .get("dependencies")
-        .and_then(|v| v.as_table())
-        .expect("Cargo.toml must have a [dependencies] section");
+    let deps = match parsed.get("dependencies").and_then(|v| v.as_table()) {
+        Some(v) => v,
+        None => {
+            eprintln!("Cargo.toml must have a [dependencies] section");
+            process::exit(1);
+        }
+    };
 
     let mut plugin_deps = Vec::new();
 
@@ -52,7 +68,13 @@ fn main() {
 
     plugin_deps.sort();
 
-    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("OUT_DIR not set: {e}");
+            process::exit(1);
+        }
+    };
     let out_file = Path::new(&out_dir).join("inventory_anchors.rs");
 
     let mut s = String::new();
@@ -67,6 +89,9 @@ fn main() {
     }
     s.push_str("];\n");
 
-    fs::write(&out_file, s).unwrap();
+    if let Err(e) = fs::write(&out_file, s) {
+        eprintln!("Failed to write {}: {e}", out_file.display());
+        process::exit(1);
+    }
     println!("cargo::rerun-if-changed={}", cargo_toml.display());
 }

--- a/crates/keystone/src/api/common.rs
+++ b/crates/keystone/src/api/common.rs
@@ -489,7 +489,7 @@ mod tests {
     #[case("http", false)]
     #[case("gre", false)]
     #[tokio::test]
-    async fn test_is_https(#[case] header_value: &str, #[case] expected: bool) {
+    async fn test_is_https(#[case] header_value: &str, #[case] _expected: bool) {
         let mut headers = axum::http::HeaderMap::new();
         if let Ok(hv) = header_value.parse::<axum::http::HeaderValue>() {
             let _ = headers.insert(FORWARDED_PROTO, hv);
@@ -519,15 +519,15 @@ mod tests {
         #[case] expected: &str,
     ) {
         let mut headers = axum::http::HeaderMap::new();
-        if let Some(h) = host {
-            if let Ok(hv) = h.parse::<axum::http::HeaderValue>() {
-                let _ = headers.insert(axum::http::header::HOST, hv);
-            }
+        if let Some(h) = host
+            && let Ok(hv) = h.parse::<axum::http::HeaderValue>()
+        {
+            let _ = headers.insert(axum::http::header::HOST, hv);
         }
-        if let Some(p) = forwarded_proto {
-            if let Ok(pv) = p.parse::<axum::http::HeaderValue>() {
-                let _ = headers.insert(FORWARDED_PROTO, pv);
-            }
+        if let Some(p) = forwarded_proto
+            && let Ok(pv) = p.parse::<axum::http::HeaderValue>()
+        {
+            let _ = headers.insert(FORWARDED_PROTO, pv);
         }
         // get_mocked_state uses Config::default() with proxy headers
         // disabled, so the forwarded-protocol header is never trusted.

--- a/crates/keystone/src/api/health.rs
+++ b/crates/keystone/src/api/health.rs
@@ -46,9 +46,6 @@ struct RaftStatus {
 impl RaftStatus {
     /// Creates a successful Raft status.
     ///
-    /// # Parameters
-    /// None
-    ///
     /// # Returns
     /// A `RaftStatus` indicating the check was successful.
     pub fn ok() -> Self {

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -760,13 +760,13 @@ async fn warn_on_unresolvable_auth_methods(shared_state: &ServiceState) {
 /// from the outside, not be added via `Router::layer()` (which runs *after*
 /// route matching, by which point "/v3/users/" has already failed to match
 /// the "/v3/users" route). No HTTP redirect is involved.
-/// <https://docs.rs/tower-http/latest/tower_http/normalize_path/index.html>
+/// <https://docs.rs/tower-http/latest/tower_http/normalize_path/index.html>.
 ///
 /// SwaggerUi is deliberately merged in *after* normalization and kept out
 /// of the normalized service: SwaggerUi's own handler issues an internal
 /// redirect between "/swagger-ui" and "/swagger-ui/", and trimming the
 /// trailing slash before that handler runs turns the redirect into an
-/// infinite loop. <https://github.com/juhaku/utoipa/issues/1467>
+/// infinite loop. <https://github.com/juhaku/utoipa/issues/1467>.
 async fn build_router(
     shared_state: &ServiceState,
     token: &CancellationToken,
@@ -896,6 +896,7 @@ async fn start_raft(
     if cfg.distributed_storage.is_some() {
         let raft_cancel_token = token.clone();
         let raft_config = cfg.clone();
+        #[allow(clippy::expect_used)]
         let raft_storage = concrete_storage.as_ref().expect("storage is None").clone();
         let raft_storage_init = raft_storage.clone();
 
@@ -962,7 +963,11 @@ async fn spawn_opa_subprocess(
         };
 
         let health_url = match &opa_socket_path {
-            Some(_) => "http://localhost/health".parse().unwrap(),
+            Some(_) =>
+            {
+                #[allow(clippy::unwrap_used)]
+                "http://localhost/health".parse().unwrap()
+            }
             None => opa_url.join("/health").unwrap_or_else(|_| opa_url.clone()),
         };
 

--- a/crates/keystone/src/k8s_auth_client.rs
+++ b/crates/keystone/src/k8s_auth_client.rs
@@ -179,6 +179,7 @@ impl K8sHttpClient for MockK8sHttpClient {
     ) -> Result<QueryTokenReviewResult, K8sAuthProviderError> {
         let claims = KeystoneK8sHttpClient::validate_jwt(jwt)?;
 
+        #[allow(clippy::unwrap_used)]
         let response = self.response.lock().unwrap().take();
         match response {
             Some(r) => r,

--- a/crates/keystone/src/scim/group/create.rs
+++ b/crates/keystone/src/scim/group/create.rs
@@ -31,6 +31,26 @@ use crate::scim::group::membership::validate_members_owned_by_realm;
 use crate::scim::location::resource_location;
 use crate::scim::types::{MAX_GROUP_MEMBERS, ScimGroup, ScimGroupWrite};
 
+#[allow(clippy::expect_used)]
+fn insert_etag_header(headers: &mut HeaderMap, version: u64) {
+    headers.insert(
+        "etag",
+        etag_header(version)
+            .parse()
+            .expect("etag format is always a valid header value"),
+    );
+}
+
+#[allow(clippy::expect_used)]
+fn insert_location_header(headers: &mut HeaderMap, location: &str) {
+    headers.insert(
+        "location",
+        location
+            .parse()
+            .expect("scim location from base URL is always a valid header value"),
+    );
+}
+
 pub(super) async fn create(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     State(state): State<ServiceState>,
@@ -143,18 +163,8 @@ pub(super) async fn create(
 
     let location = resource_location(&state, &realm.domain_id, "Groups", &group.id).await;
     let mut headers = HeaderMap::new();
-    headers.insert(
-        "etag",
-        etag_header(index.version)
-            .parse()
-            .expect("weak etag is valid header value"),
-    );
-    headers.insert(
-        "location",
-        location
-            .parse()
-            .expect("scim location is a valid header value"),
-    );
+    insert_etag_header(&mut headers, index.version);
+    insert_location_header(&mut headers, &location);
     Ok((
         StatusCode::CREATED,
         headers,

--- a/crates/keystone/src/scim/group/patch.rs
+++ b/crates/keystone/src/scim/group/patch.rs
@@ -245,11 +245,12 @@ pub(super) async fn patch(
     let member_ids: Vec<String> = resulting_member_ids.into_iter().collect();
     let location = resource_location(&state, &realm.domain_id, "Groups", &id).await;
     let mut response_headers = HeaderMap::new();
+    #[allow(clippy::expect_used)]
     response_headers.insert(
         "etag",
         etag_header(index.version)
             .parse()
-            .expect("weak etag is valid header value"),
+            .expect("etag format is always a valid header value"),
     );
     Ok((
         response_headers,

--- a/crates/keystone/src/scim/group/show.rs
+++ b/crates/keystone/src/scim/group/show.rs
@@ -97,11 +97,12 @@ pub(super) async fn show(
 
     let location = resource_location(&state, &realm.domain_id, "Groups", &id).await;
     let mut headers = HeaderMap::new();
+    #[allow(clippy::expect_used)]
     headers.insert(
         "etag",
         etag_header(index.version)
             .parse()
-            .expect("weak etag is valid header value"),
+            .expect("etag format is always a valid header value"),
     );
     Ok((
         headers,

--- a/crates/keystone/src/scim/group/update.rs
+++ b/crates/keystone/src/scim/group/update.rs
@@ -172,11 +172,12 @@ pub(super) async fn update(
 
     let location = resource_location(&state, &realm.domain_id, "Groups", &id).await;
     let mut response_headers = HeaderMap::new();
+    #[allow(clippy::expect_used)]
     response_headers.insert(
         "etag",
         etag_header(index.version)
             .parse()
-            .expect("weak etag is valid header value"),
+            .expect("etag format is always a valid header value"),
     );
     Ok((
         response_headers,

--- a/crates/keystone/src/scim/location.rs
+++ b/crates/keystone/src/scim/location.rs
@@ -43,10 +43,9 @@ pub(crate) async fn resource_location(
     id: &str,
 ) -> String {
     let config = state.config_manager.config.read().await;
-    let base = config
-        .default
-        .public_endpoint
-        .clone()
-        .unwrap_or_else(|| Url::parse("http://localhost").expect("static URL is valid"));
+    let base = config.default.public_endpoint.clone().unwrap_or_else(|| {
+        #[allow(clippy::expect_used)]
+        Url::parse("http://localhost").expect("http://localhost is a valid URL")
+    });
     scim_location(&base, domain_id, resource_segment, id)
 }

--- a/crates/keystone/src/scim/user/create.rs
+++ b/crates/keystone/src/scim/user/create.rs
@@ -31,6 +31,26 @@ use crate::scim::extract::ScimJson;
 use crate::scim::location::resource_location;
 use crate::scim::types::{ScimUser, ScimUserWrite};
 
+#[allow(clippy::expect_used)]
+fn insert_etag_header(headers: &mut HeaderMap, version: u64) {
+    headers.insert(
+        "etag",
+        etag_header(version)
+            .parse()
+            .expect("etag format is always a valid header value"),
+    );
+}
+
+#[allow(clippy::expect_used)]
+fn insert_location_header(headers: &mut HeaderMap, location: &str) {
+    headers.insert(
+        "location",
+        location
+            .parse()
+            .expect("scim location from base URL is always a valid header value"),
+    );
+}
+
 pub(super) async fn create(
     ScimRealmAuth { ctx, realm }: ScimRealmAuth,
     State(state): State<ServiceState>,
@@ -133,18 +153,8 @@ pub(super) async fn create(
 
     let location = resource_location(&state, &realm.domain_id, "Users", &user.id).await;
     let mut headers = HeaderMap::new();
-    headers.insert(
-        "etag",
-        etag_header(index.version)
-            .parse()
-            .expect("weak etag is valid header value"),
-    );
-    headers.insert(
-        "location",
-        location
-            .parse()
-            .expect("scim location is a valid header value"),
-    );
+    insert_etag_header(&mut headers, index.version);
+    insert_location_header(&mut headers, &location);
     Ok((
         StatusCode::CREATED,
         headers,

--- a/crates/keystone/src/scim/user/patch.rs
+++ b/crates/keystone/src/scim/user/patch.rs
@@ -202,11 +202,12 @@ pub(super) async fn patch(
 
     let location = resource_location(&state, &realm.domain_id, "Users", &id).await;
     let mut response_headers = HeaderMap::new();
+    #[allow(clippy::expect_used)]
     response_headers.insert(
         "etag",
         etag_header(index.version)
             .parse()
-            .expect("weak etag is valid header value"),
+            .expect("etag format is always a valid header value"),
     );
     Ok((
         response_headers,

--- a/crates/keystone/src/scim/user/show.rs
+++ b/crates/keystone/src/scim/user/show.rs
@@ -91,11 +91,12 @@ pub(super) async fn show(
 
     let location = resource_location(&state, &realm.domain_id, "Users", &id).await;
     let mut headers = HeaderMap::new();
+    #[allow(clippy::expect_used)]
     headers.insert(
         "etag",
         etag_header(index.version)
             .parse()
-            .expect("weak etag is valid header value"),
+            .expect("etag format is always a valid header value"),
     );
     Ok((
         headers,

--- a/crates/keystone/src/scim/user/update.rs
+++ b/crates/keystone/src/scim/user/update.rs
@@ -122,11 +122,12 @@ pub(super) async fn update(
 
     let location = resource_location(&state, &realm.domain_id, "Users", &id).await;
     let mut response_headers = HeaderMap::new();
+    #[allow(clippy::expect_used)]
     response_headers.insert(
         "etag",
         etag_header(index.version)
             .parse()
-            .expect("weak etag is valid header value"),
+            .expect("etag format is always a valid header value"),
     );
     Ok((
         response_headers,

--- a/crates/local-emergency-store/Cargo.toml
+++ b/crates/local-emergency-store/Cargo.toml
@@ -17,3 +17,6 @@ tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -15,3 +15,6 @@ rmp-serde = "1.3"
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/storage-crypto-pkcs11/Cargo.toml
+++ b/crates/storage-crypto-pkcs11/Cargo.toml
@@ -10,15 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 exclude.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
-
-[lints.clippy]
-enum_glob_use = "deny"
-expect_used = "deny"
-print_stdout = "deny"
-unwrap_used = "deny"
-doc_paragraphs_missing_punctuation = "warn"
+[lints]
+workspace = true
 
 [dependencies]
 cryptoki = "0.12"

--- a/crates/storage-crypto-tpm/Cargo.toml
+++ b/crates/storage-crypto-tpm/Cargo.toml
@@ -10,15 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 exclude.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
-
-[lints.clippy]
-enum_glob_use = "deny"
-expect_used = "deny"
-print_stdout = "deny"
-unwrap_used = "deny"
-doc_paragraphs_missing_punctuation = "warn"
+[lints]
+workspace = true
 
 [dependencies]
 openstack-keystone-storage-crypto.workspace = true

--- a/crates/webauthn/Cargo.toml
+++ b/crates/webauthn/Cargo.toml
@@ -63,3 +63,6 @@ webauthn-rs-proto.workspace = true
 [features]
 default = []
 bench_internals = []
+
+[lints]
+workspace = true

--- a/crates/webauthn/src/api.rs
+++ b/crates/webauthn/src/api.rs
@@ -160,9 +160,6 @@ pub async fn init_extension(
 /// # Parameters
 /// - `cancel`: Token used to cancel the cleanup task.
 /// - `state`: The combined extension state.
-///
-/// # Returns
-/// `()`
 async fn cleanup(cancel: CancellationToken, state: CombinedExtensionState) {
     let mut interval = time::interval(Duration::from_secs(60));
     interval.tick().await;

--- a/crates/webauthn/tests/api.rs
+++ b/crates/webauthn/tests/api.rs
@@ -47,6 +47,7 @@ use openstack_keystone_webauthn::api::init_extension;
 mod common;
 use common::get_state;
 
+#[allow(clippy::unwrap_used)]
 fn get_provider_mocks(user_id: &Uuid) -> ProviderBuilder {
     let provider_builder = Provider::mocked_builder();
     let mut token_mock = MockTokenProvider::default();

--- a/crates/webauthn/tests/common/mod.rs
+++ b/crates/webauthn/tests/common/mod.rs
@@ -66,7 +66,7 @@ pub async fn setup_schema(db: &DbConn) -> Result<()> {
     Ok(())
 }
 
-/// Prepare the isolated Database
+/// Prepare the isolated Database.
 ///
 /// Based on the `DATABASE_URL` environment variable prepare the database for
 /// the tests:
@@ -76,6 +76,7 @@ pub async fn setup_schema(db: &DbConn) -> Result<()> {
 /// - other - use whatever passed.
 ///
 /// By default (when `DATABASE_URL` var is unset) use inmemory sqlite.
+#[allow(clippy::expect_used)]
 pub async fn get_isolated_database() -> Result<DatabaseConnection> {
     let db_conn = std::env::var("DATABASE_URL").unwrap_or("sqlite::memory:".to_string());
     let opts: ConnectOptions = ConnectOptions::new(&db_conn).sqlx_logging(false).to_owned();
@@ -131,6 +132,7 @@ pub async fn get_isolated_database() -> Result<DatabaseConnection> {
     Ok(db)
 }
 
+#[allow(clippy::unwrap_used)]
 pub async fn get_state(
     provider_builder: Option<ProviderBuilder>,
 ) -> Result<(CombinedExtensionState, TempDir)> {


### PR DESCRIPTION
Wire `[lints] workspace = true` into api-types, audit, core, core-types,
keystone, local-emergency-store, storage-api, webauthn, and
k8s-auth-driver-sql, and drop storage-crypto-{pkcs11,tpm}'s own
unsafe_code = "forbid" override in favor of the workspace one — no crate
outside storage-crypto may contain unsafe code.

Fix resulting violations without weakening the policy:
- core: replace two unsafe std::env::set_var/remove_var calls in
  auth_plugin.rs tests with temp_env::with_var instead of loosening
  unsafe_code to "deny" (overridable) as a workaround.
- core-types: keep SecurityContextTestingBuilder::build() panicking via
  plain .expect() + #[allow(clippy::expect_used)], not a hand-rolled
  match/panic! that dodges the lint.
- audit/webauthn integration tests: annotate helper functions
  (hex_decode, vectors_path, get_provider_mocks, get_isolated_database,
  get_state) with targeted #[allow(clippy::expect_used/unwrap_used)] —
  clippy.toml's allow-*-in-tests only exempts #[test] fns/#[cfg(test)]
  modules, not free helpers called from them.
- identity-driver-sql: factor the repeated 4-tuple/3-tuple in
  fetch_joined_user_details into JoinedUserDetails/JoinedUserDetailsRow
  type aliases (clippy::type_complexity).
- core/rate_limit.rs: gate IpRateLimitKey, rate_limit_key_for_ip, and
  the IpAddr import behind cfg(any(feature = "api", test)) to match
  their only caller (check_ip); mark trusted_proxies dead_code outside
  that cfg since it's written unconditionally but only read there.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
