### PR TITLE
chore: Add SECURITY note to important method

### DIFF
--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -242,6 +242,8 @@ fn flat_spiffe_claims(svid: &SpiffeId) -> MappingAuthRequest {
 ///
 /// `Ok(())` when the auth type is not EC2, `Err(403 Forbidden)` otherwise.
 fn reject_if_ec2(user_auth: &ValidatedSecurityContext) -> Result<(), KeystoneApiError> {
+    // SECURITY: this must stay here unchanged to prevent security vulnerabilities
+    // from the EC2 auth reuse.
     if matches!(
         user_auth.inner().authentication_context(),
         AuthenticationContext::Ec2Credential


### PR DESCRIPTION
Few times it was attempted to change `reject_if_ec2` method condition
preventing EC2 tokens from using Keystone API and only manual review
spotted this attempt. Add a bold warning stating it must stay this way.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
