### PR TITLE
fix: Avoid blocking notify's event thread in watch_loop

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -608,7 +608,16 @@ impl ConfigManager {
                 if let Ok(event) = res {
                     // Only trigger for data modifications or name changes (renames/symlink swaps)
                     if event.kind.is_modify() || event.kind.is_create() {
-                        let _ = sync_tx.blocking_send(event);
+                        // `try_send`, not `blocking_send`: this callback runs on
+                        // notify's single background event-loop thread, which
+                        // also services `watch()`/`unwatch()` control requests.
+                        // Blocking here until `sync_rx` is drained can deadlock
+                        // that thread against a concurrent `watcher.watch()`
+                        // call (e.g. while registering the initial watch set)
+                        // that can only be serviced once this send completes.
+                        // A dropped event is harmless: the consumer already
+                        // coalesces any backlog via the `try_recv` drain below.
+                        let _ = sync_tx.try_send(event);
                     }
                 }
             })


### PR DESCRIPTION
sync_tx.blocking_send in the notify callback ran on notify's single
inotify background thread, which also services watcher.watch()
control requests. Under parallel tests sharing the OS temp dir, a
filesystem event could arrive before the async consumer started
draining sync_rx, blocking that thread on a full channel and
deadlocking any concurrent watch() call on the same thread. This
caused intermittent hangs/failures in crates/config tests.

Switch to try_send: a dropped event is harmless since the consumer
already coalesces backlog via the try_recv drain and 500ms debounce.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
