### PR TITLE
feat: Add SPIFFE SVID health check to readiness probe

### DIFF
--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -253,6 +253,7 @@ mod tests {
 
             storage: None,
             local_emergency_store: tokio::sync::RwLock::new(None),
+            spiffe_health_check: tokio::sync::RwLock::new(None),
             local_emergency_leaderless_tracker:
                 openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
@@ -376,6 +377,7 @@ mod tests {
 
             storage: None,
             local_emergency_store: tokio::sync::RwLock::new(None),
+            spiffe_health_check: tokio::sync::RwLock::new(None),
             local_emergency_leaderless_tracker:
                 openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
@@ -492,6 +494,7 @@ mod tests {
 
             storage: None,
             local_emergency_store: tokio::sync::RwLock::new(None),
+            spiffe_health_check: tokio::sync::RwLock::new(None),
             local_emergency_leaderless_tracker:
                 openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
@@ -573,6 +576,7 @@ mod tests {
 
             storage: None,
             local_emergency_store: tokio::sync::RwLock::new(None),
+            spiffe_health_check: tokio::sync::RwLock::new(None),
             local_emergency_leaderless_tracker:
                 openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
@@ -652,6 +656,7 @@ mod tests {
 
             storage: None,
             local_emergency_store: tokio::sync::RwLock::new(None),
+            spiffe_health_check: tokio::sync::RwLock::new(None),
             local_emergency_leaderless_tracker:
                 openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(
@@ -728,6 +733,7 @@ mod tests {
 
             storage: None,
             local_emergency_store: tokio::sync::RwLock::new(None),
+            spiffe_health_check: tokio::sync::RwLock::new(None),
             local_emergency_leaderless_tracker:
                 openstack_keystone_local_emergency_store::LeaderlessTracker::new(),
             api_key_rate_limiter: std::sync::Arc::new(governor::RateLimiter::keyed(

--- a/crates/core/src/keystone.rs
+++ b/crates/core/src/keystone.rs
@@ -33,6 +33,25 @@ use crate::policy::PolicyEnforcer;
 use crate::provider::Provider;
 use crate::rate_limit::RateLimitState;
 
+/// Outcome of a SPIFFE mTLS material freshness check, reported by the
+/// closure installed via [`Service::set_spiffe_health_check`].
+///
+/// Deliberately free of any `spiffe`-crate types: `core` is a
+/// transport-agnostic domain layer and must not depend on that crate (an
+/// infra/transport concern that belongs in `crates/keystone`). The real
+/// closure - built in `crates/keystone/src/bin/keystone.rs` - inspects a
+/// live `spiffe::X509Source` and maps its state down to this enum.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SpiffeHealthStatus {
+    /// The SPIFFE source is open and reports healthy, current material.
+    Ok,
+    /// The SPIFFE source is open but its current SVID/material is stale or
+    /// expired.
+    Warn(String),
+    /// The SPIFFE source itself is unreachable/closed.
+    Error(String),
+}
+
 // Placing ServiceState behind Arc is necessary to address DatabaseConnection
 // not implementing Clone.
 //#[derive(Clone)]
@@ -125,6 +144,26 @@ pub struct Service {
     /// `CRITICAL` log line).
     pub auth_plugin_load_failures: RwLock<HashMap<String, u64>>,
 
+    /// Type-erased hook used to observe SPIFFE mTLS material freshness for
+    /// the readiness probe (see `crates/keystone/src/api/health.rs`'s
+    /// `SpiffeStatus`).
+    ///
+    /// `core` is a transport-agnostic domain layer and must not depend on
+    /// the `spiffe` crate (that's an infra/transport concern), so this holds
+    /// a plain closure returning [`SpiffeHealthStatus`] - a spiffe-crate-free
+    /// enum - rather than an `Arc<spiffe::X509Source>` directly. `None`
+    /// unless the deployment has SPIFFE mTLS configured on at least one
+    /// interface. Populated post-construction (like `local_emergency_store`
+    /// above) via [`Self::set_spiffe_health_check`] - the real closure,
+    /// which captures a live `spiffe::X509Source`, is built in
+    /// `crates/keystone/src/bin/keystone.rs` once the config is known,
+    /// independent of the per-listener `X509Source` instances each mTLS
+    /// listener builds for itself in
+    /// `crates/keystone/src/server/listener/spiffe_common.rs`. This one
+    /// exists solely to give the health check a live handle it can query
+    /// without touching those listener-owned sources.
+    pub spiffe_health_check: RwLock<Option<Arc<dyn Fn() -> SpiffeHealthStatus + Send + Sync>>>,
+
     /// Shutdown flag.
     pub shutdown: bool,
 }
@@ -208,6 +247,7 @@ impl Service {
             rate_limiters,
             auth_plugin_limiters: RwLock::new(HashMap::new()),
             auth_plugin_load_failures: RwLock::new(HashMap::new()),
+            spiffe_health_check: RwLock::new(None),
             shutdown: false,
         })
     }
@@ -218,6 +258,18 @@ impl Service {
     /// distributed storage configured.
     pub async fn set_local_emergency_store(&self, store: Arc<dyn LocalEmergencyStore>) {
         *self.local_emergency_store.write().await = Some(store);
+    }
+
+    /// Install the SPIFFE health-check hook used by the readiness probe's
+    /// `SpiffeStatus` check. A no-op path (`spiffe_health_check` stays
+    /// `None`) if this is never called, e.g. on a node with no SPIFFE mTLS
+    /// interface configured. The closure is expected to be cheap and
+    /// non-blocking - it's called on every `/health`/`/ready` probe.
+    pub async fn set_spiffe_health_check(
+        &self,
+        check: Arc<dyn Fn() -> SpiffeHealthStatus + Send + Sync>,
+    ) {
+        *self.spiffe_health_check.write().await = Some(check);
     }
 
     /// Terminates the Keystone service.

--- a/crates/keystone/src/api/health.rs
+++ b/crates/keystone/src/api/health.rs
@@ -18,6 +18,7 @@ use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::keystone::ServiceState;
+use openstack_keystone_core::keystone::SpiffeHealthStatus;
 
 /// The health status.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, ToSchema)]
@@ -139,6 +140,66 @@ impl PolicyStatus {
     }
 }
 
+/// Health status of the SPIFFE mTLS material (ADR 0016-v2).
+///
+/// Tracks whether this node's live SPIFFE `X509Source` is still able to
+/// present a fresh SVID. A pod that has been running long enough for its
+/// SVID/trust bundle to silently drift out of sync with a freshly-joined
+/// peer will keep failing peer mTLS handshakes without ever tripping the
+/// other health checks (DB/policy/raft can all be fine) — this check exists
+/// so k8s notices and restarts the pod instead of it wedging for weeks.
+#[derive(Clone, Debug, PartialEq, Serialize, ToSchema)]
+struct SpiffeStatus {
+    /// The error message.
+    message: Option<String>,
+    /// Status of the SPIFFE mTLS material.
+    status: HealthStatus,
+}
+
+impl SpiffeStatus {
+    pub fn ok() -> Self {
+        Self {
+            message: None,
+            status: HealthStatus::Ok,
+        }
+    }
+
+    /// Builds an `Error` status from a plain message.
+    ///
+    /// Used instead of an `err<E: std::error::Error>(...)` constructor
+    /// because the underlying
+    /// [`openstack_keystone_core::keystone::SpiffeHealthStatus::Error`]
+    /// variant only carries a `String` — the real `spiffe::X509SourceError`
+    /// is converted to a message inside the `crates/keystone`-local closure
+    /// that builds it, since `core` must not depend on the `spiffe` crate.
+    pub fn err_msg<M>(message: M) -> Self
+    where
+        M: Into<String>,
+    {
+        Self {
+            message: Some(message.into()),
+            status: HealthStatus::Error,
+        }
+    }
+
+    pub fn skipped() -> Self {
+        Self {
+            message: None,
+            status: HealthStatus::Skipped,
+        }
+    }
+
+    pub fn warn<M>(message: M) -> Self
+    where
+        M: Into<String>,
+    {
+        Self {
+            message: Some(message.into()),
+            status: HealthStatus::Warn,
+        }
+    }
+}
+
 /// The health components of the system.
 #[derive(Clone, Debug, PartialEq, Serialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
@@ -149,6 +210,8 @@ struct HealthComponents {
     database: DatabaseStatus,
     /// Status of the policy enforcement engine.
     policy: PolicyStatus,
+    /// Status of the SPIFFE mTLS material.
+    spiffe: SpiffeStatus,
 }
 
 impl HealthComponents {
@@ -159,6 +222,7 @@ impl HealthComponents {
             .status
             .max(self.database.status)
             .max(self.policy.status)
+            .max(self.spiffe.status)
     }
 }
 
@@ -197,6 +261,7 @@ async fn ready(State(state): State<ServiceState>) -> impl IntoResponse {
         database: check_database(&state).await,
         policy: check_policy_engine(&state).await,
         raft: check_storage(&state).await,
+        spiffe: check_spiffe(&state).await,
     };
 
     let status = components.overall_status();
@@ -230,6 +295,7 @@ async fn health(State(state): State<ServiceState>) -> impl IntoResponse {
         database: check_database(&state).await,
         policy: check_policy_engine(&state).await,
         raft: check_storage(&state).await,
+        spiffe: check_spiffe(&state).await,
     };
 
     let status = components.overall_status();
@@ -278,6 +344,36 @@ async fn check_policy_engine(state: &ServiceState) -> PolicyStatus {
     }
 }
 
+/// Perform SPIFFE mTLS material health checks.
+///
+/// Returns `skipped` when no SPIFFE health-check hook has been installed on
+/// this node (no SPIFFE mTLS interface configured — see
+/// `Service::set_spiffe_health_check`). Otherwise calls the installed hook,
+/// which queries the live `spiffe::X509Source`'s own reported health/expiry
+/// rather than attempting a real loopback mTLS handshake, mirroring
+/// `check_storage`'s `is_initialized()`-only approach. `core` (and thus the
+/// `SpiffeHealthStatus` type this maps from) has no dependency on the
+/// `spiffe` crate — the actual `X509Source` inspection happens in the
+/// closure built by `crates/keystone/src/bin/keystone.rs`:
+///
+/// * `err` — the source itself is unreachable/closed.
+/// * `warn` — the source is open but its current SVID/material is stale or
+///   expired; this is exactly the incident scenario: a 40-day-old pod whose
+///   SVID silently drifted out of sync with a freshly-joined peer.
+/// * `ok` — the source is open and reports healthy, current material.
+async fn check_spiffe(state: &ServiceState) -> SpiffeStatus {
+    let guard = state.spiffe_health_check.read().await;
+    let Some(check) = guard.as_ref() else {
+        return SpiffeStatus::skipped();
+    };
+
+    match check() {
+        SpiffeHealthStatus::Ok => SpiffeStatus::ok(),
+        SpiffeHealthStatus::Warn(msg) => SpiffeStatus::warn(msg),
+        SpiffeHealthStatus::Error(msg) => SpiffeStatus::err_msg(msg),
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use axum::body::Body;
@@ -316,7 +412,8 @@ pub(crate) mod tests {
             HealthComponents {
                 raft: RaftStatus::ok(),
                 database: DatabaseStatus::ok(),
-                policy: PolicyStatus::ok()
+                policy: PolicyStatus::ok(),
+                spiffe: SpiffeStatus::skipped(),
             }
             .overall_status()
         );
@@ -325,7 +422,8 @@ pub(crate) mod tests {
             HealthComponents {
                 raft: RaftStatus::skipped(),
                 database: DatabaseStatus::ok(),
-                policy: PolicyStatus::ok()
+                policy: PolicyStatus::ok(),
+                spiffe: SpiffeStatus::skipped(),
             }
             .overall_status()
         );
@@ -334,7 +432,8 @@ pub(crate) mod tests {
             HealthComponents {
                 raft: RaftStatus::warn("warn"),
                 database: DatabaseStatus::ok(),
-                policy: PolicyStatus::ok()
+                policy: PolicyStatus::ok(),
+                spiffe: SpiffeStatus::skipped(),
             }
             .overall_status()
         );
@@ -343,7 +442,8 @@ pub(crate) mod tests {
             HealthComponents {
                 raft: RaftStatus::skipped(),
                 database: DatabaseStatus::ok(),
-                policy: PolicyStatus::warn("")
+                policy: PolicyStatus::warn(""),
+                spiffe: SpiffeStatus::skipped(),
             }
             .overall_status()
         );
@@ -352,7 +452,8 @@ pub(crate) mod tests {
             HealthComponents {
                 raft: RaftStatus::err(dummy_err()),
                 database: DatabaseStatus::ok(),
-                policy: PolicyStatus::warn("")
+                policy: PolicyStatus::warn(""),
+                spiffe: SpiffeStatus::skipped(),
             }
             .overall_status()
         );
@@ -361,7 +462,8 @@ pub(crate) mod tests {
             HealthComponents {
                 raft: RaftStatus::ok(),
                 database: DatabaseStatus::err(dummy_err()),
-                policy: PolicyStatus::ok()
+                policy: PolicyStatus::ok(),
+                spiffe: SpiffeStatus::skipped(),
             }
             .overall_status()
         );

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -64,7 +64,9 @@ use openstack_keystone::assignment::AssignmentHook;
 use openstack_keystone::auth_plugin_http_client::KeystoneDynamicPluginHttpFetcher;
 use openstack_keystone::auth_plugin_identity::DynamicPluginIdentityHook;
 use openstack_keystone::catalog::CatalogHook;
-use openstack_keystone::config::{Config, ConfigManager, Interface, ListenerConfig};
+use openstack_keystone::config::{
+    Config, ConfigManager, Interface, ListenerConfig, RaftTlsConfiguration,
+};
 use openstack_keystone::federation::FederationHook;
 use openstack_keystone::identity::IdentityHook;
 use openstack_keystone::idmapping::IdMappingHook;
@@ -96,6 +98,7 @@ use openstack_keystone_core::auth_plugin_startup::load_auth_plugins;
 use openstack_keystone_core::cadf_hook::CadfAuditHook;
 use openstack_keystone_core::db::sync_schema;
 use openstack_keystone_core::error::KeystoneError;
+use openstack_keystone_core::keystone::SpiffeHealthStatus;
 use openstack_keystone_core::oauth2_key::janitor as oauth2_key_janitor;
 use openstack_keystone_core::scim_resource::janitor as scim_resource_janitor;
 use openstack_keystone_credential_driver_sql::fernet::FernetKeyRepository;
@@ -286,6 +289,49 @@ async fn main() -> Result<(), Report> {
         shared_state
             .set_local_emergency_store(storage.local_emergency_store.clone())
             .await;
+    }
+
+    // Wire a live SPIFFE `X509Source` into the shared service state, when
+    // this deployment has SPIFFE mTLS configured on any interface, so the
+    // `/ready` probe's `SpiffeStatus` check (crates/keystone/src/api/health.rs)
+    // can observe SVID freshness. This is a dedicated source built solely for
+    // the health check - independent of (and in addition to) the per-listener
+    // `X509Source` instances each mTLS listener builds for itself. Best-effort:
+    // a failure here only disables the health signal, it must not block
+    // startup, since the real mTLS listeners perform their own independent
+    // SPIFFE initialization and will surface their own errors if SPIRE is
+    // unreachable.
+    //
+    // The `spiffe` crate itself must stay out of `openstack-keystone-core`
+    // (a transport-agnostic domain layer) - so instead of storing the
+    // `X509Source` on `Service` directly, a closure capturing it is handed
+    // over, mapped down to `core`'s spiffe-crate-free `SpiffeHealthStatus`
+    // enum. `core` only ever sees the closure's `SpiffeHealthStatus` output.
+    if spiffe_mtls_configured(&cfg) {
+        match spiffe::X509Source::new().await {
+            Ok(source) => {
+                let source = Arc::new(source);
+                let check: Arc<dyn Fn() -> SpiffeHealthStatus + Send + Sync> =
+                    Arc::new(move || match source.svid() {
+                        Err(err) => SpiffeHealthStatus::Error(err.to_string()),
+                        Ok(_svid) => {
+                            if source.is_healthy() {
+                                SpiffeHealthStatus::Ok
+                            } else {
+                                SpiffeHealthStatus::Warn(
+                                    "SPIFFE X509Source SVID is stale or expired; peer mTLS \
+                                     handshakes may be failing silently"
+                                        .to_string(),
+                                )
+                            }
+                        }
+                    });
+                shared_state.set_spiffe_health_check(check).await;
+            }
+            Err(e) => {
+                warn!("Failed to initialize SPIFFE X509Source for health checks: {e}");
+            }
+        }
     }
 
     // Also evicts stale rate-limit keyed-store entries (ADR-0022) and
@@ -1256,6 +1302,29 @@ async fn spawn_public_listener(
         }
     }
     Ok(())
+}
+
+/// Returns `true` if this deployment has SPIFFE mTLS configured on at least
+/// one interface (internal REST, admin UDS, or the Raft gRPC listener).
+///
+/// Used to gate the dedicated health-check `X509Source` (see the
+/// `set_spiffe_source` call site in `main`) — mirrors the "is SPIFFE enabled"
+/// signal `check_storage` already uses for `state.storage.is_none()`.
+fn spiffe_mtls_configured(cfg: &Config) -> bool {
+    let internal_spiffe = matches!(
+        cfg.interface_internal.as_ref().map(|i| &i.listener),
+        Some(ListenerConfig::Spiffe(_))
+    );
+    // The admin interface only ever speaks SPIFFE mTLS over a Unix socket
+    // (see `spawn_admin_listener`), so its mere presence is enough.
+    let admin_spiffe = cfg.interface_admin.is_some();
+    let raft_spiffe = matches!(
+        cfg.distributed_storage
+            .as_ref()
+            .map(|ds| &ds.tls_configuration),
+        Some(RaftTlsConfiguration::Spiffe(_))
+    );
+    internal_spiffe || admin_spiffe || raft_spiffe
 }
 
 /// Start the SPIFFE mTLS listener on the internal interface, when configured.


### PR DESCRIPTION
A long-lived pod's SPIFFE SVID/trust bundle can silently drift out of
sync with a freshly-joined Raft peer, causing repeated mTLS handshake
failures on peer join. The existing /ready probe only checks
database/policy/raft-initialized status, so k8s never notices and the
pod keeps failing handshakes for weeks until manually restarted.

Add a SpiffeStatus health component, following the existing
RaftStatus/DatabaseStatus/PolicyStatus pattern, that queries a live
SPIFFE X509Source's own reported health/expiry rather than attempting
a real loopback handshake. Since openstack-keystone-core is a
transport-agnostic domain layer and must not depend on the spiffe
crate, Service exposes only a type-erased closure hook
(spiffe_health_check) returning a spiffe-crate-free SpiffeHealthStatus
enum; the real X509Source inspection is built and installed from
crates/keystone/src/bin/keystone.rs, confining the spiffe dependency
to the keystone binary crate.

Signed-off-by: gtema <artem.goncharov@gmail.com>
