### PR TITLE
feat(adr0031): Add HTTP request metrics

### DIFF
--- a/crates/config/src/common.rs
+++ b/crates/config/src/common.rs
@@ -264,11 +264,18 @@ impl TlsConfiguration {
 }
 
 /// Server interface type.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Interface {
     Admin,
     Internal,
     Public,
+    /// The dedicated health/metrics listener (`interface_metrics`). Only
+    /// ever attached to that listener's own router — see
+    /// `crates/keystone/src/server/http_metrics.rs` and
+    /// `docs/superpowers/specs/2026-07-31-http-status-metrics-design.md`
+    /// for why this is safe alongside the security-relevant use of this
+    /// enum in `crates/core/src/api/auth.rs`.
+    Metrics,
 }
 
 #[cfg(test)]
@@ -323,5 +330,18 @@ tls_client_ca_file = {:?}
             cfg.tls_key_content
                 .is_some_and(|x| x.expose_secret() == "key".as_bytes()),
         );
+    }
+
+    #[test]
+    fn interface_is_hashable_and_copy() {
+        use std::collections::HashSet;
+
+        let a = Interface::Public;
+        let b = a; // requires Copy
+        let mut set: HashSet<Interface> = HashSet::new(); // requires Eq + Hash
+        set.insert(a);
+        set.insert(b);
+        set.insert(Interface::Metrics);
+        assert_eq!(set.len(), 2);
     }
 }

--- a/crates/config/src/interface.rs
+++ b/crates/config/src/interface.rs
@@ -73,12 +73,21 @@ pub struct MetricsInterface {
     /// `0.0.0.0:8099`.
     #[serde(default = "default_metrics_tcp_address")]
     pub tcp_address: SocketAddr,
+
+    /// Whether to record and expose the `keystone_http_requests_total` /
+    /// `keystone_http_request_duration_seconds` /
+    /// `keystone_http_requests_in_flight` metric trio (ADR 0031). Defaults
+    /// to enabled; set to `false` to disable the recording middleware
+    /// entirely (not just hide it from `/metrics`).
+    #[serde(default = "crate::common::default_true")]
+    pub http_requests_enabled: bool,
 }
 
 impl Default for MetricsInterface {
     fn default() -> Self {
         Self {
             tcp_address: default_metrics_tcp_address(),
+            http_requests_enabled: true,
         }
     }
 }
@@ -165,5 +174,20 @@ trust_domains = "a,b,c"
         } else {
             panic!("should be Http listener");
         }
+    }
+
+    #[test]
+    fn metrics_interface_http_requests_enabled_defaults_true() {
+        let sot: MetricsInterface = serde_json::from_value(json!({})).unwrap();
+        assert!(sot.http_requests_enabled);
+    }
+
+    #[test]
+    fn metrics_interface_http_requests_enabled_explicit_false() {
+        let sot: MetricsInterface = serde_json::from_value(json!({
+            "http_requests_enabled": false,
+        }))
+        .unwrap();
+        assert!(!sot.http_requests_enabled);
     }
 }

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{
-    Router, ServiceExt,
+    Extension, Router, ServiceExt,
     extract::{ConnectInfo, DefaultBodyLimit, State},
     http::{self, HeaderName, Request, StatusCode, header},
     middleware,
@@ -83,6 +83,8 @@ use openstack_keystone::revoke::RevokeHook;
 use openstack_keystone::role::RoleHook;
 use openstack_keystone::scim;
 use openstack_keystone::server::access_log::log_request;
+use openstack_keystone::server::http_metrics::format_prometheus_text as format_http_metrics_text;
+use openstack_keystone::server::http_metrics::{HttpMetrics, record_http_metrics};
 use openstack_keystone::server::listener::{raft_grpc, spiffe_tls, spiffe_tls_uds};
 use openstack_keystone::server::proxy_headers;
 use openstack_keystone::server::request_cache;
@@ -392,7 +394,7 @@ async fn main() -> Result<(), Report> {
     );
     warn_on_unresolvable_auth_methods(&shared_state).await;
 
-    let app = build_router(&shared_state, &token, main_router, openapi).await?;
+    let (app, http_metrics) = build_router(&shared_state, &token, main_router, openapi).await?;
     let build_router_took = listen_phase_start.elapsed();
     debug!("build_router took {:.3}s", build_router_took.as_secs_f32());
 
@@ -412,7 +414,7 @@ async fn main() -> Result<(), Report> {
     spawn_opa_subprocess(&cfg, &token, &mut handles).await?;
     spawn_public_listener(&cfg, app.clone(), &token, &mut handles).await?;
     spawn_internal_listener(&cfg, app.clone(), &token, &mut handles)?;
-    spawn_metrics_listener(&cfg, &shared_state, &token, &mut handles).await?;
+    spawn_metrics_listener(&cfg, &shared_state, &http_metrics, &token, &mut handles).await?;
     spawn_admin_listener(&cfg, app, &token, &mut handles);
 
     info!(
@@ -898,7 +900,7 @@ async fn build_router(
     token: &CancellationToken,
     main_router: Router<ServiceState>,
     openapi: utoipa::openapi::OpenApi,
-) -> Result<Router, Report> {
+) -> Result<(Router, Option<Arc<HttpMetrics>>), Report> {
     let x_request_id = HeaderName::from_static("x-openstack-request-id");
     let sensitive_headers: Arc<[_]> = vec![
         header::AUTHORIZATION,
@@ -1003,12 +1005,34 @@ async fn build_router(
 
     app = app.layer(middleware);
 
+    let http_metrics = if shared_state
+        .config_manager
+        .config
+        .read()
+        .await
+        .interface_metrics
+        .http_requests_enabled
+    {
+        let http_metrics = Arc::new(HttpMetrics::new());
+        // `Router::layer()` applies in *reverse* call order (last-added is
+        // outermost, unlike `ServiceBuilder`'s top-to-bottom convention
+        // used above) — `Extension` must be added *after* `from_fn` so it
+        // runs first and the extractor inside `record_http_metrics` has
+        // something to read.
+        app = app
+            .layer(middleware::from_fn(record_http_metrics))
+            .layer(Extension(http_metrics.clone()));
+        Some(http_metrics)
+    } else {
+        None
+    };
+
     let normalized_app = NormalizePathLayer::trim_trailing_slash().layer(app);
     let app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi))
         .fallback_service(normalized_app);
 
-    Ok(app)
+    Ok((app, http_metrics))
 }
 
 /// Start the Raft gRPC listener and join the cluster, when distributed
@@ -1430,6 +1454,7 @@ fn spawn_internal_listener(
 async fn spawn_metrics_listener(
     cfg: &Config,
     shared_state: &ServiceState,
+    http_metrics: &Option<Arc<HttpMetrics>>,
     token: &CancellationToken,
     handles: &mut tokio::task::JoinSet<()>,
 ) -> Result<(), Report> {
@@ -1441,10 +1466,19 @@ async fn spawn_metrics_listener(
     let cancel_token = token.clone();
 
     let (metrics_router, _) = api::metrics_router().split_for_parts();
-    let metrics_app = Router::new()
+    let mut metrics_app = Router::new()
         .merge(metrics_router.with_state(shared_state.clone()))
         .route("/metrics", axum::routing::get(metrics_handler))
         .with_state(shared_state.clone());
+    if let Some(http_metrics) = http_metrics {
+        // Same reverse-order caveat as `build_router`: `from_fn` must be
+        // added first (innermost) so both `Extension` layers, added after,
+        // run before it and have already inserted their values.
+        metrics_app = metrics_app
+            .layer(middleware::from_fn(record_http_metrics))
+            .layer(Extension(Interface::Metrics))
+            .layer(Extension(http_metrics.clone()));
+    }
 
     handles.spawn(async move {
         if let Err(e) = axum::serve(listener, metrics_app.into_make_service())
@@ -1503,7 +1537,10 @@ fn spawn_admin_listener(
 /// exposition format (v0.0.4). No authentication required; operators are
 /// expected to firewall `:5000/metrics` (or expose it only on an internal
 /// interface).
-async fn metrics_handler(State(state): State<ServiceState>) -> impl IntoResponse {
+async fn metrics_handler(
+    State(state): State<ServiceState>,
+    http_metrics: Option<Extension<Arc<HttpMetrics>>>,
+) -> impl IntoResponse {
     let mut body =
         openstack_keystone_audit::metrics::format_prometheus_text(&state.audit_dispatcher);
     body.push_str(
@@ -1511,6 +1548,9 @@ async fn metrics_handler(State(state): State<ServiceState>) -> impl IntoResponse
             &*state.auth_plugin_load_failures.read().await,
         ),
     );
+    if let Some(Extension(http_metrics)) = http_metrics {
+        body.push_str(&format_http_metrics_text(&http_metrics));
+    }
     (
         StatusCode::OK,
         [(
@@ -1715,7 +1755,7 @@ mod tests {
         let (main_router, _main_api) = api::openapi_router().split_for_parts();
         let openapi = api::ApiDoc::openapi();
 
-        let app = build_router(&state, &token, main_router, openapi)
+        let (app, _http_metrics) = build_router(&state, &token, main_router, openapi)
             .await
             .expect("router assembly succeeds");
 
@@ -1748,7 +1788,7 @@ mod tests {
         let (main_router, _main_api) = api::openapi_router().split_for_parts();
         let openapi = api::ApiDoc::openapi();
 
-        let app = build_router(&state, &token, main_router, openapi)
+        let (app, _http_metrics) = build_router(&state, &token, main_router, openapi)
             .await
             .expect("router assembly succeeds");
 
@@ -1767,6 +1807,198 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response.into_body().collect().await.unwrap().to_bytes();
         assert!(!body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn build_router_records_http_metrics_when_enabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = test_config(tmp.path().to_path_buf());
+        cfg.interface_metrics.http_requests_enabled = true;
+        let state = test_state(cfg).await;
+        let token = CancellationToken::new();
+        let (main_router, _main_api) = api::openapi_router().split_for_parts();
+        let openapi = api::ApiDoc::openapi();
+
+        let (app, http_metrics) = build_router(&state, &token, main_router, openapi)
+            .await
+            .expect("router assembly succeeds");
+        let http_metrics = http_metrics.expect("HttpMetrics must be Some when enabled");
+
+        let _ = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v3/")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let text = format_http_metrics_text(&http_metrics);
+        // The matched-path template for this route is "/v3" (no trailing
+        // slash) even though the request URI is "/v3/": `NormalizePathLayer`
+        // trims the trailing slash before the request reaches the inner
+        // router (and `record_http_metrics`), so the label reflects the
+        // canonical route template, not the raw request URI.
+        assert!(
+            text.contains("keystone_http_requests_total{method=\"GET\",route=\"/v3\""),
+            "expected a recorded /v3 request, got:\n{text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_router_skips_http_metrics_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = test_config(tmp.path().to_path_buf());
+        cfg.interface_metrics.http_requests_enabled = false;
+        let state = test_state(cfg).await;
+        let token = CancellationToken::new();
+        let (main_router, _main_api) = api::openapi_router().split_for_parts();
+        let openapi = api::ApiDoc::openapi();
+
+        let (app, http_metrics) = build_router(&state, &token, main_router, openapi)
+            .await
+            .expect("router assembly succeeds");
+        assert!(
+            http_metrics.is_none(),
+            "HttpMetrics must be None when disabled"
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v3/")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "disabling metrics must not break normal routing"
+        );
+    }
+
+    /// Reports whether an `Interface` extension is present on the request
+    /// by the time it reaches this handler, mounted inside `build_router`'s
+    /// `main_router`. Used by
+    /// `build_router_never_inserts_interface_extension` below to guard the
+    /// security-critical invariant that `build_router`'s main `app` never
+    /// gains an `Interface` extension: `crates/core/src/api/auth.rs` reads
+    /// that extension to gate the admin-SVID auth short-circuit, and only
+    /// connection-level listener code (never the shared router built here)
+    /// is supposed to stamp it — see
+    /// `crates/keystone/src/server/http_metrics.rs`'s `record_http_metrics`
+    /// doc comment for the full rationale.
+    async fn interface_probe_handler(req: Request<axum::body::Body>) -> String {
+        match req.extensions().get::<Interface>() {
+            Some(iface) => format!("present:{iface:?}"),
+            None => "absent".to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_router_never_inserts_interface_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state(test_config(tmp.path().to_path_buf())).await;
+        let token = CancellationToken::new();
+        let main_router: Router<ServiceState> = Router::new().route(
+            "/__test_interface_probe",
+            axum::routing::get(interface_probe_handler),
+        );
+        let openapi = api::ApiDoc::openapi();
+
+        let (app, _http_metrics) = build_router(&state, &token, main_router, openapi)
+            .await
+            .expect("router assembly succeeds");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/__test_interface_probe")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            body, "absent",
+            "build_router's main app must never stamp an Interface extension \
+             itself — that extension gates the admin-SVID auth short-circuit \
+             in crates/core/src/api/auth.rs, and only connection-level \
+             listener code is supposed to set it"
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_handler_includes_http_metrics_when_enabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = test_config(tmp.path().to_path_buf());
+        cfg.interface_metrics.http_requests_enabled = true;
+        let state = test_state(cfg).await;
+
+        let http_metrics = Arc::new(HttpMetrics::new());
+        http_metrics.record_request(
+            &axum::http::Method::GET,
+            "/v3/probe",
+            200,
+            std::time::Duration::from_millis(1),
+        );
+
+        let app = Router::new()
+            .route("/metrics", axum::routing::get(metrics_handler))
+            .layer(Extension(http_metrics))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains(
+            "keystone_http_requests_total{method=\"GET\",route=\"/v3/probe\",status=\"200\"} 1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn metrics_handler_omits_http_metrics_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = test_config(tmp.path().to_path_buf());
+        cfg.interface_metrics.http_requests_enabled = false;
+        let state = test_state(cfg).await;
+
+        // No `Extension<Arc<HttpMetrics>>` layered at all, matching what
+        // `spawn_metrics_listener` does when the flag is off.
+        let app = Router::new()
+            .route("/metrics", axum::routing::get(metrics_handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let text = String::from_utf8_lossy(&body);
+        assert!(!text.contains("keystone_http_requests_total"));
+        // The always-on metrics must still be present.
+        assert!(text.contains("keystone_audit_events_total"));
     }
 
     #[tokio::test]

--- a/crates/keystone/src/server.rs
+++ b/crates/keystone/src/server.rs
@@ -13,6 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # Keystone server listeners
 pub mod access_log;
+pub mod http_metrics;
 pub mod listener;
 pub mod proxy_headers;
 pub mod request_cache;

--- a/crates/keystone/src/server/http_metrics.rs
+++ b/crates/keystone/src/server/http_metrics.rs
@@ -1,0 +1,668 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # HTTP request metrics (ADR 0031)
+//!
+//! Hand-rolled Prometheus text exposition for the HTTP request trio
+//! (`keystone_http_requests_total`, `keystone_http_request_duration_seconds`,
+//! `keystone_http_requests_in_flight`), consistent with the project's
+//! decision not to depend on the `prometheus`/`metrics` crates (see
+//! `crates/audit/src/metrics.rs` and
+//! `doc/src/adr/0031-prometheus-metrics.md`).
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use std::time::Instant;
+
+use axum::extract::{Extension, MatchedPath, Request};
+use axum::http::Method;
+use axum::middleware::Next;
+use axum::response::Response;
+use dashmap::DashMap;
+use openstack_keystone_config::Interface;
+
+/// Bucket upper bounds in seconds, tuned for Keystone's fast auth/token
+/// paths (tighter low end than Prometheus client-library defaults).
+const BUCKET_BOUNDS: [f64; 11] = [
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+];
+
+/// `((method, route), (bucket_counts, sum_seconds, count))` yielded by
+/// [`HttpMetrics::duration_seconds_iter`].
+type DurationSecondsEntry = ((&'static str, String), (Vec<(f64, u64)>, f64, u64));
+
+/// Maps an [`axum::http::Method`] to a bounded label value for the
+/// `method` Prometheus label: the 9 standard HTTP methods, or the literal
+/// `"other"` for anything else.
+///
+/// `record_http_metrics` runs *before* axum's routing produces 404/405, so
+/// an unauthenticated client can send arbitrary RFC-token HTTP methods
+/// (hyper's `Method::Extension` accepts any token) straight into this
+/// middleware. Without this bound, each distinct attacker-supplied method
+/// string would mint its own permanent entry in `requests_total` /
+/// `duration_seconds` and its own Prometheus series — unbounded map growth
+/// and unbounded `/metrics` payload size (ADR 0031). Mirrors the `route`
+/// label's `"unmatched"` fallback for unmatched paths.
+fn method_label(method: &Method) -> &'static str {
+    match method.as_str() {
+        "GET" => "GET",
+        "HEAD" => "HEAD",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "PATCH" => "PATCH",
+        "DELETE" => "DELETE",
+        "OPTIONS" => "OPTIONS",
+        "TRACE" => "TRACE",
+        "CONNECT" => "CONNECT",
+        _ => "other",
+    }
+}
+
+/// Number of [`Interface`] variants; used to size the fixed-array in-flight
+/// gauge storage in [`HttpMetrics`]. Must be kept in sync with the enum
+/// (`interface_index` below matches on all variants exhaustively, so adding
+/// a variant without updating this constant fails to compile).
+const INTERFACE_COUNT: usize = 4;
+
+/// Maps an [`Interface`] to its fixed-array index for the in-flight gauge.
+const fn interface_index(interface: Interface) -> usize {
+    match interface {
+        Interface::Public => 0,
+        Interface::Internal => 1,
+        Interface::Admin => 2,
+        Interface::Metrics => 3,
+    }
+}
+
+/// A fixed-bucket histogram, storing per-bucket counts as `AtomicU64` plus
+/// a sum (as micros, to keep it integer/atomic) and a total count.
+pub struct Histogram {
+    bucket_counts: [AtomicU64; BUCKET_BOUNDS.len()],
+    sum_micros: AtomicU64,
+    count: AtomicU64,
+}
+
+impl Histogram {
+    pub fn new() -> Self {
+        Self {
+            bucket_counts: std::array::from_fn(|_| AtomicU64::new(0)),
+            sum_micros: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    pub fn record(&self, value_seconds: f64) {
+        for (bound, counter) in BUCKET_BOUNDS.iter().zip(self.bucket_counts.iter()) {
+            if value_seconds <= *bound {
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        let micros = (value_seconds * 1_000_000.0).round().max(0.0) as u64;
+        self.sum_micros.fetch_add(micros, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `(upper_bound, cumulative_count)` pairs, ascending, plus a final
+    /// `(f64::INFINITY, total_count)` entry for the `+Inf` bucket.
+    pub fn bucket_counts(&self) -> Vec<(f64, u64)> {
+        let mut out: Vec<(f64, u64)> = BUCKET_BOUNDS
+            .iter()
+            .zip(self.bucket_counts.iter())
+            .map(|(bound, counter)| (*bound, counter.load(Ordering::Relaxed)))
+            .collect();
+        out.push((f64::INFINITY, self.count()));
+        out
+    }
+
+    pub fn sum(&self) -> f64 {
+        self.sum_micros.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+
+    pub fn count(&self) -> u64 {
+        self.count.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for Histogram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Shared state backing the ADR 0031 HTTP request metric trio. Lives in
+/// `crates/keystone`, not `core` — `core` must stay HTTP-unaware. Reached
+/// by the recording middleware and by `metrics_handler` via
+/// `axum::Extension<Arc<HttpMetrics>>`, never through `ServiceState`.
+pub struct HttpMetrics {
+    requests_total: DashMap<(&'static str, String, u16), AtomicU64>,
+    duration_seconds: DashMap<(&'static str, String), Histogram>,
+    /// In-flight gauge, one slot per [`Interface`] variant (indexed via
+    /// [`interface_index`]). `Interface` is a closed 4-variant enum and any
+    /// single listener only ever touches one slot, so a fixed array of
+    /// atomics avoids taking a `DashMap` write-lock (via
+    /// `entry(..).or_insert_with(..)`, which write-locks the shard even
+    /// when the key already exists — it always does here) on every single
+    /// request.
+    in_flight: [AtomicI64; INTERFACE_COUNT],
+}
+
+impl HttpMetrics {
+    pub fn new() -> Self {
+        Self {
+            requests_total: DashMap::new(),
+            duration_seconds: DashMap::new(),
+            in_flight: std::array::from_fn(|_| AtomicI64::new(0)),
+        }
+    }
+
+    pub fn record_request(&self, method: &Method, route: &str, status: u16, elapsed: Duration) {
+        let method = method_label(method);
+
+        self.requests_total
+            .entry((method, route.to_owned(), status))
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::Relaxed);
+
+        self.duration_seconds
+            .entry((method, route.to_owned()))
+            .or_default()
+            .record(elapsed.as_secs_f64());
+    }
+
+    pub fn inc_in_flight(&self, interface: Interface) {
+        self.in_flight[interface_index(interface)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn dec_in_flight(&self, interface: Interface) {
+        self.in_flight[interface_index(interface)].fetch_sub(1, Ordering::Relaxed);
+    }
+
+    pub fn requests_total_iter(
+        &self,
+    ) -> impl Iterator<Item = ((&'static str, String, u16), u64)> + '_ {
+        self.requests_total
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().load(Ordering::Relaxed)))
+    }
+
+    pub fn duration_seconds_iter(&self) -> impl Iterator<Item = DurationSecondsEntry> + '_ {
+        self.duration_seconds.iter().map(|entry| {
+            let histogram = entry.value();
+            (
+                entry.key().clone(),
+                (
+                    histogram.bucket_counts(),
+                    histogram.sum(),
+                    histogram.count(),
+                ),
+            )
+        })
+    }
+
+    pub fn in_flight_iter(&self) -> impl Iterator<Item = (Interface, i64)> + '_ {
+        [
+            Interface::Public,
+            Interface::Internal,
+            Interface::Admin,
+            Interface::Metrics,
+        ]
+        .into_iter()
+        .map(|interface| {
+            (
+                interface,
+                self.in_flight[interface_index(interface)].load(Ordering::Relaxed),
+            )
+        })
+    }
+}
+
+impl Default for HttpMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII guard that increments `metrics`' in-flight gauge for `interface` on
+/// construction and decrements it on drop, so the decrement still runs if
+/// the wrapped future panics mid-flight (e.g. a handler panic unwinding
+/// through `next.run(req).await`) and not just on the ordinary return path.
+struct InFlightGuard<'a> {
+    metrics: &'a HttpMetrics,
+    interface: Interface,
+}
+
+impl<'a> InFlightGuard<'a> {
+    fn new(metrics: &'a HttpMetrics, interface: Interface) -> Self {
+        metrics.inc_in_flight(interface);
+        Self { metrics, interface }
+    }
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.metrics.dec_in_flight(self.interface);
+    }
+}
+
+/// Records one request into `metrics`: increments the in-flight gauge for
+/// the request's `Interface` on entry, decrements on exit (via
+/// [`InFlightGuard`], so this happens even if the handler panics), and on
+/// completion records the request/status counter and latency histogram
+/// keyed by `(method, route)`.
+///
+/// `route` is the Axum `MatchedPath` template (e.g. `/v3/users/{user_id}`),
+/// falling back to the literal string `"unmatched"` when no route matched
+/// (404s / probed paths) — this keeps the label's cardinality bounded
+/// against arbitrary attacker-supplied paths (ADR 0031). `method` is bounded
+/// the same way by [`method_label`] inside `HttpMetrics::record_request`,
+/// falling back to `"other"` for any non-standard method — this middleware
+/// runs *before* axum's routing produces 404/405, so an unauthenticated
+/// client can otherwise mint unbounded label cardinality via arbitrary
+/// RFC-token HTTP methods.
+///
+/// Reads (never writes) the `Interface` extension already stamped by
+/// connection-level code (see
+/// `docs/superpowers/specs/2026-07-31-http-status-metrics-design.md` for
+/// why this must not insert its own `Interface` layer: that extension also
+/// gates the admin-SVID auth short-circuit in `crates/core/src/api/auth.rs`).
+pub async fn record_http_metrics(
+    Extension(metrics): Extension<Arc<HttpMetrics>>,
+    matched_path: Option<MatchedPath>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let method = req.method().clone();
+    let interface = req
+        .extensions()
+        .get::<Interface>()
+        .copied()
+        .unwrap_or(Interface::Public);
+    let route = matched_path
+        .as_ref()
+        .map(|p| p.as_str().to_owned())
+        .unwrap_or_else(|| "unmatched".to_owned());
+
+    let guard = InFlightGuard::new(&metrics, interface);
+    let start = Instant::now();
+    let response = next.run(req).await;
+    let elapsed = start.elapsed();
+    drop(guard);
+
+    metrics.record_request(&method, &route, response.status().as_u16(), elapsed);
+
+    response
+}
+
+fn interface_label(interface: Interface) -> &'static str {
+    match interface {
+        Interface::Public => "public",
+        Interface::Internal => "internal",
+        Interface::Admin => "admin",
+        Interface::Metrics => "metrics",
+    }
+}
+
+/// Serialise the HTTP request metric trio as Prometheus text exposition
+/// format (version 0.0.4).
+pub fn format_prometheus_text(metrics: &HttpMetrics) -> String {
+    let mut out = String::new();
+
+    out.push_str(
+        "# HELP keystone_http_requests_total Total HTTP requests by method, route, and status.\n",
+    );
+    out.push_str("# TYPE keystone_http_requests_total counter\n");
+    for ((method, route, status), count) in metrics.requests_total_iter() {
+        out.push_str(&format!(
+            "keystone_http_requests_total{{method=\"{method}\",route=\"{route}\",status=\"{status}\"}} {count}\n"
+        ));
+    }
+
+    out.push_str(
+        "# HELP keystone_http_request_duration_seconds HTTP request latency by method and route.\n",
+    );
+    out.push_str("# TYPE keystone_http_request_duration_seconds histogram\n");
+    for ((method, route), (buckets, sum, count)) in metrics.duration_seconds_iter() {
+        for (bound, cumulative) in buckets {
+            let le = if bound.is_infinite() {
+                "+Inf".to_owned()
+            } else {
+                bound.to_string()
+            };
+            out.push_str(&format!(
+                "keystone_http_request_duration_seconds_bucket{{method=\"{method}\",route=\"{route}\",le=\"{le}\"}} {cumulative}\n"
+            ));
+        }
+        out.push_str(&format!(
+            "keystone_http_request_duration_seconds_sum{{method=\"{method}\",route=\"{route}\"}} {sum}\n"
+        ));
+        out.push_str(&format!(
+            "keystone_http_request_duration_seconds_count{{method=\"{method}\",route=\"{route}\"}} {count}\n"
+        ));
+    }
+
+    out.push_str(
+        "# HELP keystone_http_requests_in_flight In-flight HTTP requests by listener interface.\n",
+    );
+    out.push_str("# TYPE keystone_http_requests_in_flight gauge\n");
+    for (interface, value) in metrics.in_flight_iter() {
+        out.push_str(&format!(
+            "keystone_http_requests_in_flight{{interface=\"{}\"}} {value}\n",
+            interface_label(interface)
+        ));
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_places_value_in_correct_and_higher_buckets() {
+        let h = Histogram::new();
+        h.record(0.02); // falls in 0.025 bucket and every bucket above it
+
+        let counts = h.bucket_counts();
+        let (bound_0_01, count_0_01) = counts[2];
+        assert_eq!(bound_0_01, 0.01);
+        assert_eq!(count_0_01, 0, "0.02 must not count in the 0.01 bucket");
+
+        let (bound_0_025, count_0_025) = counts[3];
+        assert_eq!(bound_0_025, 0.025);
+        assert_eq!(count_0_025, 1, "0.02 must count in the 0.025 bucket");
+
+        let (bound_5, count_5) = counts[10];
+        assert_eq!(bound_5, 5.0);
+        assert_eq!(count_5, 1, "0.02 must count in every bucket above it");
+
+        let (inf_bound, inf_count) = *counts.last().unwrap();
+        assert!(inf_bound.is_infinite());
+        assert_eq!(inf_count, 1);
+    }
+
+    #[test]
+    fn sum_and_count_accumulate() {
+        let h = Histogram::new();
+        h.record(0.1);
+        h.record(0.2);
+        assert_eq!(h.count(), 2);
+        assert!((h.sum() - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn record_request_increments_matching_counter_only() {
+        let m = HttpMetrics::new();
+        m.record_request(
+            &Method::GET,
+            "/v3/users/{user_id}",
+            200,
+            Duration::from_millis(5),
+        );
+        m.record_request(
+            &Method::GET,
+            "/v3/users/{user_id}",
+            404,
+            Duration::from_millis(1),
+        );
+
+        let counts: Vec<_> = m.requests_total_iter().collect();
+        assert_eq!(
+            counts.len(),
+            2,
+            "status 200 and 404 must be separate series"
+        );
+        let ok_count = counts
+            .iter()
+            .find(|((method, route, status), _)| {
+                method == &Method::GET && route == "/v3/users/{user_id}" && *status == 200
+            })
+            .map(|(_, c)| *c);
+        assert_eq!(ok_count, Some(1));
+    }
+
+    #[test]
+    fn record_request_feeds_duration_histogram_for_route() {
+        let m = HttpMetrics::new();
+        m.record_request(&Method::GET, "/v3/users", 200, Duration::from_millis(5));
+        m.record_request(&Method::GET, "/v3/users", 200, Duration::from_millis(15));
+
+        let durations: Vec<_> = m.duration_seconds_iter().collect();
+        assert_eq!(
+            durations.len(),
+            1,
+            "same (method, route) shares one histogram"
+        );
+        let (_, (_, _sum, count)) = &durations[0];
+        assert_eq!(*count, 2);
+    }
+
+    #[test]
+    fn in_flight_gauge_increments_and_decrements() {
+        let m = HttpMetrics::new();
+        m.inc_in_flight(Interface::Public);
+        m.inc_in_flight(Interface::Public);
+        m.dec_in_flight(Interface::Public);
+
+        let value = m
+            .in_flight_iter()
+            .find(|(iface, _)| *iface == Interface::Public)
+            .map(|(_, v)| v);
+        assert_eq!(value, Some(1));
+    }
+
+    #[test]
+    fn format_prometheus_text_contains_help_and_type_for_all_three_metrics() {
+        let m = HttpMetrics::new();
+        m.record_request(&Method::GET, "/v3/users", 200, Duration::from_millis(5));
+        m.inc_in_flight(Interface::Public);
+
+        let text = format_prometheus_text(&m);
+        assert!(text.contains("# TYPE keystone_http_requests_total counter"));
+        assert!(text.contains("# TYPE keystone_http_request_duration_seconds histogram"));
+        assert!(text.contains("# TYPE keystone_http_requests_in_flight gauge"));
+        assert!(text.contains(
+            "keystone_http_requests_total{method=\"GET\",route=\"/v3/users\",status=\"200\"} 1"
+        ));
+        assert!(text.contains("keystone_http_requests_in_flight{interface=\"public\"} 1"));
+    }
+
+    #[test]
+    fn format_prometheus_text_histogram_has_le_buckets_and_inf() {
+        let m = HttpMetrics::new();
+        m.record_request(&Method::GET, "/v3/users", 200, Duration::from_millis(5));
+
+        let text = format_prometheus_text(&m);
+        assert!(text.contains(
+            "keystone_http_request_duration_seconds_bucket{method=\"GET\",route=\"/v3/users\",le=\"+Inf\"}"
+        ));
+        assert!(text.contains(
+            "keystone_http_request_duration_seconds_sum{method=\"GET\",route=\"/v3/users\"}"
+        ));
+        assert!(text.contains(
+            "keystone_http_request_duration_seconds_count{method=\"GET\",route=\"/v3/users\"} 1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn middleware_records_matched_path_as_route() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::routing::get;
+        use tower::ServiceExt;
+
+        let metrics = Arc::new(HttpMetrics::new());
+        let app: Router = Router::new()
+            .route("/v3/widgets/{id}", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(record_http_metrics))
+            .layer(Extension(metrics.clone()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v3/widgets/abc-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let counts: Vec<_> = metrics.requests_total_iter().collect();
+        assert_eq!(counts.len(), 1);
+        let ((_, route, status), count) = &counts[0];
+        assert_eq!(
+            route, "/v3/widgets/{id}",
+            "must record the template, not the raw path with the id"
+        );
+        assert_eq!(*status, 200);
+        assert_eq!(*count, 1);
+    }
+
+    #[test]
+    fn in_flight_guard_decrements_on_panic_unwind() {
+        // `record_http_metrics` can't be driven through `oneshot` here: a
+        // panicking handler poisons/aborts the underlying hyper service in
+        // this axum/tower version rather than handing `oneshot` a clean
+        // `Err`, so a panic-catching wrapper around the full middleware
+        // stack isn't a reliable way to observe the fix. Instead, exercise
+        // `InFlightGuard` directly: construct it (which increments the
+        // gauge), then panic while it's still alive and confirm — from
+        // outside the `catch_unwind` — that the gauge was still
+        // decremented, proving `Drop::drop` ran during unwind and not just
+        // on the ordinary return path.
+        let metrics = HttpMetrics::new();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = InFlightGuard::new(&metrics, Interface::Public);
+            assert_eq!(
+                metrics
+                    .in_flight_iter()
+                    .find(|(iface, _)| *iface == Interface::Public)
+                    .map(|(_, v)| v),
+                Some(1),
+                "constructing the guard must increment the gauge"
+            );
+            panic!("simulated handler panic while request is in flight");
+        }));
+
+        assert!(result.is_err(), "the inner closure must have panicked");
+        let value = metrics
+            .in_flight_iter()
+            .find(|(iface, _)| *iface == Interface::Public)
+            .map(|(_, v)| v);
+        assert_eq!(
+            value,
+            Some(0),
+            "guard's Drop impl must decrement the gauge even when unwinding"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_labels_unmatched_requests() {
+        use axum::Router;
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let metrics = Arc::new(HttpMetrics::new());
+        let app: Router = Router::new()
+            .layer(axum::middleware::from_fn(record_http_metrics))
+            .layer(Extension(metrics.clone()));
+
+        let _ = app
+            .oneshot(
+                Request::builder()
+                    .uri("/does/not/exist")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let counts: Vec<_> = metrics.requests_total_iter().collect();
+        assert_eq!(counts.len(), 1);
+        let ((_, route, _), _) = &counts[0];
+        assert_eq!(route, "unmatched");
+    }
+
+    #[test]
+    fn method_label_passes_through_standard_methods() {
+        assert_eq!(method_label(&Method::GET), "GET");
+        assert_eq!(method_label(&Method::HEAD), "HEAD");
+        assert_eq!(method_label(&Method::POST), "POST");
+        assert_eq!(method_label(&Method::PUT), "PUT");
+        assert_eq!(method_label(&Method::PATCH), "PATCH");
+        assert_eq!(method_label(&Method::DELETE), "DELETE");
+        assert_eq!(method_label(&Method::OPTIONS), "OPTIONS");
+        assert_eq!(method_label(&Method::TRACE), "TRACE");
+        assert_eq!(method_label(&Method::CONNECT), "CONNECT");
+    }
+
+    #[test]
+    fn method_label_bounds_arbitrary_methods_to_other() {
+        let arbitrary = Method::from_bytes(b"WHATEVER").unwrap();
+        assert_eq!(method_label(&arbitrary), "other");
+    }
+
+    #[test]
+    fn record_request_collapses_arbitrary_methods_into_a_single_other_series() {
+        let m = HttpMetrics::new();
+        let m1 = Method::from_bytes(b"FOO").unwrap();
+        let m2 = Method::from_bytes(b"BAR").unwrap();
+        let m3 = Method::from_bytes(b"BAZ").unwrap();
+
+        m.record_request(&m1, "/v3/probe", 200, Duration::from_millis(1));
+        m.record_request(&m2, "/v3/probe", 200, Duration::from_millis(1));
+        m.record_request(&m3, "/v3/probe", 200, Duration::from_millis(1));
+
+        let counts: Vec<_> = m.requests_total_iter().collect();
+        assert_eq!(
+            counts.len(),
+            1,
+            "arbitrary attacker-supplied methods must not each mint their own series"
+        );
+        let ((method, _, _), count) = &counts[0];
+        assert_eq!(*method, "other");
+        assert_eq!(*count, 3);
+    }
+
+    #[tokio::test]
+    async fn middleware_bounds_arbitrary_method_label_to_other() {
+        use axum::Router;
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let metrics = Arc::new(HttpMetrics::new());
+        let app: Router = Router::new()
+            .layer(axum::middleware::from_fn(record_http_metrics))
+            .layer(Extension(metrics.clone()));
+
+        let _ = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::from_bytes(b"WEIRDMETHOD").unwrap())
+                    .uri("/does/not/exist")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let counts: Vec<_> = metrics.requests_total_iter().collect();
+        assert_eq!(counts.len(), 1);
+        let ((method, _, _), _) = &counts[0];
+        assert_eq!(*method, "other");
+    }
+}

--- a/doc/plans/2026-07-31-http-status-metrics-design.md
+++ b/doc/plans/2026-07-31-http-status-metrics-design.md
@@ -1,0 +1,241 @@
+# HTTP Status Metrics — Design
+
+Date: 2026-07-31
+Status: Approved
+Related: `doc/src/adr/0031-prometheus-metrics.md`
+
+## Purpose
+
+Implement the HTTP request metric trio already catalogued in ADR 0031:
+
+- `keystone_http_requests_total{method, route, status}` (counter)
+- `keystone_http_request_duration_seconds{method, route}` (histogram)
+- `keystone_http_requests_in_flight{interface}` (gauge)
+
+so operators can watch 5xx rate and latency per route without scraping logs.
+
+## Constraints carried from ADR 0031
+
+- `route` must be the Axum `MatchedPath` template (e.g. `/v3/users/{user_id}`),
+  never the raw path — resource IDs must never appear as a label value.
+- `core` crate must stay HTTP-unaware; nothing here may be added to
+  `crates/core/src/keystone.rs`'s `Service` struct.
+- No `unwrap()`/`expect()`/`unsafe`; hand-rolled Prometheus text exposition
+  (no `prometheus`/`metrics` crate), consistent with
+  `crates/audit/src/metrics.rs`.
+
+## Module layout
+
+New file `crates/keystone/src/server/http_metrics.rs`, sibling to
+`access_log.rs`. Contains:
+
+- `HttpMetrics` struct (state)
+- `record_http_metrics` (Axum middleware)
+- `format_prometheus_text` (exposition formatter, same shape as
+  `openstack_keystone_audit::metrics::format_prometheus_text`)
+
+## State shape
+
+```rust
+pub struct HttpMetrics {
+    requests_total: DashMap<(Method, String, u16), AtomicU64>,   // (method, route, status)
+    duration_seconds: DashMap<(Method, String), Histogram>,      // (method, route)
+    in_flight: DashMap<Interface, AtomicI64>,
+}
+```
+
+`Histogram` is a small hand-rolled bucket-counter (cumulative counts per
+bucket + a running sum), consistent with the project's no-external-metrics-
+crate decision. Bucket bounds (keystone-tuned, tighter low end for fast
+auth/token paths):
+
+```
+0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5
+```
+
+`dashmap = "6.2"` is already a workspace dependency (used elsewhere in the
+tree) — no new dependency to add.
+
+`Interface` is the existing enum from `crates/config/src/common.rs`
+(`Admin`/`Internal`/`Public`). **This is a security-relevant extension, not
+just a config type**: `spiffe_tls.rs`'s `attach_request_context` inserts it
+into `axum::http::Extensions` at connection-accept time on the mTLS
+listeners, and `crates/core/src/api/auth.rs:88,127` reads it to gate the
+admin-SVID short-circuit auth path (`interface == Interface::Admin`). The
+public listener never inserts it; `auth.rs:88` defaults to
+`Interface::Public` when absent.
+
+Consequently this design does **not** add any `.layer(Extension(Interface::…))`
+to the listeners — doing so risks shadowing/overwriting the
+already-security-critical value depending on tower layer ordering, which is
+exactly the class of authentication-chain bug the security model guards
+against. `record_http_metrics` only **reads** the extension the same way
+`auth.rs:88` already does:
+
+```rust
+let interface = req
+    .extensions()
+    .get::<Interface>()
+    .copied()
+    .unwrap_or(Interface::Public);
+```
+
+The enum gets `Copy, Eq, Hash` derives (currently `Debug, Deserialize, Clone,
+PartialEq`) so it can be used as a `DashMap` key, plus one new variant:
+
+```rust
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Interface {
+    Admin,
+    Internal,
+    Public,
+    Metrics,
+}
+```
+
+`Metrics` is safe to add because it is only ever inserted on the fully
+separate `metrics_app` router (`spawn_metrics_listener`), which has no `Auth`
+extractor and is never merged into `build_router`'s `app` — it cannot shadow
+or interact with the security-critical `Admin`/`Internal`/`Public` values set
+by the mTLS listeners. `spawn_metrics_listener` adds
+`.layer(Extension(Interface::Metrics))` to `metrics_app` only, and a
+lightweight variant of the middleware (or the same `record_http_metrics`,
+reused) is layered there purely for the `in_flight` gauge's `metrics` value —
+matching ADR 0031's stated `interface ∈ {public, internal, admin, metrics}`.
+The `requests_total`/`duration_seconds` breakdown is not expected to be
+meaningful for the single `/metrics` route, so this listener only needs to
+participate in the in-flight gauge, not the full trio.
+
+## Config gate
+
+New field on the existing `MetricsInterface` config struct
+(`crates/config/src/interface.rs`):
+
+```rust
+pub struct MetricsInterface {
+    pub tcp_address: SocketAddr,
+    #[serde(default = "default_true")]
+    pub http_requests_enabled: bool,
+}
+```
+
+Default `true`. Only gates this HTTP trio — the pre-existing audit and
+auth-plugin-load-failure metrics stay always-on and are unaffected.
+
+When `false`: the middleware layer is **not added** to the router (zero
+runtime overhead), and `metrics_handler` skips the HTTP-metrics text block
+entirely. `tower::Layer` has no blanket impl for `Option<L>`, so the
+conditional layer is applied as a plain `if` around an extra `Router::layer`
+call *after* the shared `ServiceBuilder` middleware stack has already been
+applied and collapsed into a `Router` (`Router::layer` always returns
+`Router<S>` regardless of the layer's concrete type, so this doesn't change
+the surrounding code's types):
+
+```rust
+let mut app = /* ...existing merge/nest/layer(middleware) as today... */;
+
+let http_metrics = if shared_state.config_manager.config.read().await
+    .interface_metrics.http_requests_enabled
+{
+    let hm = Arc::new(HttpMetrics::new());
+    app = app
+        .layer(Extension(hm.clone()))
+        .layer(middleware::from_fn(record_http_metrics));
+    Some(hm)
+} else {
+    None
+};
+```
+
+## State threading
+
+- `build_router`'s return type changes from `Result<Router, Report>` to
+  `Result<(Router, Option<Arc<HttpMetrics>>), Report>` — it constructs the
+  `Arc<HttpMetrics>` itself (reading the config flag it already has access
+  to via `shared_state`, same as the existing `webauthn.enabled` check) and
+  hands the instance back to the caller.
+- `main()` destructures that tuple and passes the `Option<Arc<HttpMetrics>>`
+  into `spawn_metrics_listener` as a new parameter, so both places share the
+  same instance.
+- `spawn_metrics_listener` adds `.layer(Extension(http_metrics.clone()))` to
+  `metrics_app` (only when `Some`) so `metrics_handler` can read it via
+  `Option<Extension<Arc<HttpMetrics>>>`.
+- No new `Interface` insertion on the public/internal/admin path —
+  `record_http_metrics` reads the `Interface` extension already stamped by
+  existing connection-level code (see State shape section above for why
+  insertion is deliberately avoided there). The metrics listener is the one
+  exception, as already described.
+
+`Extension` is used (not `from_fn_with_state`/second `State`) because
+`main_router`/`metrics_router` are already typed `Router<ServiceState>`;
+adding a second distinct state type would require threading it through
+every nested router (`webauthn`, `SCIM`) and OpenAPI-generated routers.
+`Extension` sidesteps that — it rides in `Request` extensions independent of
+the router's `State` generic.
+
+## Middleware
+
+`record_http_metrics` layered immediately after `log_request` in
+`build_router`'s `ServiceBuilder` chain (same position rationale: needs to
+see the final response status, so it runs inside `TraceLayer`'s span but
+after body compression/propagation don't matter for this metric).
+
+Per request:
+
+1. Read `Extension<Interface>` (defaults to `Interface::Public` if somehow
+   absent — should not happen in practice since every listener tags itself).
+2. Increment `in_flight[interface]` on entry.
+3. Run `next.run(req)`, timing with `Instant`.
+4. Read `MatchedPath` from request extensions; falls back to the literal
+   string `"unmatched"` when absent (404 / probed paths) — bounds
+   cardinality against path-probing traffic instead of letting arbitrary
+   attacker-supplied paths become label values.
+5. Decrement `in_flight[interface]`.
+6. Increment `requests_total[(method, route, status)]`.
+7. Record latency into `duration_seconds[(method, route)]`.
+
+## Exposition
+
+`metrics_handler` (in `keystone.rs`) gains a third block, appended after the
+existing audit and auth-plugin-load-failure text, only when
+`Extension<Arc<HttpMetrics>>` is present (i.e. feature enabled):
+
+```rust
+async fn metrics_handler(
+    State(state): State<ServiceState>,
+    http_metrics: Option<Extension<Arc<HttpMetrics>>>,
+) -> impl IntoResponse {
+    let mut body = format_prometheus_text(&state.audit_dispatcher);
+    body.push_str(&format_load_failure_metrics(&*state.auth_plugin_load_failures.read().await));
+    if let Some(Extension(http)) = http_metrics {
+        body.push_str(&http_metrics::format_prometheus_text(&http));
+    }
+    ...
+}
+```
+
+Same `text/plain; version=0.0.4` content type, same `/metrics` endpoint —
+no new route.
+
+## Testing
+
+- `http_metrics.rs` `tests` submodule: formatter output shape (counter/
+  histogram/gauge text lines, `_total`/`_bucket`/`_sum`/`_count` suffixes),
+  unmatched-path fallback, histogram bucket placement at boundary values,
+  concurrent-increment correctness.
+- Extend existing `build_router_*` tests in `keystone.rs`'s test module to
+  cover both `http_requests_enabled = true` (layer present, `/metrics`
+  includes the new block) and `= false` (layer absent, block absent) —
+  confirms the config gate actually removes the middleware rather than
+  just suppressing output.
+- `MetricsInterface` config parsing test (`crates/config`) for the new
+  field's default and explicit-`false` override, alongside the existing
+  `enable_proxy_headers_parsing`-style tests.
+
+## Non-goals / deferred
+
+- No changes to `deploy/prometheus/alert_rules.yaml` in this pass (can
+  follow once the metric is live and real cardinality/volume is observed).
+- No dashboard/Grafana work.
+- Duration histogram does not distinguish streaming vs buffered responses;
+  out of scope.


### PR DESCRIPTION
Scopes the ADR 0031 HTTP request trio (counter/histogram/gauge)
implementation: module layout, state threading via Extension, config
gate, and the Interface-extension security consideration around the
admin-SVID auth path.

Also replace the in-flight gauge's DashMap (which write-locks its shard
on every request even though Interface is a closed 4-variant enum) with
a fixed-size atomic array indexed by interface, and add a regression
test guarding that build_router's main app never stamps its own
Interface extension, which would silently widen the admin-SVID auth
short-circuit's gating surface.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
