### PR TITLE
feat(loadtest): Add v4 raft-backed scenarios

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,15 @@ Backend traits in `crates/core/src/backend.rs` follow CRUD naming:
   `tools/run-loadtest-local.sh` entirely and point `load_test` straight at
   the cluster's exposed URL/port with `--host`, using `OS_CLOUD`/`OS_*` env
   vars matching that deployment's admin credentials.
+- `tests/loadtest/sample_metrics.sh <output-file> [interval-seconds]` polls
+  `kubectl top` (keystone-rs/keystone-py pods + node) and host
+  free/loadavg on a loop, for correlating CPU/memory against a concurrent
+  loadtest run in the skaffold k3s deployment. Requires metrics-server
+  already working (`kubectl top nodes` succeeds standalone). Run it in the
+  background bracketing the `load_test` invocation, then `kill` it:
+  `./sample_metrics.sh /tmp/metrics.log 3 & SAMPLER=$!; load_test ...; kill "$SAMPLER"`.
+  See the script's header comment for the output format and an `awk`
+  one-liner to derive per-pod min/max/avg memory from it.
 
 ## Commit Message Rules
 

--- a/tests/loadtest/Cargo.lock
+++ b/tests/loadtest/Cargo.lock
@@ -180,8 +180,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1342,6 +1344,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 name = "load_test"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "fastrand",
  "goose",
  "openstack_sdk",

--- a/tests/loadtest/Cargo.toml
+++ b/tests/loadtest/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 dist = false
 
 [dependencies]
+chrono = "0.4"
 goose = { version = "^0.18" }
 tokio = { version = "1.49" }
 openstack_sdk = { version = "^0.22", default-features = false, features = ["async", "identity"] }

--- a/tests/loadtest/sample_metrics.sh
+++ b/tests/loadtest/sample_metrics.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Samples `kubectl top` (keystone-rs/keystone-py pods + node) and host
+# free/loadavg on a fixed interval, for correlating memory/CPU behavior with
+# a concurrent tools/run-loadtest-local.sh or manual `load_test` run against
+# the skaffold k3s deployment (see AGENTS.md "Running loadtests locally").
+#
+# Requires a working `kubectl` context pointed at the cluster under test and
+# metrics-server installed (`kubectl top nodes` must already work standalone).
+#
+# Usage: run in the background around your loadtest invocation, then kill it
+# once the loadtest finishes:
+#
+#   ./sample_metrics.sh /tmp/metrics.log 3 &
+#   SAMPLER=$!
+#   OS_CLOUD=ciab-rs ./target/release/load_test --host http://keystone-rs.local \
+#     --users 50 --hatch-rate 10 --run-time 90s --report-file reports/run.md
+#   kill "$SAMPLER"
+#
+# Args: $1 output file (required), $2 sample interval in seconds (default 3).
+#
+# Output is plain text blocks separated by "=== <unix-ts> ===", one block per
+# sample; parse per-pod min/max/avg memory with e.g.:
+#
+#   awk -v p="keystone-rs-0" '$1==p {gsub("Mi","",$3); print $3}' metrics.log \
+#     | awk '{s+=$1; if(min==""||$1<min)min=$1; if($1>max)max=$1; n++}
+#            END{printf "min=%dMi max=%dMi avg=%.0fMi\n", min, max, s/n}'
+set -u
+OUT="${1:?output file}"
+INTERVAL="${2:-3}"
+: > "$OUT"
+while true; do
+  ts=$(date +%s)
+  {
+    echo "=== $ts ==="
+    kubectl top pods -l app.kubernetes.io/name=keystone-rs --no-headers 2>/dev/null
+    kubectl top pods -l app.kubernetes.io/name=keystone-py --no-headers 2>/dev/null
+    kubectl top nodes --no-headers 2>/dev/null
+    free -m | awk 'NR==2{print "host_mem_used_mb="$3, "host_mem_total_mb="$2}'
+    awk '{print "loadavg="$1,$2,$3}' /proc/loadavg
+  } >> "$OUT"
+  sleep "$INTERVAL"
+done

--- a/tests/loadtest/src/main.rs
+++ b/tests/loadtest/src/main.rs
@@ -22,6 +22,7 @@ use std::env;
 
 mod seed;
 mod v3;
+mod v4;
 
 use crate::v3::auth::lifecycle::{token_lifecycle, validate as validate_token};
 use crate::v3::auth::password::{
@@ -46,6 +47,19 @@ use crate::v3::user::{
     create as user_create, delete as user_delete, list as user_list, show as user_show,
     show_random as user_show_random,
 };
+use crate::v4::api_key::{
+    create as api_key_create, list as api_key_list, revoke as api_key_revoke,
+    show as api_key_show,
+};
+use crate::v4::mapping::{
+    create as mapping_create, delete as mapping_delete, list as mapping_list,
+    show as mapping_show,
+};
+use crate::v4::oauth2::{
+    create_client as oauth2_client_create, delete_client as oauth2_client_delete,
+    jwks as oauth2_jwks, list_clients as oauth2_client_list,
+    show_client as oauth2_client_show, well_known as oauth2_well_known,
+};
 
 /// Per-GooseUser session state shared across transactions.
 pub struct Session {
@@ -57,6 +71,15 @@ pub struct Session {
     pub project_id: Option<String>,
     /// ID of the role created in on_start for RoleCRUD scenario.
     pub role_id: Option<String>,
+    /// client_id of the API key created in on_start for ApiKeyCRUD scenario
+    /// (raft-backed, ADR 0021).
+    pub api_key_client_id: Option<String>,
+    /// mapping_id of the ruleset created in on_start for MappingCRUD
+    /// scenario (raft-backed, ADR 0020).
+    pub mapping_id: Option<String>,
+    /// provider_id of the OAuth2 client created in on_start for
+    /// OAuth2ClientCRUD scenario (raft-backed, ADR 0026).
+    pub oauth2_client_id: Option<String>,
 }
 
 #[tokio::main]
@@ -213,6 +236,48 @@ async fn main() -> Result<(), GooseError> {
             scenario!("SystemScopeAuth")
                 .set_weight(2)?
                 .register_transaction(transaction!(system_scope_auth)),
+        )
+        // Raft-backed API Key CRUD (ADR 0021): create/revoke go through
+        // api-key-driver-raft's log-append + quorum-commit write path.
+        .register_scenario(
+            scenario!("ApiKeyCRUD")
+                .set_weight(1)?
+                .register_transaction(transaction!(openstack_login).set_on_start())
+                .register_transaction(transaction!(api_key_create).set_on_start())
+                .register_transaction(transaction!(api_key_show))
+                .register_transaction(transaction!(api_key_list))
+                .register_transaction(transaction!(api_key_revoke).set_on_stop()),
+        )
+        // Raft-backed Mapping ruleset CRUD (ADR 0020): mapping-driver-raft is
+        // the largest raft driver -- rules carry nested claim/identity/role
+        // payloads, so this exercises bigger raft log entries than api_key.
+        .register_scenario(
+            scenario!("MappingCRUD")
+                .set_weight(1)?
+                .register_transaction(transaction!(openstack_login).set_on_start())
+                .register_transaction(transaction!(mapping_create).set_on_start())
+                .register_transaction(transaction!(mapping_show))
+                .register_transaction(transaction!(mapping_list))
+                .register_transaction(transaction!(mapping_delete).set_on_stop()),
+        )
+        // Raft-backed OAuth2 client CRUD (ADR 0026 §5): oauth2-client-driver-raft.
+        .register_scenario(
+            scenario!("OAuth2ClientCRUD")
+                .set_weight(1)?
+                .register_transaction(transaction!(openstack_login).set_on_start())
+                .register_transaction(transaction!(oauth2_client_create).set_on_start())
+                .register_transaction(transaction!(oauth2_client_show))
+                .register_transaction(transaction!(oauth2_client_list))
+                .register_transaction(transaction!(oauth2_client_delete).set_on_stop()),
+        )
+        // Read-heavy OAuth2 discovery: jwks + well-known are unauthenticated,
+        // linearizable-read-policy paths (ADR 0016-v2 §3) -- the actual
+        // steady-state traffic most OAuth2 relying parties generate.
+        .register_scenario(
+            scenario!("OAuth2Discovery")
+                .set_weight(3)?
+                .register_transaction(transaction!(oauth2_jwks))
+                .register_transaction(transaction!(oauth2_well_known)),
         );
 
     attack.execute().await?;
@@ -251,6 +316,9 @@ pub async fn openstack_login(user: &mut GooseUser) -> TransactionResult {
         user_id: None,
         project_id: None,
         role_id: None,
+        api_key_client_id: None,
+        mapping_id: None,
+        oauth2_client_id: None,
     });
     Ok(())
 }

--- a/tests/loadtest/src/v4.rs
+++ b/tests/loadtest/src/v4.rs
@@ -1,0 +1,17 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod api_key;
+pub(crate) mod mapping;
+pub(crate) mod oauth2;

--- a/tests/loadtest/src/v4/api_key.rs
+++ b/tests/loadtest/src/v4/api_key.rs
@@ -1,0 +1,153 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Raft-backed API Key (SCIM ingress machine identity) CRUD, ADR 0021.
+//!
+//! Every write goes through `api-key-driver-raft` -- create/revoke are raft
+//! log-append + quorum-commit operations, unlike the SQL-backed v3 CRUD.
+
+use chrono::{Duration, Utc};
+use goose::prelude::*;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::Session;
+
+const DEFAULT_DOMAIN_ID: &str = "default";
+
+/// List API keys (raft read path). `domain_id` is a mandatory filter (ADR
+/// 0021 §5.B) -- API keys are always domain-owned, no "all domains" mode.
+pub async fn list(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+
+    let path = format!("/v4/api-keys?domain_id={DEFAULT_DOMAIN_ID}");
+    let req = user
+        .get_request_builder(&GooseMethod::Get, &path)?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("GET /v4/api-keys")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// Create an API key owned by this virtual user (on_start for ApiKeyCRUD).
+pub async fn create(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+
+    let provider_id = format!("loadtest-provider-{}", Uuid::new_v4().as_simple());
+    let expires_at = Utc::now() + Duration::hours(1);
+    let body = json!({
+        "api_key": {
+            "domain_id": DEFAULT_DOMAIN_ID,
+            "provider_id": provider_id,
+            "expires_at": expires_at.to_rfc3339(),
+            "description": "loadtest key"
+        }
+    });
+
+    let req = user
+        .get_request_builder(&GooseMethod::Post, "/v4/api-keys")?
+        .header("x-auth-token", &token)
+        .json(&body);
+
+    let goose_request = GooseRequest::builder()
+        .name("POST /v4/api-keys (setup)")
+        .set_request_builder(req)
+        .build();
+
+    let mut goose = user.request(goose_request).await?;
+    let response = match goose.response {
+        Ok(r) => r,
+        Err(e) => {
+            return user.set_failure(
+                &format!("api_key create failed: {e}"),
+                &mut goose.request,
+                None,
+                None,
+            );
+        }
+    };
+
+    if !response.status().is_success() {
+        return user.set_failure(
+            &format!("api_key create returned {}", response.status()),
+            &mut goose.request,
+            None,
+            None,
+        );
+    }
+
+    let val: serde_json::Value = response.json().await.unwrap_or_default();
+    let client_id = val["api_key"]["client_id"].as_str().map(str::to_owned);
+
+    let session = user.get_session_data_unchecked_mut::<Session>();
+    session.api_key_client_id = client_id;
+
+    Ok(())
+}
+
+/// Show the API key owned by this virtual user.
+pub async fn show(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+    let client_id = match &session.api_key_client_id {
+        Some(id) => id.clone(),
+        None => return Ok(()),
+    };
+
+    let path = format!("/v4/api-keys/{client_id}?domain_id={DEFAULT_DOMAIN_ID}");
+    let req = user
+        .get_request_builder(&GooseMethod::Get, &path)?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("GET /v4/api-keys/:client_id")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// Revoke the API key owned by this virtual user (on_stop for ApiKeyCRUD).
+pub async fn revoke(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+    let client_id = match &session.api_key_client_id {
+        Some(id) => id.clone(),
+        None => return Ok(()),
+    };
+
+    let path = format!("/v4/api-keys/{client_id}/revoke?domain_id={DEFAULT_DOMAIN_ID}");
+    let req = user
+        .get_request_builder(&GooseMethod::Post, &path)?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("POST /v4/api-keys/:client_id/revoke (teardown)")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+
+    let session = user.get_session_data_unchecked_mut::<Session>();
+    session.api_key_client_id = None;
+
+    Ok(())
+}

--- a/tests/loadtest/src/v4/mapping.rs
+++ b/tests/loadtest/src/v4/mapping.rs
@@ -1,0 +1,160 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Raft-backed Unified Mapping Engine ruleset CRUD, ADR 0020.
+//!
+//! `mapping-driver-raft` is the largest raft driver in the workspace -- rules
+//! can carry nested authorizations/groups/identity bindings, so this exercises
+//! larger raft log entries than the simple api_key/oauth2_client payloads.
+
+use goose::prelude::*;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::Session;
+
+/// List mapping rulesets (raft read path).
+pub async fn list(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+
+    let req = user
+        .get_request_builder(&GooseMethod::Get, "/v4/mappings/rulesets")?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("GET /v4/mappings/rulesets")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// Create a mapping ruleset owned by this virtual user (on_start for MappingCRUD).
+pub async fn create(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+
+    let idp_id = format!("loadtest-idp-{}", Uuid::new_v4().as_simple());
+    let body = json!({
+        "mapping": {
+            "domain_resolution_mode": { "type": "fixed" },
+            "enabled": true,
+            "source": { "type": "federation", "idp_id": idp_id },
+            "rules": [{
+                "name": "loadtest-rule",
+                "description": "loadtest rule",
+                "match": {
+                    "all_of": [{
+                        "type": "condition",
+                        "equals": { "claim": "sub", "value": "loadtest" }
+                    }]
+                },
+                "identity": { "user_name": "loadtest-user" },
+                "groups": [],
+                "authorizations": []
+            }]
+        }
+    });
+
+    let req = user
+        .get_request_builder(&GooseMethod::Post, "/v4/mappings/rulesets")?
+        .header("x-auth-token", &token)
+        .json(&body);
+
+    let goose_request = GooseRequest::builder()
+        .name("POST /v4/mappings/rulesets (setup)")
+        .set_request_builder(req)
+        .build();
+
+    let mut goose = user.request(goose_request).await?;
+    let response = match goose.response {
+        Ok(r) => r,
+        Err(e) => {
+            return user.set_failure(
+                &format!("mapping ruleset create failed: {e}"),
+                &mut goose.request,
+                None,
+                None,
+            );
+        }
+    };
+
+    if !response.status().is_success() {
+        return user.set_failure(
+            &format!("mapping ruleset create returned {}", response.status()),
+            &mut goose.request,
+            None,
+            None,
+        );
+    }
+
+    let val: serde_json::Value = response.json().await.unwrap_or_default();
+    let mapping_id = val["mapping"]["mapping_id"].as_str().map(str::to_owned);
+
+    let session = user.get_session_data_unchecked_mut::<Session>();
+    session.mapping_id = mapping_id;
+
+    Ok(())
+}
+
+/// Show the mapping ruleset owned by this virtual user.
+pub async fn show(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+    let mapping_id = match &session.mapping_id {
+        Some(id) => id.clone(),
+        None => return Ok(()),
+    };
+
+    let path = format!("/v4/mappings/rulesets/{mapping_id}");
+    let req = user
+        .get_request_builder(&GooseMethod::Get, &path)?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("GET /v4/mappings/rulesets/:mapping_id")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// Delete the mapping ruleset owned by this virtual user (on_stop for MappingCRUD).
+pub async fn delete(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+    let mapping_id = match &session.mapping_id {
+        Some(id) => id.clone(),
+        None => return Ok(()),
+    };
+
+    let path = format!("/v4/mappings/rulesets/{mapping_id}");
+    let req = user
+        .get_request_builder(&GooseMethod::Delete, &path)?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("DELETE /v4/mappings/rulesets/:mapping_id (teardown)")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+
+    let session = user.get_session_data_unchecked_mut::<Session>();
+    session.mapping_id = None;
+
+    Ok(())
+}

--- a/tests/loadtest/src/v4/oauth2.rs
+++ b/tests/loadtest/src/v4/oauth2.rs
@@ -1,0 +1,178 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Raft-backed OAuth2 client registration CRUD (`oauth2-client-driver-raft`,
+//! ADR 0026 §5) plus the read-heavy jwks/well-known discovery endpoints,
+//! which are the actual steady-state traffic most OAuth2 consumers generate.
+
+use goose::prelude::*;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::Session;
+
+const DEFAULT_DOMAIN_ID: &str = "default";
+
+/// GET jwks for the `default` domain (read-heavy, exercises linearizable
+/// reads against `oauth2-key-driver-raft`).
+pub async fn jwks(user: &mut GooseUser) -> TransactionResult {
+    let path = format!("/v4/oauth2/{DEFAULT_DOMAIN_ID}/jwks");
+    let req = user.get_request_builder(&GooseMethod::Get, &path)?;
+
+    let goose_request = GooseRequest::builder()
+        .name("GET /v4/oauth2/:domain_id/jwks")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// GET well-known OIDC discovery document for the `default` domain.
+pub async fn well_known(user: &mut GooseUser) -> TransactionResult {
+    let path = format!("/v4/oauth2/{DEFAULT_DOMAIN_ID}/.well-known/openid-configuration");
+    let req = user.get_request_builder(&GooseMethod::Get, &path)?;
+
+    let goose_request = GooseRequest::builder()
+        .name("GET /v4/oauth2/:domain_id/.well-known/openid-configuration")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// List registered OAuth2 clients for the `default` domain.
+pub async fn list_clients(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+
+    let path = format!("/v4/oauth2/{DEFAULT_DOMAIN_ID}/clients");
+    let req = user
+        .get_request_builder(&GooseMethod::Get, &path)?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("GET /v4/oauth2/:domain_id/clients")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// Register an OAuth2 client owned by this virtual user (on_start for
+/// OAuth2ClientCRUD).
+pub async fn create_client(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+
+    let provider_id = format!("loadtest-client-{}", Uuid::new_v4().as_simple());
+    let body = json!({
+        "oauth2_client": {
+            "confidential": true,
+            "grant_types": ["client_credentials"],
+            "provider_id": provider_id,
+            "token_endpoint_auth_method": "client_secret_basic"
+        }
+    });
+
+    let path = format!("/v4/oauth2/{DEFAULT_DOMAIN_ID}/clients");
+    let req = user
+        .get_request_builder(&GooseMethod::Post, &path)?
+        .header("x-auth-token", &token)
+        .json(&body);
+
+    let goose_request = GooseRequest::builder()
+        .name("POST /v4/oauth2/:domain_id/clients (setup)")
+        .set_request_builder(req)
+        .build();
+
+    let mut goose = user.request(goose_request).await?;
+    let response = match goose.response {
+        Ok(r) => r,
+        Err(e) => {
+            return user.set_failure(
+                &format!("oauth2 client create failed: {e}"),
+                &mut goose.request,
+                None,
+                None,
+            );
+        }
+    };
+
+    if !response.status().is_success() {
+        return user.set_failure(
+            &format!("oauth2 client create returned {}", response.status()),
+            &mut goose.request,
+            None,
+            None,
+        );
+    }
+
+    let session = user.get_session_data_unchecked_mut::<Session>();
+    session.oauth2_client_id = Some(provider_id);
+
+    Ok(())
+}
+
+/// Show the OAuth2 client owned by this virtual user.
+pub async fn show_client(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+    let client_id = match &session.oauth2_client_id {
+        Some(id) => id.clone(),
+        None => return Ok(()),
+    };
+
+    let path = format!("/v4/oauth2/{DEFAULT_DOMAIN_ID}/clients/{client_id}");
+    let req = user
+        .get_request_builder(&GooseMethod::Get, &path)?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("GET /v4/oauth2/:domain_id/clients/:provider_id")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+    Ok(())
+}
+
+/// Delete the OAuth2 client owned by this virtual user (on_stop for
+/// OAuth2ClientCRUD).
+pub async fn delete_client(user: &mut GooseUser) -> TransactionResult {
+    let session = user.get_session_data_unchecked::<Session>();
+    let token = session.token.clone();
+    let client_id = match &session.oauth2_client_id {
+        Some(id) => id.clone(),
+        None => return Ok(()),
+    };
+
+    let path = format!("/v4/oauth2/{DEFAULT_DOMAIN_ID}/clients/{client_id}");
+    let req = user
+        .get_request_builder(&GooseMethod::Delete, &path)?
+        .header("x-auth-token", &token);
+
+    let goose_request = GooseRequest::builder()
+        .name("DELETE /v4/oauth2/:domain_id/clients/:provider_id (teardown)")
+        .set_request_builder(req)
+        .build();
+
+    user.request(goose_request).await?;
+
+    let session = user.get_session_data_unchecked_mut::<Session>();
+    session.oauth2_client_id = None;
+
+    Ok(())
+}


### PR DESCRIPTION
No goose coverage existed for api_key/mapping/oauth2_client, the only
endpoints that exercise raft log-append/quorum-commit instead of SQL.
sample_metrics.sh correlates CPU/memory with a concurrent run.

Signed-off-by: gtema <artem.goncharov@gmail.com>
