### PR TITLE
feat: Add domain config types and backend trait

### DIFF
--- a/crates/config/src/identity.rs
+++ b/crates/config/src/identity.rs
@@ -11,14 +11,18 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::common::default_sql_driver;
 use crate::pagination::ListLimitConfig;
 
 /// Identity provider.
-#[derive(Debug, Deserialize, Clone)]
+///
+/// Also the single definition of the `identity` group of the per-domain
+/// configuration API; see [`crate::ldap::LdapProvider`] for how the two are
+/// related.
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct IdentityProvider {
     /// Caching.
     #[serde(default)]
@@ -42,6 +46,7 @@ pub struct IdentityProvider {
     pub password_hashing_algorithm: PasswordHashingAlgo,
 
     /// Default number of password hashing rounds.
+    #[serde(default)]
     pub password_hash_rounds: Option<usize>,
 
     /// User options id to name mapping.
@@ -69,7 +74,7 @@ impl Default for IdentityProvider {
 }
 
 /// Password hashing algorithm.
-#[derive(Debug, Default, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub enum PasswordHashingAlgo {
     /// Bcrypt.
     #[default]

--- a/crates/config/src/ldap.rs
+++ b/crates/config/src/ldap.rs
@@ -15,21 +15,33 @@
 //!
 //! Maps 1:1 with Python Keystone's `[ldap]` config section (`conf.ldap.*`) so
 //! a config file written for Python Keystone works unmodified here.
+//!
+//! The struct is also the single definition of the `ldap` group of the
+//! per-domain configuration API (`/v3/domains/{domain_id}/config/ldap`): a
+//! domain's stored options are overlaid onto the serialized `[ldap]` section
+//! and read back as an `LdapProvider`. Nothing about an option is therefore
+//! spelled twice, and the only thing the domain configuration layer adds is
+//! the whitelist of option *names* a domain may override.
 use std::collections::{HashMap, HashSet};
 
 use secrecy::SecretString;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// LDAP identity backend configuration.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LdapProvider {
     // --- Connection ---
     /// LDAP server URL.
     #[serde(default = "default_url")]
     pub url: String,
     /// Service bind DN used for all directory queries.
+    #[serde(default)]
     pub user: Option<String>,
     /// Service bind password.
+    ///
+    /// Never serialized: it is the one sensitive option of the per-domain
+    /// configuration API, which may write it but must never return it.
+    #[serde(default, skip_serializing)]
     pub password: Option<SecretString>,
     /// Enable TLS for the connection.
     #[serde(default)]
@@ -42,9 +54,11 @@ pub struct LdapProvider {
     /// follow-up; see ADR-0027 implementation notes). Set
     /// `tls_req_cert = never` for a self-signed test directory in the
     /// meantime, or install the CA into the system trust store.
+    #[serde(default)]
     pub tls_cacertfile: Option<String>,
     /// Path to a directory of CA certificates used to validate the LDAP
     /// server. Same not-yet-applied caveat as `tls_cacertfile`.
+    #[serde(default)]
     pub tls_cacertdir: Option<String>,
     /// Certificate validation strictness for TLS connections.
     #[serde(default)]
@@ -56,7 +70,11 @@ pub struct LdapProvider {
     #[serde(default)]
     pub randomize_urls: bool,
     /// Enable the service connection pool.
-    #[serde(default = "default_true_bool")]
+    ///
+    /// Serialized as `use_pool`, which is the python-keystone and domain API
+    /// spelling. `pool` remains accepted for existing Rust Keystone config
+    /// files and remains the field name used by the LDAP driver.
+    #[serde(default = "default_true_bool", rename = "use_pool", alias = "pool")]
     pub pool: bool,
     /// Service connection pool size.
     #[serde(default = "default_pool_size")]
@@ -75,7 +93,14 @@ pub struct LdapProvider {
     pub pool_connection_lifetime: f64,
     /// Enable the dedicated authentication connection pool, isolating
     /// end-user bind storms from the service query pool.
-    #[serde(default = "default_true_bool")]
+    ///
+    /// Serialized as `use_auth_pool`; `auth_pool` remains accepted for
+    /// existing Rust Keystone config files. See [`Self::pool`].
+    #[serde(
+        default = "default_true_bool",
+        rename = "use_auth_pool",
+        alias = "auth_pool"
+    )]
     pub auth_pool: bool,
     /// Authentication connection pool size.
     #[serde(default = "default_auth_pool_size")]
@@ -128,6 +153,7 @@ pub struct LdapProvider {
     /// Attribute mapped to a user's `default_project_id`. Unused by this
     /// read-only backend (Python only consults it on write), kept for config
     /// parity.
+    #[serde(default)]
     pub user_default_project_id_attribute: Option<String>,
     /// Attribute used to determine whether a user is enabled.
     #[serde(default = "default_user_enabled_attribute")]
@@ -136,6 +162,7 @@ pub struct LdapProvider {
     /// state, when the attribute stores a bitmask rather than a boolean
     /// (e.g. Active Directory's `userAccountControl`). Ignores
     /// `user_enabled_invert` when set, matching Python Keystone.
+    #[serde(default)]
     pub user_enabled_mask: Option<i32>,
     /// Invert the interpretation of `user_enabled_attribute`. Has no effect
     /// when `user_enabled_mask` or `user_enabled_emulation` is in use.
@@ -149,17 +176,22 @@ pub struct LdapProvider {
     pub user_enabled_default: String,
     /// Extra LDAP attributes exposed under `extra` in the API response,
     /// mapped as `ldap_attribute -> extra_key`.
-    #[serde(default)]
+    #[serde(default, with = "attribute_mapping")]
     pub user_additional_attribute_mapping: HashMap<String, String>,
     /// Additional LDAP filter clause AND-ed into every user search.
+    #[serde(default)]
     pub user_filter: Option<String>,
     /// Attributes never surfaced as `extra`, even if mapped.
-    #[serde(default = "default_user_attribute_ignore")]
+    #[serde(
+        default = "default_user_attribute_ignore",
+        serialize_with = "serialize_sorted"
+    )]
     pub user_attribute_ignore: HashSet<String>,
     /// Emulate the enabled attribute via group membership.
     #[serde(default)]
     pub user_enabled_emulation: bool,
     /// DN of the group used for enabled-emulation membership checks.
+    #[serde(default)]
     pub user_enabled_emulation_dn: Option<String>,
     /// Use the group configuration options for the enabled-emulation group.
     #[serde(default)]
@@ -190,13 +222,14 @@ pub struct LdapProvider {
     #[serde(default)]
     pub group_members_are_ids: bool,
     /// Attributes never surfaced as `extra`, even if mapped.
-    #[serde(default)]
+    #[serde(default, serialize_with = "serialize_sorted")]
     pub group_attribute_ignore: HashSet<String>,
     /// Extra LDAP attributes exposed under `extra` in the API response,
     /// mapped as `ldap_attribute -> extra_key`.
-    #[serde(default)]
+    #[serde(default, with = "attribute_mapping")]
     pub group_additional_attribute_mapping: HashMap<String, String>,
     /// Additional LDAP filter clause AND-ed into every group search.
+    #[serde(default)]
     pub group_filter: Option<String>,
     /// Use `LDAP_MATCHING_RULE_IN_CHAIN` for Active Directory nested group
     /// resolution.
@@ -270,7 +303,7 @@ impl Default for LdapProvider {
 }
 
 /// TLS certificate validation strictness (`[ldap] tls_req_cert`).
-#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub enum TlsReqCert {
     /// Reject the connection if no certificate is provided or verification
     /// fails.
@@ -289,7 +322,7 @@ pub enum TlsReqCert {
 }
 
 /// Default search scope for subtree LDAP operations (`[ldap] query_scope`).
-#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub enum QueryScope {
     /// Single-level search relative to the tree DN.
     #[default]
@@ -307,7 +340,7 @@ pub enum QueryScope {
 /// per-search or per-connection alias-dereferencing control. Every search
 /// therefore uses the `ldap3`/OpenLDAP client library default regardless of
 /// this setting (tracked as a follow-up; see ADR-0027 implementation notes).
-#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub enum AliasDereferencing {
     /// Fall back to the default dereferencing behavior configured by the
     /// underlying LDAP client library.
@@ -326,6 +359,109 @@ pub enum AliasDereferencing {
     /// Dereference aliases only when locating the search base.
     #[serde(rename = "finding")]
     Finding,
+}
+
+/// Serialize a set of attribute names as a sorted list.
+///
+/// A `HashSet` has no order of its own, and these options are reported
+/// verbatim by `GET /v3/domains/config/ldap/default`; sorting keeps that
+/// response stable from one run to the next.
+///
+/// # Parameters
+/// - `values`: The attribute names.
+/// - `serializer`: The serde serializer.
+///
+/// # Returns
+/// - `Result<S::Ok, S::Error>` - The serialized list.
+fn serialize_sorted<S: serde::Serializer>(
+    values: &HashSet<String>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let mut values: Vec<&String> = values.iter().collect();
+    values.sort();
+    serializer.collect_seq(values)
+}
+
+/// `ldap_attribute:keystone_attribute` mappings, in oslo.config's spelling.
+///
+/// python-keystone declares the `*_additional_attribute_mapping` options as
+/// list options whose entries are `ldap_attribute:keystone_attribute` pairs,
+/// which is how a config file and the per-domain configuration API both
+/// deliver them. A JSON object is accepted as well, for config sources that
+/// can express one.
+mod attribute_mapping {
+    use std::collections::HashMap;
+
+    use serde::de::{Deserializer, Error as _};
+    use serde::{Deserialize, Serialize, Serializer};
+
+    /// Every accepted spelling of a mapping.
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        /// The comma separated form a config file delivers.
+        Csv(String),
+        /// The `attribute:key` list form.
+        List(Vec<String>),
+        /// The object form.
+        Map(HashMap<String, String>),
+    }
+
+    /// Deserialize a mapping from either spelling.
+    ///
+    /// # Parameters
+    /// - `deserializer`: The serde deserializer.
+    ///
+    /// # Returns
+    /// - `Result<HashMap<String, String>, D::Error>` - The mapping, or an error
+    ///   when a list entry is not an `attribute:key` pair.
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<String, String>, D::Error> {
+        let entries = match Repr::deserialize(deserializer)? {
+            Repr::Map(mapping) => return Ok(mapping),
+            Repr::List(entries) => entries,
+            Repr::Csv(entries) => entries
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(str::to_string)
+                .collect(),
+        };
+        entries
+            .into_iter()
+            .map(|entry| {
+                entry
+                    .split_once(':')
+                    .map(|(attribute, key)| (attribute.trim().to_string(), key.trim().to_string()))
+                    .ok_or_else(|| {
+                        D::Error::custom(format!(
+                            "expected an `ldap_attribute:keystone_attribute` pair, got `{entry}`"
+                        ))
+                    })
+            })
+            .collect()
+    }
+
+    /// Serialize a mapping in the list spelling, sorted for stability.
+    ///
+    /// # Parameters
+    /// - `mapping`: The mapping.
+    /// - `serializer`: The serde serializer.
+    ///
+    /// # Returns
+    /// - `Result<S::Ok, S::Error>` - The serialized list.
+    pub(super) fn serialize<S: Serializer>(
+        mapping: &HashMap<String, String>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut entries: Vec<String> = mapping
+            .iter()
+            .map(|(attribute, key)| format!("{attribute}:{key}"))
+            .collect();
+        entries.sort();
+        entries.serialize(serializer)
+    }
 }
 
 fn default_url() -> String {
@@ -454,6 +590,103 @@ mod tests {
         assert!(!cfg.group_members_are_ids);
         assert!(cfg.pool);
         assert!(cfg.auth_pool);
+    }
+
+    #[test]
+    fn test_parse_pooling_flags_in_both_spellings() {
+        for (spelling, flag) in [("use_pool", "pool"), ("use_auth_pool", "auth_pool")] {
+            for name in [spelling, flag] {
+                let c = Config::builder()
+                    .add_source(File::from_str(
+                        &format!("[ldap]\n{name} = false\n"),
+                        FileFormat::Ini,
+                    ))
+                    .build()
+                    .unwrap();
+                let parsed: LdapProvider = c.get("ldap").unwrap();
+                let parsed = match spelling {
+                    "use_pool" => parsed.pool,
+                    _ => parsed.auth_pool,
+                };
+                assert!(!parsed, "`{name}` was ignored");
+            }
+        }
+    }
+
+    #[test]
+    fn test_attribute_mapping_spellings() {
+        let c = Config::builder()
+            .add_source(File::from_str(
+                r#"
+[ldap]
+user_additional_attribute_mapping = mail:email, l:location
+"#,
+                FileFormat::Ini,
+            ))
+            .build()
+            .unwrap();
+        let parsed: LdapProvider = c.get("ldap").unwrap();
+        assert_eq!(
+            parsed.user_additional_attribute_mapping,
+            HashMap::from([
+                ("mail".to_string(), "email".to_string()),
+                ("l".to_string(), "location".to_string()),
+            ])
+        );
+
+        // The list spelling is also what serialization produces, sorted so the
+        // per-domain configuration default endpoints answer stably.
+        assert_eq!(
+            serde_json::to_value(&parsed).unwrap()["user_additional_attribute_mapping"],
+            serde_json::json!(["l:location", "mail:email"])
+        );
+    }
+
+    #[test]
+    fn test_serialization_omits_the_password() {
+        let cfg = LdapProvider {
+            password: Some(SecretString::from("s3cr3t")),
+            ..LdapProvider::default()
+        };
+        let encoded = serde_json::to_value(&cfg).unwrap();
+        assert!(
+            !encoded.to_string().contains("s3cr3t"),
+            "the bind password was serialized"
+        );
+        assert!(encoded.get("password").is_none());
+    }
+
+    #[test]
+    fn test_round_trips_through_json() {
+        let cfg = LdapProvider {
+            url: "ldaps://directory.example.com".into(),
+            user_attribute_ignore: HashSet::from(["mail".into(), "enabled".into()]),
+            group_additional_attribute_mapping: HashMap::from([(
+                "description".to_string(),
+                "purpose".to_string(),
+            )]),
+            ..LdapProvider::default()
+        };
+        let decoded: LdapProvider = serde_json::from_value(serde_json::to_value(&cfg).unwrap())
+            .expect("a serialized section deserializes back");
+        assert_eq!(decoded.url, cfg.url);
+        assert_eq!(decoded.user_attribute_ignore, cfg.user_attribute_ignore);
+        assert_eq!(
+            decoded.group_additional_attribute_mapping,
+            cfg.group_additional_attribute_mapping
+        );
+    }
+
+    #[test]
+    fn test_deserializes_a_partial_section() {
+        // Every field either carries a `#[serde(default)]` or has a declared
+        // default, so a partial object decodes: this is what lets a domain's
+        // stored options be overlaid onto the global section.
+        let parsed: LdapProvider =
+            serde_json::from_value(serde_json::json!({"url": "ldap://host"})).unwrap();
+        assert_eq!(parsed.url, "ldap://host");
+        assert_eq!(parsed.user_objectclass, default_user_objectclass());
+        assert!(parsed.user.is_none());
     }
 
     #[test]

--- a/crates/config/src/pagination.rs
+++ b/crates/config/src/pagination.rs
@@ -14,19 +14,197 @@
 //! Per-provider list-pagination limits, mirroring python-keystone's
 //! per-resource `list_limit` config plus a global `[DEFAULT] list_limit` /
 //! `max_db_limit` fallback (see `keystone.common.driver_hints.Hints`).
-use serde::Deserialize;
+use serde::de::{Deserializer, Error as _};
+use serde::{Deserialize, Serialize, Serializer};
 
 /// Reusable per-provider pagination limit configuration.
 ///
 /// Embedded as a field in each domain's provider config section (e.g.
 /// `IdentityProvider.list_limit`), rather than duplicated inline, so every
 /// domain gets the same two knobs.
-#[derive(Debug, Default, Deserialize, Clone)]
+///
+/// Both spellings of the option are accepted:
+///
+/// ```ini
+/// [identity]
+/// # python-keystone's spelling: the page size on its own
+/// list_limit = 100
+/// ```
+///
+/// ```yaml
+/// identity:
+///   list_limit:
+///     list_limit: 100
+///     max_list_limit: 1000
+/// ```
+///
+/// and the scalar spelling is what serialization produces whenever
+/// `max_list_limit` is unset, so an `[identity] list_limit` reported by — or
+/// overridden through — the per-domain configuration API keeps the shape
+/// python-keystone gives it.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ListLimitConfig {
     /// Default page size applied when the client omits `limit`. Falls back
     /// to the global `[DEFAULT] list_limit` when unset.
     pub list_limit: Option<u64>,
     /// Absolute cap a client-supplied `limit` is clamped to. Falls back to
     /// the global `[DEFAULT] max_db_limit` when unset.
+    ///
+    /// It has no scalar spelling of its own: python-keystone only knows the
+    /// global `[DEFAULT] max_db_limit`.
     pub max_list_limit: Option<u64>,
+}
+
+/// The two accepted spellings of a [`ListLimitConfig`].
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum Repr {
+    /// `list_limit = 100`, python-keystone's spelling.
+    Limit(Option<u64>),
+    /// The same, as delivered by a source that only carries strings.
+    Text(String),
+    /// The full mapping of both knobs.
+    Full {
+        /// See [`ListLimitConfig::list_limit`].
+        #[serde(default)]
+        list_limit: Option<u64>,
+        /// See [`ListLimitConfig::max_list_limit`].
+        #[serde(default)]
+        max_list_limit: Option<u64>,
+    },
+}
+
+impl<'de> Deserialize<'de> for ListLimitConfig {
+    /// Accept either the scalar page size or the full mapping.
+    ///
+    /// # Parameters
+    /// - `deserializer`: The serde deserializer.
+    ///
+    /// # Returns
+    /// - `Result<Self, D::Error>` - The parsed limits, or an error when the
+    ///   value is neither spelling.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(match Repr::deserialize(deserializer)? {
+            Repr::Limit(list_limit) => Self {
+                list_limit,
+                max_list_limit: None,
+            },
+            Repr::Text(text) => Self {
+                list_limit: Some(text.trim().parse().map_err(|_| {
+                    D::Error::custom(format!("expected a page size, got `{text}`"))
+                })?),
+                max_list_limit: None,
+            },
+            Repr::Full {
+                list_limit,
+                max_list_limit,
+            } => Self {
+                list_limit,
+                max_list_limit,
+            },
+        })
+    }
+}
+
+impl Serialize for ListLimitConfig {
+    /// Use the scalar spelling unless `max_list_limit` needs saying.
+    ///
+    /// # Parameters
+    /// - `serializer`: The serde serializer.
+    ///
+    /// # Returns
+    /// - `Result<S::Ok, S::Error>` - The serialized limits.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+
+        match self.max_list_limit {
+            None => self.list_limit.serialize(serializer),
+            Some(max_list_limit) => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("list_limit", &self.list_limit)?;
+                map.serialize_entry("max_list_limit", &max_list_limit)?;
+                map.end()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn accepts_the_scalar_spelling() {
+        let parsed: ListLimitConfig = serde_json::from_value(json!(100)).unwrap();
+        assert_eq!(parsed.list_limit, Some(100));
+        assert_eq!(parsed.max_list_limit, None);
+    }
+
+    #[test]
+    fn accepts_the_full_spelling() {
+        let parsed: ListLimitConfig =
+            serde_json::from_value(json!({"list_limit": 10, "max_list_limit": 20})).unwrap();
+        assert_eq!(parsed.list_limit, Some(10));
+        assert_eq!(parsed.max_list_limit, Some(20));
+    }
+
+    #[test]
+    fn accepts_a_partial_mapping() {
+        let parsed: ListLimitConfig =
+            serde_json::from_value(json!({"max_list_limit": 20})).unwrap();
+        assert_eq!(parsed.list_limit, None);
+        assert_eq!(parsed.max_list_limit, Some(20));
+    }
+
+    #[test]
+    fn accepts_null() {
+        let parsed: ListLimitConfig = serde_json::from_value(json!(null)).unwrap();
+        assert_eq!(parsed, ListLimitConfig::default());
+    }
+
+    #[test]
+    fn serializes_as_a_scalar_without_a_cap() {
+        let config = ListLimitConfig {
+            list_limit: Some(100),
+            max_list_limit: None,
+        };
+        assert_eq!(serde_json::to_value(&config).unwrap(), json!(100));
+        assert_eq!(
+            serde_json::to_value(ListLimitConfig::default()).unwrap(),
+            json!(null)
+        );
+    }
+
+    #[test]
+    fn serializes_as_a_mapping_with_a_cap() {
+        let config = ListLimitConfig {
+            list_limit: None,
+            max_list_limit: Some(20),
+        };
+        assert_eq!(
+            serde_json::to_value(&config).unwrap(),
+            json!({"list_limit": null, "max_list_limit": 20})
+        );
+    }
+
+    #[test]
+    fn round_trips_both_spellings() {
+        for config in [
+            ListLimitConfig::default(),
+            ListLimitConfig {
+                list_limit: Some(5),
+                max_list_limit: None,
+            },
+            ListLimitConfig {
+                list_limit: Some(5),
+                max_list_limit: Some(50),
+            },
+        ] {
+            let encoded = serde_json::to_value(&config).unwrap();
+            let decoded: ListLimitConfig = serde_json::from_value(encoded).unwrap();
+            assert_eq!(decoded, config);
+        }
+    }
 }

--- a/crates/core-types/src/domain_config.rs
+++ b/crates/core-types/src/domain_config.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Domain configuration provider types
+//!
+//! Per-domain overrides of the identity backend configuration, as exposed by
+//! the `/v3/domains/{domain_id}/config` API family.
+//!
+//! The data model mirrors python-keystone's
+//! `keystone.resource.core.DomainConfigManager`:
+//!
+//! - configuration is organized into *groups* (`identity` and `ldap` only),
+//!   each holding a flat set of *options*,
+//! - an option is only storable when it is explicitly listed as either
+//!   whitelisted or sensitive (see [`whitelisted_options`] /
+//!   [`sensitive_options`]); anything else is dropped with a warning, so
+//!   making a new option domain-configurable is always a deliberate act,
+//! - sensitive options (today only `ldap.password`) are stored separately and
+//!   are never returned by the API: they are stripped on serialization and
+//!   redacted in `Debug`.
+//!
+//! What an option *is* — its type, its default, how a config file spells it —
+//! is not restated here. It comes from the config section the option
+//! overrides, [`openstack_keystone_config::IdentityProvider`] or
+//! [`openstack_keystone_config::LdapProvider`]; see [`DomainConfig`].
+//!
+//! Values are persisted verbatim as JSON ([`DomainConfigValue`]), matching
+//! python-keystone's `JsonBlob` columns.
+
+mod config;
+mod error;
+mod lenient;
+mod option;
+
+pub use config::*;
+pub use error::*;
+pub use option::*;

--- a/crates/core-types/src/domain_config/config.rs
+++ b/crates/core-types/src/domain_config/config.rs
@@ -1,0 +1,1220 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Domain configuration structures
+//!
+//! A domain configuration is a set of *overrides* of the global `[identity]`
+//! and `[ldap]` config sections, so it is held as the options a domain
+//! actually set — `group -> option -> value`, values verbatim as JSON, the
+//! way the persistence layer stores them — rather than as a second set of
+//! structs mirroring those sections.
+//!
+//! What the options *mean* is defined once, by
+//! [`openstack_keystone_config::IdentityProvider`] and
+//! [`openstack_keystone_config::LdapProvider`]:
+//!
+//! - [`DomainConfig::resolve_identity`] / [`DomainConfig::resolve_ldap`]
+//!   overlay a domain's options onto the global section and hand back the
+//!   very struct the identity backend is configured with;
+//! - [`DomainConfig::defaults`] serializes the global sections and keeps the
+//!   whitelisted keys, which is what the `/v3/domains/config/…/default`
+//!   endpoints answer;
+//! - [`DomainConfig::validate_values`] checks a client's values by decoding
+//!   them into those same structs.
+//!
+//! The only thing this module states about an individual option is whether a
+//! domain may set it at all (see [`super::whitelisted_options`]) — names, not
+//! types. An option added to `LdapProvider` therefore cannot drift from its
+//! domain-configurable counterpart, because there is no counterpart.
+
+use std::borrow::Cow;
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+
+use openstack_keystone_config::{Config, IdentityProvider, LdapProvider};
+use serde::de::DeserializeOwned;
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map, Value};
+
+use super::lenient;
+use super::{
+    DomainConfigGroupName, DomainConfigOption, DomainConfigProviderError, DomainConfigValue,
+};
+
+/// One configuration group with the options a domain set in it.
+///
+/// Returned by the group-scoped endpoints
+/// (`/v3/domains/{domain_id}/config/{group}`), which address exactly one
+/// group.
+#[derive(Clone)]
+pub struct DomainConfigGroup {
+    /// The group these options belong to.
+    name: DomainConfigGroupName,
+    /// The options, by name.
+    options: Map<String, Value>,
+}
+
+impl DomainConfigGroup {
+    /// An empty group.
+    ///
+    /// # Parameters
+    /// - `name`: The group.
+    ///
+    /// # Returns
+    /// - `Self` - The group with no option set.
+    pub fn new(name: DomainConfigGroupName) -> Self {
+        Self {
+            name,
+            options: Map::new(),
+        }
+    }
+
+    /// Name of the group.
+    ///
+    /// # Returns
+    /// - `DomainConfigGroupName` - The group discriminant.
+    pub fn name(&self) -> DomainConfigGroupName {
+        self.name
+    }
+
+    /// The options set in the group.
+    ///
+    /// Sensitive options are included; see [`Self::serialize`] for what
+    /// reaches a response.
+    ///
+    /// # Returns
+    /// - `&Map<String, Value>` - The options by name.
+    pub fn options(&self) -> &Map<String, Value> {
+        &self.options
+    }
+
+    /// Read a single option.
+    ///
+    /// # Parameters
+    /// - `option`: The option name.
+    ///
+    /// # Returns
+    /// - `Option<&Value>` - The value when the domain set the option.
+    pub fn get(&self, option: &str) -> Option<&Value> {
+        self.options.get(option)
+    }
+
+    /// Set a single option.
+    ///
+    /// # Parameters
+    /// - `option`: The option name.
+    /// - `value`: The value to store.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())`, or
+    ///   [`DomainConfigProviderError::UnsupportedOption`] when the option is
+    ///   neither whitelisted nor sensitive in this group.
+    pub fn set<O: Into<String>, V: Into<Value>>(
+        &mut self,
+        option: O,
+        value: V,
+    ) -> Result<(), DomainConfigProviderError> {
+        let option = option.into();
+        if !super::is_supported(self.name, &option) {
+            return Err(DomainConfigProviderError::UnsupportedOption {
+                group: self.name.to_string(),
+                option,
+            });
+        }
+        self.options.insert(option, value.into());
+        Ok(())
+    }
+
+    /// Whether the group carries no option at all.
+    ///
+    /// # Returns
+    /// - `bool` - `true` when every option, sensitive ones included, is unset.
+    pub fn is_empty(&self) -> bool {
+        self.options.is_empty()
+    }
+
+    /// Build a group from a client supplied object.
+    ///
+    /// Unsupported options are dropped with a warning rather than rejected,
+    /// which is what python-keystone's `_config_to_list` does with them.
+    ///
+    /// # Parameters
+    /// - `name`: The group being built.
+    /// - `value`: The options object.
+    ///
+    /// # Returns
+    /// - `Result<Self, DomainConfigProviderError>` - The group, or
+    ///   [`DomainConfigProviderError::GroupNotAMapping`] when the value is not
+    ///   an object.
+    pub fn from_value(
+        name: DomainConfigGroupName,
+        value: Value,
+    ) -> Result<Self, DomainConfigProviderError> {
+        let Value::Object(options) = value else {
+            return Err(DomainConfigProviderError::GroupNotAMapping(
+                name.to_string(),
+            ));
+        };
+        Ok(Self {
+            name,
+            options: retain_supported(name, options),
+        })
+    }
+
+    /// Build a group from the options stored for it.
+    ///
+    /// Like [`DomainConfig::from_options`], this is the read path and skips
+    /// stored options it does not recognize. An option belonging to a
+    /// *different* group is still an error: that is a caller mistake rather
+    /// than data drift.
+    ///
+    /// # Parameters
+    /// - `name`: The group being built.
+    /// - `options`: The stored options; every one must belong to `name`.
+    ///
+    /// # Returns
+    /// - `Result<Self, DomainConfigProviderError>` - The group, or an error
+    ///   when an option belongs to another group.
+    pub fn from_options<I>(
+        name: DomainConfigGroupName,
+        options: I,
+    ) -> Result<Self, DomainConfigProviderError>
+    where
+        I: IntoIterator<Item = DomainConfigOption>,
+    {
+        let mut group = Self::new(name);
+        for option in options {
+            if option.group != name {
+                return Err(DomainConfigProviderError::UnsupportedOption {
+                    group: name.to_string(),
+                    option: option.option,
+                });
+            }
+            if !super::is_supported(name, &option.option) {
+                warn_unsupported(name, &option.option, "stored");
+                continue;
+            }
+            group.options.insert(option.option, option.value.into());
+        }
+        Ok(group)
+    }
+
+    /// Flatten the group into stored options.
+    ///
+    /// # Returns
+    /// - `Vec<DomainConfigOption>` - One entry per set option, sensitive ones
+    ///   flagged as such.
+    pub fn to_options(&self) -> Vec<DomainConfigOption> {
+        self.options
+            .iter()
+            .map(|(option, value)| {
+                DomainConfigOption::new(
+                    self.name,
+                    option.clone(),
+                    DomainConfigValue::from(value.clone()),
+                )
+            })
+            .collect()
+    }
+
+    /// Check that every option holds a value its option can take.
+    ///
+    /// The check is the config section this group overrides: an option is
+    /// validated by the same declaration the running service is configured
+    /// from, so a new option needs nothing added here.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())`, or
+    ///   [`DomainConfigProviderError::InvalidOptionValue`] naming the option
+    ///   that cannot be decoded.
+    pub fn validate_values(&self) -> Result<(), DomainConfigProviderError> {
+        match self.name {
+            DomainConfigGroupName::Identity => {
+                decode_group::<IdentityProvider>(self)?;
+            }
+            DomainConfigGroupName::Ldap => {
+                decode_group::<LdapProvider>(self)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Widen the group into a configuration holding only it.
+    ///
+    /// # Returns
+    /// - `DomainConfig` - A configuration with just this group populated.
+    pub fn into_config(self) -> DomainConfig {
+        DomainConfig {
+            groups: BTreeMap::from([(self.name, self)]),
+        }
+    }
+
+    /// The options a response may carry.
+    ///
+    /// # Returns
+    /// - `impl Iterator<Item = (&String, &Value)>` - Every option that is not
+    ///   sensitive.
+    fn readable(&self) -> impl Iterator<Item = (&String, &Value)> {
+        self.options
+            .iter()
+            .filter(|(option, _)| !super::is_sensitive(self.name, option))
+    }
+}
+
+impl Serialize for DomainConfigGroup {
+    /// Serialize the readable options.
+    ///
+    /// Sensitive options are dropped: the same structure serves the internal,
+    /// fully resolved configuration and the API response, so a bind password
+    /// must not be able to reach the wire through it.
+    ///
+    /// # Parameters
+    /// - `serializer`: The serde serializer.
+    ///
+    /// # Returns
+    /// - `Result<S::Ok, S::Error>` - The serialized group.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        for (option, value) in self.readable() {
+            map.serialize_entry(option, value)?;
+        }
+        map.end()
+    }
+}
+
+impl fmt::Debug for DomainConfigGroup {
+    /// Redact the value of sensitive options so they cannot reach logs or
+    /// traces through a `{:?}` of the surrounding structure.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut out = f.debug_map();
+        for (option, value) in &self.options {
+            if super::is_sensitive(self.name, option) {
+                out.entry(option, &"REDACTED");
+            } else {
+                out.entry(option, value);
+            }
+        }
+        out.finish()
+    }
+}
+
+/// The configuration of a single domain.
+///
+/// This is the body of `{"config": {...}}` in the v3 API. Sensitive options it
+/// carries (`ldap.password`) are stripped on serialization and redacted in
+/// `Debug`, so the same structure serves both the internal, fully resolved
+/// configuration and the API response.
+#[derive(Clone, Default)]
+pub struct DomainConfig {
+    /// The configured groups, in a stable order.
+    groups: BTreeMap<DomainConfigGroupName, DomainConfigGroup>,
+}
+
+impl DomainConfig {
+    /// An empty configuration.
+    ///
+    /// # Returns
+    /// - `Self` - A configuration with no group.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the configuration carries no option at all.
+    ///
+    /// # Returns
+    /// - `bool` - `true` when no group holds a single option.
+    pub fn is_empty(&self) -> bool {
+        self.groups.values().all(DomainConfigGroup::is_empty)
+    }
+
+    /// The configured groups.
+    ///
+    /// # Returns
+    /// - `impl Iterator<Item = &DomainConfigGroup>` - The groups, `identity`
+    ///   before `ldap`.
+    pub fn groups(&self) -> impl Iterator<Item = &DomainConfigGroup> {
+        self.groups.values()
+    }
+
+    /// Borrow a single group.
+    ///
+    /// # Parameters
+    /// - `name`: The group to look up.
+    ///
+    /// # Returns
+    /// - `Option<&DomainConfigGroup>` - The group when it is present.
+    pub fn group(&self, name: DomainConfigGroupName) -> Option<&DomainConfigGroup> {
+        self.groups.get(&name)
+    }
+
+    /// Take a single group out of the configuration.
+    ///
+    /// # Parameters
+    /// - `name`: The group to extract.
+    ///
+    /// # Returns
+    /// - `Option<DomainConfigGroup>` - The group when it is present.
+    pub fn into_group(mut self, name: DomainConfigGroupName) -> Option<DomainConfigGroup> {
+        self.groups.remove(&name)
+    }
+
+    /// Add a group, replacing one of the same name.
+    ///
+    /// # Parameters
+    /// - `group`: The group to insert.
+    pub fn insert(&mut self, group: DomainConfigGroup) {
+        self.groups.insert(group.name, group);
+    }
+
+    /// Set a single option, creating its group when needed.
+    ///
+    /// # Parameters
+    /// - `group`: The group holding the option.
+    /// - `option`: The option name.
+    /// - `value`: The value to store.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())`, or
+    ///   [`DomainConfigProviderError::UnsupportedOption`].
+    pub fn set<O: Into<String>, V: Into<Value>>(
+        &mut self,
+        group: DomainConfigGroupName,
+        option: O,
+        value: V,
+    ) -> Result<(), DomainConfigProviderError> {
+        self.groups
+            .entry(group)
+            .or_insert_with(|| DomainConfigGroup::new(group))
+            .set(option, value)
+    }
+
+    /// Build a configuration from a client supplied object.
+    ///
+    /// The payload is checked the way python-keystone's `_assert_valid_config`
+    /// checks it — at least one group, each group a non-empty mapping — and
+    /// unsupported *options* are then dropped with a warning, as
+    /// `_config_to_list` does. An unsupported *group* is an error, because the
+    /// api-ref promises a `403` for one.
+    ///
+    /// # Parameters
+    /// - `value`: The `config` object of the request body.
+    ///
+    /// # Returns
+    /// - `Result<Self, DomainConfigProviderError>` - The configuration, or the
+    ///   error the request should be rejected with.
+    pub fn from_value(value: Value) -> Result<Self, DomainConfigProviderError> {
+        let Value::Object(groups) = value else {
+            return Err(DomainConfigProviderError::EmptyConfig);
+        };
+        if groups.is_empty() {
+            return Err(DomainConfigProviderError::EmptyConfig);
+        }
+        let mut config = Self::new();
+        for (name, options) in groups {
+            let name: DomainConfigGroupName = name.parse()?;
+            // The shape is checked before the option names are looked at, the
+            // order python-keystone checks them in: a group left empty by the
+            // whitelist is not the same thing as one that arrived empty, and
+            // only the latter is an error.
+            match &options {
+                Value::Object(options) if !options.is_empty() => {}
+                _ => {
+                    return Err(DomainConfigProviderError::GroupNotAMapping(
+                        name.to_string(),
+                    ));
+                }
+            }
+            config.insert(DomainConfigGroup::from_value(name, options)?);
+        }
+        Ok(config)
+    }
+
+    /// Validate a configuration a driver is about to store.
+    ///
+    /// Half of python-keystone's `DomainConfigManager._assert_valid_config`:
+    /// the request must address at least one group. The other half — a group
+    /// must be a *non-empty* mapping — is checked by [`Self::from_value`], on
+    /// the payload as it arrived. Checking it again here would reject the
+    /// request python-keystone accepts: a group holding nothing but options
+    /// outside the whitelist is left empty on purpose, and stores nothing.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())` when the payload
+    ///   is usable, otherwise [`DomainConfigProviderError::EmptyConfig`].
+    pub fn validate(&self) -> Result<(), DomainConfigProviderError> {
+        if self.groups.is_empty() {
+            return Err(DomainConfigProviderError::EmptyConfig);
+        }
+        Ok(())
+    }
+
+    /// Check that every option holds a value its option can take.
+    ///
+    /// The check is the config structs themselves: each group is decoded into
+    /// the section it overrides, so an option is validated by the same
+    /// declaration the running service is configured from, and a new option
+    /// needs nothing added here.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())`, or
+    ///   [`DomainConfigProviderError::InvalidOptionValue`] naming the option
+    ///   that cannot be decoded.
+    pub fn validate_values(&self) -> Result<(), DomainConfigProviderError> {
+        self.groups
+            .values()
+            .try_for_each(DomainConfigGroup::validate_values)
+    }
+
+    /// Build a configuration from the flat option list a driver stores.
+    ///
+    /// This is the read path, so it is deliberately tolerant of rows it does
+    /// not recognize: a stored option that is no longer whitelisted is skipped
+    /// with a warning rather than failing the whole configuration, which would
+    /// otherwise leave the domain unreadable — and its identity backend
+    /// uninitializable — until an operator deleted the row. python-keystone's
+    /// `_list_to_config` likewise does not re-validate on read; the whitelist
+    /// is enforced on the write path instead.
+    ///
+    /// # Parameters
+    /// - `options`: The stored options across all groups.
+    ///
+    /// # Returns
+    /// - `Self` - The configuration.
+    pub fn from_options<I>(options: I) -> Self
+    where
+        I: IntoIterator<Item = DomainConfigOption>,
+    {
+        let mut config = Self::new();
+        for option in options {
+            if !super::is_supported(option.group, &option.option) {
+                warn_unsupported(option.group, &option.option, "stored");
+                continue;
+            }
+            config
+                .groups
+                .entry(option.group)
+                .or_insert_with(|| DomainConfigGroup::new(option.group))
+                .options
+                .insert(option.option, option.value.into());
+        }
+        config
+    }
+
+    /// Flatten the configuration into the option list a driver stores.
+    ///
+    /// # Returns
+    /// - `Vec<DomainConfigOption>` - One entry per set option, sensitive ones
+    ///   flagged as such.
+    pub fn to_options(&self) -> Vec<DomainConfigOption> {
+        self.groups
+            .values()
+            .flat_map(DomainConfigGroup::to_options)
+            .collect()
+    }
+
+    /// The domain's `[identity]` section: the global one with the domain's
+    /// overrides applied.
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration.
+    ///
+    /// # Returns
+    /// - `Result<IdentityProvider, DomainConfigProviderError>` - The resolved
+    ///   section, or an error naming the option that could not be decoded.
+    pub fn resolve_identity(
+        &self,
+        config: &Config,
+    ) -> Result<IdentityProvider, DomainConfigProviderError> {
+        let mut identity: IdentityProvider =
+            self.resolve(DomainConfigGroupName::Identity, &config.identity)?;
+        // `list_limit` is whitelisted as python-keystone spells it, the page
+        // size on its own, so overriding it replaces the whole option and with
+        // it the operator's `max_list_limit` — which has no domain-settable
+        // spelling of its own. Overriding the page size must not lift the cap
+        // on what a client can ask for.
+        if identity.list_limit.max_list_limit.is_none() {
+            identity.list_limit.max_list_limit = config.identity.list_limit.max_list_limit;
+        }
+        Ok(identity)
+    }
+
+    /// The domain's `[ldap]` section: the global one with the domain's
+    /// overrides applied.
+    ///
+    /// `%(option)s` references are *not* expanded here; run
+    /// [`Self::substitute`] first when the configuration comes from storage
+    /// and may carry them.
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration.
+    ///
+    /// # Returns
+    /// - `Result<LdapProvider, DomainConfigProviderError>` - The resolved
+    ///   section, or an error naming the option that could not be decoded.
+    fn resolve_ldap(&self, config: &Config) -> Result<LdapProvider, DomainConfigProviderError> {
+        let domain_overrides_password = self
+            .group(DomainConfigGroupName::Ldap)
+            .is_some_and(|group| group.get("password").is_some());
+        let mut ldap: LdapProvider = self.resolve(DomainConfigGroupName::Ldap, &config.ldap)?;
+        // The bind password is never serialized, so the overlay cannot carry
+        // the global one. Inherit it only when the domain did not address the
+        // option at all: an explicit null requests an anonymous bind.
+        if !domain_overrides_password {
+            ldap.password.clone_from(&config.ldap.password);
+        }
+        Ok(ldap)
+    }
+
+    /// Overlay a group onto the global section it overrides.
+    ///
+    /// # Parameters
+    /// - `name`: The group to apply.
+    /// - `section`: The global config section.
+    ///
+    /// # Returns
+    /// - `Result<T, DomainConfigProviderError>` - The resolved section.
+    fn resolve<T: Clone + Serialize + DeserializeOwned>(
+        &self,
+        name: DomainConfigGroupName,
+        section: &T,
+    ) -> Result<T, DomainConfigProviderError> {
+        let Some(group) = self.groups.get(&name) else {
+            return Ok(section.clone());
+        };
+        let Value::Object(mut merged) = serde_json::to_value(section)? else {
+            return Err(DomainConfigProviderError::GroupNotAMapping(
+                name.to_string(),
+            ));
+        };
+        for (option, value) in &group.options {
+            merged.insert(option.clone(), value.clone());
+        }
+        lenient::from_value(Value::Object(merged)).map_err(|source| {
+            // Pinpoint the offending option the way `decode_group` does.
+            decode_group::<T>(group)
+                .err()
+                .unwrap_or(DomainConfigProviderError::InvalidValue {
+                    group: name.to_string(),
+                    source,
+                })
+        })
+    }
+
+    /// Resolve `%(option)s` references between the options of a group.
+    ///
+    /// A whitelisted option may reference another option of the same group,
+    /// most usefully a sensitive one, so that a bind password appears in the
+    /// stored `ldap.url` only as `%(password)s`:
+    ///
+    /// ```text
+    /// ldap://%(user)s:%(password)s@ldap.example.com:389/
+    /// ```
+    ///
+    /// The result is a [`ResolvedDomainConfig`], which cannot be serialized:
+    /// the raw, unsubstituted value is what the config endpoints return, while
+    /// the resolved one exists so the identity backend can be handed a usable
+    /// connection string and has secrets inlined into options that are
+    /// otherwise readable. This is why substitution is a separate step rather
+    /// than part of a driver read: `DomainConfigBackend::get_domain_config`
+    /// serves the API too.
+    ///
+    /// Port of python-keystone's substitution pass in
+    /// `DomainConfigManager.get_config_with_sensitive_info`, with two
+    /// deliberate differences:
+    ///
+    /// - references resolve against every option of the group, not only the
+    ///   sensitive ones, so that the `%(user)s` of the example above resolves
+    ///   too;
+    /// - a reference that cannot be resolved, or a value whose `%` escapes are
+    ///   malformed, leaves *that value* untouched with a warning, matching what
+    ///   python-keystone does when the `%` operator raises.
+    ///
+    /// # Returns
+    /// - `ResolvedDomainConfig` - The configuration with every reference
+    ///   resolved.
+    pub fn substitute(&self) -> ResolvedDomainConfig {
+        let options = self.to_options();
+        let mut references: HashMap<DomainConfigGroupName, HashMap<&str, String>> = HashMap::new();
+        for option in &options {
+            // Sensitive options win: a name can only be spelled in one of the
+            // two lists, so this only guards against stored drift.
+            let entry = references
+                .entry(option.group)
+                .or_default()
+                .entry(option.option.as_str());
+            match entry {
+                Entry::Vacant(slot) => {
+                    slot.insert(option.value.to_string());
+                }
+                Entry::Occupied(mut slot) if option.sensitive() => {
+                    slot.insert(option.value.to_string());
+                }
+                Entry::Occupied(_) => {}
+            }
+        }
+
+        let substituted = options.iter().map(|option| {
+            // Only whitelisted string values are expanded: a secret is used
+            // verbatim, and a number or a list has nothing to expand.
+            let (Some(text), false) = (option.value.as_str(), option.sensitive()) else {
+                return option.clone();
+            };
+            let resolved = references
+                .get(&option.group)
+                .map_or(Cow::Borrowed(text), |group| {
+                    substitute_references(option.group, &option.option, text, group)
+                });
+            match resolved {
+                Cow::Borrowed(_) => option.clone(),
+                Cow::Owned(resolved) => {
+                    DomainConfigOption::new(option.group, option.option.clone(), resolved)
+                }
+            }
+        });
+        ResolvedDomainConfig(Self::from_options(substituted.collect::<Vec<_>>()))
+    }
+
+    /// Global defaults for every readable option, as served by
+    /// `GET /v3/domains/config/default`.
+    ///
+    /// The defaults are the running configuration itself, keyed down to the
+    /// whitelisted options; an option that is not configured is reported as
+    /// `null`, the way python-keystone's `get_config_default` reports it.
+    /// Sensitive options are never part of it — `password` is not whitelisted
+    /// and is not serialized either.
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration.
+    ///
+    /// # Returns
+    /// - `Result<Self, DomainConfigProviderError>` - The defaults of both
+    ///   groups, or a serialization error.
+    pub fn defaults(config: &Config) -> Result<Self, DomainConfigProviderError> {
+        let mut identity = DomainConfigGroup {
+            name: DomainConfigGroupName::Identity,
+            options: whitelisted_only(
+                DomainConfigGroupName::Identity,
+                serde_json::to_value(&config.identity)?,
+            )?,
+        };
+        // `[identity] list_limit` falls back to the global `[DEFAULT]
+        // list_limit`, the same chain `Config::resolve_list_limit` applies.
+        // Reporting only the section-local value would tell an operator `null`
+        // while their listings are really capped.
+        identity.options.insert(
+            "list_limit".to_string(),
+            match config
+                .identity
+                .list_limit
+                .list_limit
+                .or(config.default.list_limit)
+            {
+                Some(limit) => Value::from(limit),
+                None => Value::Null,
+            },
+        );
+
+        let ldap = DomainConfigGroup {
+            name: DomainConfigGroupName::Ldap,
+            options: whitelisted_only(
+                DomainConfigGroupName::Ldap,
+                serde_json::to_value(&config.ldap)?,
+            )?,
+        };
+
+        let mut defaults = Self::new();
+        defaults.insert(identity);
+        defaults.insert(ldap);
+        Ok(defaults)
+    }
+
+    /// Global defaults of a single group.
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration.
+    /// - `group`: The group to report.
+    ///
+    /// # Returns
+    /// - `Result<DomainConfigGroup, DomainConfigProviderError>` - The defaults
+    ///   of the group.
+    pub fn default_group(
+        config: &Config,
+        group: DomainConfigGroupName,
+    ) -> Result<DomainConfigGroup, DomainConfigProviderError> {
+        Self::defaults(config)?
+            .into_group(group)
+            // `defaults` populates every group.
+            .ok_or_else(|| DomainConfigProviderError::UnsupportedGroup(group.to_string()))
+    }
+
+    /// Global defaults as a flat option list.
+    ///
+    /// Every whitelisted option is present, in whitelist order, with a JSON
+    /// `null` value when nothing is configured for it.
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration.
+    /// - `group`: Restrict the result to a single group, or `None` for all.
+    ///
+    /// # Returns
+    /// - `Result<Vec<DomainConfigOption>, DomainConfigProviderError>` - The
+    ///   defaults in whitelist order, or a serialization error.
+    pub fn default_options(
+        config: &Config,
+        group: Option<DomainConfigGroupName>,
+    ) -> Result<Vec<DomainConfigOption>, DomainConfigProviderError> {
+        let defaults = Self::defaults(config)?;
+        let mut options = Vec::new();
+        for name in DomainConfigGroupName::ALL
+            .iter()
+            .copied()
+            .filter(|name| group.is_none_or(|wanted| wanted == *name))
+        {
+            let configured = defaults.group(name);
+            options.extend(super::whitelisted_options(name).iter().map(|option| {
+                DomainConfigOption::new(
+                    name,
+                    *option,
+                    configured
+                        .and_then(|group| group.get(option))
+                        .cloned()
+                        .unwrap_or(Value::Null),
+                )
+            }));
+        }
+        Ok(options)
+    }
+
+    /// Default value of a single option, as served by
+    /// `GET /v3/domains/config/{group}/{option}/default`.
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration.
+    /// - `group`: The group holding the option.
+    /// - `option`: The option to read.
+    ///
+    /// # Returns
+    /// - `Result<Option<DomainConfigValue>, DomainConfigProviderError>` - The
+    ///   default value, or an error when the option is not readable.
+    pub fn default_option(
+        config: &Config,
+        group: DomainConfigGroupName,
+        option: &str,
+    ) -> Result<Option<DomainConfigValue>, DomainConfigProviderError> {
+        // Sensitive options have no readable default: python-keystone builds
+        // the default response from the whitelist only.
+        if !super::is_whitelisted(group, option) {
+            return Err(DomainConfigProviderError::UnsupportedOption {
+                group: group.to_string(),
+                option: option.to_string(),
+            });
+        }
+        Ok(Self::default_options(config, Some(group))?
+            .into_iter()
+            .find(|stored| stored.option == option)
+            .map(|stored| stored.value))
+    }
+}
+
+impl Serialize for DomainConfig {
+    /// Serialize the readable options of every group.
+    ///
+    /// A group left with nothing readable — one holding only a bind password —
+    /// is omitted rather than reported empty.
+    ///
+    /// # Parameters
+    /// - `serializer`: The serde serializer.
+    ///
+    /// # Returns
+    /// - `Result<S::Ok, S::Error>` - The serialized configuration.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        for group in self.groups.values() {
+            if group.readable().next().is_none() {
+                continue;
+            }
+            map.serialize_entry(group.name.as_str(), group)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for DomainConfig {
+    /// Decode a client supplied `config` object.
+    ///
+    /// Shares [`DomainConfig::from_value`]'s rules; use that directly to get
+    /// the typed error a response needs.
+    ///
+    /// # Parameters
+    /// - `deserializer`: The serde deserializer.
+    ///
+    /// # Returns
+    /// - `Result<Self, D::Error>` - The configuration, or the failure as a
+    ///   serde error.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+
+        Self::from_value(Value::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+impl fmt::Debug for DomainConfig {
+    /// Redact sensitive values; see [`DomainConfigGroup`]'s `Debug`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut out = f.debug_map();
+        for (name, group) in &self.groups {
+            out.entry(&name.as_str(), group);
+        }
+        out.finish()
+    }
+}
+
+/// A configuration whose `%(option)s` references have been expanded.
+///
+/// The result of [`DomainConfig::substitute`], and deliberately a type of its
+/// own: expansion inlines secrets into options that are otherwise readable —
+/// an `ldap.url` spelled `ldap://%(user)s:%(password)s@host` comes out of it
+/// carrying the bind password — so it must never reach a response or a log.
+/// It therefore implements neither `Serialize` nor `Deref`, and its `Debug`
+/// shows nothing; what it is for is [`Self::resolve_ldap`].
+#[derive(Clone)]
+pub struct ResolvedDomainConfig(DomainConfig);
+
+/// An LDAP section whose option substitutions have been expanded.
+///
+/// Any string option may now contain a secret, so the ordinary derived
+/// [`Debug`](fmt::Debug) implementation of [`LdapProvider`] is not safe for
+/// this value. The wrapper stays in place through the provider handoff and
+/// redacts the whole section while still allowing read-only use through
+/// [`Deref`].
+#[derive(Clone)]
+pub struct ResolvedLdapProvider(LdapProvider);
+
+impl Deref for ResolvedLdapProvider {
+    type Target = LdapProvider;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Debug for ResolvedLdapProvider {
+    /// Show nothing: after expansion any field may hold a secret.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ResolvedLdapProvider(REDACTED)")
+    }
+}
+
+impl ResolvedDomainConfig {
+    /// The domain's `[identity]` section; see
+    /// [`DomainConfig::resolve_identity`].
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration.
+    ///
+    /// # Returns
+    /// - `Result<IdentityProvider, DomainConfigProviderError>` - The resolved
+    ///   section.
+    pub fn resolve_identity(
+        &self,
+        config: &Config,
+    ) -> Result<IdentityProvider, DomainConfigProviderError> {
+        self.0.resolve_identity(config)
+    }
+
+    /// The domain's `[ldap]` section; see [`DomainConfig::resolve_ldap`].
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration.
+    ///
+    /// # Returns
+    /// - `Result<ResolvedLdapProvider, DomainConfigProviderError>` - The
+    ///   resolved section, references expanded and Debug-redacted.
+    pub fn resolve_ldap(
+        &self,
+        config: &Config,
+    ) -> Result<ResolvedLdapProvider, DomainConfigProviderError> {
+        self.0.resolve_ldap(config).map(ResolvedLdapProvider)
+    }
+
+    /// Read a single expanded option.
+    ///
+    /// Test only: an expanded value may carry a secret whatever its option is
+    /// called, so nothing outside these tests gets to pull one out. A consumer
+    /// that needs the expanded configuration takes it as a section, through
+    /// [`Self::resolve_ldap`].
+    ///
+    /// # Parameters
+    /// - `group`: The group holding the option.
+    /// - `option`: The option name.
+    ///
+    /// # Returns
+    /// - `Option<&Value>` - The expanded value when the domain set the option.
+    #[cfg(test)]
+    pub(crate) fn option(&self, group: DomainConfigGroupName, option: &str) -> Option<&Value> {
+        self.0.group(group).and_then(|group| group.get(option))
+    }
+}
+
+impl fmt::Debug for ResolvedDomainConfig {
+    /// Show nothing: after expansion any option may hold a secret, so there is
+    /// no subset of this that is safe to log.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ResolvedDomainConfig(REDACTED)")
+    }
+}
+
+/// Payload of `PUT /v3/domains/{domain_id}/config`.
+///
+/// A create replaces the domain's stored configuration in full: options absent
+/// from the payload are removed.
+#[derive(Clone, Debug, Default)]
+pub struct DomainConfigCreate(pub DomainConfig);
+
+/// Payload of `PATCH /v3/domains/{domain_id}/config` and of the group- and
+/// option-scoped updates.
+///
+/// An update merges into the stored configuration: options absent from the
+/// payload keep their current value.
+#[derive(Clone, Debug, Default)]
+pub struct DomainConfigUpdate(pub DomainConfig);
+
+macro_rules! domain_config_wrapper {
+    ($name:ident) => {
+        impl $name {
+            /// Consume the wrapper and yield the configuration.
+            ///
+            /// # Returns
+            /// - `DomainConfig` - The wrapped configuration.
+            pub fn into_inner(self) -> DomainConfig {
+                self.0
+            }
+        }
+
+        impl From<DomainConfig> for $name {
+            fn from(config: DomainConfig) -> Self {
+                Self(config)
+            }
+        }
+
+        impl From<$name> for DomainConfig {
+            fn from(wrapper: $name) -> Self {
+                wrapper.0
+            }
+        }
+
+        impl Deref for $name {
+            type Target = DomainConfig;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl DerefMut for $name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
+}
+
+domain_config_wrapper!(DomainConfigCreate);
+domain_config_wrapper!(DomainConfigUpdate);
+
+/// Drop the options of an object a domain may not set.
+///
+/// # Parameters
+/// - `group`: The group the options belong to.
+/// - `options`: The supplied options.
+///
+/// # Returns
+/// - `Map<String, Value>` - The supported options.
+fn retain_supported(
+    group: DomainConfigGroupName,
+    options: Map<String, Value>,
+) -> Map<String, Value> {
+    options
+        .into_iter()
+        .filter(|(option, _)| {
+            let supported = super::is_supported(group, option);
+            if !supported {
+                warn_unsupported(group, option, "user provided");
+            }
+            supported
+        })
+        .collect()
+}
+
+/// Keep only the readable options of a serialized config section.
+///
+/// # Parameters
+/// - `group`: The group the section maps to.
+/// - `section`: The serialized section.
+///
+/// # Returns
+/// - `Result<Map<String, Value>, DomainConfigProviderError>` - The whitelisted
+///   options, or [`DomainConfigProviderError::GroupNotAMapping`] when the
+///   section is not an object.
+fn whitelisted_only(
+    group: DomainConfigGroupName,
+    section: Value,
+) -> Result<Map<String, Value>, DomainConfigProviderError> {
+    let Value::Object(options) = section else {
+        return Err(DomainConfigProviderError::GroupNotAMapping(
+            group.to_string(),
+        ));
+    };
+    Ok(options
+        .into_iter()
+        .filter(|(option, _)| super::is_whitelisted(group, option))
+        .collect())
+}
+
+/// Decode a group into the config section it overrides.
+///
+/// serde reports a failing value without naming the field it came from, which
+/// on a 50 option group leaves an operator guessing. On failure we therefore
+/// retry option by option — only on the error path, and each retry is a
+/// single-entry map — so the message can name the culprit.
+///
+/// # Parameters
+/// - `group`: The group to decode.
+///
+/// # Returns
+/// - `Result<T, DomainConfigProviderError>` - The decoded section, or
+///   [`DomainConfigProviderError::InvalidOptionValue`] naming the offending
+///   option, falling back to [`DomainConfigProviderError::InvalidValue`] when
+///   no single option reproduces the failure.
+fn decode_group<T: DeserializeOwned>(
+    group: &DomainConfigGroup,
+) -> Result<T, DomainConfigProviderError> {
+    let source = match lenient::from_value(Value::Object(group.options.clone())) {
+        Ok(decoded) => return Ok(decoded),
+        Err(source) => source,
+    };
+    for (option, value) in &group.options {
+        let mut single = Map::new();
+        single.insert(option.clone(), value.clone());
+        if let Err(source) = lenient::from_value::<T>(Value::Object(single)) {
+            return Err(DomainConfigProviderError::InvalidOptionValue {
+                group: group.name.to_string(),
+                option: option.clone(),
+                // The message quotes the value that was rejected, which a
+                // secret's must not be.
+                source: match super::is_sensitive(group.name, option) {
+                    true => serde::de::Error::custom("the value is not one the option can hold"),
+                    false => source,
+                },
+            });
+        }
+    }
+    Err(DomainConfigProviderError::InvalidValue {
+        group: group.name.to_string(),
+        // No single option accounts for the failure, so the message cannot be
+        // attributed — and therefore cannot be shown to carry no secret.
+        source: match group
+            .options
+            .keys()
+            .any(|option| super::is_sensitive(group.name, option))
+        {
+            true => serde::de::Error::custom("a value is not one its option can hold"),
+            false => source,
+        },
+    })
+}
+
+/// Log an option that is neither whitelisted nor sensitive.
+///
+/// # Parameters
+/// - `group`: The group the option was found in.
+/// - `option`: The option name.
+/// - `origin`: Where the option came from, for the message.
+fn warn_unsupported(group: DomainConfigGroupName, option: &str, origin: &str) {
+    tracing::warn!(
+        group = %group,
+        option = %option,
+        "ignoring a {origin} domain config option that is neither whitelisted nor sensitive"
+    );
+}
+
+/// Expand the `%(option)s` references of a single value.
+///
+/// Only the `s` conversion is accepted, which is the only one python-keystone's
+/// values can carry, and `%%` stands for a literal `%`. Anything else is a
+/// value the `%` operator would have raised on, so it is left alone.
+///
+/// # Parameters
+/// - `group`: The group of the value, for the warning.
+/// - `option`: The option of the value, for the warning.
+/// - `text`: The raw value.
+/// - `references`: The options of the group, by name.
+///
+/// # Returns
+/// - `Cow<'a, str>` - The expanded value, borrowed when it is unchanged.
+fn substitute_references<'a>(
+    group: DomainConfigGroupName,
+    option: &str,
+    text: &'a str,
+    references: &HashMap<&str, String>,
+) -> Cow<'a, str> {
+    if !text.contains('%') {
+        return Cow::Borrowed(text);
+    }
+    let mut resolved = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(marker) = rest.find('%') {
+        resolved.push_str(&rest[..marker]);
+        let tail = &rest[marker + 1..];
+        if let Some(tail) = tail.strip_prefix('%') {
+            resolved.push('%');
+            rest = tail;
+            continue;
+        }
+        let Some((name, tail)) = tail
+            .strip_prefix('(')
+            .and_then(|tail| tail.split_once(')'))
+            .and_then(|(name, tail)| Some((name, tail.strip_prefix('s')?)))
+        else {
+            tracing::warn!(
+                group = %group,
+                option = %option,
+                "leaving the value of a domain config option as it is: \
+                 it looks like an incorrectly constructed option substitution reference"
+            );
+            return Cow::Borrowed(text);
+        };
+        let Some(value) = references.get(name) else {
+            tracing::warn!(
+                group = %group,
+                option = %option,
+                reference = %name,
+                "leaving the value of a domain config option as it is: \
+                 it references an option that is not configured for the domain"
+            );
+            return Cow::Borrowed(text);
+        };
+        resolved.push_str(value);
+        rest = tail;
+    }
+    resolved.push_str(rest);
+    Cow::Owned(resolved)
+}
+
+#[cfg(test)]
+#[path = "config/tests.rs"]
+mod tests;

--- a/crates/core-types/src/domain_config/config/tests.rs
+++ b/crates/core-types/src/domain_config/config/tests.rs
@@ -1,0 +1,911 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Domain configuration structure tests
+
+use std::collections::HashSet;
+
+use secrecy::{ExposeSecret, SecretString};
+use serde_json::json;
+
+use super::*;
+use crate::domain_config::{
+    LDAP_WHITELISTED_OPTIONS, is_sensitive, sensitive_options, whitelisted_options,
+};
+
+const PASSWORD: &str = "ldap-top-secret";
+
+/// A configuration exercising both groups, a sensitive option and every
+/// scalar kind the `ldap` group can hold.
+fn sample_config() -> DomainConfig {
+    config_from(json!({
+        "identity": {"driver": "ldap", "list_limit": 100},
+        "ldap": {
+            "url": "ldap://myldap.com:389/",
+            "user_tree_dn": "ou=Users,dc=example,dc=com",
+            "password": PASSWORD,
+            "page_size": 10,
+            "use_tls": true,
+            "pool_retry_delay": 0.5,
+            "user_attribute_ignore": ["default_project_id"],
+        },
+    }))
+}
+
+/// Build a configuration from a request body, failing the test if it is
+/// rejected.
+fn config_from(value: Value) -> DomainConfig {
+    DomainConfig::from_value(value).expect("a valid domain configuration")
+}
+
+/// Option names of a group, as flattened for storage.
+fn option_names(options: &[DomainConfigOption], group: DomainConfigGroupName) -> HashSet<String> {
+    options
+        .iter()
+        .filter(|option| option.group == group)
+        .map(|option| option.option.clone())
+        .collect()
+}
+
+#[test]
+fn config_round_trips_through_options() {
+    let options = sample_config().to_options();
+    assert_eq!(
+        option_names(&options, DomainConfigGroupName::Identity),
+        HashSet::from(["driver".to_string(), "list_limit".to_string()])
+    );
+
+    let restored = DomainConfig::from_options(options);
+    let ldap = restored.group(DomainConfigGroupName::Ldap).expect("ldap");
+    assert_eq!(ldap.get("url"), Some(&json!("ldap://myldap.com:389/")));
+    assert_eq!(ldap.get("page_size"), Some(&json!(10)));
+    assert_eq!(ldap.get("use_tls"), Some(&json!(true)));
+    assert_eq!(ldap.get("pool_retry_delay"), Some(&json!(0.5)));
+    assert_eq!(
+        ldap.get("user_attribute_ignore"),
+        Some(&json!(["default_project_id"]))
+    );
+    assert_eq!(ldap.get("password"), Some(&json!(PASSWORD)));
+    assert_eq!(
+        restored
+            .group(DomainConfigGroupName::Identity)
+            .and_then(|group| group.get("list_limit")),
+        Some(&json!(100))
+    );
+}
+
+#[test]
+fn values_are_stored_verbatim() {
+    // Whatever JSON type a client wrote is what a read gives back: the
+    // persistence layer keeps `JsonBlob` columns, as python-keystone does.
+    let config = config_from(json!({"ldap": {"page_size": "10", "use_tls": "True"}}));
+    let ldap = config.group(DomainConfigGroupName::Ldap).expect("ldap");
+    assert_eq!(ldap.get("page_size"), Some(&json!("10")));
+    assert_eq!(ldap.get("use_tls"), Some(&json!("True")));
+}
+
+#[test]
+fn to_options_flags_the_password_as_sensitive() {
+    let options = sample_config().to_options();
+    let password = options
+        .iter()
+        .find(|option| option.option == "password")
+        .expect("the password is stored");
+    assert!(password.sensitive());
+    assert_eq!(password.group, DomainConfigGroupName::Ldap);
+    assert!(
+        options
+            .iter()
+            .filter(|option| option.option != "password")
+            .all(|option| !option.sensitive())
+    );
+}
+
+#[test]
+fn config_does_not_serialize_the_password() {
+    let rendered = serde_json::to_string(&sample_config()).expect("serializable");
+    assert!(
+        !rendered.contains(PASSWORD),
+        "the password reached the wire"
+    );
+    assert!(!rendered.contains("password"));
+    assert!(rendered.contains("ldap://myldap.com:389/"));
+}
+
+#[test]
+fn a_group_holding_only_a_secret_is_not_serialized() {
+    let config = config_from(json!({"ldap": {"password": PASSWORD}}));
+    assert_eq!(
+        serde_json::to_value(&config).expect("serializable"),
+        json!({})
+    );
+    assert_eq!(
+        serde_json::to_value(config.group(DomainConfigGroupName::Ldap)).expect("serializable"),
+        json!({})
+    );
+}
+
+#[test]
+fn config_debug_does_not_leak_the_password() {
+    let rendered = format!("{:?}", sample_config());
+    assert!(!rendered.contains(PASSWORD), "the password reached a log");
+    assert!(rendered.contains("REDACTED"));
+    assert!(rendered.contains("ldap://myldap.com:389/"));
+}
+
+#[test]
+fn config_deserializes_the_password() {
+    // Sensitive options are write-only, not unwritable.
+    let config: DomainConfig =
+        serde_json::from_value(json!({"ldap": {"password": PASSWORD}})).expect("deserializable");
+    assert_eq!(
+        config
+            .group(DomainConfigGroupName::Ldap)
+            .and_then(|group| group.get("password")),
+        Some(&json!(PASSWORD))
+    );
+}
+
+#[test]
+fn config_drops_options_outside_the_whitelist() {
+    // python-keystone's `_config_to_list` ignores an option it does not
+    // recognize rather than failing the request.
+    let config = config_from(json!({"ldap": {"url": "ldap://host", "bind_dn": "cn=admin"}}));
+    let ldap = config.group(DomainConfigGroupName::Ldap).expect("ldap");
+    assert_eq!(ldap.get("url"), Some(&json!("ldap://host")));
+    assert_eq!(ldap.get("bind_dn"), None);
+
+    // An option of the *other* group is not whitelisted here either.
+    let config = config_from(json!({"ldap": {"url": "ldap://host", "driver": "sql"}}));
+    assert_eq!(
+        config
+            .group(DomainConfigGroupName::Ldap)
+            .and_then(|group| group.get("driver")),
+        None
+    );
+}
+
+#[test]
+fn set_rejects_an_option_outside_the_whitelist() {
+    let mut config = DomainConfig::new();
+    let err = config
+        .set(DomainConfigGroupName::Ldap, "bind_dn", "cn=admin")
+        .expect_err("an unsupported option is refused");
+    assert_eq!(
+        err.to_string(),
+        "option bind_dn in group ldap is not supported for domain specific configurations"
+    );
+    config
+        .set(DomainConfigGroupName::Ldap, "url", "ldap://host")
+        .expect("a whitelisted option is accepted");
+    config
+        .set(DomainConfigGroupName::Ldap, "password", PASSWORD)
+        .expect("a sensitive option is writable");
+}
+
+#[test]
+fn config_skips_unsupported_options_on_read() {
+    // A stored option that is no longer whitelisted must not make the whole
+    // configuration unreadable, and with it the domain's identity backend
+    // uninitializable.
+    let config = DomainConfig::from_options([
+        DomainConfigOption::new(DomainConfigGroupName::Ldap, "url", "ldap://host"),
+        DomainConfigOption::new(DomainConfigGroupName::Ldap, "removed_option", "value"),
+    ]);
+    let ldap = config.group(DomainConfigGroupName::Ldap).expect("ldap");
+    assert_eq!(ldap.get("url"), Some(&json!("ldap://host")));
+    assert_eq!(ldap.get("removed_option"), None);
+}
+
+#[test]
+fn config_rejects_unknown_groups() {
+    let err = DomainConfig::from_value(json!({"assignment": {"driver": "sql"}}))
+        .expect_err("an unsupported group is refused");
+    assert_eq!(
+        err.to_string(),
+        "group assignment is not supported for domain specific configurations"
+    );
+}
+
+#[test]
+fn a_group_left_empty_by_the_whitelist_is_storable() {
+    // python-keystone checks the shape of the payload before it looks at the
+    // option names, warns about the ones it does not recognize and stores what
+    // is left — nothing, here — rather than failing the request.
+    let config = config_from(json!({"ldap": {"bind_dn": "cn=admin"}}));
+    config
+        .validate()
+        .expect("a group the whitelist emptied is not an empty request");
+    assert!(config.is_empty());
+    assert!(config.to_options().is_empty());
+}
+
+#[test]
+fn config_rejects_an_empty_payload() {
+    for value in [json!({}), json!(null), json!("ldap")] {
+        let err = DomainConfig::from_value(value.clone()).expect_err("refused");
+        assert_eq!(err.to_string(), "no options specified", "{value}");
+    }
+    let err = DomainConfig::new()
+        .validate()
+        .expect_err("an empty configuration is refused");
+    assert_eq!(err.to_string(), "no options specified");
+}
+
+#[test]
+fn config_rejects_a_group_that_is_not_a_mapping_of_options() {
+    for value in [json!({"ldap": {}}), json!({"ldap": "ldap://host"})] {
+        let err = DomainConfig::from_value(value.clone()).expect_err("refused");
+        assert_eq!(
+            err.to_string(),
+            "the value of group ldap specified in the config should be a dictionary of options",
+            "{value}"
+        );
+    }
+}
+
+#[test]
+fn validate_accepts_a_group_holding_only_the_password() {
+    // A domain may configure nothing but its bind password; the group is not
+    // empty just because nothing in it is readable.
+    config_from(json!({"ldap": {"password": PASSWORD}}))
+        .validate()
+        .expect("a sensitive option is an option");
+}
+
+#[test]
+fn group_round_trips_through_options() {
+    let group = DomainConfigGroup::from_options(
+        DomainConfigGroupName::Identity,
+        [DomainConfigOption::new(
+            DomainConfigGroupName::Identity,
+            "driver",
+            "ldap",
+        )],
+    )
+    .expect("a group of its own options");
+    assert_eq!(group.name(), DomainConfigGroupName::Identity);
+    assert_eq!(group.get("driver"), Some(&json!("ldap")));
+    assert_eq!(group.to_options().len(), 1);
+
+    let config = group.into_config();
+    assert!(config.group(DomainConfigGroupName::Ldap).is_none());
+    assert!(!config.is_empty());
+}
+
+#[test]
+fn group_rejects_options_of_another_group() {
+    let err = DomainConfigGroup::from_options(
+        DomainConfigGroupName::Identity,
+        [DomainConfigOption::new(
+            DomainConfigGroupName::Ldap,
+            "url",
+            "ldap://host",
+        )],
+    )
+    .expect_err("an option of another group is refused");
+    assert_eq!(
+        err.to_string(),
+        "option url in group identity is not supported for domain specific configurations"
+    );
+}
+
+mod values {
+    //! What an option may hold is defined by the config section it overrides,
+    //! not by this module; these check that it is really consulted.
+
+    use super::*;
+
+    #[test]
+    fn accepts_the_config_file_spelling_of_a_value() {
+        // Every value of a per-domain `keystone.<domain>.conf` is a string.
+        config_from(json!({"ldap": {
+            "use_tls": "True",
+            "page_size": "10",
+            "pool_retry_delay": "0.1",
+            "user_attribute_ignore": "mail,enabled",
+            "tls_req_cert": "never",
+        }}))
+        .validate_values()
+        .expect("oslo.config spellings are accepted");
+    }
+
+    #[test]
+    fn accepts_integer_spelled_booleans() {
+        config_from(json!({"ldap": {"use_tls": 1, "use_pool": 0}}))
+            .validate_values()
+            .expect("0/1 are accepted for a boolean");
+    }
+
+    #[test]
+    fn rejects_a_value_the_option_cannot_hold() {
+        let err = config_from(json!({"ldap": {"page_size": "ten"}}))
+            .validate_values()
+            .expect_err("a page size is an integer");
+        assert_eq!(
+            err.to_string(),
+            "invalid value for option page_size in group ldap: expected an integer, got `\"ten\"`"
+        );
+    }
+
+    #[test]
+    fn names_the_offending_option_among_many() {
+        // serde reports a failing value without naming the field it came from,
+        // which on a 49 option group leaves an operator guessing.
+        let err = config_from(json!({"ldap": {
+            "url": "ldap://host",
+            "page_size": 10,
+            "use_tls": "maybe",
+            "suffix": "dc=example,dc=com",
+        }}))
+        .validate_values()
+        .expect_err("a boolean is a boolean");
+        assert_eq!(
+            err.to_string(),
+            "invalid value for option use_tls in group ldap: expected a boolean, got `\"maybe\"`"
+        );
+    }
+
+    #[test]
+    fn accepts_both_spellings_of_the_identity_list_limit() {
+        for value in [json!(100), json!("100")] {
+            config_from(json!({"identity": {"list_limit": value}}))
+                .validate_values()
+                .expect("a page size");
+        }
+        let err = config_from(json!({"identity": {"list_limit": "many"}}))
+            .validate_values()
+            .expect_err("refused");
+        assert!(
+            err.to_string()
+                .starts_with("invalid value for option list_limit in group identity"),
+            "{err}"
+        );
+    }
+}
+
+mod resolution {
+    //! The point of the whole module: a domain's options resolve into the very
+    //! struct the identity backend is configured with.
+
+    use super::*;
+
+    #[test]
+    fn overlays_the_domain_options_onto_the_global_section() {
+        let mut config = Config::default();
+        config.ldap.url = "ldap://global".to_string();
+        config.ldap.suffix = "dc=global".to_string();
+
+        let ldap = config_from(json!({"ldap": {"url": "ldap://domain", "page_size": "25"}}))
+            .resolve_ldap(&config)
+            .expect("resolvable");
+        assert_eq!(ldap.url, "ldap://domain");
+        assert_eq!(ldap.page_size, 25);
+        // Untouched options keep the global value...
+        assert_eq!(ldap.suffix, "dc=global");
+        // ...and options the domain may not set keep theirs, defaults
+        // included.
+        assert_eq!(ldap.user_objectclass, config.ldap.user_objectclass);
+    }
+
+    #[test]
+    fn keeps_the_global_bind_password_when_the_domain_sets_none() {
+        let mut config = Config::default();
+        config.ldap.password = Some(SecretString::from("global-secret"));
+
+        let ldap = config_from(json!({"ldap": {"url": "ldap://domain"}}))
+            .resolve_ldap(&config)
+            .expect("resolvable");
+        assert_eq!(
+            ldap.password
+                .map(|password| password.expose_secret().to_string()),
+            Some("global-secret".to_string()),
+            "the global bind password must survive the overlay"
+        );
+    }
+
+    #[test]
+    fn takes_the_domain_bind_password_over_the_global_one() {
+        let mut config = Config::default();
+        config.ldap.password = Some(SecretString::from("global-secret"));
+
+        let ldap = config_from(json!({"ldap": {"password": PASSWORD}}))
+            .resolve_ldap(&config)
+            .expect("resolvable");
+        assert_eq!(
+            ldap.password
+                .map(|password| password.expose_secret().to_string()),
+            Some(PASSWORD.to_string())
+        );
+    }
+
+    #[test]
+    fn an_explicit_null_password_does_not_inherit_the_global_one() {
+        let mut config = Config::default();
+        config.ldap.password = Some(SecretString::from("global-secret"));
+
+        let ldap = config_from(json!({"ldap": {"password": null}}))
+            .resolve_ldap(&config)
+            .expect("resolvable");
+        assert!(
+            ldap.password.is_none(),
+            "an explicit null requests an anonymous bind"
+        );
+    }
+
+    #[test]
+    fn keeps_the_global_list_limit_cap_when_the_domain_sets_a_page_size() {
+        // `max_list_limit` has no domain-settable spelling of its own, and
+        // `list_limit` is whitelisted as the scalar python-keystone spells it,
+        // so overriding the page size must not lift the operator's cap on what
+        // a client may ask for.
+        let mut config = Config::default();
+        config.identity.list_limit.list_limit = Some(50);
+        config.identity.list_limit.max_list_limit = Some(1000);
+
+        let identity = config_from(json!({"identity": {"list_limit": 100}}))
+            .resolve_identity(&config)
+            .expect("resolvable");
+        assert_eq!(identity.list_limit.list_limit, Some(100));
+        assert_eq!(identity.list_limit.max_list_limit, Some(1000));
+    }
+
+    #[test]
+    fn resolves_a_domain_that_configured_nothing() {
+        let mut config = Config::default();
+        config.ldap.url = "ldap://global".to_string();
+        config.identity.driver = "ldap".to_string();
+
+        let empty = DomainConfig::new();
+        assert_eq!(
+            empty.resolve_ldap(&config).expect("resolvable").url,
+            "ldap://global"
+        );
+        assert_eq!(
+            empty.resolve_identity(&config).expect("resolvable").driver,
+            "ldap"
+        );
+    }
+
+    #[test]
+    fn resolves_the_identity_group() {
+        let config = Config::default();
+        let identity = config_from(json!({"identity": {"driver": "ldap", "list_limit": 100}}))
+            .resolve_identity(&config)
+            .expect("resolvable");
+        assert_eq!(identity.driver, "ldap");
+        assert_eq!(identity.list_limit.list_limit, Some(100));
+        assert_eq!(
+            identity.max_password_length, config.identity.max_password_length,
+            "an option a domain cannot set keeps the global value"
+        );
+    }
+
+    #[test]
+    fn reports_the_option_that_cannot_be_resolved() {
+        let err = config_from(json!({"ldap": {"page_size": "ten"}}))
+            .resolve_ldap(&Config::default())
+            .expect_err("a page size is an integer");
+        assert_eq!(
+            err.to_string(),
+            "invalid value for option page_size in group ldap: expected an integer, got `\"ten\"`"
+        );
+    }
+
+    #[test]
+    fn a_substituted_configuration_cannot_reach_a_response() {
+        // Expansion inlines the bind password into `ldap.url`, which is a
+        // readable option; the type it comes back in is what keeps it off the
+        // wire and out of a log.
+        let substituted = config_from(json!({"ldap": {
+            "url": "ldap://%(password)s@myldap.com:389/",
+            "password": PASSWORD,
+        }}))
+        .substitute();
+        assert!(
+            substituted
+                .option(DomainConfigGroupName::Ldap, "url")
+                .and_then(Value::as_str)
+                .is_some_and(|url| url.contains(PASSWORD)),
+            "the reference resolved, so this is the value that must not escape"
+        );
+        assert!(!format!("{substituted:?}").contains(PASSWORD));
+
+        let ldap = substituted
+            .resolve_ldap(&Config::default())
+            .expect("resolvable");
+        assert!(
+            ldap.url.contains(PASSWORD),
+            "the provider received the secret"
+        );
+        assert_eq!(format!("{ldap:?}"), "ResolvedLdapProvider(REDACTED)");
+        assert!(!format!("{ldap:?}").contains(PASSWORD));
+    }
+
+    #[test]
+    fn resolves_a_substituted_configuration() {
+        let config = Config::default();
+        let stored = config_from(json!({"ldap": {
+            "url": "ldap://%(user)s:%(password)s@myldap.com:389/",
+            "user": "cn=admin",
+            "password": PASSWORD,
+        }}));
+        let ldap = stored
+            .substitute()
+            .resolve_ldap(&config)
+            .expect("resolvable");
+        assert_eq!(
+            ldap.url.as_str(),
+            format!("ldap://cn=admin:{PASSWORD}@myldap.com:389/")
+        );
+    }
+}
+
+#[test]
+fn every_configurable_option_is_an_option_of_the_config_section() {
+    // The anti-drift check: the whitelist names options of the very sections
+    // it overrides, so an option that is renamed or dropped there fails here
+    // rather than silently becoming unsettable.
+    let sections = [
+        (
+            DomainConfigGroupName::Identity,
+            serde_json::to_value(IdentityProvider::default()).expect("serializable"),
+        ),
+        (
+            DomainConfigGroupName::Ldap,
+            serde_json::to_value(LdapProvider::default()).expect("serializable"),
+        ),
+    ];
+    for (group, section) in sections {
+        let section = section.as_object().expect("a config section is a mapping");
+        for option in whitelisted_options(group) {
+            assert!(
+                section.contains_key(*option),
+                "`{option}` is whitelisted for group {group} but is not an option of its config section"
+            );
+        }
+    }
+
+    // Sensitive options are never serialized, so they are checked by writing
+    // one: `ldap.password` has to reach `LdapProvider::password`.
+    assert_eq!(
+        sensitive_options(DomainConfigGroupName::Ldap),
+        &["password"]
+    );
+    let ldap = config_from(json!({"ldap": {"password": PASSWORD}}))
+        .resolve_ldap(&Config::default())
+        .expect("resolvable");
+    assert_eq!(
+        ldap.password
+            .map(|password| password.expose_secret().to_string()),
+        Some(PASSWORD.to_string())
+    );
+}
+
+#[test]
+fn defaults_cover_every_whitelisted_option() {
+    let config = Config::default();
+    let options = DomainConfig::default_options(&config, None).expect("defaults");
+
+    for group in DomainConfigGroupName::ALL {
+        let expected: HashSet<String> = whitelisted_options(*group)
+            .iter()
+            .map(|option| (*option).to_string())
+            .collect();
+        assert_eq!(
+            option_names(&options, *group),
+            expected,
+            "default options of group {group} drifted from the whitelist"
+        );
+    }
+}
+
+#[test]
+fn defaults_never_include_sensitive_options() {
+    let mut config = Config::default();
+    config.ldap.password = Some(SecretString::from(PASSWORD));
+
+    let options = DomainConfig::default_options(&config, None).expect("defaults");
+    for option in &options {
+        assert!(
+            !is_sensitive(option.group, &option.option),
+            "{} leaked into the defaults",
+            option.option
+        );
+    }
+    let defaults = DomainConfig::defaults(&config).expect("defaults");
+    assert!(
+        defaults
+            .group(DomainConfigGroupName::Ldap)
+            .and_then(|group| group.get("password"))
+            .is_none()
+    );
+    assert!(!format!("{defaults:?}").contains(PASSWORD));
+}
+
+#[test]
+fn defaults_carry_the_configured_values() {
+    let mut config = Config::default();
+    config.identity.driver = "ldap".to_string();
+    config.ldap.url = "ldaps://ldap.example.com".to_string();
+    config.ldap.page_size = 42;
+    config.ldap.use_tls = true;
+    config.ldap.pool = false;
+
+    let defaults = DomainConfig::defaults(&config).expect("defaults");
+    assert_eq!(
+        defaults
+            .group(DomainConfigGroupName::Identity)
+            .and_then(|group| group.get("driver")),
+        Some(&json!("ldap"))
+    );
+    let ldap = defaults.group(DomainConfigGroupName::Ldap).expect("ldap");
+    assert_eq!(ldap.get("url"), Some(&json!("ldaps://ldap.example.com")));
+    assert_eq!(ldap.get("page_size"), Some(&json!(42)));
+    assert_eq!(ldap.get("use_tls"), Some(&json!(true)));
+    // python-keystone's spelling of the pooling flags is the one the API
+    // contract uses, and now the one the config section carries.
+    assert_eq!(ldap.get("use_pool"), Some(&json!(false)));
+    assert_eq!(ldap.get("use_auth_pool"), Some(&json!(true)));
+}
+
+#[test]
+fn defaults_report_a_list_option_as_a_list() {
+    let defaults = DomainConfig::defaults(&Config::default()).expect("defaults");
+    let ldap = defaults.group(DomainConfigGroupName::Ldap).expect("ldap");
+    assert_eq!(
+        ldap.get("user_attribute_ignore"),
+        Some(&json!(["default_project_id"])),
+        "oslo.config's list options are reported as lists"
+    );
+    assert_eq!(
+        ldap.get("user_additional_attribute_mapping"),
+        Some(&json!([]))
+    );
+}
+
+#[test]
+fn identity_list_limit_default_falls_back_to_the_global_one() {
+    // `Config::resolve_list_limit` resolves `[identity] list_limit` through
+    // `[DEFAULT] list_limit`. The defaults endpoint exists to tell an operator
+    // the value a domain inherits, so it has to follow the same chain.
+    let mut config = Config::default();
+    config.default.list_limit = Some(200);
+    assert_eq!(config.identity.list_limit.list_limit, None);
+    assert_eq!(
+        DomainConfig::default_option(&config, DomainConfigGroupName::Identity, "list_limit")
+            .expect("readable")
+            .map(DomainConfigValue::into_value),
+        Some(json!(200)),
+        "the global list_limit is what identity listings are really capped at"
+    );
+
+    // The section-local value still wins when it is set.
+    config.identity.list_limit.list_limit = Some(50);
+    assert_eq!(
+        DomainConfig::default_option(&config, DomainConfigGroupName::Identity, "list_limit")
+            .expect("readable")
+            .map(DomainConfigValue::into_value),
+        Some(json!(50))
+    );
+}
+
+#[test]
+fn defaults_of_a_group_are_restricted_to_it() {
+    let config = Config::default();
+    let options = DomainConfig::default_options(&config, Some(DomainConfigGroupName::Ldap))
+        .expect("defaults");
+    assert!(
+        options
+            .iter()
+            .all(|option| option.group == DomainConfigGroupName::Ldap)
+    );
+    assert_eq!(options.len(), LDAP_WHITELISTED_OPTIONS.len());
+
+    let group = DomainConfig::default_group(&config, DomainConfigGroupName::Identity)
+        .expect("the identity defaults");
+    assert_eq!(group.name(), DomainConfigGroupName::Identity);
+    assert_eq!(group.get("driver"), Some(&json!(config.identity.driver)));
+}
+
+#[test]
+fn default_option_reads_a_single_value() {
+    let config = Config::default();
+    let value = DomainConfig::default_option(&config, DomainConfigGroupName::Identity, "driver")
+        .expect("readable")
+        .expect("driver default");
+    assert_eq!(value.as_str(), Some(config.identity.driver.as_str()));
+}
+
+#[test]
+fn default_option_keeps_unconfigured_options_as_null() {
+    // `[ldap] user` has no default, and python-keystone still reports it.
+    let value =
+        DomainConfig::default_option(&Config::default(), DomainConfigGroupName::Ldap, "user")
+            .expect("readable")
+            .expect("user default");
+    assert!(value.as_value().is_null());
+}
+
+#[test]
+fn default_option_refuses_sensitive_options() {
+    for option in sensitive_options(DomainConfigGroupName::Ldap) {
+        let err =
+            DomainConfig::default_option(&Config::default(), DomainConfigGroupName::Ldap, option)
+                .expect_err("a secret has no readable default");
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "option {option} in group ldap is not supported for domain specific configurations"
+            )
+        );
+    }
+}
+
+#[test]
+fn create_and_update_wrap_a_config() {
+    let create = DomainConfigCreate::from(sample_config());
+    assert_eq!(
+        create
+            .group(DomainConfigGroupName::Ldap)
+            .and_then(|group| group.get("url")),
+        Some(&json!("ldap://myldap.com:389/"))
+    );
+    assert!(!create.into_inner().is_empty());
+
+    let mut update = DomainConfigUpdate::default();
+    assert!(update.is_empty());
+    update
+        .set(DomainConfigGroupName::Identity, "driver", "sql")
+        .expect("a whitelisted option");
+    assert!(!update.is_empty());
+    assert_eq!(DomainConfig::from(update).to_options().len(), 1);
+}
+
+mod substitution {
+    use super::*;
+
+    /// An `ldap` group whose `url` references other options of the group.
+    fn config_with_references(url: &str) -> DomainConfig {
+        config_from(json!({"ldap": {
+            "url": url,
+            "user": "cn=admin",
+            "password": PASSWORD,
+        }}))
+    }
+
+    /// The `ldap.url` of a substituted configuration.
+    fn substituted_url(config: &DomainConfig) -> String {
+        config
+            .substitute()
+            .option(DomainConfigGroupName::Ldap, "url")
+            .and_then(Value::as_str)
+            .expect("the url survives substitution")
+            .to_string()
+    }
+
+    #[test]
+    fn resolves_a_sensitive_reference() {
+        assert_eq!(
+            substituted_url(&config_with_references(
+                "ldap://%(user)s:%(password)s@myldap.com:389/"
+            )),
+            format!("ldap://cn=admin:{PASSWORD}@myldap.com:389/")
+        );
+    }
+
+    #[test]
+    fn leaves_the_stored_value_untouched() {
+        let config = config_with_references("ldap://%(password)s@myldap.com:389/");
+        config.substitute();
+        assert_eq!(
+            config
+                .group(DomainConfigGroupName::Ldap)
+                .and_then(|group| group.get("url")),
+            Some(&json!("ldap://%(password)s@myldap.com:389/")),
+            "substitution must not rewrite what is stored and returned by the API"
+        );
+    }
+
+    #[test]
+    fn keeps_a_value_that_references_nothing() {
+        assert_eq!(
+            substituted_url(&config_with_references("ldap://myldap.com:389/")),
+            "ldap://myldap.com:389/"
+        );
+    }
+
+    #[test]
+    fn keeps_a_value_referencing_an_option_that_is_not_configured() {
+        // python-keystone warns and leaves the value as it is rather than
+        // failing the read of the whole configuration.
+        assert_eq!(
+            substituted_url(&config_with_references("ldap://%(suffix)s/")),
+            "ldap://%(suffix)s/"
+        );
+    }
+
+    #[test]
+    fn keeps_a_malformed_reference() {
+        for url in [
+            "ldap://%(password@myldap.com/",
+            "ldap://%(password)d@myldap.com/",
+            "ldap://100%@myldap.com/",
+        ] {
+            assert_eq!(substituted_url(&config_with_references(url)), url);
+        }
+    }
+
+    #[test]
+    fn unescapes_a_literal_percent() {
+        assert_eq!(
+            substituted_url(&config_with_references("ldap://myldap.com/100%%")),
+            "ldap://myldap.com/100%"
+        );
+    }
+
+    #[test]
+    fn does_not_substitute_into_a_secret() {
+        let config = config_from(json!({"ldap": {"user": "cn=admin", "password": "%(user)s"}}));
+        assert_eq!(
+            config
+                .substitute()
+                .option(DomainConfigGroupName::Ldap, "password"),
+            Some(&json!("%(user)s"))
+        );
+    }
+
+    #[test]
+    fn does_not_cross_group_boundaries() {
+        let config = config_from(json!({
+            "identity": {"driver": "%(password)s"},
+            "ldap": {"password": PASSWORD},
+        }));
+        assert_eq!(
+            config
+                .substitute()
+                .option(DomainConfigGroupName::Identity, "driver"),
+            Some(&json!("%(password)s")),
+            "an option must not reach the secrets of another group"
+        );
+    }
+
+    #[test]
+    fn leaves_values_that_are_not_strings_alone() {
+        let config = config_from(json!({"ldap": {
+            "page_size": 10,
+            "use_tls": true,
+            "password": PASSWORD,
+        }}));
+        let substituted = config.substitute();
+        assert_eq!(
+            substituted.option(DomainConfigGroupName::Ldap, "page_size"),
+            Some(&json!(10))
+        );
+        assert_eq!(
+            substituted.option(DomainConfigGroupName::Ldap, "use_tls"),
+            Some(&json!(true))
+        );
+    }
+
+    #[test]
+    fn keeps_an_unconfigured_group_unconfigured() {
+        assert!(
+            config_with_references("ldap://myldap.com/")
+                .substitute()
+                .option(DomainConfigGroupName::Identity, "driver")
+                .is_none()
+        );
+    }
+}

--- a/crates/core-types/src/domain_config/error.rs
+++ b/crates/core-types/src/domain_config/error.rs
@@ -1,0 +1,177 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Domain configuration provider errors
+
+use thiserror::Error;
+
+use crate::error::BuilderError;
+
+/// Domain configuration provider error.
+///
+/// The `Unsupported*` and `Empty*` variants correspond to python-keystone's
+/// `InvalidDomainConfig`, which the v3 API reports as `403 Forbidden` (see
+/// `api-ref/source/v3/domains-config-v3.inc`: "If you try to create or update
+/// configuration options for groups other than the `identity` or `ldap`
+/// groups, the `Forbidden (403)` response code is returned"). [`Self::NotFound`]
+/// corresponds to `DomainConfigNotFound` (`404`).
+#[derive(Error, Debug)]
+pub enum DomainConfigProviderError {
+    /// Conflict.
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Driver error.
+    #[error("backend driver error: {0}")]
+    Driver(String),
+
+    /// The request carried no configuration at all.
+    #[error("no options specified")]
+    EmptyConfig,
+
+    /// A group in the request did not carry a mapping of options.
+    #[error("the value of group {0} specified in the config should be a dictionary of options")]
+    GroupNotAMapping(String),
+
+    /// A stored (or supplied) option value has a type the option cannot hold,
+    /// and the offending option could be pinpointed.
+    #[error("invalid value for option {option} in group {group}: {source}")]
+    InvalidOptionValue {
+        /// The group holding the offending option.
+        group: String,
+        /// The offending option.
+        option: String,
+        /// The underlying (de)serialization failure.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// A group could not be decoded and no single option accounts for it.
+    #[error("invalid value for an option of the group {group}: {source}")]
+    InvalidValue {
+        /// The group that could not be decoded.
+        group: String,
+        /// The underlying (de)serialization failure.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// No configuration exists for the requested domain/group/option.
+    #[error("could not find {group_or_option} for domain {domain_id}")]
+    NotFound {
+        /// The domain the lookup was scoped to.
+        domain_id: String,
+        /// Human readable description of what was looked up, e.g.
+        /// `option url in group ldap` or `any options`.
+        group_or_option: String,
+    },
+
+    /// An option was specified without its group. The API routing makes this
+    /// impossible, so it always indicates a coding error.
+    #[error("option {0} found with no group specified while checking domain configuration request")]
+    OptionWithoutGroup(String),
+
+    /// (de)serialization error.
+    #[error("data serialization error")]
+    Serde {
+        /// The source of the error.
+        #[from]
+        source: serde_json::Error,
+    },
+
+    /// Structures builder error.
+    #[error(transparent)]
+    StructBuilder {
+        /// The source of the error.
+        #[from]
+        source: BuilderError,
+    },
+
+    /// The requested group is not one of the domain-configurable groups.
+    #[error("group {0} is not supported for domain specific configurations")]
+    UnsupportedGroup(String),
+
+    /// The requested option is not whitelisted (nor sensitive) in its group.
+    #[error("option {option} in group {group} is not supported for domain specific configurations")]
+    UnsupportedOption {
+        /// The group the option was looked up in.
+        group: String,
+        /// The rejected option name.
+        option: String,
+    },
+
+    /// Unsupported driver.
+    #[error("unsupported driver `{0}` for the domain config provider")]
+    UnsupportedDriver(String),
+
+    /// Request validation error.
+    #[error("request validation error: {}", source)]
+    Validation {
+        /// The source of the error.
+        #[from]
+        source: validator::ValidationErrors,
+    },
+}
+
+impl DomainConfigProviderError {
+    /// Build a [`Self::NotFound`] for a whole domain configuration.
+    ///
+    /// # Parameters
+    /// - `domain_id`: The domain the configuration was looked up for.
+    ///
+    /// # Returns
+    /// - `Self` - The `NotFound` error with python-keystone's `any options`
+    ///   wording.
+    pub fn config_not_found<D: Into<String>>(domain_id: D) -> Self {
+        Self::NotFound {
+            domain_id: domain_id.into(),
+            group_or_option: "any options".to_string(),
+        }
+    }
+
+    /// Build a [`Self::NotFound`] for a single group.
+    ///
+    /// # Parameters
+    /// - `domain_id`: The domain the configuration was looked up for.
+    /// - `group`: The group that has no stored options.
+    ///
+    /// # Returns
+    /// - `Self` - The `NotFound` error.
+    pub fn group_not_found<D: Into<String>, G: std::fmt::Display>(domain_id: D, group: G) -> Self {
+        Self::NotFound {
+            domain_id: domain_id.into(),
+            group_or_option: format!("group {group}"),
+        }
+    }
+
+    /// Build a [`Self::NotFound`] for a single option.
+    ///
+    /// # Parameters
+    /// - `domain_id`: The domain the configuration was looked up for.
+    /// - `group`: The group the option belongs to.
+    /// - `option`: The option that has no stored value.
+    ///
+    /// # Returns
+    /// - `Self` - The `NotFound` error.
+    pub fn option_not_found<D: Into<String>, G: std::fmt::Display, O: std::fmt::Display>(
+        domain_id: D,
+        group: G,
+        option: O,
+    ) -> Self {
+        Self::NotFound {
+            domain_id: domain_id.into(),
+            group_or_option: format!("option {option} in group {group}"),
+        }
+    }
+}

--- a/crates/core-types/src/domain_config/lenient.rs
+++ b/crates/core-types/src/domain_config/lenient.rs
@@ -1,0 +1,590 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # oslo.config compatible decoding of stored values
+//!
+//! Domain configuration values reach us from two sources with different
+//! fidelity: the REST API, where a client sends real JSON types, and a
+//! `keystone.<domain>.conf` file, where every value is a string.
+//! python-keystone hands both to oslo.config, which coerces the string form
+//! (`"True"`, `"10"`, `"a,b"`) into the type the option was declared with.
+//!
+//! [`from_value`] reproduces that coercion while decoding into the ordinary
+//! config structs of [`openstack_keystone_config`], so a `use_tls` written as
+//! `true` and one written as `"True"` decode identically without either
+//! struct having to declare anything about it. It is a [`Deserializer`]
+//! adaptor rather than a set of field attributes precisely so that it stays
+//! independent of the struct it decodes into: an option added to
+//! `LdapProvider` is covered by it the day it is added.
+
+use std::fmt;
+
+use serde::de::value::StringDeserializer;
+use serde::de::{
+    self, DeserializeOwned, DeserializeSeed, Deserializer, IntoDeserializer, MapAccess, SeqAccess,
+    Visitor,
+};
+use serde_json::{Map, Value};
+
+/// Decode a JSON value into `T`, coercing scalars the way oslo.config does.
+///
+/// # Parameters
+/// - `value`: The raw value, as stored or as sent by a client.
+///
+/// # Returns
+/// - `Result<T, serde_json::Error>` - The decoded value, or an error naming
+///   what was expected and what arrived.
+pub fn from_value<T: DeserializeOwned>(value: Value) -> Result<T, serde_json::Error> {
+    T::deserialize(LenientValue(value))
+}
+
+/// A JSON value that decodes leniently; see [`from_value`].
+struct LenientValue(Value);
+
+/// Describe a value that cannot be coerced to what the target asked for.
+///
+/// # Parameters
+/// - `expected`: What the option can hold.
+/// - `value`: The value that arrived.
+///
+/// # Returns
+/// - `serde_json::Error` - The error to report.
+fn mismatch(expected: &str, value: &Value) -> serde_json::Error {
+    de::Error::custom(format!("expected {expected}, got `{value}`"))
+}
+
+/// Coerce a value to a boolean the way oslo.config's `BoolOpt` reads it.
+///
+/// Integers are accepted as `0`/`1` because that is what a `BoolOpt` becomes
+/// once the stored JSON reaches python code.
+///
+/// # Parameters
+/// - `value`: The raw value.
+///
+/// # Returns
+/// - `Result<bool, serde_json::Error>` - The flag, or a mismatch error.
+fn coerce_bool(value: &Value) -> Result<bool, serde_json::Error> {
+    match value {
+        Value::Bool(flag) => Ok(*flag),
+        Value::Number(number) => match number.as_i64() {
+            Some(0) => Ok(false),
+            Some(1) => Ok(true),
+            _ => Err(mismatch("a boolean", value)),
+        },
+        Value::String(text) => match text.trim().to_ascii_lowercase().as_str() {
+            "true" | "t" | "yes" | "y" | "on" | "1" => Ok(true),
+            "false" | "f" | "no" | "n" | "off" | "0" => Ok(false),
+            _ => Err(mismatch("a boolean", value)),
+        },
+        _ => Err(mismatch("a boolean", value)),
+    }
+}
+
+/// Coerce a value to a signed integer.
+///
+/// # Parameters
+/// - `value`: The raw value.
+///
+/// # Returns
+/// - `Result<i64, serde_json::Error>` - The integer, or a mismatch error.
+fn coerce_i64(value: &Value) -> Result<i64, serde_json::Error> {
+    match value {
+        Value::Number(number) => number.as_i64().ok_or_else(|| mismatch("an integer", value)),
+        Value::String(text) => text
+            .trim()
+            .parse()
+            .map_err(|_| mismatch("an integer", value)),
+        _ => Err(mismatch("an integer", value)),
+    }
+}
+
+/// Coerce a value to an unsigned integer.
+///
+/// # Parameters
+/// - `value`: The raw value.
+///
+/// # Returns
+/// - `Result<u64, serde_json::Error>` - The integer, or a mismatch error.
+fn coerce_u64(value: &Value) -> Result<u64, serde_json::Error> {
+    match value {
+        Value::Number(number) => number
+            .as_u64()
+            .ok_or_else(|| mismatch("a positive integer", value)),
+        Value::String(text) => text
+            .trim()
+            .parse()
+            .map_err(|_| mismatch("a positive integer", value)),
+        _ => Err(mismatch("a positive integer", value)),
+    }
+}
+
+/// Coerce a value to a floating point number.
+///
+/// # Parameters
+/// - `value`: The raw value.
+///
+/// # Returns
+/// - `Result<f64, serde_json::Error>` - The number, or a mismatch error.
+fn coerce_f64(value: &Value) -> Result<f64, serde_json::Error> {
+    match value {
+        Value::Number(number) => number.as_f64().ok_or_else(|| mismatch("a number", value)),
+        Value::String(text) => text.trim().parse().map_err(|_| mismatch("a number", value)),
+        _ => Err(mismatch("a number", value)),
+    }
+}
+
+/// Coerce a value to a string.
+///
+/// A scalar is rendered the way python's `str()` renders it, which is what a
+/// `StrOpt` given a JSON boolean or number ends up holding.
+///
+/// # Parameters
+/// - `value`: The raw value.
+///
+/// # Returns
+/// - `Result<String, serde_json::Error>` - The text, or a mismatch error.
+fn coerce_string(value: &Value) -> Result<String, serde_json::Error> {
+    match value {
+        Value::String(text) => Ok(text.clone()),
+        Value::Bool(true) => Ok("True".to_string()),
+        Value::Bool(false) => Ok("False".to_string()),
+        Value::Number(number) => Ok(number.to_string()),
+        _ => Err(mismatch("a string", value)),
+    }
+}
+
+/// Coerce a value to a list the way oslo.config's `ListOpt` reads it.
+///
+/// # Parameters
+/// - `value`: The raw value; a JSON array, or the comma separated spelling.
+///
+/// # Returns
+/// - `Result<Vec<Value>, serde_json::Error>` - The entries, with surrounding
+///   whitespace removed and empty ones dropped, or a mismatch error.
+fn coerce_seq(value: Value) -> Result<Vec<Value>, serde_json::Error> {
+    match value {
+        Value::Array(entries) => Ok(entries),
+        Value::String(ref text) => Ok(text
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .map(|entry| Value::String(entry.to_string()))
+            .collect()),
+        ref other => Err(mismatch("a list", other)),
+    }
+}
+
+impl<'de> Deserializer<'de> for LenientValue {
+    type Error = serde_json::Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.0 {
+            Value::Null => visitor.visit_unit(),
+            Value::Bool(flag) => visitor.visit_bool(flag),
+            Value::String(text) => visitor.visit_string(text),
+            Value::Array(entries) => visitor.visit_seq(SeqAdaptor::new(entries)),
+            Value::Object(map) => visitor.visit_map(MapAdaptor::new(map)),
+            // Numbers carry a width of their own; serde_json already picks the
+            // right `visit_*` for them.
+            number => number.deserialize_any(visitor),
+        }
+    }
+
+    fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_bool(coerce_bool(&self.0)?)
+    }
+
+    fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i64(coerce_i64(&self.0)?)
+    }
+
+    fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i64(coerce_i64(&self.0)?)
+    }
+
+    fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i64(coerce_i64(&self.0)?)
+    }
+
+    fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i64(coerce_i64(&self.0)?)
+    }
+
+    fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u64(coerce_u64(&self.0)?)
+    }
+
+    fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u64(coerce_u64(&self.0)?)
+    }
+
+    fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u64(coerce_u64(&self.0)?)
+    }
+
+    fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u64(coerce_u64(&self.0)?)
+    }
+
+    fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_f64(coerce_f64(&self.0)?)
+    }
+
+    fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_f64(coerce_f64(&self.0)?)
+    }
+
+    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_string(coerce_string(&self.0)?)
+    }
+
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.0 {
+            Value::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_seq(SeqAdaptor::new(coerce_seq(self.0)?))
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.0 {
+            Value::Object(map) => visitor.visit_map(MapAdaptor::new(map)),
+            ref other => Err(mismatch("a mapping", other)),
+        }
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.0 {
+            // The config enums are unit-only (`tls_req_cert = never`), which
+            // is the only spelling a config file can deliver.
+            Value::String(text) => {
+                let variant: StringDeserializer<Self::Error> = text.into_deserializer();
+                visitor.visit_enum(variant)
+            }
+            other => other.deserialize_enum(name, variants, visitor),
+        }
+    }
+
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_unit()
+    }
+}
+
+/// Sequence access that keeps its entries lenient.
+struct SeqAdaptor {
+    /// The remaining entries.
+    entries: std::vec::IntoIter<Value>,
+}
+
+impl SeqAdaptor {
+    /// Wrap the entries of an array.
+    ///
+    /// # Parameters
+    /// - `entries`: The array entries.
+    ///
+    /// # Returns
+    /// - `Self` - The access.
+    fn new(entries: Vec<Value>) -> Self {
+        Self {
+            entries: entries.into_iter(),
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for SeqAdaptor {
+    type Error = serde_json::Error;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error> {
+        match self.entries.next() {
+            Some(entry) => seed.deserialize(LenientValue(entry)).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.entries.len())
+    }
+}
+
+/// Map access that keeps its values lenient.
+struct MapAdaptor {
+    /// The remaining entries.
+    entries: serde_json::map::IntoIter,
+    /// The value of the entry whose key was just handed out.
+    value: Option<Value>,
+}
+
+impl MapAdaptor {
+    /// Wrap the entries of an object.
+    ///
+    /// # Parameters
+    /// - `map`: The object.
+    ///
+    /// # Returns
+    /// - `Self` - The access.
+    fn new(map: Map<String, Value>) -> Self {
+        Self {
+            entries: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for MapAdaptor {
+    type Error = serde_json::Error;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, Self::Error> {
+        match self.entries.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                let key: StringDeserializer<Self::Error> = key.into_deserializer();
+                seed.deserialize(key).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, Self::Error> {
+        // `next_key_seed` always sets the value first; the fallback only keeps
+        // a misbehaving visitor from panicking.
+        seed.deserialize(LenientValue(self.value.take().unwrap_or(Value::Null)))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.entries.len())
+    }
+}
+
+impl fmt::Debug for LenientValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("LenientValue").field(&self.0).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use openstack_keystone_config::{
+        AliasDereferencing, IdentityProvider, LdapProvider, QueryScope, TlsReqCert,
+    };
+    use secrecy::ExposeSecret;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn decodes_real_json_types() {
+        let ldap: LdapProvider = from_value(json!({
+            "url": "ldaps://directory.example.com",
+            "use_tls": true,
+            "page_size": 100,
+            "pool_retry_delay": 0.5,
+            "user_attribute_ignore": ["mail", "enabled"],
+        }))
+        .unwrap();
+        assert_eq!(ldap.url, "ldaps://directory.example.com");
+        assert!(ldap.use_tls);
+        assert_eq!(ldap.page_size, 100);
+        assert!((ldap.pool_retry_delay - 0.5).abs() < f64::EPSILON);
+        assert_eq!(
+            ldap.user_attribute_ignore,
+            HashSet::from(["mail".to_string(), "enabled".to_string()])
+        );
+    }
+
+    #[test]
+    fn decodes_the_config_file_spelling_of_every_scalar() {
+        let ldap: LdapProvider = from_value(json!({
+            "use_tls": "True",
+            "use_pool": "0",
+            "page_size": "100",
+            "pool_retry_delay": "0.5",
+            "user_attribute_ignore": "mail, enabled ,",
+            "tls_req_cert": "never",
+            "query_scope": "sub",
+            "alias_dereferencing": "always",
+        }))
+        .unwrap();
+        assert!(ldap.use_tls);
+        assert!(!ldap.pool);
+        assert_eq!(ldap.page_size, 100);
+        assert!((ldap.pool_retry_delay - 0.5).abs() < f64::EPSILON);
+        assert_eq!(
+            ldap.user_attribute_ignore,
+            HashSet::from(["mail".to_string(), "enabled".to_string()])
+        );
+        assert_eq!(ldap.tls_req_cert, TlsReqCert::Never);
+        assert_eq!(ldap.query_scope, QueryScope::Sub);
+        assert_eq!(ldap.alias_dereferencing, AliasDereferencing::Always);
+    }
+
+    #[test]
+    fn accepts_integers_for_booleans() {
+        let ldap: LdapProvider = from_value(json!({"use_tls": 1, "use_pool": 0})).unwrap();
+        assert!(ldap.use_tls);
+        assert!(!ldap.pool);
+    }
+
+    #[test]
+    fn decodes_both_spellings_of_an_attribute_mapping() {
+        for value in [
+            json!({"user_additional_attribute_mapping": ["mail:email"]}),
+            json!({"user_additional_attribute_mapping": "mail:email"}),
+            json!({"user_additional_attribute_mapping": {"mail": "email"}}),
+        ] {
+            let ldap: LdapProvider = from_value(value.clone()).unwrap();
+            assert_eq!(
+                ldap.user_additional_attribute_mapping,
+                HashMap::from([("mail".to_string(), "email".to_string())]),
+                "{value}"
+            );
+        }
+    }
+
+    #[test]
+    fn decodes_a_secret_option() {
+        let ldap: LdapProvider = from_value(json!({"password": "s3cr3t"})).unwrap();
+        assert_eq!(
+            ldap.password
+                .map(|password| password.expose_secret().to_string()),
+            Some("s3cr3t".to_string())
+        );
+    }
+
+    #[test]
+    fn keeps_a_string_option_a_string() {
+        // `user_enabled_default` doubles as a boolean and as an integer
+        // literal, so it must stay whatever the client wrote.
+        let ldap: LdapProvider = from_value(json!({"user_enabled_default": "512"})).unwrap();
+        assert_eq!(ldap.user_enabled_default, "512");
+        let ldap: LdapProvider = from_value(json!({"user_enabled_default": true})).unwrap();
+        assert_eq!(ldap.user_enabled_default, "True");
+    }
+
+    #[test]
+    fn decodes_both_spellings_of_a_list_limit() {
+        let identity: IdentityProvider = from_value(json!({"list_limit": 100})).unwrap();
+        assert_eq!(identity.list_limit.list_limit, Some(100));
+        let identity: IdentityProvider = from_value(json!({"list_limit": "100"})).unwrap();
+        assert_eq!(identity.list_limit.list_limit, Some(100));
+        let identity: IdentityProvider =
+            from_value(json!({"list_limit": {"list_limit": 5, "max_list_limit": 50}})).unwrap();
+        assert_eq!(identity.list_limit.list_limit, Some(5));
+        assert_eq!(identity.list_limit.max_list_limit, Some(50));
+    }
+
+    #[test]
+    fn reports_what_it_expected() {
+        let err = from_value::<LdapProvider>(json!({"page_size": "ten"})).unwrap_err();
+        assert_eq!(err.to_string(), "expected an integer, got `\"ten\"`");
+        let err = from_value::<LdapProvider>(json!({"use_tls": "maybe"})).unwrap_err();
+        assert_eq!(err.to_string(), "expected a boolean, got `\"maybe\"`");
+        let err = from_value::<LdapProvider>(json!({"pool_retry_delay": "later"})).unwrap_err();
+        assert_eq!(err.to_string(), "expected a number, got `\"later\"`");
+        let err = from_value::<LdapProvider>(json!({"url": ["a"]})).unwrap_err();
+        assert_eq!(err.to_string(), "expected a string, got `[\"a\"]`");
+    }
+
+    #[test]
+    fn leaves_unknown_options_alone() {
+        // The whitelist is what rejects an unsupported option; decoding must
+        // not fail on a stored row it has no field for.
+        let ldap: LdapProvider = from_value(json!({"bind_dn": "cn=admin"})).unwrap();
+        assert_eq!(ldap.url, LdapProvider::default().url);
+    }
+}

--- a/crates/core-types/src/domain_config/option.rs
+++ b/crates/core-types/src/domain_config/option.rs
@@ -1,0 +1,539 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Domain configuration groups, options and values
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::DomainConfigProviderError;
+
+/// Name of a domain-configurable option group.
+///
+/// Only the two groups that influence the per-domain identity backend are
+/// configurable, matching the keys of python-keystone's
+/// `DomainConfigManager.whitelisted_options`.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DomainConfigGroupName {
+    /// The `[identity]` group: which identity driver the domain uses.
+    Identity,
+    /// The `[ldap]` group: how that domain's LDAP directory is reached.
+    Ldap,
+}
+
+impl DomainConfigGroupName {
+    /// Every configurable group, in a stable order.
+    pub const ALL: &'static [Self] = &[Self::Identity, Self::Ldap];
+
+    /// Wire name of the group.
+    ///
+    /// # Returns
+    /// - `&'static str` - The group name as it appears in the API and in the
+    ///   persistence layer.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Identity => "identity",
+            Self::Ldap => "ldap",
+        }
+    }
+}
+
+impl fmt::Display for DomainConfigGroupName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for DomainConfigGroupName {
+    type Err = DomainConfigProviderError;
+
+    /// Parse a group name coming from the API path or from storage.
+    ///
+    /// # Parameters
+    /// - `s`: The group name.
+    ///
+    /// # Returns
+    /// - `Result<Self, DomainConfigProviderError>` - The parsed group, or
+    ///   [`DomainConfigProviderError::UnsupportedGroup`].
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "identity" => Ok(Self::Identity),
+            "ldap" => Ok(Self::Ldap),
+            other => Err(DomainConfigProviderError::UnsupportedGroup(
+                other.to_string(),
+            )),
+        }
+    }
+}
+
+/// Whitelisted (readable) options of the `identity` group.
+pub const IDENTITY_WHITELISTED_OPTIONS: &[&str] = &["driver", "list_limit"];
+
+/// Sensitive (write-only) options of the `identity` group.
+pub const IDENTITY_SENSITIVE_OPTIONS: &[&str] = &[];
+
+/// Whitelisted (readable) options of the `ldap` group.
+///
+/// Transcribed verbatim from python-keystone's
+/// `DomainConfigManager.whitelisted_options['ldap']`. As the upstream comment
+/// stresses, the list is explicit rather than derived from the `[ldap]` config
+/// section: a newly added `[ldap]` option must never become domain-writable by
+/// accident.
+pub const LDAP_WHITELISTED_OPTIONS: &[&str] = &[
+    "url",
+    "user",
+    "suffix",
+    "query_scope",
+    "page_size",
+    "alias_dereferencing",
+    "debug_level",
+    "chase_referrals",
+    "user_tree_dn",
+    "user_filter",
+    "user_objectclass",
+    "user_id_attribute",
+    "user_name_attribute",
+    "user_mail_attribute",
+    "user_description_attribute",
+    "user_pass_attribute",
+    "user_enabled_attribute",
+    "user_enabled_invert",
+    "user_enabled_mask",
+    "user_enabled_default",
+    "user_attribute_ignore",
+    "user_default_project_id_attribute",
+    "user_enabled_emulation",
+    "user_enabled_emulation_dn",
+    "user_enabled_emulation_use_group_config",
+    "user_additional_attribute_mapping",
+    "group_tree_dn",
+    "group_filter",
+    "group_objectclass",
+    "group_id_attribute",
+    "group_name_attribute",
+    "group_members_are_ids",
+    "group_member_attribute",
+    "group_desc_attribute",
+    "group_attribute_ignore",
+    "group_additional_attribute_mapping",
+    "tls_cacertfile",
+    "tls_cacertdir",
+    "use_tls",
+    "tls_req_cert",
+    "use_pool",
+    "pool_size",
+    "pool_retry_max",
+    "pool_retry_delay",
+    "pool_connection_timeout",
+    "pool_connection_lifetime",
+    "use_auth_pool",
+    "auth_pool_size",
+    "auth_pool_connection_lifetime",
+];
+
+/// Sensitive (write-only) options of the `ldap` group.
+///
+/// Sensitive options can be written through the API but are never returned by
+/// it, and are expected to live in separate storage from the whitelisted ones.
+pub const LDAP_SENSITIVE_OPTIONS: &[&str] = &["password"];
+
+/// Whitelisted (readable) options of a group.
+///
+/// # Parameters
+/// - `group`: The group to look up.
+///
+/// # Returns
+/// - `&'static [&'static str]` - The readable option names of that group.
+pub const fn whitelisted_options(group: DomainConfigGroupName) -> &'static [&'static str] {
+    match group {
+        DomainConfigGroupName::Identity => IDENTITY_WHITELISTED_OPTIONS,
+        DomainConfigGroupName::Ldap => LDAP_WHITELISTED_OPTIONS,
+    }
+}
+
+/// Sensitive (write-only) options of a group.
+///
+/// # Parameters
+/// - `group`: The group to look up.
+///
+/// # Returns
+/// - `&'static [&'static str]` - The sensitive option names of that group.
+pub const fn sensitive_options(group: DomainConfigGroupName) -> &'static [&'static str] {
+    match group {
+        DomainConfigGroupName::Identity => IDENTITY_SENSITIVE_OPTIONS,
+        DomainConfigGroupName::Ldap => LDAP_SENSITIVE_OPTIONS,
+    }
+}
+
+/// Whether the option is readable through the API.
+///
+/// # Parameters
+/// - `group`: The group the option belongs to.
+/// - `option`: The option name.
+///
+/// # Returns
+/// - `bool` - `true` when the option is whitelisted.
+pub fn is_whitelisted(group: DomainConfigGroupName, option: &str) -> bool {
+    whitelisted_options(group).contains(&option)
+}
+
+/// Whether the option holds a secret and must never be returned.
+///
+/// # Parameters
+/// - `group`: The group the option belongs to.
+/// - `option`: The option name.
+///
+/// # Returns
+/// - `bool` - `true` when the option is sensitive.
+pub fn is_sensitive(group: DomainConfigGroupName, option: &str) -> bool {
+    sensitive_options(group).contains(&option)
+}
+
+/// Whether the option may be stored at all (whitelisted or sensitive).
+///
+/// # Parameters
+/// - `group`: The group the option belongs to.
+/// - `option`: The option name.
+///
+/// # Returns
+/// - `bool` - `true` when the option is supported.
+pub fn is_supported(group: DomainConfigGroupName, option: &str) -> bool {
+    is_whitelisted(group, option) || is_sensitive(group, option)
+}
+
+/// Validate a group/option pair addressed by a request.
+///
+/// Port of python-keystone's
+/// `DomainConfigManager._assert_valid_group_and_option`, including the case
+/// where neither is given (the request addresses the whole configuration).
+///
+/// # Parameters
+/// - `group`: The group named in the request path, if any.
+/// - `option`: The option named in the request path, if any.
+///
+/// # Returns
+/// - `Result<Option<DomainConfigGroupName>, DomainConfigProviderError>` - The
+///   parsed group when one was given, `None` when the request addresses every
+///   group, or an error when the pair is not supported.
+pub fn assert_valid_group_and_option(
+    group: Option<&str>,
+    option: Option<&str>,
+) -> Result<Option<DomainConfigGroupName>, DomainConfigProviderError> {
+    let Some(group) = group else {
+        return match option {
+            // The API routing should make this unreachable.
+            Some(option) => Err(DomainConfigProviderError::OptionWithoutGroup(
+                option.to_string(),
+            )),
+            None => Ok(None),
+        };
+    };
+
+    let group = DomainConfigGroupName::from_str(group)?;
+    if let Some(option) = option
+        && !is_supported(group, option)
+    {
+        return Err(DomainConfigProviderError::UnsupportedOption {
+            group: group.to_string(),
+            option: option.to_string(),
+        });
+    }
+    Ok(Some(group))
+}
+
+/// A single domain configuration option value.
+///
+/// Values round-trip verbatim as JSON, matching the `JsonBlob` columns
+/// python-keystone stores them in: whatever type the client wrote is what a
+/// later read returns.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct DomainConfigValue(Value);
+
+impl DomainConfigValue {
+    /// Wrap a JSON value.
+    ///
+    /// # Parameters
+    /// - `value`: The value to wrap.
+    ///
+    /// # Returns
+    /// - `Self` - The wrapped value.
+    pub fn new<V: Into<Value>>(value: V) -> Self {
+        Self(value.into())
+    }
+
+    /// Borrow the underlying JSON value.
+    ///
+    /// # Returns
+    /// - `&Value` - The wrapped value.
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
+
+    /// Consume the wrapper and yield the JSON value.
+    ///
+    /// # Returns
+    /// - `Value` - The wrapped value.
+    pub fn into_value(self) -> Value {
+        self.0
+    }
+
+    /// Borrow the value as a string, when it is one.
+    ///
+    /// # Returns
+    /// - `Option<&str>` - The string, or `None` for any other JSON type.
+    pub fn as_str(&self) -> Option<&str> {
+        self.0.as_str()
+    }
+}
+
+impl From<Value> for DomainConfigValue {
+    fn from(value: Value) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DomainConfigValue> for Value {
+    fn from(value: DomainConfigValue) -> Self {
+        value.0
+    }
+}
+
+impl From<&str> for DomainConfigValue {
+    fn from(value: &str) -> Self {
+        Self(Value::from(value))
+    }
+}
+
+impl From<String> for DomainConfigValue {
+    fn from(value: String) -> Self {
+        Self(Value::from(value))
+    }
+}
+
+impl fmt::Display for DomainConfigValue {
+    /// Render the value the way a config consumer expects it: strings bare
+    /// (so `%(password)s` substitution does not inject JSON quotes), anything
+    /// else as compact JSON.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0.as_str() {
+            Some(value) => f.write_str(value),
+            None => write!(f, "{}", self.0),
+        }
+    }
+}
+
+/// A single stored configuration option.
+///
+/// This is the flat shape the persistence layer works with, mirroring
+/// python-keystone's option dicts (`{group, option, value, sensitive}`) and
+/// the `(domain_id, group, option, value)` primary key of its
+/// `whitelisted_config` / `sensitive_config` tables.
+#[derive(Clone, PartialEq)]
+pub struct DomainConfigOption {
+    /// The group the option belongs to.
+    pub group: DomainConfigGroupName,
+    /// The option name.
+    pub option: String,
+    /// The option value.
+    pub value: DomainConfigValue,
+    /// Whether the value is a secret and therefore belongs in the sensitive
+    /// storage and must never be returned by the API.
+    ///
+    /// Private, and derived from the option name by [`Self::new`], so that it
+    /// cannot disagree with [`is_sensitive`]: a driver routes an option to the
+    /// readable or the sensitive table by this flag, while every read path
+    /// decides by name. An option built with the flag cleared would put a bind
+    /// password in the table the readable endpoints query.
+    sensitive: bool,
+}
+
+impl DomainConfigOption {
+    /// Build an option, deriving its sensitivity from the option name.
+    ///
+    /// # Parameters
+    /// - `group`: The group the option belongs to.
+    /// - `option`: The option name.
+    /// - `value`: The option value.
+    ///
+    /// # Returns
+    /// - `Self` - The option with [`Self::sensitive`] set from
+    ///   [`is_sensitive`].
+    pub fn new<O: Into<String>, V: Into<DomainConfigValue>>(
+        group: DomainConfigGroupName,
+        option: O,
+        value: V,
+    ) -> Self {
+        let option = option.into();
+        let sensitive = is_sensitive(group, &option);
+        Self {
+            group,
+            option,
+            value: value.into(),
+            sensitive,
+        }
+    }
+
+    /// Whether the value is a secret.
+    ///
+    /// # Returns
+    /// - `bool` - `true` when the option belongs in the sensitive storage and
+    ///   must never be returned by the API.
+    pub fn sensitive(&self) -> bool {
+        self.sensitive
+    }
+}
+
+impl fmt::Debug for DomainConfigOption {
+    /// Redact the value of sensitive options so they cannot reach logs or
+    /// traces through a `{:?}` of the surrounding structure.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut out = f.debug_struct("DomainConfigOption");
+        out.field("group", &self.group)
+            .field("option", &self.option);
+        if self.sensitive {
+            out.field("value", &"REDACTED");
+        } else {
+            out.field("value", &self.value);
+        }
+        out.field("sensitive", &self.sensitive).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn group_name_round_trips() {
+        for group in DomainConfigGroupName::ALL {
+            assert_eq!(
+                *group,
+                DomainConfigGroupName::from_str(group.as_str()).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_group_is_rejected() {
+        let err = DomainConfigGroupName::from_str("assignment").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "group assignment is not supported for domain specific configurations"
+        );
+    }
+
+    #[test]
+    fn whitelist_matches_python_keystone() {
+        // The counts are asserted so that an accidental edit of the list is
+        // visible in the diff of a failing test, not just in the constant.
+        assert_eq!(IDENTITY_WHITELISTED_OPTIONS.len(), 2);
+        assert_eq!(LDAP_WHITELISTED_OPTIONS.len(), 49);
+        assert!(IDENTITY_SENSITIVE_OPTIONS.is_empty());
+        assert_eq!(LDAP_SENSITIVE_OPTIONS, &["password"]);
+
+        // `password` is sensitive, therefore deliberately absent from the
+        // readable list.
+        assert!(!LDAP_WHITELISTED_OPTIONS.contains(&"password"));
+        assert!(is_sensitive(DomainConfigGroupName::Ldap, "password"));
+        assert!(!is_whitelisted(DomainConfigGroupName::Ldap, "password"));
+        assert!(is_supported(DomainConfigGroupName::Ldap, "password"));
+    }
+
+    #[test]
+    fn whitelist_has_no_duplicates() {
+        for group in DomainConfigGroupName::ALL {
+            let options = whitelisted_options(*group);
+            let unique: std::collections::HashSet<_> = options.iter().collect();
+            assert_eq!(unique.len(), options.len(), "duplicate option in {group}");
+        }
+    }
+
+    #[test]
+    fn assert_valid_group_and_option_accepts_the_whole_config() {
+        assert_eq!(assert_valid_group_and_option(None, None).unwrap(), None);
+    }
+
+    #[test]
+    fn assert_valid_group_and_option_accepts_supported_pairs() {
+        assert_eq!(
+            assert_valid_group_and_option(Some("ldap"), Some("url")).unwrap(),
+            Some(DomainConfigGroupName::Ldap)
+        );
+        assert_eq!(
+            assert_valid_group_and_option(Some("identity"), None).unwrap(),
+            Some(DomainConfigGroupName::Identity)
+        );
+        // Sensitive options are addressable for writes.
+        assert_eq!(
+            assert_valid_group_and_option(Some("ldap"), Some("password")).unwrap(),
+            Some(DomainConfigGroupName::Ldap)
+        );
+    }
+
+    #[test]
+    fn assert_valid_group_and_option_rejects_unknown_option() {
+        let err = assert_valid_group_and_option(Some("ldap"), Some("bind_dn")).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "option bind_dn in group ldap is not supported for domain specific configurations"
+        );
+    }
+
+    #[test]
+    fn assert_valid_group_and_option_rejects_option_without_group() {
+        let err = assert_valid_group_and_option(None, Some("url")).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "option url found with no group specified while checking domain configuration request"
+        );
+    }
+
+    #[test]
+    fn assert_valid_group_and_option_rejects_cross_group_option() {
+        // `driver` belongs to `identity`, not to `ldap`.
+        assert!(assert_valid_group_and_option(Some("ldap"), Some("driver")).is_err());
+        assert!(assert_valid_group_and_option(Some("identity"), Some("url")).is_err());
+    }
+
+    #[test]
+    fn value_display_leaves_strings_bare() {
+        assert_eq!(
+            DomainConfigValue::from("ldap://host").to_string(),
+            "ldap://host"
+        );
+        assert_eq!(DomainConfigValue::new(10).to_string(), "10");
+        assert_eq!(DomainConfigValue::new(true).to_string(), "true");
+    }
+
+    #[test]
+    fn option_debug_redacts_sensitive_values() {
+        let option = DomainConfigOption::new(DomainConfigGroupName::Ldap, "password", "s3cr3t");
+        assert!(option.sensitive());
+        let rendered = format!("{option:?}");
+        assert!(!rendered.contains("s3cr3t"), "Debug leaked the password");
+        assert!(rendered.contains("REDACTED"));
+    }
+
+    #[test]
+    fn option_debug_keeps_non_sensitive_values() {
+        let option = DomainConfigOption::new(DomainConfigGroupName::Ldap, "url", "ldap://host");
+        assert!(!option.sensitive());
+        assert!(format!("{option:?}").contains("ldap://host"));
+    }
+}

--- a/crates/core-types/src/error.rs
+++ b/crates/core-types/src/error.rs
@@ -23,6 +23,7 @@ use crate::auth::AuthenticationError;
 use crate::auth_plugin_identity::AuthPluginIdentityProviderError;
 use crate::catalog::CatalogProviderError;
 use crate::credential::CredentialProviderError;
+use crate::domain_config::DomainConfigProviderError;
 use crate::federation::FederationProviderError;
 use crate::identity::IdentityProviderError;
 use crate::idmapping::IdMappingProviderError;
@@ -114,6 +115,14 @@ pub enum KeystoneError {
         /// The source of the error.
         #[from]
         source: CredentialProviderError,
+    },
+
+    /// Domain configuration provider.
+    #[error(transparent)]
+    DomainConfigProvider {
+        /// The source of the error.
+        #[from]
+        source: DomainConfigProviderError,
     },
 
     /// Auth plugin identity-binding index provider.

--- a/crates/core-types/src/lib.rs
+++ b/crates/core-types/src/lib.rs
@@ -26,6 +26,7 @@ pub mod auth;
 pub mod auth_plugin_identity;
 pub mod catalog;
 pub mod credential;
+pub mod domain_config;
 pub mod error;
 pub mod events;
 pub mod federation;

--- a/crates/core/src/domain_config/backend.rs
+++ b/crates/core/src/domain_config/backend.rs
@@ -1,0 +1,310 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Domain configuration driver interface
+
+use async_trait::async_trait;
+
+use openstack_keystone_core_types::domain_config::*;
+
+use crate::domain_config::DomainConfigProviderError;
+use crate::keystone::ServiceState;
+
+/// Domain configuration driver interface.
+///
+/// Mirrors the granularity of the `/v3/domains/{domain_id}/config` API: every
+/// verb exists for the whole configuration, for a single group and for a
+/// single option.
+///
+/// # Sensitive options
+///
+/// `ldap.password` is sensitive: it can be written but must never be read
+/// back. Drivers are expected to keep sensitive options in separate storage
+/// (python-keystone uses a second table) and:
+///
+/// - return them as part of [`DomainConfig`] from [`Self::get_domain_config`],
+///   which the identity backend needs in order to bind (see
+///   [`DomainConfig::resolve_ldap`]) and which never reaches the wire because
+///   [`DomainConfig`] strips them on serialization;
+/// - never return them from [`Self::get_domain_config_group`] or
+///   [`Self::get_domain_config_option`], which back the readable endpoints.
+///
+/// The option-scoped methods traffic in [`DomainConfigOption`] rather than a
+/// bare [`DomainConfigValue`] for the same reason: a value on its own carries
+/// no sensitivity marker, so it renders in full under `Debug` and serializes
+/// transparently. Since drivers in this workspace are conventionally annotated
+/// with `#[tracing::instrument]`, a bare value would put a bind password into
+/// the span fields of every write to `ldap.password`. `DomainConfigOption`
+/// redacts its value in `Debug` whenever the option is sensitive.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait DomainConfigBackend: Send + Sync {
+    /// Replace the whole configuration of a domain.
+    ///
+    /// Backs `PUT /v3/domains/{domain_id}/config`: options absent from
+    /// `config` are removed, sensitive storage included.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain to configure.
+    /// - `config`: The configuration to store.
+    ///
+    /// # Returns
+    /// - `Result<DomainConfig, DomainConfigProviderError>` - The stored
+    ///   configuration, or an error.
+    async fn create_domain_config<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        config: DomainConfigCreate,
+    ) -> Result<DomainConfig, DomainConfigProviderError>;
+
+    /// Get the whole configuration of a domain.
+    ///
+    /// The result includes sensitive options, so that the identity backend can
+    /// be initialized from it; see the trait level note.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    ///
+    /// # Returns
+    /// - `Result<Option<DomainConfig>, DomainConfigProviderError>` - The
+    ///   configuration, `None` when the domain has none, or an error.
+    async fn get_domain_config<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+    ) -> Result<Option<DomainConfig>, DomainConfigProviderError>;
+
+    /// Get a single configuration group of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group to read.
+    ///
+    /// # Returns
+    /// - `Result<Option<DomainConfigGroup>, DomainConfigProviderError>` - The
+    ///   group without any sensitive option, `None` when the domain has no
+    ///   option stored in it, or an error.
+    async fn get_domain_config_group<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+    ) -> Result<Option<DomainConfigGroup>, DomainConfigProviderError>;
+
+    /// Get a single configuration option of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group holding the option.
+    /// - `option`: The option to read.
+    ///
+    /// # Returns
+    /// - `Result<Option<DomainConfigOption>, DomainConfigProviderError>` - The
+    ///   stored option, or `None` when it is not stored for the domain or is
+    ///   sensitive, or an error.
+    async fn get_domain_config_option<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+        option: &'a str,
+    ) -> Result<Option<DomainConfigOption>, DomainConfigProviderError>;
+
+    /// Merge changes into the whole configuration of a domain.
+    ///
+    /// Backs `PATCH /v3/domains/{domain_id}/config`: options absent from
+    /// `config` keep their stored value.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `config`: The options to change.
+    ///
+    /// # Returns
+    /// - `Result<DomainConfig, DomainConfigProviderError>` - The resulting
+    ///   configuration, or an error.
+    async fn update_domain_config<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        config: DomainConfigUpdate,
+    ) -> Result<DomainConfig, DomainConfigProviderError>;
+
+    /// Merge changes into a single configuration group of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group to change.
+    /// - `config`: The options to change; only `group` may be populated.
+    ///
+    /// # Returns
+    /// - `Result<DomainConfigGroup, DomainConfigProviderError>` - The
+    ///   resulting group, or an error.
+    async fn update_domain_config_group<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+        config: DomainConfigUpdate,
+    ) -> Result<DomainConfigGroup, DomainConfigProviderError>;
+
+    /// Change a single configuration option of a domain.
+    ///
+    /// The option to write is passed whole rather than as a `(group, option,
+    /// value)` triple so that a sensitive value is never held in a type that
+    /// renders it in full; see the trait level note.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `option`: The option to change, carrying its group, name and value.
+    ///
+    /// # Returns
+    /// - `Result<DomainConfigOption, DomainConfigProviderError>` - The stored
+    ///   option, or an error.
+    async fn update_domain_config_option<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        option: DomainConfigOption,
+    ) -> Result<DomainConfigOption, DomainConfigProviderError>;
+
+    /// Delete the whole configuration of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful, or
+    ///   an error.
+    async fn delete_domain_config<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+    ) -> Result<(), DomainConfigProviderError>;
+
+    /// Delete a single configuration group of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group to delete.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful, or
+    ///   an error.
+    async fn delete_domain_config_group<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+    ) -> Result<(), DomainConfigProviderError>;
+
+    /// Delete a single configuration option of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group holding the option.
+    /// - `option`: The option to delete.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful, or
+    ///   an error.
+    async fn delete_domain_config_option<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+        option: &'a str,
+    ) -> Result<(), DomainConfigProviderError>;
+
+    /// Get the global defaults a domain without configuration falls back to.
+    ///
+    /// Backs `GET /v3/domains/config/default`. Defaults come from the running
+    /// configuration rather than from storage, so the provided implementation
+    /// is what every driver wants; it is overridable only for drivers that
+    /// resolve defaults differently.
+    ///
+    /// Every whitelisted option is reported, with a `null` value when nothing
+    /// is configured for it, the way python-keystone's `get_config_default`
+    /// does. Use [`DomainConfig::default_options`] for the same thing as a flat
+    /// list.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    ///
+    /// # Returns
+    /// - `Result<DomainConfig, DomainConfigProviderError>` - The defaults of
+    ///   every group, without any sensitive option, or an error.
+    async fn get_default_config(
+        &self,
+        state: &ServiceState,
+    ) -> Result<DomainConfig, DomainConfigProviderError> {
+        let config = state.config_manager.config.read().await;
+        DomainConfig::defaults(&config)
+    }
+
+    /// Get the global defaults of a single group.
+    ///
+    /// Backs `GET /v3/domains/config/{group}/default`.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `group`: The group to read.
+    ///
+    /// # Returns
+    /// - `Result<DomainConfigGroup, DomainConfigProviderError>` - The defaults
+    ///   of the group, without any sensitive option, or an error.
+    async fn get_default_group(
+        &self,
+        state: &ServiceState,
+        group: DomainConfigGroupName,
+    ) -> Result<DomainConfigGroup, DomainConfigProviderError> {
+        let config = state.config_manager.config.read().await;
+        DomainConfig::default_group(&config, group)
+    }
+
+    /// Get the global default of a single option.
+    ///
+    /// Backs `GET /v3/domains/config/{group}/{option}/default`.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `group`: The group holding the option.
+    /// - `option`: The option to read.
+    ///
+    /// # Returns
+    /// - `Result<Option<DomainConfigOption>, DomainConfigProviderError>` - The
+    ///   default (a JSON `null` value when nothing is configured for it), or
+    ///   [`DomainConfigProviderError::UnsupportedOption`] when the option is
+    ///   not readable.
+    async fn get_default_option<'a>(
+        &self,
+        state: &ServiceState,
+        group: DomainConfigGroupName,
+        option: &'a str,
+    ) -> Result<Option<DomainConfigOption>, DomainConfigProviderError> {
+        let config = state.config_manager.config.read().await;
+        Ok(DomainConfig::default_option(&config, group, option)?
+            .map(|value| DomainConfigOption::new(group, option, value)))
+    }
+}

--- a/crates/core/src/domain_config/error.rs
+++ b/crates/core/src/domain_config/error.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Domain configuration provider error
+
+pub use openstack_keystone_core_types::domain_config::DomainConfigProviderError;
+
+impl From<crate::error::DatabaseError> for DomainConfigProviderError {
+    /// Convert a database error into a domain configuration provider error.
+    ///
+    /// # Parameters
+    /// - `source`: The database error to convert.
+    ///
+    /// # Returns
+    /// - `Self` - The converted `DomainConfigProviderError`.
+    fn from(source: crate::error::DatabaseError) -> Self {
+        match source {
+            cfl @ crate::error::DatabaseError::Conflict { .. } => Self::Conflict(cfl.to_string()),
+            other => Self::Driver(other.to_string()),
+        }
+    }
+}

--- a/crates/core/src/domain_config/mod.rs
+++ b/crates/core/src/domain_config/mod.rs
@@ -1,0 +1,31 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Domain configuration provider
+//!
+//! Per-domain overrides of the identity backend configuration, letting an
+//! operator onboard a domain with its own LDAP directory without restarting
+//! the service.
+//!
+//! A domain's configuration is a small set of options grouped into `identity`
+//! and `ldap`; a domain that has none falls back to the global configuration.
+//! Options are addressed at three granularities — the whole configuration, a
+//! single group, or a single option — which is why the backend trait carries a
+//! method triple for each verb.
+
+pub mod backend;
+pub mod error;
+
+pub use backend::DomainConfigBackend;
+pub use error::DomainConfigProviderError;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -91,6 +91,7 @@ pub mod catalog;
 pub mod common;
 pub mod credential;
 pub mod db;
+pub mod domain_config;
 pub mod error;
 pub mod events;
 pub mod federation;


### PR DESCRIPTION
Phase 0 of #954: the core types and the driver interface for per-domain
identity backend configuration. No SQL driver, no API handlers, no policy
files — those are Phases 1–5 of the parent issue.

Closes #955.

## What's here

**`crates/core-types/src/domain_config/`**

| Type | Purpose |
|---|---|
| `DomainConfigGroupName` | `identity` \| `ldap`, parsed from the request path |
| `DomainConfigOption` | flat `(group, option, value, sensitive)` row a driver stores |
| `DomainConfigValue` | the option value, JSON verbatim |
| `DomainConfigIdentity` / `DomainConfigLdap` | typed groups, one field per supported option |
| `DomainConfigGroup` | one group with its options |
| `DomainConfig` | a domain's whole configuration (`{"config": {...}}`) |
| `DomainConfigCreate` / `DomainConfigUpdate` | PUT (replace) vs PATCH (merge) payloads, distinct types so they can't be swapped at a call site |
| `DomainConfigProviderError` | provider error, incl. the `InvalidDomainConfig` / `DomainConfigNotFound` cases |

**`crates/core/src/domain_config/`** — the `DomainConfigBackend` trait, with
the whole-config / group / option method triple for each verb plus the three
default-config getters, and the `DatabaseError` conversion.

## Fidelity to python-keystone

The option model is transcribed from `keystone/resource/core.py`'s
`DomainConfigManager`, not paraphrased:

- `whitelisted_options` — `identity: [driver, list_limit]` and 49 `ldap`
  options, `sensitive_options = {identity: [], ldap: [password]}`. A test
  asserts the counts and that every whitelisted option has a struct field;
  the lists were also diffed against the upstream source programmatically
  (names *and* order identical).
- Upstream spells the list out rather than deriving it from the `[ldap]`
  section, precisely so a new `[ldap]` option can't become domain-writable by
  accident. Kept that property.
- `_assert_valid_group_and_option` and `_assert_valid_config` are ported
  including their exact wording, so the eventual API returns the same
  messages (403 for an unsupported group/option, per the api-ref).
- `get_config_default` reports unset options as `null` rather than omitting
  them; `DomainConfig::default_options` reproduces that, while the typed
  `DomainConfig::defaults` omits them.
- `_list_to_config` does not re-validate on read, and neither does
  `DomainConfig::from_options` — see "Read tolerance" below.

Note: the parent issue's option table is a paraphrase and lists names that
don't exist upstream (`tree_filter`, `connection_pooling`, `user_mapping`,
`pool_startup_sleep`, …). This follows the actual Python whitelist.

## Sensitive options

`ldap.password` is the one sensitive option. It is a `secrecy::SecretString`
with `#[serde(skip_serializing)]`, following the existing
`IdentityProvider::oidc_client_secret` pattern in this crate, so:

- it can be written and used to bind, and survives a round trip through
  `to_options()` / `from_options()` (the identity backend needs it),
- it never reaches an API response — `DomainConfig` serialization drops it,
- it never reaches a log line — `SecretString` keeps it out of `Debug`, and
  `DomainConfigOption` has a hand-written `Debug` that redacts the value of
  any option flagged sensitive,
- it has no readable default: `default_option()` refuses it outright.

The **option-scoped** backend methods take and return `DomainConfigOption`
rather than a bare `DomainConfigValue` for the same reason: a value on its
own carries no sensitivity marker, so it renders in full under `Debug` and
serializes transparently. Since drivers in this workspace are conventionally
annotated with `#[tracing::instrument]`, a bare value would have put a bind
password into the span fields of every write to `ldap.password`, and the
obvious handler would have echoed it into the PATCH response body. The group
and whole-config paths were already structurally safe via `skip_serializing`;
this one needed the stronger type. It is the one place this deviates from the
signature list in #955 (`(domain_id, group, option, value)` → `(domain_id,
option)`) — same information, safe by construction rather than by driver
discipline.

Tests cover each of these.

## Value typing

Values round-trip verbatim as JSON, matching upstream's `JsonBlob` columns.
Scalars additionally accept their string spelling (`"True"`, `"10"`,
`"0.1"`, `"a,b"`) and integers `0`/`1` for booleans, reproducing
oslo.config's coercion — this is how a per-domain `keystone.<domain>.conf`
file will deliver every value in the file-based-driver phase.

Coercion goes through `serde_json::Value` rather than an untagged enum so a
rejected value gets a usable message, and the offending option is pinpointed
by retrying option by option on the error path (a group has up to 49 of them
and serde reports a failing `deserialize_with` without any field context):

```
invalid value for option page_size in group ldap: expected an integer, got `"ten"`
```

## Read tolerance

`DomainConfig::from_options` skips stored options it doesn't recognize,
logging a warning, instead of failing. Validating on read would mean a single
stale row — after a whitelist narrowing, a downgrade, or a write that slipped
past validation — leaves the whole domain configuration unreadable and its
identity backend uninitializable until an operator deleted the row by hand.
The whitelist is enforced on the write path instead (serde
`deny_unknown_fields` plus `assert_valid_group_and_option` on the path
parameters), which is also where python-keystone enforces it.

## Known deviation, flagged for later phases

This workspace's `crates/config/src/ldap.rs` parses the pooling flags as
`pool` / `auth_pool`, while python-keystone (and therefore the domain-config
API contract) spells them `use_pool` / `use_auth_pool`. This module uses the
upstream names; the mapping between the two is done in
`DomainConfigLdap::defaults` and commented there. Worth deciding in Phase 5
whether `LdapProvider` should gain serde aliases — as it stands, a
keystone.conf written for Python with `[ldap] use_pool = false` is silently
ignored by the config parser.

Relatedly, `DomainConfigIdentity::defaults` resolves `[identity] list_limit`
through the global `[DEFAULT] list_limit`, the same chain
`Config::resolve_list_limit` applies — the defaults endpoint exists to report
the value a domain inherits, so reporting only the section-local value would
say `null` while listings are really capped.

## Structural note

The issue names `crates/core/src/backend.rs`; that file doesn't exist in this
workspace — backend traits live in per-domain modules
(`crates/core/src/<domain>/backend.rs`). Followed the existing convention.

## Testing

- `cargo test -p openstack-keystone-core-types` — 164 passed (41 new)
- `cargo test -p openstack-keystone-core` — 666 passed
- `cargo clippy` on both crates — no warnings from `domain_config`
- `cargo check --workspace --all-targets` — clean apart from the
  pre-existing `crates/storage/benches/*` failures (they're behind the
  `bench_internals` feature and fail on `main` too)
