### PR TITLE
fix: Fix ID sanitizer and capture client IP in audit

### DIFF
--- a/crates/audit/src/lib.rs
+++ b/crates/audit/src/lib.rs
@@ -34,4 +34,4 @@ pub mod types;
 pub use dispatcher::{AuditChannelDead, AuditChannelReceivers, AuditDispatcher};
 pub use kdf::derive_audit_hmac_key;
 pub use spool::{HmacKeyStore, SpoolError};
-pub use types::{CadfEvent, CadfEventPayload, Initiator, Observer, Target};
+pub use types::{CadfEvent, CadfEventPayload, Host, Initiator, Observer, Target};

--- a/crates/audit/src/sanitize.rs
+++ b/crates/audit/src/sanitize.rs
@@ -32,8 +32,13 @@ pub enum HostKind {
 /// Sanitize a resource / principal UUID for use in audit records.
 ///
 /// Strips everything except hex digits and hyphens, caps at 64 characters,
-/// then applies a strict UUID-format check (len 36, 4 hyphens at positions
-/// 8/13/18/23, 32 hex digits). Returns `"unknown"` for anything that fails.
+/// then accepts either of the two UUID renderings Keystone actually produces:
+/// canonical hyphenated (len 36, hyphens at positions 8/13/18/23, 32 hex
+/// digits) or simple/no-hyphen (`Uuid::simple()`, exactly 32 hex digits, no
+/// hyphens) — which is the format `Uuid::new_v4().simple()` produces and is
+/// used for every resource ID minted across the codebase (projects, users,
+/// roles, tokens, etc.). Returns `"unknown"` for anything that fails both
+/// shapes.
 pub fn sanitize_audit_id(id: &str) -> String {
     if id.trim().is_empty() {
         return "unknown".to_string();
@@ -46,14 +51,15 @@ pub fn sanitize_audit_id(id: &str) -> String {
     if cleaned.is_empty() {
         return "unknown".to_string();
     }
-    if cleaned.len() == 36
+    let is_canonical_uuid = cleaned.len() == 36
         && cleaned.chars().filter(|c| *c == '-').count() == 4
         && cleaned.chars().filter(|c| c.is_ascii_hexdigit()).count() == 32
         && cleaned.get(8..9) == Some("-")
         && cleaned.get(13..14) == Some("-")
         && cleaned.get(18..19) == Some("-")
-        && cleaned.get(23..24) == Some("-")
-    {
+        && cleaned.get(23..24) == Some("-");
+    let is_simple_uuid = cleaned.len() == 32 && cleaned.chars().all(|c| c.is_ascii_hexdigit());
+    if is_canonical_uuid || is_simple_uuid {
         cleaned
     } else {
         "unknown".to_string()
@@ -102,6 +108,20 @@ pub fn sanitize_initiator_host(raw: &str, kind: HostKind) -> Option<String> {
     }
 }
 
+/// Sanitize a client IP address for use as `Initiator.address`.
+///
+/// Parses via [`std::net::IpAddr`] and re-renders through `Display` so the
+/// stored value is guaranteed to be a well-formed IPv4/IPv6 address (no
+/// port, no scope id oddities, no injected characters) rather than whatever
+/// a proxy header happened to contain. Returns `None` for anything that
+/// doesn't parse as an IP.
+pub fn sanitize_initiator_address(raw: &str) -> Option<String> {
+    raw.trim()
+        .parse::<std::net::IpAddr>()
+        .ok()
+        .map(|ip| ip.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +141,29 @@ mod tests {
     #[test]
     fn non_uuid_hex_string_returns_unknown() {
         assert_eq!(sanitize_audit_id("deadbeef"), "unknown");
+    }
+
+    #[test]
+    fn simple_uuid_no_hyphens_passes() {
+        // Uuid::new_v4().simple() format used for every resource ID minted
+        // across the codebase (projects, users, roles, tokens, etc.).
+        let id = "550e8400e29b41d4a716446655440000";
+        assert_eq!(sanitize_audit_id(id), id);
+    }
+
+    #[test]
+    fn simple_uuid_uppercase_passes() {
+        let id = "550E8400E29B41D4A716446655440000";
+        assert_eq!(sanitize_audit_id(id), id);
+    }
+
+    #[test]
+    fn thirty_two_hex_chars_but_not_uuid_shape_still_passes() {
+        // Any 32-char pure-hex string is accepted as "simple UUID" shaped;
+        // this is intentional since Keystone doesn't validate UUID version
+        // bits elsewhere either.
+        let id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assert_eq!(sanitize_audit_id(id), id);
     }
 
     #[test]
@@ -217,6 +260,35 @@ mod tests {
         let raw = "a".repeat(200);
         let result = sanitize_initiator_host(&raw, HostKind::Other).unwrap_or_default();
         assert_eq!(result.len(), 128);
+    }
+
+    // ---- sanitize_initiator_address ----
+
+    #[test]
+    fn valid_ipv4_passes() {
+        assert_eq!(
+            sanitize_initiator_address("203.0.113.42"),
+            Some("203.0.113.42".to_string())
+        );
+    }
+
+    #[test]
+    fn valid_ipv6_passes() {
+        assert_eq!(
+            sanitize_initiator_address("2001:db8::1"),
+            Some("2001:db8::1".to_string())
+        );
+    }
+
+    #[test]
+    fn address_with_port_rejected() {
+        assert_eq!(sanitize_initiator_address("203.0.113.42:8080"), None);
+    }
+
+    #[test]
+    fn garbage_address_rejected() {
+        assert_eq!(sanitize_initiator_address("'; DROP TABLE x; --"), None);
+        assert_eq!(sanitize_initiator_address(""), None);
     }
 
     #[test]

--- a/crates/audit/src/types.rs
+++ b/crates/audit/src/types.rs
@@ -109,6 +109,9 @@ impl CadfEventPayload {
     pub fn outcome(&self) -> &str {
         &self.outcome
     }
+    pub fn initiator(&self) -> &Initiator {
+        &self.initiator
+    }
     pub fn observer(&self) -> &Observer {
         &self.observer
     }
@@ -154,11 +157,58 @@ impl CadfEvent {
     }
 }
 
+/// CADF `Resource.host` sub-object (DSP0262 §9.3.3, "Host Data Type").
+///
+/// Per the CADF spec, `host` on a `Resource` (and therefore on `Initiator`,
+/// which is a `Resource`) is itself a structured type, not a bare string.
+/// The spec defines four attributes: `id`, `address`, `agent`, `platform`.
+/// Only `id` and `address` are populated here; `agent`/`platform` are valid
+/// CADF attributes we don't currently capture and are omitted rather than
+/// modeled speculatively.
+///
+/// - `id`: pre-auth identity signal (EC2 access key, federation idp_id).
+///   Content arrives before authentication and is fully attacker-controlled;
+///   sanitized at construction (see `sanitize::sanitize_initiator_host`).
+/// - `address`: the client network address the request was received from.
+///   Sanitized via `sanitize::sanitize_initiator_address` (parses as a
+///   well-formed `IpAddr`; anything else is dropped, never stored raw).
+///
+/// # Serialization note
+///
+/// Both fields are **omitted entirely** (not set to `null`) when absent,
+/// via `#[serde(skip_serializing_if = "Option::is_none")]`. See
+/// [`Initiator`]'s serialization note for the same rule at the `host` level.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct Host {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    address: Option<String>,
+}
+
+impl Host {
+    /// Construct a `Host` carrying only a pre-auth identity signal (`id`).
+    pub fn from_id(id: String) -> Self {
+        Self {
+            id: Some(id),
+            address: None,
+        }
+    }
+
+    pub fn id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+    pub fn address(&self) -> Option<&str> {
+        self.address.as_deref()
+    }
+}
+
 /// Audit initiator — only opaque identifiers, never PII.
 ///
 /// Human-readable fields (usernames, emails, project names) are excluded by
-/// design. The `host` field carries pre-auth signals; sanitization rules are
-/// enforced at construction time (see `sanitize::sanitize_initiator_host`).
+/// design. The `host` field is a [`Host`] sub-object carrying pre-auth
+/// signals and the client network address; sanitization rules are enforced
+/// at construction time, never on raw input (see `sanitize` module).
 ///
 /// # Serialization note
 ///
@@ -175,10 +225,8 @@ pub struct Initiator {
     id: String,
     project_id: Option<String>,
     domain_id: Option<String>,
-    /// Pre-auth signal (EC2 access key, federation idp_id). No PII.
-    /// Omitted from serialization (not null'd) when absent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    host: Option<String>,
+    host: Option<Host>,
 }
 
 impl Initiator {
@@ -186,7 +234,7 @@ impl Initiator {
         id: String,
         project_id: Option<String>,
         domain_id: Option<String>,
-        host: Option<String>,
+        host: Option<Host>,
     ) -> Self {
         Self {
             id,
@@ -194,6 +242,27 @@ impl Initiator {
             domain_id,
             host,
         }
+    }
+
+    /// Attach a client IP address to `host.address`, sanitized via
+    /// [`crate::sanitize::sanitize_initiator_address`]. Preserves any
+    /// pre-auth `host.id` signal already set.
+    #[must_use]
+    pub fn with_address(mut self, address: Option<String>) -> Self {
+        let Some(address) = address.and_then(|a| crate::sanitize::sanitize_initiator_address(&a))
+        else {
+            return self;
+        };
+        match &mut self.host {
+            Some(host) => host.address = Some(address),
+            None => {
+                self.host = Some(Host {
+                    id: None,
+                    address: Some(address),
+                })
+            }
+        }
+        self
     }
 
     pub fn id(&self) -> &str {
@@ -205,8 +274,12 @@ impl Initiator {
     pub fn domain_id(&self) -> Option<&str> {
         self.domain_id.as_deref()
     }
-    pub fn host(&self) -> Option<&str> {
-        self.host.as_deref()
+    pub fn host(&self) -> Option<&Host> {
+        self.host.as_ref()
+    }
+    /// Convenience passthrough for `host.address`.
+    pub fn address(&self) -> Option<&str> {
+        self.host.as_ref().and_then(Host::address)
     }
 }
 
@@ -283,5 +356,51 @@ mod tests {
             !dispatcher.verify_hmac(&event, &key),
             "tampered signature must fail"
         );
+    }
+
+    #[test]
+    fn with_address_creates_host_when_none_set() {
+        let initiator = Initiator::new("uid".to_string(), None, None, None)
+            .with_address(Some("203.0.113.42".to_string()));
+        assert_eq!(initiator.address(), Some("203.0.113.42"));
+        assert_eq!(initiator.host().and_then(Host::id), None);
+    }
+
+    #[test]
+    fn with_address_preserves_existing_host_id() {
+        let initiator = Initiator::new(
+            "uid".to_string(),
+            None,
+            None,
+            Some(Host::from_id("idp-1".to_string())),
+        )
+        .with_address(Some("203.0.113.42".to_string()));
+        assert_eq!(initiator.host().and_then(Host::id), Some("idp-1"));
+        assert_eq!(initiator.address(), Some("203.0.113.42"));
+    }
+
+    #[test]
+    fn with_address_invalid_ip_leaves_host_untouched() {
+        let initiator = Initiator::new("uid".to_string(), None, None, None)
+            .with_address(Some("not-an-ip".to_string()));
+        assert!(initiator.host().is_none());
+        assert_eq!(initiator.address(), None);
+    }
+
+    #[test]
+    fn host_serializes_nested_under_initiator() {
+        let initiator = Initiator::new("uid".to_string(), None, None, None)
+            .with_address(Some("203.0.113.42".to_string()));
+        let json = serde_json::to_value(&initiator).unwrap();
+        assert_eq!(json["host"]["address"], "203.0.113.42");
+        assert!(json["host"].get("id").is_none());
+        assert!(json.get("address").is_none(), "no top-level address field");
+    }
+
+    #[test]
+    fn host_omitted_entirely_when_absent() {
+        let initiator = Initiator::new("uid".to_string(), None, None, None);
+        let json = serde_json::to_value(&initiator).unwrap();
+        assert!(json.get("host").is_none());
     }
 }

--- a/crates/core-types/src/auth.rs
+++ b/crates/core-types/src/auth.rs
@@ -308,6 +308,18 @@ pub struct SecurityContext {
     /// for contexts created outside an HTTP request (e.g. tests, CLI).
     #[builder(default)]
     correlation_id: Option<String>,
+
+    /// Client IP address the request was received from, for audit purposes.
+    ///
+    /// Set by the `Auth` extractor / auth handlers immediately after the
+    /// context is constructed. This is the trusted-proxy/forwarding-header
+    /// resolved effective client address (`resolve_client_ip_from_headers`,
+    /// ADR 0022) -- NOT `public_ingress_peer_addr`'s raw TCP peer, which is
+    /// the proxy's own address whenever Keystone sits behind one. Defaults
+    /// to `None` for contexts created outside an HTTP request (e.g. tests,
+    /// CLI).
+    #[builder(default)]
+    peer_addr: Option<String>,
 }
 
 /// Builder for constructing [`SecurityContext`] in test code.
@@ -383,6 +395,7 @@ impl SecurityContextTestingBuilder {
             token_restriction: self.token_restriction,
             token: self.token,
             correlation_id: None,
+            peer_addr: None,
         }
     }
 }
@@ -612,6 +625,19 @@ impl SecurityContext {
     /// Called by the auth handler immediately after the VSC is constructed.
     pub fn set_correlation_id(&mut self, id: impl Into<String>) {
         self.correlation_id = Some(id.into());
+    }
+
+    /// Returns the client IP address the request was received from, if set.
+    pub fn peer_addr(&self) -> Option<&str> {
+        self.peer_addr.as_deref()
+    }
+
+    /// Attach the client peer address to this context.
+    ///
+    /// Called by the `Auth` extractor / auth handlers immediately after the
+    /// context is constructed.
+    pub fn set_peer_addr(&mut self, addr: impl Into<String>) {
+        self.peer_addr = Some(addr.into());
     }
 
     /// Construct a [`SecurityContext`] for testing and mocks via a builder.

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -87,7 +87,29 @@ where
             .cloned()
             .unwrap_or(Interface::Public);
 
+        // Resolved once and stamped on every `vsc` this extractor builds, so
+        // audit events for every authenticated request carry the client IP
+        // without each handler needing its own `PeerAddr` extractor.
+        //
+        // `public_ingress_peer_addr` is the raw, pre-resolution TCP peer
+        // (behind a trusted reverse proxy, that's the proxy's address, not
+        // the real client's) -- it must be re-resolved through the
+        // operator's configured trusted-proxy/forwarding-header settings,
+        // exactly like `rate_limit::check_ip` and `api_key_auth` do, or
+        // every audited event behind a proxy would record the proxy's IP.
+        let raw_peer_addr = crate::net::public_ingress_peer_addr(&parts.extensions);
+
         let state = Arc::from_ref(state);
+
+        let peer_addr = {
+            let config = state.config_manager.config.read().await;
+            crate::net::resolve_client_ip_from_headers(
+                &parts.headers,
+                raw_peer_addr.map(|addr| addr.ip()),
+                &config.oslo_middleware.trusted_proxies,
+                config.oslo_middleware.trusted_header,
+            )
+        };
 
         // Check the SPIFFE svid first as the primary identity source
         if let Some(svid) = parts.extensions.get::<SpiffeId>() {
@@ -122,12 +144,15 @@ where
 
                 let mut ctx = SecurityContext::try_from(auth_result)?;
                 ctx.set_is_admin();
-                let vsc = ValidatedSecurityContext::new_for_scope(
+                let mut vsc = ValidatedSecurityContext::new_for_scope(
                     ctx,
                     ScopeInfo::System("all".into()),
                     &state,
                 )
                 .await?;
+                if let Some(addr) = peer_addr {
+                    vsc.set_peer_addr(addr.to_string());
+                }
                 return Ok(Auth(vsc));
             }
 
@@ -142,8 +167,11 @@ where
                 )
                 .await?;
             let ctx = SecurityContext::try_from(result)?;
-            let vsc =
+            let mut vsc =
                 ValidatedSecurityContext::new_for_scope(ctx, ScopeInfo::Unscoped, &state).await?;
+            if let Some(addr) = peer_addr {
+                vsc.set_peer_addr(addr.to_string());
+            }
             return Ok(Auth(vsc));
         }
 
@@ -155,7 +183,7 @@ where
         {
             tracing::debug!("authenticating request with the x-auth-token");
             let auth_token = SecretString::from(auth_header.to_owned());
-            let vsc = state
+            let mut vsc = state
                 .provider
                 .get_token_provider()
                 .authorize_by_token(
@@ -170,6 +198,9 @@ where
 
             vsc.fully_resolved()?;
             reject_if_ec2(&vsc)?;
+            if let Some(addr) = peer_addr {
+                vsc.set_peer_addr(addr.to_string());
+            }
             return Ok(Auth(vsc));
         }
 
@@ -234,14 +265,22 @@ mod tests {
     use std::sync::Arc;
 
     async fn create_test_state(mapping_provider: MockMappingProvider) -> ServiceState {
-        let config = Config::default();
+        create_test_state_with_config(mapping_provider, Config::default(), None).await
+    }
+
+    async fn create_test_state_with_config(
+        mapping_provider: MockMappingProvider,
+        config: Config,
+        token_provider: Option<crate::token::MockTokenProvider>,
+    ) -> ServiceState {
         let config_manager = ConfigManager::not_watched(config);
         let policy_enforcer = Arc::new(MockPolicy::default());
         let db = sea_orm::DatabaseConnection::default();
-        let provider = Provider::mocked_builder()
-            .mock_mapping(mapping_provider)
-            .build()
-            .unwrap();
+        let mut provider_builder = Provider::mocked_builder().mock_mapping(mapping_provider);
+        if let Some(token_provider) = token_provider {
+            provider_builder = provider_builder.mock_token(token_provider);
+        }
+        let provider = provider_builder.build().unwrap();
         let service = Service {
             config_manager,
             db,
@@ -677,6 +716,69 @@ mod tests {
 
         let result = Auth::from_request_parts(&mut parts, &state).await;
         assert!(result.is_ok());
+    }
+
+    /// The raw TCP peer (`OriginalPeerAddr`) is a trusted reverse proxy;
+    /// `peer_addr` on the `Auth`-built `ValidatedSecurityContext` must carry
+    /// the XFF-resolved real client, never the proxy's own address.
+    /// Regression test: this extractor previously stamped the raw peer
+    /// directly, which would silently record every proxy's IP in audit
+    /// events for every authenticated request behind a reverse proxy.
+    #[tokio::test]
+    async fn test_x_auth_token_peer_addr_uses_resolved_ip_behind_trusted_proxy() {
+        use crate::net::OriginalPeerAddr;
+        use crate::token::MockTokenProvider;
+
+        let mut config = Config::default();
+        config
+            .oslo_middleware
+            .trusted_proxies
+            .push("10.0.0.0/8".parse().unwrap());
+
+        let mut token_mock = MockTokenProvider::new();
+        token_mock.expect_authorize_by_token().once().returning(
+            move |_exec, _token, _allow_rescope, _restrict_to| {
+                let mut security_context = SecurityContextTestingBuilder::default()
+                    .authentication_context(AuthenticationContext::Password)
+                    .principal(
+                        PrincipalInfoBuilder::default()
+                            .identity(IdentityInfo::Principal(
+                                PrincipalIdentityInfoBuilder::default()
+                                    .id("token-user")
+                                    .issuer("test.domain")
+                                    .build()
+                                    .unwrap(),
+                            ))
+                            .build()
+                            .unwrap(),
+                    )
+                    .build();
+                security_context.set_authorization_scope(ScopeInfo::Unscoped)?;
+                Ok(ValidatedSecurityContext::test_new(security_context))
+            },
+        );
+
+        let state =
+            create_test_state_with_config(MockMappingProvider::new(), config, Some(token_mock))
+                .await;
+
+        let mut parts = make_parts();
+        parts
+            .headers
+            .insert("X-Auth-Token", "valid-token-string".parse().unwrap());
+        parts
+            .headers
+            .insert("x-forwarded-for", "203.0.113.77".parse().unwrap());
+        let peer: std::net::SocketAddr = "10.0.0.1:1234".parse().unwrap();
+        parts.extensions.insert(OriginalPeerAddr(peer));
+
+        let result = Auth::from_request_parts(&mut parts, &state).await;
+        let auth = result.expect("token auth should succeed");
+        assert_eq!(
+            auth.0.inner().peer_addr(),
+            Some("203.0.113.77"),
+            "peer_addr must be the XFF-resolved client, not the trusted proxy's own address"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/api_key/janitor.rs
+++ b/crates/core/src/api_key/janitor.rs
@@ -167,7 +167,7 @@ fn emit_maintenance_event(dispatcher: &Arc<AuditDispatcher>, action: &str, clien
     let initiator = Initiator::new("api_key_janitor".to_string(), None, None, None);
     let payload = CadfEventPayload::new(
         event_id,
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id,
         Utc::now().to_rfc3339(),

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -520,6 +520,18 @@ impl ValidatedSecurityContext {
         self.0.correlation_id().unwrap_or("unknown")
     }
 
+    /// Attach the client peer address to this context.
+    ///
+    /// Called by the `Auth` extractor immediately after the VSC is
+    /// constructed, and by the login handler after building the pre-scope
+    /// context. `Deref` only exposes read access to the inner
+    /// `SecurityContext`, so this delegate is needed wherever only a
+    /// [`ValidatedSecurityContext`] (not the raw `SecurityContext`) is in
+    /// hand.
+    pub fn set_peer_addr(&mut self, addr: impl Into<String>) {
+        self.0.set_peer_addr(addr);
+    }
+
     /// Construct without validation. ONLY for tests and mocks.
     #[cfg(any(test, feature = "mock"))]
     pub fn test_new(ctx: SecurityContext) -> Self {

--- a/crates/core/src/auth/tests.rs
+++ b/crates/core/src/auth/tests.rs
@@ -1781,6 +1781,35 @@ fn correlation_id_reflects_set_value_and_falls_back_to_unknown() {
     assert_eq!(vsc_without_correlation_id.correlation_id(), "unknown");
 }
 
+/// `peer_addr()` returns whatever was attached via `set_peer_addr` (on
+/// either `SecurityContext` or, via the `ValidatedSecurityContext`
+/// delegate, after the context is already wrapped), and `None` when never
+/// set -- mirrors `correlation_id`'s set-after-construction shape, used so
+/// the `Auth` extractor / login handler can stamp the resolved client IP
+/// onto an already-built context.
+#[test]
+fn peer_addr_reflects_set_value_and_defaults_to_none() {
+    let mut ctx = SecurityContextTestingBuilder::default()
+        .authentication_context(AuthenticationContext::Password)
+        .principal(make_user_identity("uid"))
+        .build();
+    ctx.set_peer_addr("203.0.113.42");
+    let mut vsc = ValidatedSecurityContext::test_new(ctx);
+    assert_eq!(vsc.inner().peer_addr(), Some("203.0.113.42"));
+
+    // Delegate setter on ValidatedSecurityContext itself (needed where only
+    // the wrapped VSC is in hand, e.g. the X-Auth-Token branch of `Auth`).
+    vsc.set_peer_addr("198.51.100.7");
+    assert_eq!(vsc.inner().peer_addr(), Some("198.51.100.7"));
+
+    let ctx_without_peer_addr = SecurityContextTestingBuilder::default()
+        .authentication_context(AuthenticationContext::Password)
+        .principal(make_user_identity("uid"))
+        .build();
+    let vsc_without_peer_addr = ValidatedSecurityContext::test_new(ctx_without_peer_addr);
+    assert_eq!(vsc_without_peer_addr.inner().peer_addr(), None);
+}
+
 // --- Mapping: domain scope match returns pre-populated roles ---
 #[tokio::test]
 async fn test_new_for_scope_mapping_domain_scope_match() {

--- a/crates/core/src/auth_plugin.rs
+++ b/crates/core/src/auth_plugin.rs
@@ -155,7 +155,7 @@ pub(crate) async fn emit_wasm_plugin_audit(
     let node_id = dispatcher.node_id().to_string();
     let payload = CadfEventPayload::new(
         format!("{node_id}:{}", Uuid::new_v4()),
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         Uuid::new_v4().to_string(),
         chrono::Utc::now().to_rfc3339(),

--- a/crates/core/src/cadf_hook.rs
+++ b/crates/core/src/cadf_hook.rs
@@ -141,6 +141,7 @@ pub fn build_initiator_from_vsc(vsc: &ValidatedSecurityContext) -> Initiator {
         domain_id.filter(|id| id != "unknown"),
         None,
     )
+    .with_address(vsc.inner().peer_addr().map(str::to_string))
 }
 
 /// Build an all-`"unknown"` [`Initiator`] for total auth failure.
@@ -210,7 +211,7 @@ impl AuditHook for CadfAuditHook {
         let event_id = format!("{}:{}", node_id, Uuid::new_v4());
         let payload = CadfEventPayload::new(
             event_id,
-            "1.0".to_string(),
+            "1.1".to_string(),
             "default".to_string(),
             ctx.correlation_id().to_string(),
             event.timestamp.to_rfc3339(),
@@ -242,7 +243,37 @@ impl AuditHook for CadfAuditHook {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openstack_keystone_core_types::auth::{
+        AuthenticationContext, IdentityInfo, PrincipalInfo, SecurityContextTestingBuilder,
+        UserIdentityInfo,
+    };
     use openstack_keystone_core_types::events::EventPayload;
+    use openstack_keystone_core_types::identity::{UserOptions, UserResponse};
+    use std::collections::HashMap;
+
+    fn make_user_identity(user_id: impl Into<String>) -> PrincipalInfo {
+        let uid = user_id.into();
+        let u = UserResponse {
+            id: uid.clone(),
+            domain_id: "d1".to_string(),
+            enabled: true,
+            name: "u".to_string(),
+            extra: HashMap::new(),
+            default_project_id: None,
+            federated: None,
+            options: UserOptions::default(),
+            password_expires_at: None,
+        };
+        let ui = UserIdentityInfo {
+            user_id: uid.clone(),
+            user: Some(u),
+            user_domain: None,
+            user_groups: Vec::new(),
+        };
+        PrincipalInfo {
+            identity: IdentityInfo::User(ui),
+        }
+    }
 
     #[test]
     fn map_event_to_action_covers_all_variants() {
@@ -322,6 +353,31 @@ mod tests {
         let target = build_target_from_event(&e);
         assert_eq!(target.id, "unknown");
         assert_eq!(target.type_uri, "data/security/identity/user");
+    }
+
+    #[test]
+    fn build_initiator_from_vsc_carries_peer_addr_as_address() {
+        let mut ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("uid"))
+            .build();
+        ctx.set_peer_addr("203.0.113.42");
+        let vsc = ValidatedSecurityContext::test_new(ctx);
+
+        let initiator = build_initiator_from_vsc(&vsc);
+        assert_eq!(initiator.address(), Some("203.0.113.42"));
+    }
+
+    #[test]
+    fn build_initiator_from_vsc_without_peer_addr_has_no_address() {
+        let ctx = SecurityContextTestingBuilder::default()
+            .authentication_context(AuthenticationContext::Password)
+            .principal(make_user_identity("uid"))
+            .build();
+        let vsc = ValidatedSecurityContext::test_new(ctx);
+
+        let initiator = build_initiator_from_vsc(&vsc);
+        assert_eq!(initiator.address(), None);
     }
 
     #[test]

--- a/crates/core/src/catalog/backend.rs
+++ b/crates/core/src/catalog/backend.rs
@@ -240,8 +240,8 @@ pub trait CatalogBackend: Send + Sync {
     /// - `id`: The unique identifier of the endpoint group.
     ///
     /// # Returns
-    /// A `Result` containing an `Option` with the `EndpointGroup` if found, or a
-    /// `CatalogProviderError`.
+    /// A `Result` containing an `Option` with the `EndpointGroup` if found, or
+    /// a `CatalogProviderError`.
     async fn get_endpoint_group<'a>(
         &self,
         state: &ServiceState,

--- a/crates/core/src/catalog/provider_api.rs
+++ b/crates/core/src/catalog/provider_api.rs
@@ -239,8 +239,8 @@ pub trait CatalogApi: Send + Sync {
     /// - `id`: The unique identifier of the endpoint group.
     ///
     /// # Returns
-    /// A `Result` containing an `Option` with the `EndpointGroup` if found, or a
-    /// `CatalogProviderError`.
+    /// A `Result` containing an `Option` with the `EndpointGroup` if found, or
+    /// a `CatalogProviderError`.
     async fn get_endpoint_group<'a>(
         &self,
         exec: &ExecutionContext<'a>,

--- a/crates/core/src/catalog/service.rs
+++ b/crates/core/src/catalog/service.rs
@@ -615,8 +615,8 @@ impl CatalogApi for CatalogService {
     /// - `id`: The unique identifier of the endpoint group.
     ///
     /// # Returns
-    /// A `Result` containing an `Option` with the endpoint group if found, or an
-    /// `Error`.
+    /// A `Result` containing an `Option` with the endpoint group if found, or
+    /// an `Error`.
     async fn get_endpoint_group<'a>(
         &self,
         exec: &ExecutionContext<'a>,

--- a/crates/core/src/oauth2_key/janitor.rs
+++ b/crates/core/src/oauth2_key/janitor.rs
@@ -147,7 +147,7 @@ fn emit_maintenance_event(dispatcher: &Arc<AuditDispatcher>, action: &str, domai
     let initiator = Initiator::new("oauth2_key_janitor".to_string(), None, None, None);
     let payload = CadfEventPayload::new(
         event_id,
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id,
         Utc::now().to_rfc3339(),

--- a/crates/keystone/src/api/v3/auth/token/create.rs
+++ b/crates/keystone/src/api/v3/auth/token/create.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Create token (authenticate).
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use axum::{
     Json,
@@ -64,12 +64,28 @@ pub(super) async fn create(
     PeerAddr(peer_addr): PeerAddr,
     TracedJson(req): TracedJson<AuthRequest>,
 ) -> Result<impl IntoResponse, KeystoneApiError> {
-    let result = create_inner(&state, query, req, &headers, peer_addr).await;
-    let initiator = result
-        .as_ref()
-        .ok()
-        .map(|(vsc, _)| build_initiator_from_vsc(vsc))
-        .unwrap_or_else(build_initiator_unknown);
+    // Client IP for the audit trail, resolved through the operator's
+    // configured trusted-proxy/forwarding-header settings. This is a
+    // distinct trust boundary from rate limiting and auth-plugin dispatch
+    // inside `create_inner`, which each apply their own resolution over the
+    // same raw `peer_addr` (see `crate::net` module docs) -- `peer_addr`
+    // itself is the raw, pre-resolution TCP peer and must not be recorded
+    // directly, or every audited login behind a reverse proxy would record
+    // the proxy's address instead of the real client's.
+    let audit_ip = {
+        let config = state.config_manager.config.read().await;
+        openstack_keystone_core::net::resolve_client_ip_from_headers(
+            &headers,
+            peer_addr.map(|addr| addr.ip()),
+            &config.oslo_middleware.trusted_proxies,
+            config.oslo_middleware.trusted_header,
+        )
+    };
+    let result = create_inner(&state, query, req, &headers, peer_addr, audit_ip).await;
+    let initiator = match result.as_ref() {
+        Ok((vsc, _)) => build_initiator_from_vsc(vsc),
+        Err(_) => build_initiator_unknown().with_address(audit_ip.map(|ip| ip.to_string())),
+    };
     let (outcome, reason) = match &result {
         Ok(_) => ("success", None),
         Err(e) => ("failure", Some(error_variant_name(e))),
@@ -86,6 +102,7 @@ async fn create_inner(
     req: AuthRequest,
     headers: &HeaderMap,
     peer_addr: Option<SocketAddr>,
+    audit_ip: Option<IpAddr>,
 ) -> Result<(ValidatedSecurityContext, Response), KeystoneApiError> {
     req.validate()?;
 
@@ -116,11 +133,14 @@ async fn create_inner(
         return Err(KeystoneApiError::AuthenticationRescopeForbidden);
     }
 
-    let vsc = state
+    let mut vsc = state
         .provider
         .get_token_provider()
         .issue_token_context(state, &ctx, &authz_info)
         .await?;
+    if let Some(ip) = audit_ip {
+        vsc.set_peer_addr(ip.to_string());
+    }
 
     let mut api_token = TokenResponse {
         token: TokenBuilder::try_from(&vsc)?.build()?,
@@ -794,6 +814,75 @@ mod tests {
         assert!(
             resp2.headers().contains_key(header::RETRY_AFTER),
             "429 response must carry Retry-After header"
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_audit_initiator_address_uses_resolved_ip_behind_trusted_proxy() {
+        // The raw TCP peer (`ConnectInfo`) is a trusted reverse proxy; the
+        // audited `initiator.host.address` must be the XFF-resolved real
+        // client, never the proxy's own address. Regression test for a bug
+        // where `public_ingress_peer_addr`'s raw peer was recorded directly,
+        // which would silently record every proxy's IP in production.
+        let mut config = Config::default();
+        config
+            .oslo_middleware
+            .trusted_proxies
+            .push("10.0.0.0/8".parse().unwrap());
+
+        let mut identity_mock = MockIdentityProvider::default();
+        identity_mock
+            .expect_authenticate_by_password()
+            .returning(|_, _| Err(IdentityProviderError::UserNotFound("uid".into())));
+        let provider = Provider::mocked_builder()
+            .mock_identity(identity_mock)
+            .build()
+            .unwrap();
+
+        let (audit_dispatcher, mut receivers) = AuditDispatcher::new(
+            "test-node",
+            uuid::Uuid::new_v4().to_string(),
+            Arc::from(b"test-hmac-key-32-bytes-long!!!!".as_slice()),
+            0,
+        );
+
+        let state = Arc::new(
+            Service::new(
+                ConfigManager::not_watched(config),
+                DatabaseConnection::default(),
+                provider,
+                Arc::new(MockPolicy::default()),
+                audit_dispatcher,
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+
+        let peer: SocketAddr = "10.0.0.1:1234".parse().unwrap();
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let mut request = Request::builder()
+            .uri("/")
+            .method("POST")
+            .header(header::CONTENT_TYPE, "application/json")
+            .header("x-forwarded-for", "203.0.113.55")
+            .body(Body::from(auth_body()))
+            .unwrap();
+        request.extensions_mut().insert(ConnectInfo(peer));
+        let _ = api.as_service().oneshot(request).await.unwrap();
+
+        let event = receivers
+            .perimeter
+            .try_recv()
+            .expect("perimeter audit event should have been emitted");
+        assert_eq!(
+            event.payload().initiator().address(),
+            Some("203.0.113.55"),
+            "audit initiator must carry the XFF-resolved client IP, not the trusted proxy's own address"
         );
     }
 

--- a/crates/keystone/src/audit.rs
+++ b/crates/keystone/src/audit.rs
@@ -190,7 +190,7 @@ pub fn emit_perimeter_authenticate_event(
     let event_id = format!("{}:{}", node_id, Uuid::new_v4());
     let payload = CadfEventPayload::new(
         event_id,
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id.to_string(),
         chrono::Utc::now().to_rfc3339(),
@@ -230,7 +230,7 @@ pub fn emit_api_key_control_event(
     let event_id = format!("{}:{}", node_id, Uuid::new_v4());
     let payload = CadfEventPayload::new(
         event_id,
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id.to_string(),
         chrono::Utc::now().to_rfc3339(),
@@ -270,7 +270,7 @@ pub fn emit_oauth2_session_event(
     let event_id = format!("{}:{}", node_id, Uuid::new_v4());
     let payload = CadfEventPayload::new(
         event_id,
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id.to_string(),
         chrono::Utc::now().to_rfc3339(),
@@ -309,7 +309,7 @@ pub async fn emit_oauth2_refresh_reuse_critical_event(
     let event_id = format!("{}:{}", node_id, Uuid::new_v4());
     let payload = CadfEventPayload::new(
         event_id,
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id.to_string(),
         chrono::Utc::now().to_rfc3339(),
@@ -354,7 +354,7 @@ pub fn emit_oauth2_key_rotation_event(
     let event_id = format!("{}:{}", node_id, Uuid::new_v4());
     let payload = CadfEventPayload::new(
         event_id,
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id.to_string(),
         chrono::Utc::now().to_rfc3339(),
@@ -396,7 +396,7 @@ pub async fn emit_oauth2_emergency_key_rotation_critical_event(
     let event_id = format!("{}:{}", node_id, Uuid::new_v4());
     let payload = CadfEventPayload::new(
         event_id,
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id.to_string(),
         chrono::Utc::now().to_rfc3339(),
@@ -451,7 +451,7 @@ pub async fn emit_oauth2_local_emergency_key_reconciled_event(
     let event_id = format!("{}:{}", node_id, Uuid::new_v4());
     let payload = CadfEventPayload::new(
         event_id.clone(),
-        "1.0".to_string(),
+        "1.1".to_string(),
         "default".to_string(),
         correlation_id.to_string(),
         chrono::Utc::now().to_rfc3339(),

--- a/crates/keystone/src/federation/api/jwt.rs
+++ b/crates/keystone/src/federation/api/jwt.rs
@@ -28,7 +28,7 @@ use crate::audit::{CorrelationId, emit_perimeter_authenticate_event, error_varia
 use crate::federation::api::error::OidcError;
 use crate::keystone::ServiceState;
 use openstack_keystone_audit::sanitize::{HostKind, sanitize_initiator_host};
-use openstack_keystone_audit::types::Initiator;
+use openstack_keystone_audit::types::{Host, Initiator};
 use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
@@ -79,7 +79,8 @@ pub async fn login(
     // is recorded as `Initiator.host` regardless of outcome (ADR 0023 §"Perimeter
     // Auditing").
     let host = sanitize_initiator_host(&idp_id, HostKind::FederationIdpUuid)
-        .or_else(|| sanitize_initiator_host(&idp_id, HostKind::FederationIdpNonUuid));
+        .or_else(|| sanitize_initiator_host(&idp_id, HostKind::FederationIdpNonUuid))
+        .map(Host::from_id);
     let initiator = Initiator::new("unknown".to_string(), None, None, host);
     let (outcome, reason) = match &result {
         Ok(_) => ("success", None),

--- a/crates/keystone/src/federation/api/oidc.rs
+++ b/crates/keystone/src/federation/api/oidc.rs
@@ -28,7 +28,7 @@ use crate::federation::api::error::OidcError;
 use crate::federation::api::types::*;
 use crate::keystone::ServiceState;
 use openstack_keystone_audit::sanitize::{HostKind, sanitize_initiator_host};
-use openstack_keystone_audit::types::Initiator;
+use openstack_keystone_audit::types::{Host, Initiator};
 use openstack_keystone_core::auth::ExecutionContext;
 use openstack_keystone_core_types::auth::AuthenticationResult;
 use openstack_keystone_core_types::mapping::auth::MappingAuthRequest;
@@ -81,7 +81,8 @@ pub async fn callback(
     let initiator = match &idp_id_out {
         Some(idp_id) => {
             let host = sanitize_initiator_host(idp_id, HostKind::FederationIdpUuid)
-                .or_else(|| sanitize_initiator_host(idp_id, HostKind::FederationIdpNonUuid));
+                .or_else(|| sanitize_initiator_host(idp_id, HostKind::FederationIdpNonUuid))
+                .map(Host::from_id);
             Initiator::new("unknown".to_string(), None, None, host)
         }
         None => build_initiator_unknown(),

--- a/doc/src/adr/0023-audit.md
+++ b/doc/src/adr/0023-audit.md
@@ -11,6 +11,24 @@ Accepted
 > sanitization rules, `refresh_hmac_key` version-collision fix, HMAC key
 > retention policy, cross-node spool tamper detection, and
 > `map_event_to_action` dangling-reference correction.
+>
+> **Schema v1.1 (2026-07-30):** Two fixes applied after real-world audit logs
+> showed successful logins and mutations recording `"unknown"` identifiers
+> and no client IP at all:
+> 1. `sanitize_audit_id` rejected every ID Keystone actually mints. It only
+>    accepted canonical hyphenated UUIDs (36 chars); every real ID uses
+>    `Uuid::new_v4().simple()` (32 hex chars, no hyphens). Now accepts both
+>    shapes.
+> 2. `Initiator.host` — a bare `String` carrying only the pre-auth signal —
+>    is restructured into a CADF-conformant nested `Host` object
+>    (DSP0262 §9.3.3) with `id` (the former string value) and a new
+>    `address` attribute for the client network address. Per spec, `host` on
+>    a `Resource` (which `Initiator` is) is a structured type; `address` is
+>    that type's designated network-address attribute, not a sibling field
+>    on `Initiator`. This is a breaking wire-format change (`host` was a
+>    string, is now an object), so the payload `version` field bumps from
+>    `"1.0"` to `"1.1"`. SIEMs parsing `host` as a string must be updated to
+>    read it as an object before ingesting v1.1 events.
 
 ## Context
 
@@ -92,26 +110,48 @@ impl CadfEvent {
     pub fn boot_session_id(&self) -> &str { &self.event.boot_session_id }
 }
 
+// `host` is a nested CADF `Host` object (DSP0262 §9.3.3), not a bare
+// string — `Resource.host` (Initiator is a `Resource`) is spec-defined as a
+// structured type with `id`, `address`, `agent`, `platform`. Only `id` and
+// `address` are populated; `agent`/`platform` are valid but unused.
 #[derive(Serialize, Clone)]
-pub struct Initiator {
-    id: String, project_id: Option<String>, domain_id: Option<String>,
+pub struct Host {
     /// Pre-auth signal (EC2 access key, federation idp_id). No PII.
     /// Content arrives before authentication and is fully attacker-controlled.
-    /// Sanitization rules (enforced at construction, not by Initiator itself):
+    /// Sanitization rules (enforced at construction, not by Host itself):
     ///   EC2 access key  — must match /^AKIA[A-Z0-9]{16}$/; rejected otherwise.
     ///   Federation idp_id (UUID) — passed through sanitize_audit_id().
     ///   Federation idp_id (non-UUID) — filtered to [a-zA-Z0-9._-], max 64 chars.
     ///   Any other value — filtered to printable ASCII (0x20–0x7E), max 128 chars.
     ///   Field is omitted (None) if empty after filtering.
-    host: Option<String>,
+    id: Option<String>,
+    /// Client network address. Parsed via `std::net::IpAddr` and re-rendered
+    /// through `Display`; anything that doesn't parse as an IP is dropped
+    /// rather than stored raw. Field is omitted (None) if never set.
+    address: Option<String>,
+}
+impl Host {
+    fn from_id(id: String) -> Self { Self { id: Some(id), address: None } }
+    pub fn id(&self) -> Option<&str> { self.id.as_deref() }
+    pub fn address(&self) -> Option<&str> { self.address.as_deref() }
+}
+
+#[derive(Serialize, Clone)]
+pub struct Initiator {
+    id: String, project_id: Option<String>, domain_id: Option<String>,
+    host: Option<Host>,
 }
 impl Initiator {
     fn new(id: String, project_id: Option<String>, domain_id: Option<String>,
-        host: Option<String>) -> Self
+        host: Option<Host>) -> Self
     { Self { id, project_id, domain_id, host } }
     pub fn id(&self) -> &str { &self.id }
     pub fn project_id(&self) -> Option<&str> { self.project_id.as_deref() }
     pub fn domain_id(&self) -> Option<&str> { self.domain_id.as_deref() }
+    pub fn host(&self) -> Option<&Host> { self.host.as_ref() }
+    /// Attach a client IP to `host.address`, sanitized. Preserves any
+    /// pre-auth `host.id` signal already set.
+    fn with_address(mut self, address: Option<String>) -> Self { /* ... */ self }
 }
 #[derive(Serialize, Clone)]
 pub struct Target { pub id: String, pub type_uri: String }
@@ -133,7 +173,12 @@ impl VerifiedFernetToken {
 }
 ```
 
-**ID sanitization** - Strips non-ASCII, caps at 64 chars:
+**ID sanitization** - Strips non-ASCII, caps at 64 chars. Accepts either
+UUID rendering Keystone actually produces: canonical hyphenated, or
+`Uuid::simple()` (no hyphens) — the latter is what every resource ID
+minted across the codebase uses (`Uuid::new_v4().simple()`), so a
+strict-canonical-only check (schema v1.0) coerced every real ID to
+`"unknown"`:
 
 ```rust
 fn sanitize_audit_id(id: &str) -> String {
@@ -142,17 +187,17 @@ fn sanitize_audit_id(id: &str) -> String {
         .filter(|c| c.is_ascii_hexdigit() || *c == '-')
         .take(64).collect();
     if cleaned.is_empty() { return "unknown".to_string(); }
-    // Strict UUID check: len 36, 4 hyphens at canonical positions, 32 hex digits.
-    // Reject any non-UUID format — prevents crafted ID bypass.
-    if cleaned.len() == 36
+    // Canonical: len 36, 4 hyphens at canonical positions, 32 hex digits.
+    let is_canonical = cleaned.len() == 36
         && cleaned.chars().filter(|c| *c == '-').count() == 4
         && cleaned.chars().filter(|c| c.is_ascii_hexdigit()).count() == 32
         && cleaned.get(8..9) == Some("-")
         && cleaned.get(13..14) == Some("-")
         && cleaned.get(18..19) == Some("-")
-        && cleaned.get(23..24) == Some("-") {
-        cleaned
-    } else { "unknown".to_string() }
+        && cleaned.get(23..24) == Some("-");
+    // Simple: exactly 32 hex digits, no hyphens (Uuid::simple() format).
+    let is_simple = cleaned.len() == 32 && cleaned.chars().all(|c| c.is_ascii_hexdigit());
+    if is_canonical || is_simple { cleaned } else { "unknown".to_string() }
 }
 ```
 
@@ -177,10 +222,11 @@ impl AuditDispatcher {
     // Signs over unsigned payload. HMAC input is the JCS-canonical (RFC 8785)
     // UTF-8 JSON of all payload fields with keys in lexicographic order, no
     // extra whitespace. Most Option-typed fields serialize as `null` when
-    // absent. Exception: `Initiator.host` uses skip_serializing_if and is
-    // **omitted entirely** (not set to `null`) when absent. SIEMs MUST
-    // re-serialize the received JSON (minus `signature`) without inserting
-    // absent keys. This is the sole canonical form for HMAC verification.
+    // absent. Exception: `Initiator.host` (and, nested within it, `host.id`
+    // / `host.address`) uses skip_serializing_if and is **omitted entirely**
+    // (not set to `null`) when absent. SIEMs MUST re-serialize the received
+    // JSON (minus `signature`) without inserting absent keys. This is the
+    // sole canonical form for HMAC verification.
     fn finalize_event(&self, partial: CadfEventPayload) -> CadfEvent {
         let (key, version) = self.hmac_key_and_version.load_full().as_ref();
         let completed = CadfEventPayload {
@@ -254,8 +300,21 @@ Captures access attempts at the boundary.
    parsed but policy/scope failed): uses `VerifiedFernetToken` from
    `vsc.verified_token()` to extract sanitized initiator. For endpoints with
    pre-auth identity signals (EC2 `access` key, federation `idp_id`), include
-   non-PII identifiers as `initiator.host` or a custom attachment — these don't
-   require a validated context and don't risk PII leakage.
+   non-PII identifiers as `initiator.host.id` — these don't require a
+   validated context and don't risk PII leakage. The client network address
+   is stamped separately as `initiator.host.address` once available, resolved
+   via ADR 0022's `resolve_client_ip_from_headers` under its own trusted-proxy
+   configuration (`[oslo_middleware]`) — **not** `public_ingress_peer_addr`,
+   which returns the raw, pre-resolution TCP peer (the reverse proxy's own
+   address whenever Keystone sits behind one) and exists so each trust
+   boundary (rate limiting, auth-plugin dispatch, audit) can apply its own
+   resolution independently, per the `crate::net` module's trusted-proxy
+   model. For authenticated requests, the `Auth` extractor resolves it once
+   and sets it on every `ValidatedSecurityContext` it builds (via
+   `SecurityContext.peer_addr`, mirroring how `correlation_id` is threaded);
+   the login endpoint, which authenticates before any `ValidatedSecurityContext`
+   exists, resolves and stamps it directly, independently of the raw peer
+   address it separately feeds to rate limiting and auth-plugin dispatch.
 
 2. **Completion (Middleware):** Post-handler extracts `CorrelationId` and
    `ReadOnlyInitiator`, emits event with HTTP status mapped to outcome.


### PR DESCRIPTION
sanitize_audit_id() only accepted canonical hyphenated UUIDs (36 chars),
but every ID Keystone actually mints uses Uuid::new_v4().simple() (32
hex chars, no hyphens). Every real ID was therefore silently coerced to
"unknown" in Initiator and Target fields, regardless of whether the
caller correctly threaded the real ID through. Accept both shapes.

Add Initiator.address (distinct from the ADR-0023 host field, which
carries pre-auth signals, not network addresses), sanitized through a
new sanitize_initiator_address() that validates via std::net::IpAddr.

Thread the client peer address through by adding peer_addr to
SecurityContext, mirroring the existing correlation_id field. The Auth
extractor resolves it once via public_ingress_peer_addr and stamps it
on every ValidatedSecurityContext it builds, so every audited mutation
carries the client IP with no per-handler changes. The login handler,
which authenticates before any ValidatedSecurityContext exists, stamps
it separately using the PeerAddr it already extracts for rate
limiting.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
