### PR TITLE
feat(config): Support configurable log file rotation

### DIFF
--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -16,6 +16,16 @@ use std::path::PathBuf;
 use url::Url;
 
 /// Default configuration section.
+///
+/// The `log_rotation_type`/`log_rotate_interval`/`log_rotate_interval_type`/
+/// `max_logfile_count` fields below mirror a subset of `oslo_log`'s options
+/// (also configured under `[DEFAULT]` in python-keystone). They are kept as
+/// plain fields here rather than nested under a `#[serde(flatten)]`d
+/// sub-struct: `config-rs` reads INI values as strings, and its `flatten`
+/// support buffers each value through serde's generic `Content` type before
+/// re-deserializing it into the target field, which cannot coerce a
+/// string-typed numeric value into an integer — so a flattened numeric
+/// field would fail to parse from a real `keystone.conf` file.
 #[derive(Debug, Default, Deserialize, Clone)]
 pub struct DefaultSection {
     /// If set to true, the logging level for the file will be set to DEBUG
@@ -52,4 +62,109 @@ pub struct DefaultSection {
     /// `max_list_limit` of its own. Mirrors python-keystone's
     /// `[DEFAULT] max_db_limit`.
     pub max_db_limit: Option<u64>,
+
+    /// Log rotation strategy for [`log_dir`](Self::log_dir). Mirrors
+    /// oslo_log's `log_rotation_type`.
+    ///
+    /// oslo_log also exposes a `size`-based rotation strategy
+    /// (`log_rotation_type = size`, `max_logfile_size_mb`); the underlying
+    /// rolling-file-appender only rotates on a fixed time period, not file
+    /// size, so `size` is intentionally not an accepted value here rather
+    /// than being silently accepted and ignored.
+    #[serde(default)]
+    pub log_rotation_type: LogRotationType,
+
+    /// Number of `log_rotate_interval_type` units between rotations.
+    /// Mirrors oslo_log's `log_rotate_interval`. The underlying
+    /// rolling-file-appender only supports rotating on every single unit
+    /// (matching oslo_log's own default of `1`); any other value is logged
+    /// as a startup warning and treated as `1`. Only used when
+    /// `log_rotation_type = "interval"`.
+    pub log_rotate_interval: Option<u32>,
+
+    /// Unit for `log_rotate_interval`. Mirrors oslo_log's
+    /// `log_rotate_interval_type`. Only used when `log_rotation_type =
+    /// "interval"`.
+    #[serde(default)]
+    pub log_rotate_interval_type: LogRotateIntervalType,
+
+    /// Maximum number of rotated log files to retain; older files beyond
+    /// this count are deleted on rotation. Mirrors oslo_log's
+    /// `max_logfile_count`. Only used when `log_rotation_type =
+    /// "interval"`.
+    pub max_logfile_count: Option<usize>,
+}
+
+/// Log rotation strategy. Mirrors oslo_log's `log_rotation_type`.
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogRotationType {
+    /// No rotation: a single, ever-growing log file. Matches oslo_log's own
+    /// default.
+    #[default]
+    None,
+    /// Rotate on a fixed time interval; see
+    /// [`DefaultSection::log_rotate_interval_type`].
+    Interval,
+}
+
+/// Unit for [`DefaultSection::log_rotate_interval`]. Mirrors oslo_log's
+/// `log_rotate_interval_type`.
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogRotateIntervalType {
+    /// Rotate every minute.
+    Minutes,
+    /// Rotate every hour.
+    Hours,
+    /// Rotate every day, matching oslo_log's own default.
+    #[default]
+    Days,
+    /// Rotate at midnight; the rolling-file-appender treats this the same
+    /// as `days`.
+    Midnight,
+}
+
+#[cfg(test)]
+mod tests {
+    use config::{Config, File, FileFormat};
+
+    use super::*;
+
+    #[test]
+    fn defaults_to_no_log_rotation() {
+        let sot = DefaultSection::default();
+        assert_eq!(sot.log_rotation_type, LogRotationType::None);
+        assert_eq!(sot.log_rotate_interval, None);
+        assert_eq!(sot.log_rotate_interval_type, LogRotateIntervalType::Days);
+        assert_eq!(sot.max_logfile_count, None);
+    }
+
+    #[test]
+    fn parses_log_rotation_options_from_ini() {
+        let c = Config::builder()
+            .add_source(File::from_str(
+                "log_rotation_type = interval\n\
+                 log_rotate_interval = 1\n\
+                 log_rotate_interval_type = hours\n\
+                 max_logfile_count = 7",
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let sot: DefaultSection = c.try_deserialize().unwrap();
+        assert_eq!(sot.log_rotation_type, LogRotationType::Interval);
+        assert_eq!(sot.log_rotate_interval, Some(1));
+        assert_eq!(sot.log_rotate_interval_type, LogRotateIntervalType::Hours);
+        assert_eq!(sot.max_logfile_count, Some(7));
+    }
+
+    #[test]
+    fn rejects_unsupported_size_rotation_type() {
+        let c = Config::builder()
+            .add_source(File::from_str("log_rotation_type = size", FileFormat::Ini))
+            .build()
+            .unwrap();
+        assert!(c.try_deserialize::<DefaultSection>().is_err());
+    }
 }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -545,8 +545,7 @@ fn init_tracing(verbose: u8, cfg: &Config) -> Option<tracing_appender::non_block
     let mut guard = None;
 
     if let Some(log_dir) = &cfg.default.log_dir {
-        // create a file appender that rotates hourly
-        let file_appender = tracing_appender::rolling::never(log_dir, "keystone.log");
+        let file_appender = build_file_appender(log_dir, &cfg.default);
         // make the file appender non-blocking; the guard must outlive the
         // registry to make sure buffered logs get flushed to output.
         // Explicitly disable lossy mode so events are never dropped when the
@@ -588,6 +587,57 @@ fn init_tracing(verbose: u8, cfg: &Config) -> Option<tracing_appender::non_block
         .init();
 
     guard
+}
+
+/// Build the file-log appender for `[DEFAULT] log_dir`, honoring the
+/// `oslo_log`-mirroring rotation options (`log_rotation_type`,
+/// `log_rotate_interval_type`, `max_logfile_count`) documented on
+/// [`openstack_keystone::config::DefaultSection`].
+///
+/// Called before the tracing subscriber is installed by `init_tracing`, so
+/// diagnostics here use `eprintln!` directly rather than the `tracing`
+/// macros.
+fn build_file_appender(
+    log_dir: &std::path::Path,
+    default: &openstack_keystone::config::DefaultSection,
+) -> tracing_appender::rolling::RollingFileAppender {
+    use openstack_keystone::config::{LogRotateIntervalType, LogRotationType};
+    use tracing_appender::rolling::{RollingFileAppender, Rotation};
+
+    let rotation = match default.log_rotation_type {
+        LogRotationType::None => Rotation::NEVER,
+        LogRotationType::Interval => {
+            if !matches!(default.log_rotate_interval, None | Some(1)) {
+                eprintln!(
+                    "log_rotate_interval={} is not supported (rotation only ever \
+                     happens on a single {:?} unit boundary); ignoring the configured value",
+                    default.log_rotate_interval.unwrap_or(1),
+                    default.log_rotate_interval_type
+                );
+            }
+            match default.log_rotate_interval_type {
+                LogRotateIntervalType::Minutes => Rotation::MINUTELY,
+                LogRotateIntervalType::Hours => Rotation::HOURLY,
+                LogRotateIntervalType::Days | LogRotateIntervalType::Midnight => Rotation::DAILY,
+            }
+        }
+    };
+
+    let mut builder = RollingFileAppender::builder()
+        .rotation(rotation)
+        .filename_prefix("keystone")
+        .filename_suffix("log");
+    if let Some(max_logfile_count) = default.max_logfile_count {
+        builder = builder.max_log_files(max_logfile_count);
+    }
+
+    builder.build(log_dir).unwrap_or_else(|err| {
+        eprintln!(
+            "Failed to build the rotating log file appender ({err}); falling back to a \
+             single non-rotating log file"
+        );
+        tracing_appender::rolling::never(log_dir, "keystone.log")
+    })
 }
 
 /// Load or generate the persisted audit HMAC key-encryption-key (KEK),

--- a/doc/src/configuration/options.md
+++ b/doc/src/configuration/options.md
@@ -9,7 +9,7 @@ the feature guide for constraints and safe production values.
 
 | Section | Options |
 | --- | --- |
-| `[DEFAULT]` | `debug`, `log_dir`, `public_endpoint`, `use_stderr`, `use_journal` |
+| `[DEFAULT]` | `debug`, `log_dir`, `public_endpoint`, `use_stderr`, `use_journal`, `log_rotation_type`, `log_rotate_interval`, `log_rotate_interval_type`, `max_logfile_count` |
 | `[database]` | `connection`, `connection_debug` |
 | `[interface_public]` | `tcp_address`, listener `type`, and listener-specific TLS/SPIFFE fields |
 | `[interface_internal]` | `tcp_address`, listener `type`, `trust_domains`, and TLS content/file fields |


### PR DESCRIPTION
Wire up oslo_log's log rotation options for the file logger. New
[DEFAULT] settings log_rotation_type, log_rotate_interval,
log_rotate_interval_type and max_logfile_count are mapped onto
tracing-appender's RollingFileAppender builder.

Rotation defaults to "none", matching both oslo_log's own default
and the previous hardcoded behavior. Only time-based rotation is
implemented, since the rolling-file-appender only rotates on a
fixed period, not file size; log_rotation_type = "size" is
rejected at config-parse time rather than silently ignored, and
log_rotate_interval values other than 1 log a startup warning and
are treated as 1.

The new fields are kept flat on DefaultSection instead of a nested
flattened sub-struct: config-rs reads INI values as strings, and
its serde flatten support buffers them through serde's Content
type first, which cannot coerce a string into an integer - so a
flattened numeric field would fail to parse from a real
keystone.conf file.

Closes #1124

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
