### PR TITLE
feat: Add domain config SQL driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,6 +4854,7 @@ dependencies = [
  "openstack-keystone-core-types",
  "openstack-keystone-credential-driver-sql",
  "openstack-keystone-distributed-storage",
+ "openstack-keystone-domain-config-driver-sql",
  "openstack-keystone-federation-driver-sql",
  "openstack-keystone-identity-driver-ldap",
  "openstack-keystone-identity-driver-sql",
@@ -5285,6 +5286,20 @@ dependencies = [
  "uuid",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "openstack-keystone-domain-config-driver-sql"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "inventory",
+ "openstack-keystone-core",
+ "openstack-keystone-core-types",
+ "sea-orm",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/auth-plugin-core",
   "crates/auth-plugin-identity-driver-raft",
   "crates/auth-plugin-runtime",
+  "crates/domain-config-driver-sql",
   "crates/federation-driver-sql",
   "crates/identity-driver-ldap",
   "crates/identity-driver-sql",
@@ -129,6 +130,7 @@ openstack-keystone-core = { version = "0.1.0", path = "crates/core" }
 openstack-keystone-core-types = { version = "0.1.0", path = "crates/core-types" }
 openstack-keystone-credential-driver-sql = { version = "0.1", path = "crates/credential-driver-sql/" }
 openstack-keystone-distributed-storage = { version = "0.1.0", path = "crates/storage"}
+openstack-keystone-domain-config-driver-sql = { version = "0.1", path = "crates/domain-config-driver-sql/" }
 openstack-keystone-auth-plugin-core = { version = "0.1.0", path = "crates/auth-plugin-core" }
 openstack-keystone-auth-plugin-identity-driver-raft = { version = "0.1.0", path = "crates/auth-plugin-identity-driver-raft" }
 openstack-keystone-auth-plugin-runtime = { version = "0.1.0", path = "crates/auth-plugin-runtime" }

--- a/crates/core-types/src/domain_config/error.rs
+++ b/crates/core-types/src/domain_config/error.rs
@@ -40,6 +40,12 @@ pub enum DomainConfigProviderError {
     #[error("no options specified")]
     EmptyConfig,
 
+    /// A group scoped request carried options of another group.
+    #[error(
+        "trying to update group {0}, so that, and only that, group must be specified in the config"
+    )]
+    GroupMismatch(String),
+
     /// A group in the request did not carry a mapping of options.
     #[error("the value of group {0} specified in the config should be a dictionary of options")]
     GroupNotAMapping(String),

--- a/crates/core/src/domain_config/backend.rs
+++ b/crates/core/src/domain_config/backend.rs
@@ -237,6 +237,73 @@ pub trait DomainConfigBackend: Send + Sync {
         option: &'a str,
     ) -> Result<(), DomainConfigProviderError>;
 
+    /// Try to register a domain for a configuration type.
+    ///
+    /// A registration is a lock one domain holds over a configuration type, so
+    /// that at most one domain drives a given mechanism at a time —
+    /// python-keystone claims the `SQL` type for the single domain whose
+    /// identity backend may be the SQL one while domain specific drivers are
+    /// loaded from the database.
+    ///
+    /// Drivers are expected to make the claim atomic (python-keystone relies on
+    /// the primary key of its `config_register` table) rather than reading the
+    /// current holder and then writing: two nodes claiming the same type
+    /// concurrently must not both be told they hold it.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain claiming the type.
+    /// - `driver_type`: The registration type to claim.
+    ///
+    /// # Returns
+    /// - `Result<bool, DomainConfigProviderError>` - `true` when the domain now
+    ///   holds the registration, `false` when somebody already does — which
+    ///   includes the domain making the request, matching python-keystone's
+    ///   `obtain_registration`.
+    async fn obtain_registration<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        driver_type: &'a str,
+    ) -> Result<bool, DomainConfigProviderError>;
+
+    /// Read which domain holds the registration of a configuration type.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `driver_type`: The registration type to look up.
+    ///
+    /// # Returns
+    /// - `Result<Option<String>, DomainConfigProviderError>` - The ID of the
+    ///   domain holding it, `None` when nobody does (python-keystone's
+    ///   `ConfigRegistrationNotFound`), or an error.
+    async fn read_registration<'a>(
+        &self,
+        state: &ServiceState,
+        driver_type: &'a str,
+    ) -> Result<Option<String>, DomainConfigProviderError>;
+
+    /// Release the registrations a domain holds.
+    ///
+    /// Releasing what the domain does not hold is not an error, and never takes
+    /// a registration away from another domain.
+    ///
+    /// # Parameters
+    /// - `state`: The current service state.
+    /// - `domain_id`: The ID of the domain releasing them.
+    /// - `driver_type`: The single type to release, or `None` for every type
+    ///   the domain holds.
+    ///
+    /// # Returns
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful, or
+    ///   an error.
+    async fn release_registration<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        driver_type: Option<&'a str>,
+    ) -> Result<(), DomainConfigProviderError>;
+
     /// Get the global defaults a domain without configuration falls back to.
     ///
     /// Backs `GET /v3/domains/config/default`. Defaults come from the running

--- a/crates/core/src/plugin_manager.rs
+++ b/crates/core/src/plugin_manager.rs
@@ -40,6 +40,7 @@ use crate::catalog::backend::CatalogBackend;
 use crate::catalog::error::CatalogProviderError;
 use crate::credential::CredentialProviderError;
 use crate::credential::backend::CredentialBackend;
+use crate::domain_config::backend::DomainConfigBackend;
 use crate::federation::backend::FederationBackend;
 use crate::federation::error::FederationProviderError;
 use crate::identity::backend::IdentityBackend;
@@ -114,6 +115,7 @@ declare_backend_registry!(
     dyn AssignmentBackend,
     dyn CatalogBackend,
     dyn CredentialBackend,
+    dyn DomainConfigBackend,
     dyn DynamicPluginIdentityBackend,
     dyn FederationBackend,
     dyn IdentityBackend,

--- a/crates/domain-config-driver-sql/Cargo.toml
+++ b/crates/domain-config-driver-sql/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "openstack-keystone-domain-config-driver-sql"
+description = "OpenStack Keystone SQL driver for the domain configuration provider"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+exclude.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+inventory.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
+sea-orm = { workspace = true, features = ["default"] }
+serde_json.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+openstack-keystone-core = { workspace = true, features = ["mock"] }
+sea-orm = { workspace = true, features = ["mock", "sqlx-sqlite", "runtime-tokio"] }
+tokio = { workspace = true, features = ["macros"] }
+
+[lints]
+workspace = true

--- a/crates/domain-config-driver-sql/src/create.rs
+++ b/crates/domain-config-driver-sql/src/create.rs
@@ -1,0 +1,318 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Replace the whole configuration of a domain.
+
+use sea_orm::entity::*;
+use sea_orm::{ConnectionTrait, DatabaseConnection, TransactionTrait};
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::domain_config::*;
+
+use crate::entity::prelude::{
+    SensitiveConfig as DbSensitiveConfig, WhitelistedConfig as DbWhitelistedConfig,
+};
+use crate::{delete, option};
+
+/// Replace the whole configuration of a domain.
+///
+/// Backs `PUT /v3/domains/{domain_id}/config`: whatever the domain had is
+/// dropped first, so an option absent from `config` is gone from both tables
+/// afterwards.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain to configure.
+/// - `config`: The configuration to store.
+///
+/// # Returns
+/// - `Result<DomainConfig, DomainConfigProviderError>` - The stored
+///   configuration.
+pub async fn create(
+    db: &DatabaseConnection,
+    domain_id: &str,
+    config: DomainConfigCreate,
+) -> Result<DomainConfig, DomainConfigProviderError> {
+    let config = config.into_inner();
+    config.validate()?;
+    // The values are decoded into the config sections they override, so a
+    // value no option can hold is refused rather than stored for every later
+    // read of the domain to trip over.
+    config.validate_values()?;
+    let options = config.to_options();
+
+    let txn = db.begin().await.context("starting the transaction")?;
+    // Delete-then-insert, not an upsert: this is a replace, so an option the
+    // domain has stored but `config` does not carry has to be gone afterwards,
+    // and an upsert would leave it behind. The delete is unfiltered for the
+    // same reason — it has to reach the groups the request does not mention —
+    // and it covers both tables, so a sensitive option is not left orphaned
+    // behind a replaced `ldap` group. This is what python-keystone's
+    // `create_config_options` does: it deletes every row of the domain from
+    // `WhiteListedConfig` and `SensitiveConfig` before inserting the new
+    // option list, in one transaction so a failed insert cannot leave the
+    // domain unconfigured.
+    delete::delete_rows(&txn, domain_id, None, None).await?;
+    insert(&txn, domain_id, &options).await?;
+    txn.commit().await.context("committing the transaction")?;
+
+    // What was stored, not what was asked for, the way `update_config` answers
+    // and the way python-keystone's `create_config` answers from the rows it
+    // wrote. The two differ over a group the whitelist emptied, which the
+    // request still carries and no read would ever report again.
+    Ok(DomainConfig::from_options(options))
+}
+
+/// Insert options into the table each belongs to.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain the options belong to.
+/// - `options`: The options to store.
+///
+/// # Returns
+/// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful.
+async fn insert<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+    options: &[DomainConfigOption],
+) -> Result<(), DomainConfigProviderError> {
+    let (whitelisted, sensitive) = option::to_rows(domain_id, options)?;
+    if !whitelisted.is_empty() {
+        DbWhitelistedConfig::insert_many(whitelisted)
+            .exec(db)
+            .await
+            .context("creating domain config options")?;
+    }
+    if !sensitive.is_empty() {
+        DbSensitiveConfig::insert_many(sensitive)
+            .exec(db)
+            .await
+            .context("creating sensitive domain config options")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Statement, Transaction};
+
+    use super::*;
+    use crate::tests::{ldap_config, whitelisted_row};
+
+    #[tokio::test]
+    async fn test_create() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([
+                MockExecResult {
+                    rows_affected: 2,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+            ])
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .append_query_results([vec![crate::tests::sensitive_row(
+                "did",
+                "ldap",
+                "password",
+                r#""s3cr3t""#,
+            )]])
+            .into_connection();
+
+        create(&db, "did", DomainConfigCreate(ldap_config()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::many(vec![
+                Statement::from_string(DatabaseBackend::Postgres, r#"BEGIN"#),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1"#,
+                    ["did".into()]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "sensitive_config" WHERE "sensitive_config"."domain_id" = $1"#,
+                    ["did".into()]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"INSERT INTO "whitelisted_config" ("domain_id", "group", "option", "value") VALUES ($1, $2, $3, $4) RETURNING "domain_id", "group", "option""#,
+                    [
+                        "did".into(),
+                        "ldap".into(),
+                        "url".into(),
+                        r#""ldap://host""#.into()
+                    ]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"INSERT INTO "sensitive_config" ("domain_id", "group", "option", "value") VALUES ($1, $2, $3, $4) RETURNING "domain_id", "group", "option""#,
+                    [
+                        "did".into(),
+                        "ldap".into(),
+                        "password".into(),
+                        r#""s3cr3t""#.into()
+                    ]
+                ),
+                Statement::from_string(DatabaseBackend::Postgres, r#"COMMIT"#),
+            ])]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_of_a_group_the_whitelist_emptied_stores_nothing() {
+        // python-keystone warns about the options it does not recognize, drops
+        // them and succeeds; the domain ends up with the configuration it
+        // asked for, which is none.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 0,
+                    ..Default::default()
+                },
+            ])
+            .into_connection();
+
+        let config = create(
+            &db,
+            "did",
+            DomainConfigCreate(crate::tests::domain_config(
+                serde_json::json!({"ldap": {"bind_dn": "cn=admin"}}),
+            )),
+        )
+        .await
+        .unwrap();
+        assert!(config.is_empty());
+        // Not merely empty: the group the request carried is gone, so the
+        // answer is the one a later read of the domain gives.
+        assert!(config.group(DomainConfigGroupName::Ldap).is_none());
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::many(vec![
+                Statement::from_string(DatabaseBackend::Postgres, r#"BEGIN"#),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1"#,
+                    ["did".into()]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "sensitive_config" WHERE "sensitive_config"."domain_id" = $1"#,
+                    ["did".into()]
+                ),
+                Statement::from_string(DatabaseBackend::Postgres, r#"COMMIT"#),
+            ])]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_rolls_the_delete_back_when_the_insert_fails() {
+        // What the delete-then-insert being one transaction buys: a failure
+        // after the old rows are gone must not leave the domain unconfigured.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+                MockExecResult {
+                    rows_affected: 1,
+                    ..Default::default()
+                },
+            ])
+            .append_query_errors([sea_orm::DbErr::Custom("connection lost".to_string())])
+            .into_connection();
+
+        create(&db, "did", DomainConfigCreate(ldap_config()))
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::many(vec![
+                Statement::from_string(DatabaseBackend::Postgres, r#"BEGIN"#),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1"#,
+                    ["did".into()]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "sensitive_config" WHERE "sensitive_config"."domain_id" = $1"#,
+                    ["did".into()]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"INSERT INTO "whitelisted_config" ("domain_id", "group", "option", "value") VALUES ($1, $2, $3, $4) RETURNING "domain_id", "group", "option""#,
+                    [
+                        "did".into(),
+                        "ldap".into(),
+                        "url".into(),
+                        r#""ldap://host""#.into()
+                    ]
+                ),
+                Statement::from_string(DatabaseBackend::Postgres, r#"ROLLBACK"#),
+            ])],
+            "the delete is rolled back and nothing is committed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_a_value_the_option_cannot_hold() {
+        // Storing it would fail every later resolution of the domain's
+        // identity backend, not just a read of the option.
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let err = create(
+            &db,
+            "did",
+            DomainConfigCreate(crate::tests::domain_config(
+                serde_json::json!({"ldap": {"page_size": "a lot"}}),
+            )),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid value for option page_size in group ldap: expected an integer, got `\"a lot\"`"
+        );
+        assert_eq!(db.into_transaction_log(), []);
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_an_empty_config() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let err = create(&db, "did", DomainConfigCreate::default())
+            .await
+            .unwrap_err();
+        assert_eq!(err.to_string(), "no options specified");
+        assert_eq!(db.into_transaction_log(), []);
+    }
+}

--- a/crates/domain-config-driver-sql/src/delete.rs
+++ b/crates/domain-config-driver-sql/src/delete.rs
@@ -1,0 +1,302 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Delete the stored configuration of a domain.
+
+use sea_orm::entity::*;
+use sea_orm::query::*;
+use sea_orm::{ConnectionTrait, DatabaseConnection, TransactionTrait};
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::domain_config::*;
+
+use crate::entity::prelude::{
+    SensitiveConfig as DbSensitiveConfig, WhitelistedConfig as DbWhitelistedConfig,
+};
+use crate::entity::{sensitive_config, whitelisted_config};
+
+/// Delete options of a domain from both tables.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: Restrict the delete to a single group.
+/// - `option`: Restrict the delete to a single option.
+///
+/// # Returns
+/// - `Result<u64, DomainConfigProviderError>` - How many rows were deleted
+///   across both tables.
+pub(crate) async fn delete_rows<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+    group: Option<DomainConfigGroupName>,
+    option: Option<&str>,
+) -> Result<u64, DomainConfigProviderError> {
+    let mut whitelisted = DbWhitelistedConfig::delete_many()
+        .filter(whitelisted_config::Column::DomainId.eq(domain_id));
+    let mut sensitive =
+        DbSensitiveConfig::delete_many().filter(sensitive_config::Column::DomainId.eq(domain_id));
+    if let Some(group) = group {
+        whitelisted = whitelisted.filter(whitelisted_config::Column::Group.eq(group.as_str()));
+        sensitive = sensitive.filter(sensitive_config::Column::Group.eq(group.as_str()));
+    }
+    if let Some(option) = option {
+        whitelisted = whitelisted.filter(whitelisted_config::Column::Option.eq(option));
+        sensitive = sensitive.filter(sensitive_config::Column::Option.eq(option));
+    }
+    let deleted = whitelisted
+        .exec(db)
+        .await
+        .context("deleting domain config options")?
+        .rows_affected;
+    Ok(deleted
+        + sensitive
+            .exec(db)
+            .await
+            .context("deleting sensitive domain config options")?
+            .rows_affected)
+}
+
+/// Delete the whole configuration of a domain.
+///
+/// Deleting a configuration that is not there is not an error: there is
+/// nothing left to remove either way, and python-keystone's driver does not
+/// report one.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+///
+/// # Returns
+/// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful.
+pub async fn delete_config(
+    db: &DatabaseConnection,
+    domain_id: &str,
+) -> Result<(), DomainConfigProviderError> {
+    let txn = db.begin().await.context("starting the transaction")?;
+    delete_rows(&txn, domain_id, None, None).await?;
+    txn.commit().await.context("committing the transaction")?;
+    Ok(())
+}
+
+/// Delete a single configuration group of a domain.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: The group to delete.
+///
+/// # Returns
+/// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful, or
+///   [`DomainConfigProviderError::NotFound`] when the domain has no option
+///   stored in the group.
+pub async fn delete_group(
+    db: &DatabaseConnection,
+    domain_id: &str,
+    group: DomainConfigGroupName,
+) -> Result<(), DomainConfigProviderError> {
+    // A partial delete reports what is not there, as python-keystone's
+    // `delete_config` does. The row count answers that without a preceding
+    // read, and the transaction rolls back the half that did match, if any.
+    let txn = db.begin().await.context("starting the transaction")?;
+    if delete_rows(&txn, domain_id, Some(group), None).await? == 0 {
+        return Err(DomainConfigProviderError::group_not_found(domain_id, group));
+    }
+    txn.commit().await.context("committing the transaction")?;
+    Ok(())
+}
+
+/// Delete a single configuration option of a domain.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: The group holding the option.
+/// - `option`: The option to delete.
+///
+/// # Returns
+/// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful, or
+///   [`DomainConfigProviderError::NotFound`] when the option is not stored for
+///   the domain.
+pub async fn delete_option(
+    db: &DatabaseConnection,
+    domain_id: &str,
+    group: DomainConfigGroupName,
+    option: &str,
+) -> Result<(), DomainConfigProviderError> {
+    let txn = db.begin().await.context("starting the transaction")?;
+    if delete_rows(&txn, domain_id, Some(group), Some(option)).await? == 0 {
+        return Err(DomainConfigProviderError::option_not_found(
+            domain_id, group, option,
+        ));
+    }
+    txn.commit().await.context("committing the transaction")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult, Statement, Transaction};
+
+    use super::*;
+
+    fn deleted(rows: u64) -> MockExecResult {
+        MockExecResult {
+            rows_affected: rows,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_config() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([deleted(2), deleted(1)])
+            .into_connection();
+
+        delete_config(&db, "did").await.unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::many(vec![
+                Statement::from_string(DatabaseBackend::Postgres, r#"BEGIN"#),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1"#,
+                    ["did".into()]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "sensitive_config" WHERE "sensitive_config"."domain_id" = $1"#,
+                    ["did".into()]
+                ),
+                Statement::from_string(DatabaseBackend::Postgres, r#"COMMIT"#),
+            ])]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_config_of_an_unconfigured_domain_is_not_an_error() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([deleted(0), deleted(0)])
+            .into_connection();
+
+        delete_config(&db, "did").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_group() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([deleted(1), deleted(1)])
+            .into_connection();
+
+        delete_group(&db, "did", DomainConfigGroupName::Ldap)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::many(vec![
+                Statement::from_string(DatabaseBackend::Postgres, r#"BEGIN"#),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1 AND "whitelisted_config"."group" = $2"#,
+                    ["did".into(), "ldap".into()]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "sensitive_config" WHERE "sensitive_config"."domain_id" = $1 AND "sensitive_config"."group" = $2"#,
+                    ["did".into(), "ldap".into()]
+                ),
+                Statement::from_string(DatabaseBackend::Postgres, r#"COMMIT"#),
+            ])]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_group_that_is_not_configured() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([deleted(0), deleted(0)])
+            .into_connection();
+
+        let err = delete_group(&db, "did", DomainConfigGroupName::Ldap)
+            .await
+            .unwrap_err();
+        assert_eq!(err.to_string(), "could not find group ldap for domain did");
+    }
+
+    #[tokio::test]
+    async fn test_delete_group_of_a_domain_with_only_a_sensitive_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([deleted(0), deleted(1)])
+            .into_connection();
+
+        delete_group(&db, "did", DomainConfigGroupName::Ldap)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([deleted(1), deleted(0)])
+            .into_connection();
+
+        delete_option(&db, "did", DomainConfigGroupName::Ldap, "url")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::many(vec![
+                Statement::from_string(DatabaseBackend::Postgres, r#"BEGIN"#),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1 AND "whitelisted_config"."group" = $2 AND "whitelisted_config"."option" = $3"#,
+                    ["did".into(), "ldap".into(), "url".into()]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"DELETE FROM "sensitive_config" WHERE "sensitive_config"."domain_id" = $1 AND "sensitive_config"."group" = $2 AND "sensitive_config"."option" = $3"#,
+                    ["did".into(), "ldap".into(), "url".into()]
+                ),
+                Statement::from_string(DatabaseBackend::Postgres, r#"COMMIT"#),
+            ])]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_option_that_is_not_configured() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([deleted(0), deleted(0)])
+            .into_connection();
+
+        let err = delete_option(&db, "did", DomainConfigGroupName::Ldap, "url")
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "could not find option url in group ldap for domain did"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_a_sensitive_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([deleted(0), deleted(1)])
+            .into_connection();
+
+        delete_option(&db, "did", DomainConfigGroupName::Ldap, "password")
+            .await
+            .unwrap();
+    }
+}

--- a/crates/domain-config-driver-sql/src/entity.rs
+++ b/crates/domain-config-driver-sql/src/entity.rs
@@ -1,0 +1,21 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::doc_paragraphs_missing_punctuation)]
+//! `SeaORM` Entities of the domain configuration driver.
+
+pub mod prelude;
+
+pub mod config_register;
+pub mod sensitive_config;
+pub mod whitelisted_config;

--- a/crates/domain-config-driver-sql/src/entity/config_register.rs
+++ b/crates/domain-config-driver-sql/src/entity/config_register.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `SeaORM` Entity for the domain configuration registrations.
+
+use sea_orm::entity::prelude::*;
+
+/// The domain holding the registration of a configuration type.
+///
+/// Table and columns match python-keystone's `config_register`. The
+/// registration type is the primary key, which is what makes the registration
+/// exclusive: a second domain claiming a type it already registered to another
+/// one violates the key rather than overwriting the row.
+#[derive(Clone, Debug, DeriveEntityModel, Eq, PartialEq)]
+#[sea_orm(table_name = "config_register")]
+pub struct Model {
+    /// The registration type, e.g. `SQL`.
+    ///
+    /// Named `type` in the table, as python-keystone names it.
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_name = "type",
+        column_type = "String(StringLen::N(64))"
+    )]
+    pub r#type: String,
+
+    /// The domain holding the registration.
+    #[sea_orm(column_type = "String(StringLen::N(64))")]
+    pub domain_id: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/domain-config-driver-sql/src/entity/prelude.rs
+++ b/crates/domain-config-driver-sql/src/entity/prelude.rs
@@ -1,0 +1,20 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! `SeaORM` Entity prelude of the domain configuration driver.
+#![allow(unused_imports)]
+
+pub use super::config_register::Entity as ConfigRegister;
+pub use super::sensitive_config::Entity as SensitiveConfig;
+pub use super::whitelisted_config::Entity as WhitelistedConfig;

--- a/crates/domain-config-driver-sql/src/entity/sensitive_config.rs
+++ b/crates/domain-config-driver-sql/src/entity/sensitive_config.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `SeaORM` Entity for the write-only domain configuration options.
+
+use sea_orm::entity::prelude::*;
+
+/// A single sensitive configuration option of a domain.
+///
+/// Same shape as [`super::whitelisted_config::Model`], in a separate table so
+/// that a read serving the API can never accidentally include a secret: the
+/// readable endpoints simply do not query this table. Matches
+/// python-keystone's `sensitive_config`.
+#[derive(Clone, Debug, DeriveEntityModel, Eq, PartialEq)]
+#[sea_orm(table_name = "sensitive_config")]
+pub struct Model {
+    /// The domain the option applies to.
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
+    pub domain_id: String,
+
+    /// The group holding the option, e.g. `ldap`.
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(255))"
+    )]
+    pub group: String,
+
+    /// The option name, e.g. `password`.
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(255))"
+    )]
+    pub option: String,
+
+    /// The JSON encoded option value.
+    #[sea_orm(column_type = "Text")]
+    pub value: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/domain-config-driver-sql/src/entity/whitelisted_config.rs
+++ b/crates/domain-config-driver-sql/src/entity/whitelisted_config.rs
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! `SeaORM` Entity for the readable domain configuration options.
+
+use sea_orm::entity::prelude::*;
+
+/// A single readable configuration option of a domain.
+///
+/// Table and columns match python-keystone's `whitelisted_config`, down to the
+/// `value` being the JSON encoding of the stored value in a text column (its
+/// `JsonBlob` type).
+#[derive(Clone, Debug, DeriveEntityModel, Eq, PartialEq)]
+#[sea_orm(table_name = "whitelisted_config")]
+pub struct Model {
+    /// The domain the option applies to.
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(64))"
+    )]
+    pub domain_id: String,
+
+    /// The group holding the option, e.g. `ldap`.
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(255))"
+    )]
+    pub group: String,
+
+    /// The option name, e.g. `url`.
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "String(StringLen::N(255))"
+    )]
+    pub option: String,
+
+    /// The JSON encoded option value.
+    #[sea_orm(column_type = "Text")]
+    pub value: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/domain-config-driver-sql/src/get.rs
+++ b/crates/domain-config-driver-sql/src/get.rs
@@ -1,0 +1,447 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Read the stored configuration of a domain.
+//!
+//! Only [`get_config`] reads the sensitive table. The group and option scoped
+//! reads back the endpoints that return options to a client, so they query
+//! `whitelisted_config` alone: a secret cannot reach a response it was never
+//! selected into.
+
+use sea_orm::ConnectionTrait;
+use sea_orm::entity::*;
+use sea_orm::query::*;
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::domain_config::*;
+
+use crate::entity::prelude::{
+    SensitiveConfig as DbSensitiveConfig, WhitelistedConfig as DbWhitelistedConfig,
+};
+use crate::entity::{sensitive_config, whitelisted_config};
+use crate::option;
+
+/// Read the readable options of a domain.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: Restrict the read to a single group.
+/// - `option`: Restrict the read to a single option.
+///
+/// # Returns
+/// - `Result<Vec<DomainConfigOption>, DomainConfigProviderError>` - The stored
+///   options, in a stable order.
+pub(crate) async fn load_whitelisted<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+    group: Option<DomainConfigGroupName>,
+    option: Option<&str>,
+) -> Result<Vec<DomainConfigOption>, DomainConfigProviderError> {
+    let mut query = DbWhitelistedConfig::find()
+        .filter(whitelisted_config::Column::DomainId.eq(domain_id))
+        .order_by_asc(whitelisted_config::Column::Group)
+        .order_by_asc(whitelisted_config::Column::Option);
+    if let Some(group) = group {
+        query = query.filter(whitelisted_config::Column::Group.eq(group.as_str()));
+    }
+    if let Some(option) = option {
+        query = query.filter(whitelisted_config::Column::Option.eq(option));
+    }
+    option::from_whitelisted_rows(
+        query
+            .all(db)
+            .await
+            .context("reading domain config options")?,
+    )
+}
+
+/// Read the sensitive options of a domain.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: Restrict the read to a single group.
+/// - `option`: Restrict the read to a single option.
+///
+/// # Returns
+/// - `Result<Vec<DomainConfigOption>, DomainConfigProviderError>` - The stored
+///   options, in a stable order.
+pub(crate) async fn load_sensitive<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+    group: Option<DomainConfigGroupName>,
+    option: Option<&str>,
+) -> Result<Vec<DomainConfigOption>, DomainConfigProviderError> {
+    let mut query = DbSensitiveConfig::find()
+        .filter(sensitive_config::Column::DomainId.eq(domain_id))
+        .order_by_asc(sensitive_config::Column::Group)
+        .order_by_asc(sensitive_config::Column::Option);
+    if let Some(group) = group {
+        query = query.filter(sensitive_config::Column::Group.eq(group.as_str()));
+    }
+    if let Some(option) = option {
+        query = query.filter(sensitive_config::Column::Option.eq(option));
+    }
+    option::from_sensitive_rows(
+        query
+            .all(db)
+            .await
+            .context("reading sensitive domain config options")?,
+    )
+}
+
+/// Read every option of a domain, sensitive ones included.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: Restrict the read to a single group.
+///
+/// # Returns
+/// - `Result<Vec<DomainConfigOption>, DomainConfigProviderError>` - The stored
+///   options, readable ones first.
+pub(crate) async fn load_all<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+    group: Option<DomainConfigGroupName>,
+) -> Result<Vec<DomainConfigOption>, DomainConfigProviderError> {
+    let mut options = load_whitelisted(db, domain_id, group, None).await?;
+    options.extend(load_sensitive(db, domain_id, group, None).await?);
+    Ok(options)
+}
+
+/// Get the whole configuration of a domain.
+///
+/// The result carries the sensitive options, which the identity backend needs
+/// in order to bind and which never reach a response because [`DomainConfig`]
+/// skips them on serialization.
+///
+/// The two tables are read one after the other rather than as one snapshot,
+/// the way python-keystone's `get_config_with_sensitive_info` reads them. A
+/// `PUT` that commits between the two can therefore be seen half applied — an
+/// old `ldap.url` next to a new `ldap.password`, say. Wrapping the pair in a
+/// transaction would not close that window on its own, since `READ COMMITTED`
+/// takes a fresh snapshot per statement; it takes a single query spanning both
+/// tables, which is worth doing once there is a consumer to judge it against.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+///
+/// # Returns
+/// - `Result<Option<DomainConfig>, DomainConfigProviderError>` - The
+///   configuration, or `None` when the domain has no option stored.
+pub async fn get_config<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+) -> Result<Option<DomainConfig>, DomainConfigProviderError> {
+    let options = load_all(db, domain_id, None).await?;
+    if options.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(DomainConfig::from_options(options)))
+}
+
+/// Get a single configuration group of a domain.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: The group to read.
+///
+/// # Returns
+/// - `Result<Option<DomainConfigGroup>, DomainConfigProviderError>` - The
+///   group without any sensitive option, or `None` when the domain has no
+///   readable option stored in it.
+pub async fn get_group<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+    group: DomainConfigGroupName,
+) -> Result<Option<DomainConfigGroup>, DomainConfigProviderError> {
+    let options = load_whitelisted(db, domain_id, Some(group), None).await?;
+    if options.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(DomainConfigGroup::from_options(group, options)?))
+}
+
+/// Get a single configuration option of a domain.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: The group holding the option.
+/// - `option`: The option to read.
+///
+/// # Returns
+/// - `Result<Option<DomainConfigOption>, DomainConfigProviderError>` - The
+///   stored option, or `None` when it is sensitive, not stored for the domain,
+///   or stored but no longer configurable (see [`option::decode`]).
+pub async fn get_option<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+    group: DomainConfigGroupName,
+    option: &str,
+) -> Result<Option<DomainConfigOption>, DomainConfigProviderError> {
+    // A sensitive option is write only. Answering it from the readable table
+    // would always be `None` anyway; returning early states why.
+    if is_sensitive(group, option) {
+        return Ok(None);
+    }
+    Ok(load_whitelisted(db, domain_id, Some(group), Some(option))
+        .await?
+        .into_iter()
+        .next())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+    use serde_json::json;
+
+    use super::*;
+    use crate::tests::{sensitive_row, whitelisted_row};
+
+    #[tokio::test]
+    async fn test_get_config() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![
+                whitelisted_row("did", "identity", "driver", r#""ldap""#),
+                whitelisted_row("did", "ldap", "url", r#""ldap://host""#),
+                whitelisted_row("did", "ldap", "page_size", "10"),
+            ]])
+            .append_query_results([vec![sensitive_row(
+                "did",
+                "ldap",
+                "password",
+                r#""s3cr3t""#,
+            )]])
+            .into_connection();
+
+        let config = get_config(&db, "did").await.unwrap().unwrap();
+        let identity = config.group(DomainConfigGroupName::Identity).unwrap();
+        assert_eq!(identity.get("driver"), Some(&json!("ldap")));
+        let ldap = config.group(DomainConfigGroupName::Ldap).unwrap();
+        assert_eq!(ldap.get("url"), Some(&json!("ldap://host")));
+        assert_eq!(ldap.get("page_size"), Some(&json!(10)));
+        assert_eq!(ldap.get("password"), Some(&json!("s3cr3t")));
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [
+                Transaction::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"SELECT "whitelisted_config"."domain_id", "whitelisted_config"."group", "whitelisted_config"."option", "whitelisted_config"."value" FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1 ORDER BY "whitelisted_config"."group" ASC, "whitelisted_config"."option" ASC"#,
+                    ["did".into()]
+                ),
+                Transaction::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"SELECT "sensitive_config"."domain_id", "sensitive_config"."group", "sensitive_config"."option", "sensitive_config"."value" FROM "sensitive_config" WHERE "sensitive_config"."domain_id" = $1 ORDER BY "sensitive_config"."group" ASC, "sensitive_config"."option" ASC"#,
+                    ["did".into()]
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_config_of_an_unconfigured_domain() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<whitelisted_config::Model>::new()])
+            .append_query_results([Vec::<sensitive_config::Model>::new()])
+            .into_connection();
+
+        assert!(get_config(&db, "did").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_config_of_a_domain_with_only_a_sensitive_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<whitelisted_config::Model>::new()])
+            .append_query_results([vec![sensitive_row(
+                "did",
+                "ldap",
+                "password",
+                r#""s3cr3t""#,
+            )]])
+            .into_connection();
+
+        assert!(get_config(&db, "did").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_config_skips_a_stale_row() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![
+                whitelisted_row("did", "assignment", "driver", r#""sql""#),
+                whitelisted_row("did", "ldap", "url", r#""ldap://host""#),
+            ]])
+            .append_query_results([Vec::<sensitive_config::Model>::new()])
+            .into_connection();
+
+        let config = get_config(&db, "did").await.unwrap().unwrap();
+        assert!(config.group(DomainConfigGroupName::Identity).is_none());
+        assert_eq!(
+            config
+                .group(DomainConfigGroupName::Ldap)
+                .and_then(|group| group.get("url")),
+            Some(&json!("ldap://host"))
+        );
+    }
+
+    /// A row of a configurable group whose option is no longer whitelisted has
+    /// to read exactly like a row of a group that is no longer configurable:
+    /// the domain is unconfigured, not configured with nothing. Otherwise the
+    /// two spellings of the same drift answer a client differently — `404`
+    /// against `200` with an empty configuration.
+    #[tokio::test]
+    async fn test_get_config_of_a_domain_with_only_a_stale_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "bind_dn",
+                r#""cn=admin""#,
+            )]])
+            .append_query_results([Vec::<sensitive_config::Model>::new()])
+            .into_connection();
+
+        assert!(get_config(&db, "did").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_group_of_a_group_with_only_a_stale_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "bind_dn",
+                r#""cn=admin""#,
+            )]])
+            .into_connection();
+
+        assert!(
+            get_group(&db, "did", DomainConfigGroupName::Ldap)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// The option scoped read is the one path with no later
+    /// `DomainConfig::from_options` to drop a stale row for it, so it is the
+    /// one that would otherwise hand a client an option the whitelist no
+    /// longer covers.
+    #[tokio::test]
+    async fn test_get_option_never_reads_a_stale_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "bind_dn",
+                r#""cn=admin""#,
+            )]])
+            .into_connection();
+
+        assert!(
+            get_option(&db, "did", DomainConfigGroupName::Ldap, "bind_dn")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_group_does_not_read_the_sensitive_table() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .into_connection();
+
+        let group = get_group(&db, "did", DomainConfigGroupName::Ldap)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(group.name(), DomainConfigGroupName::Ldap);
+        assert_eq!(group.get("url"), Some(&json!("ldap://host")));
+        assert!(group.get("password").is_none());
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "whitelisted_config"."domain_id", "whitelisted_config"."group", "whitelisted_config"."option", "whitelisted_config"."value" FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1 AND "whitelisted_config"."group" = $2 ORDER BY "whitelisted_config"."group" ASC, "whitelisted_config"."option" ASC"#,
+                ["did".into(), "ldap".into()]
+            ),]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_group_of_an_unconfigured_group() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<whitelisted_config::Model>::new()])
+            .into_connection();
+
+        assert!(
+            get_group(&db, "did", DomainConfigGroupName::Identity)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .into_connection();
+
+        let option = get_option(&db, "did", DomainConfigGroupName::Ldap, "url")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(option.value.as_str(), Some("ldap://host"));
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "whitelisted_config"."domain_id", "whitelisted_config"."group", "whitelisted_config"."option", "whitelisted_config"."value" FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1 AND "whitelisted_config"."group" = $2 AND "whitelisted_config"."option" = $3 ORDER BY "whitelisted_config"."group" ASC, "whitelisted_config"."option" ASC"#,
+                ["did".into(), "ldap".into(), "url".into()]
+            ),]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_option_never_reads_a_sensitive_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        assert!(
+            get_option(&db, "did", DomainConfigGroupName::Ldap, "password")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        // Not a single statement was issued for it.
+        assert_eq!(db.into_transaction_log(), []);
+    }
+}

--- a/crates/domain-config-driver-sql/src/lib.rs
+++ b/crates/domain-config-driver-sql/src/lib.rs
@@ -1,0 +1,467 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OpenStack Keystone SQL driver for the domain configuration provider
+//!
+//! Per-domain overrides of the identity backend configuration, stored the way
+//! python-keystone stores them: one row per option, in two tables that differ
+//! only in who may read them.
+//!
+//! `whitelisted_config` holds the readable options and `sensitive_config` the
+//! write-only ones (today only `ldap.password`). Keeping them apart is what
+//! makes the read paths safe by construction rather than by filtering: the
+//! group and option scoped reads, which back the endpoints that hand options
+//! to a client, only ever select from `whitelisted_config`. The whole-config
+//! read is the one exception, since the identity backend has to be handed the
+//! bind password; [`DomainConfig`] skips it on serialization, so it still
+//! cannot reach a response.
+//!
+//! A third table, `config_register`, holds no option at all: it records which
+//! domain holds the registration of a configuration type, the lock that keeps
+//! at most one domain driving a given mechanism.
+//!
+//! Values are stored as their JSON encoding in a text column, matching
+//! python-keystone's `JsonBlob`, so whatever type a client wrote is the type a
+//! later read returns. References of the form `%(option)s` are stored verbatim
+//! and resolved by [`DomainConfig::substitute`] when a consumer needs the
+//! resolved value — never on a read that can reach the API.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, Schema};
+
+use openstack_keystone_core::domain_config::backend::DomainConfigBackend;
+use openstack_keystone_core::domain_config::error::DomainConfigProviderError;
+use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
+use openstack_keystone_core::{
+    SqlDriver, SqlDriverRegistration, db::create_table, error::DatabaseError,
+};
+use openstack_keystone_core_types::domain_config::*;
+
+mod create;
+mod delete;
+pub mod entity;
+mod get;
+mod option;
+mod registration;
+mod update;
+
+/// The SQL domain configuration driver.
+#[derive(Default)]
+pub struct SqlBackend {}
+
+/// Linkage anchor — see ADR-0018. Referenced by the `keystone` crate's
+/// `build.rs`-generated `_ANCHORS` static so the linker extracts `.rlib`
+/// members, keeping `inventory::submit!` sections visible at runtime.
+#[allow(dead_code)]
+pub fn anchor() {}
+
+// Submit the plugin to the registry at compile-time
+static PLUGIN: SqlBackend = SqlBackend {};
+inventory::submit! {
+    SqlDriverRegistration { driver: &PLUGIN }
+}
+inventory::submit! {
+    BackendRegistration::<dyn DomainConfigBackend> {
+        name: "sql",
+        selected: |_| true,
+        build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn DomainConfigBackend>)
+        }),
+    }
+}
+
+#[async_trait]
+impl DomainConfigBackend for SqlBackend {
+    /// Replace the whole configuration of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain to configure.
+    /// - `config`: The configuration to store.
+    ///
+    /// # Returns
+    /// A `Result` containing the stored `DomainConfig`, or an `Error`.
+    async fn create_domain_config<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        config: DomainConfigCreate,
+    ) -> Result<DomainConfig, DomainConfigProviderError> {
+        create::create(&state.db, domain_id, config).await
+    }
+
+    /// Get the whole configuration of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `DomainConfig` if the domain
+    /// has one, or an `Error`.
+    async fn get_domain_config<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+    ) -> Result<Option<DomainConfig>, DomainConfigProviderError> {
+        get::get_config(&state.db, domain_id).await
+    }
+
+    /// Get a single configuration group of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group to read.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `DomainConfigGroup` if the
+    /// domain has a readable option stored in it, or an `Error`.
+    async fn get_domain_config_group<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+    ) -> Result<Option<DomainConfigGroup>, DomainConfigProviderError> {
+        get::get_group(&state.db, domain_id, group).await
+    }
+
+    /// Get a single configuration option of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group holding the option.
+    /// - `option`: The option to read.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the `DomainConfigOption` if it is
+    /// stored and readable, or an `Error`.
+    async fn get_domain_config_option<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+        option: &'a str,
+    ) -> Result<Option<DomainConfigOption>, DomainConfigProviderError> {
+        get::get_option(&state.db, domain_id, group, option).await
+    }
+
+    /// Merge changes into the whole configuration of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `config`: The options to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the resulting `DomainConfig`, or an `Error`.
+    async fn update_domain_config<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        config: DomainConfigUpdate,
+    ) -> Result<DomainConfig, DomainConfigProviderError> {
+        update::update_config(&state.db, domain_id, config).await
+    }
+
+    /// Merge changes into a single configuration group of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group to change.
+    /// - `config`: The options to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the resulting `DomainConfigGroup`, or an `Error`.
+    async fn update_domain_config_group<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+        config: DomainConfigUpdate,
+    ) -> Result<DomainConfigGroup, DomainConfigProviderError> {
+        update::update_group(&state.db, domain_id, group, config).await
+    }
+
+    /// Change a single configuration option of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `option`: The option to change.
+    ///
+    /// # Returns
+    /// A `Result` containing the stored `DomainConfigOption`, or an `Error`.
+    async fn update_domain_config_option<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        option: DomainConfigOption,
+    ) -> Result<DomainConfigOption, DomainConfigProviderError> {
+        update::update_option(&state.db, domain_id, option).await
+    }
+
+    /// Delete the whole configuration of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or an `Error`.
+    async fn delete_domain_config<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+    ) -> Result<(), DomainConfigProviderError> {
+        delete::delete_config(&state.db, domain_id).await
+    }
+
+    /// Delete a single configuration group of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group to delete.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or an `Error`.
+    async fn delete_domain_config_group<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+    ) -> Result<(), DomainConfigProviderError> {
+        delete::delete_group(&state.db, domain_id, group).await
+    }
+
+    /// Delete a single configuration option of a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain.
+    /// - `group`: The group holding the option.
+    /// - `option`: The option to delete.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or an `Error`.
+    async fn delete_domain_config_option<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        group: DomainConfigGroupName,
+        option: &'a str,
+    ) -> Result<(), DomainConfigProviderError> {
+        delete::delete_option(&state.db, domain_id, group, option).await
+    }
+
+    /// Try to register a domain for a configuration type.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain claiming the type.
+    /// - `driver_type`: The registration type to claim.
+    ///
+    /// # Returns
+    /// A `Result` containing `true` when the domain now holds the
+    /// registration, `false` when somebody already does, or an `Error`.
+    async fn obtain_registration<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        driver_type: &'a str,
+    ) -> Result<bool, DomainConfigProviderError> {
+        registration::obtain(&state.db, domain_id, driver_type).await
+    }
+
+    /// Read which domain holds the registration of a configuration type.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `driver_type`: The registration type to look up.
+    ///
+    /// # Returns
+    /// A `Result` containing an `Option` with the ID of the domain holding it,
+    /// or an `Error`.
+    async fn read_registration<'a>(
+        &self,
+        state: &ServiceState,
+        driver_type: &'a str,
+    ) -> Result<Option<String>, DomainConfigProviderError> {
+        registration::read(&state.db, driver_type).await
+    }
+
+    /// Release the registrations a domain holds.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The ID of the domain releasing them.
+    /// - `driver_type`: The single type to release, or `None` for every type
+    ///   the domain holds.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or an `Error`.
+    async fn release_registration<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+        driver_type: Option<&'a str>,
+    ) -> Result<(), DomainConfigProviderError> {
+        registration::release(&state.db, domain_id, driver_type).await
+    }
+}
+
+#[async_trait]
+impl SqlDriver for SqlBackend {
+    /// Set up the database tables.
+    ///
+    /// # Parameters
+    /// - `connection`: The database connection.
+    /// - `schema`: The database schema.
+    ///
+    /// # Returns
+    /// A `Result` indicating success or a `DatabaseError`.
+    async fn setup(
+        &self,
+        connection: &DatabaseConnection,
+        schema: &Schema,
+    ) -> Result<(), DatabaseError> {
+        create_table(
+            connection,
+            schema,
+            crate::entity::prelude::WhitelistedConfig,
+        )
+        .await?;
+        create_table(connection, schema, crate::entity::prelude::SensitiveConfig).await?;
+        create_table(connection, schema, crate::entity::prelude::ConfigRegister).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use openstack_keystone_core_types::domain_config::DomainConfig;
+    use serde_json::json;
+
+    use crate::entity::{sensitive_config, whitelisted_config};
+
+    /// A stored readable option row.
+    pub fn whitelisted_row(
+        domain_id: &str,
+        group: &str,
+        option: &str,
+        value: &str,
+    ) -> whitelisted_config::Model {
+        whitelisted_config::Model {
+            domain_id: domain_id.to_string(),
+            group: group.to_string(),
+            option: option.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    /// A stored sensitive option row.
+    pub fn sensitive_row(
+        domain_id: &str,
+        group: &str,
+        option: &str,
+        value: &str,
+    ) -> sensitive_config::Model {
+        sensitive_config::Model {
+            domain_id: domain_id.to_string(),
+            group: group.to_string(),
+            option: option.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    /// An `ldap` group carrying one readable and one sensitive option.
+    pub fn ldap_config() -> DomainConfig {
+        domain_config(json!({"ldap": {"url": "ldap://host", "password": "s3cr3t"}}))
+    }
+
+    /// A configuration built from a request body.
+    pub fn domain_config(value: serde_json::Value) -> DomainConfig {
+        DomainConfig::from_value(value).expect("a valid domain configuration")
+    }
+
+    /// The tables are part of python-keystone's initial schema, so this driver
+    /// only creates them from its entities, on `keystone-manage db sync`. What
+    /// that path has to get right is the columns (`group`, `option`), which are
+    /// reserved words in SQL.
+    mod schema {
+        use sea_orm::{ConnectionTrait, DbBackend, Schema};
+
+        use super::super::*;
+
+        /// Store and read back one option per table, which is what proves the
+        /// columns are usable and not only creatable.
+        async fn assert_usable<C: ConnectionTrait>(db: &C) {
+            for table in ["whitelisted_config", "sensitive_config"] {
+                db.execute_unprepared(&format!(
+                    r#"INSERT INTO "{table}" ("domain_id", "group", "option", "value")
+                       VALUES ('did', 'ldap', 'url', '"ldap://host"')"#
+                ))
+                .await
+                .unwrap_or_else(|err| panic!("inserting into {table}: {err}"));
+                db.execute_unprepared(&format!(
+                    r#"SELECT "value" FROM "{table}" WHERE "group" = 'ldap' AND "option" = 'url'"#
+                ))
+                .await
+                .unwrap_or_else(|err| panic!("reading {table}: {err}"));
+            }
+        }
+
+        #[tokio::test]
+        async fn test_setup_creates_the_tables() {
+            let db = sea_orm::Database::connect("sqlite::memory:").await.unwrap();
+            let schema = Schema::new(DbBackend::Sqlite);
+
+            SqlBackend::default().setup(&db, &schema).await.unwrap();
+
+            assert_usable(&db).await;
+        }
+
+        #[tokio::test]
+        async fn test_the_primary_key_is_the_option_of_a_domain() {
+            let db = sea_orm::Database::connect("sqlite::memory:").await.unwrap();
+            let schema = Schema::new(DbBackend::Sqlite);
+            SqlBackend::default().setup(&db, &schema).await.unwrap();
+            assert_usable(&db).await;
+
+            assert!(
+                db.execute_unprepared(
+                    r#"INSERT INTO "whitelisted_config" ("domain_id", "group", "option", "value")
+                       VALUES ('did', 'ldap', 'url', '"ldap://other"')"#
+                )
+                .await
+                .is_err(),
+                "an option must be stored once per domain"
+            );
+            // The same option of another domain, and another option of the
+            // same domain, are both fine.
+            db.execute_unprepared(
+                r#"INSERT INTO "whitelisted_config" ("domain_id", "group", "option", "value")
+                   VALUES ('other', 'ldap', 'url', '"ldap://other"'),
+                          ('did', 'identity', 'driver', '"ldap"')"#,
+            )
+            .await
+            .unwrap();
+        }
+    }
+}

--- a/crates/domain-config-driver-sql/src/option.rs
+++ b/crates/domain-config-driver-sql/src/option.rs
@@ -1,0 +1,381 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Conversion between stored rows and configuration options.
+//!
+//! Both tables hold the value as the JSON encoding of whatever the client
+//! wrote, in a text column, which is how python-keystone's `JsonBlob` type
+//! persists it.
+
+use std::str::FromStr;
+
+use sea_orm::entity::*;
+
+use openstack_keystone_core_types::domain_config::*;
+
+use crate::entity::{sensitive_config, whitelisted_config};
+
+/// Decode a stored row into a configuration option.
+///
+/// Rows are read tolerantly, the way
+/// [`DomainConfig::from_options`] treats options it no longer knows: a row that
+/// is no longer configurable is skipped with a warning rather than made to fail
+/// the whole read, which would leave the domain unreadable — and its identity
+/// backend uninitializable — until an operator deleted the row.
+///
+/// A row drifts out of the configurable set in two ways, and both are dropped
+/// here, at the one place every read passes through. Dropping them at different
+/// depths is what would make them behave differently: a group no longer
+/// configurable would leave the domain unconfigured (`404`), while an option no
+/// longer whitelisted would survive as far as the emptiness check the reads
+/// make their `None` decision on and answer an empty configuration (`200`)
+/// instead — and would be served outright by the option scoped read, which has
+/// no later [`DomainConfig::from_options`] to drop it.
+///
+/// # Parameters
+/// - `group`: The stored group name.
+/// - `option`: The stored option name.
+/// - `value`: The stored, JSON encoded value.
+///
+/// # Returns
+/// - `Result<Option<DomainConfigOption>, DomainConfigProviderError>` - The
+///   option, `None` when it is not one a domain can hold, or
+///   [`DomainConfigProviderError::InvalidOptionValue`] when the value is not
+///   the JSON the column is supposed to hold.
+fn decode(
+    group: &str,
+    option: String,
+    value: &str,
+) -> Result<Option<DomainConfigOption>, DomainConfigProviderError> {
+    let Ok(group) = DomainConfigGroupName::from_str(group) else {
+        tracing::warn!(
+            group = %group,
+            option = %option,
+            "skipping a stored domain config option of a group that is not configurable"
+        );
+        return Ok(None);
+    };
+    // Both tables are read through here, so this has to admit the sensitive
+    // options as well as the whitelisted ones.
+    if !is_supported(group, &option) {
+        tracing::warn!(
+            group = %group,
+            option = %option,
+            "skipping a stored domain config option that is not configurable"
+        );
+        return Ok(None);
+    }
+    let value: DomainConfigValue = serde_json::from_str(value).map_err(|source| {
+        DomainConfigProviderError::InvalidOptionValue {
+            group: group.to_string(),
+            option: option.clone(),
+            source,
+        }
+    })?;
+    Ok(Some(DomainConfigOption::new(group, option, value)))
+}
+
+/// Encode an option value the way both tables store it.
+///
+/// # Parameters
+/// - `option`: The option whose value to encode.
+///
+/// # Returns
+/// - `Result<String, DomainConfigProviderError>` - The JSON encoding of the
+///   value.
+fn encode(option: &DomainConfigOption) -> Result<String, DomainConfigProviderError> {
+    serde_json::to_string(&option.value).map_err(|source| {
+        DomainConfigProviderError::InvalidOptionValue {
+            group: option.group.to_string(),
+            option: option.option.clone(),
+            source,
+        }
+    })
+}
+
+/// Decode the readable rows of a query.
+///
+/// # Parameters
+/// - `rows`: The rows to decode.
+///
+/// # Returns
+/// - `Result<Vec<DomainConfigOption>, DomainConfigProviderError>` - The
+///   options, skipping the rows [`decode`] does not recognize.
+pub(crate) fn from_whitelisted_rows<I>(
+    rows: I,
+) -> Result<Vec<DomainConfigOption>, DomainConfigProviderError>
+where
+    I: IntoIterator<Item = whitelisted_config::Model>,
+{
+    rows.into_iter()
+        .filter_map(|row| decode(&row.group, row.option, &row.value).transpose())
+        .collect()
+}
+
+/// Decode the sensitive rows of a query.
+///
+/// # Parameters
+/// - `rows`: The rows to decode.
+///
+/// # Returns
+/// - `Result<Vec<DomainConfigOption>, DomainConfigProviderError>` - The
+///   options, skipping the rows [`decode`] does not recognize.
+pub(crate) fn from_sensitive_rows<I>(
+    rows: I,
+) -> Result<Vec<DomainConfigOption>, DomainConfigProviderError>
+where
+    I: IntoIterator<Item = sensitive_config::Model>,
+{
+    rows.into_iter()
+        .filter_map(|row| decode(&row.group, row.option, &row.value).transpose())
+        .collect()
+}
+
+/// Build the rows an option list is persisted as.
+///
+/// Sensitivity is a property of the option name, so the split decides the
+/// table an option lands in: a secret only ever reaches `sensitive_config`,
+/// which the readable endpoints do not query.
+///
+/// # Parameters
+/// - `domain_id`: The domain the options belong to.
+/// - `options`: The options to persist.
+///
+/// # Returns
+/// - `Result<(Vec<whitelisted_config::ActiveModel>, Vec<sensitive_config::ActiveModel>), DomainConfigProviderError>` -
+///   The readable and the sensitive rows.
+#[allow(clippy::type_complexity)]
+pub(crate) fn to_rows<'a, I>(
+    domain_id: &str,
+    options: I,
+) -> Result<
+    (
+        Vec<whitelisted_config::ActiveModel>,
+        Vec<sensitive_config::ActiveModel>,
+    ),
+    DomainConfigProviderError,
+>
+where
+    I: IntoIterator<Item = &'a DomainConfigOption>,
+{
+    let mut whitelisted = Vec::new();
+    let mut sensitive = Vec::new();
+    for option in options {
+        let value = encode(option)?;
+        if option.sensitive() {
+            sensitive.push(sensitive_config::ActiveModel {
+                domain_id: Set(domain_id.to_string()),
+                group: Set(option.group.to_string()),
+                option: Set(option.option.clone()),
+                value: Set(value),
+            });
+        } else {
+            whitelisted.push(whitelisted_config::ActiveModel {
+                domain_id: Set(domain_id.to_string()),
+                group: Set(option.group.to_string()),
+                option: Set(option.option.clone()),
+                value: Set(value),
+            });
+        }
+    }
+    Ok((whitelisted, sensitive))
+}
+
+/// Reject an option that may not be stored for a domain.
+///
+/// The option scoped write addresses one option rather than a group, so it is
+/// the one path that has to ask for both checks by hand: an option that is not
+/// supported, or one holding a value its type cannot represent, would be
+/// stored only for every later read of the domain to trip over it. An
+/// unsupported name is merely skipped with a warning, but an untypable value
+/// fails the domain's identity backend outright, which is what leaves it
+/// uninitializable until an operator deletes the row.
+///
+/// # Parameters
+/// - `option`: The option to check.
+///
+/// # Returns
+/// - `Result<(), DomainConfigProviderError>` - `Ok(())` when the option may be
+///   stored, [`DomainConfigProviderError::UnsupportedOption`] when its name is
+///   not configurable, or [`DomainConfigProviderError::InvalidOptionValue`]
+///   when the value is not one the option can hold.
+pub(crate) fn assert_storable(
+    option: &DomainConfigOption,
+) -> Result<(), DomainConfigProviderError> {
+    if !is_supported(option.group, &option.option) {
+        return Err(DomainConfigProviderError::UnsupportedOption {
+            group: option.group.to_string(),
+            option: option.option.clone(),
+        });
+    }
+    // The config section the option overrides is the only thing that knows
+    // what it may hold.
+    DomainConfigGroup::from_options(option.group, [option.clone()])?.validate_values()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_a_stored_row() {
+        let option = decode("ldap", "url".to_string(), r#""ldap://host""#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(option.group, DomainConfigGroupName::Ldap);
+        assert_eq!(option.option, "url");
+        assert_eq!(option.value.as_str(), Some("ldap://host"));
+        assert!(!option.sensitive());
+    }
+
+    #[test]
+    fn decodes_the_json_type_that_was_stored() {
+        let option = decode("ldap", "page_size".to_string(), "10")
+            .unwrap()
+            .unwrap();
+        assert_eq!(option.value, DomainConfigValue::new(10));
+    }
+
+    #[test]
+    fn decoding_marks_a_sensitive_option() {
+        let option = decode("ldap", "password".to_string(), r#""s3cr3t""#)
+            .unwrap()
+            .unwrap();
+        assert!(option.sensitive());
+    }
+
+    #[test]
+    fn decoding_skips_a_group_that_is_not_configurable() {
+        assert!(
+            decode("assignment", "driver".to_string(), r#""sql""#)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn decoding_skips_an_option_that_is_not_configurable() {
+        assert!(
+            decode("ldap", "bind_dn".to_string(), r#""cn=admin""#)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// The sensitive options are configurable too, and both tables decode
+    /// through here, so the whitelist alone must not be the test.
+    #[test]
+    fn decoding_keeps_a_sensitive_option() {
+        let option = decode("ldap", "password".to_string(), r#""s3cr3t""#)
+            .unwrap()
+            .expect("a sensitive option is still configurable");
+        assert!(option.sensitive());
+    }
+
+    #[test]
+    fn decoding_reports_a_value_that_is_not_json() {
+        let err = decode("ldap", "url".to_string(), "ldap://host").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid value for option url in group ldap: expected value at line 1 column 1"
+        );
+    }
+
+    #[test]
+    fn encoding_round_trips_through_decoding() {
+        for value in [
+            DomainConfigValue::from("ldap://host"),
+            DomainConfigValue::new(10),
+            DomainConfigValue::new(true),
+        ] {
+            let option = DomainConfigOption::new(DomainConfigGroupName::Ldap, "url", value.clone());
+            let encoded = encode(&option).unwrap();
+            assert_eq!(
+                decode("ldap", "url".to_string(), &encoded)
+                    .unwrap()
+                    .unwrap()
+                    .value,
+                value
+            );
+        }
+    }
+
+    #[test]
+    fn sensitive_options_are_split_off_into_their_own_rows() {
+        let options = vec![
+            DomainConfigOption::new(DomainConfigGroupName::Ldap, "url", "ldap://host"),
+            DomainConfigOption::new(DomainConfigGroupName::Ldap, "password", "s3cr3t"),
+        ];
+        let (whitelisted, sensitive) = to_rows("did", &options).unwrap();
+        assert_eq!(whitelisted.len(), 1);
+        assert_eq!(sensitive.len(), 1);
+        assert_eq!(whitelisted[0].option, Set("url".to_string()));
+        assert_eq!(sensitive[0].option, Set("password".to_string()));
+        assert_eq!(sensitive[0].value, Set(r#""s3cr3t""#.to_string()));
+    }
+
+    #[test]
+    fn unsupported_options_are_rejected_before_they_are_stored() {
+        let err = assert_storable(&DomainConfigOption::new(
+            DomainConfigGroupName::Ldap,
+            "bind_dn",
+            "cn=admin",
+        ))
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "option bind_dn in group ldap is not supported for domain specific configurations"
+        );
+        assert!(
+            assert_storable(&DomainConfigOption::new(
+                DomainConfigGroupName::Ldap,
+                "password",
+                "s3cr3t"
+            ))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn values_an_option_cannot_hold_are_rejected_before_they_are_stored() {
+        // Storing this would fail every later read of the domain, not just a
+        // read of the option.
+        let err = assert_storable(&DomainConfigOption::new(
+            DomainConfigGroupName::Ldap,
+            "page_size",
+            "a lot",
+        ))
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .starts_with("invalid value for option page_size in group ldap"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn values_an_option_can_hold_are_accepted_in_every_spelling() {
+        for value in [
+            DomainConfigValue::new(10),
+            // The spelling a per-domain config file delivers.
+            DomainConfigValue::from("10"),
+        ] {
+            assert_storable(&DomainConfigOption::new(
+                DomainConfigGroupName::Ldap,
+                "page_size",
+                value,
+            ))
+            .unwrap();
+        }
+    }
+}

--- a/crates/domain-config-driver-sql/src/registration.rs
+++ b/crates/domain-config-driver-sql/src/registration.rs
@@ -1,0 +1,304 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Claim, read and release the registration of a configuration type.
+//!
+//! A registration is a lock one domain holds over a configuration type, stored
+//! in `config_register` with the type as the primary key. python-keystone uses
+//! it so that at most one domain drives a given mechanism at a time — the `SQL`
+//! type, for instance, marks the single domain whose identity backend is
+//! allowed to be the SQL one when domain specific drivers are loaded from the
+//! database.
+//!
+//! Exclusivity is the primary key doing the work rather than a read followed by
+//! a write: two nodes claiming the same type concurrently both insert, and the
+//! one that loses the race is told so by the database instead of overwriting
+//! the winner.
+
+use sea_orm::entity::*;
+use sea_orm::query::*;
+use sea_orm::{DatabaseConnection, Set};
+
+use openstack_keystone_core::error::{DatabaseError, DbContextExt};
+use openstack_keystone_core_types::domain_config::DomainConfigProviderError;
+
+use crate::entity::config_register;
+use crate::entity::prelude::ConfigRegister as DbConfigRegister;
+
+/// Try to register a domain for a configuration type.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain claiming the type.
+/// - `driver_type`: The registration type to claim.
+///
+/// # Returns
+/// - `Result<bool, DomainConfigProviderError>` - `true` when the domain now
+///   holds the registration, `false` when somebody already does — the
+///   requesting domain itself included.
+pub async fn obtain(
+    db: &DatabaseConnection,
+    domain_id: &str,
+    driver_type: &str,
+) -> Result<bool, DomainConfigProviderError> {
+    let row = config_register::ActiveModel {
+        r#type: Set(driver_type.to_owned()),
+        domain_id: Set(domain_id.to_owned()),
+    };
+    match DbConfigRegister::insert(row)
+        .exec(db)
+        .await
+        .context("obtaining a domain config registration")
+    {
+        Ok(_) => Ok(true),
+        // Losing the primary key race is the answer, not a failure: the type is
+        // taken. python-keystone's `obtain_registration` swallows
+        // `DBDuplicateEntry` the same way and returns `False`, which includes
+        // the case of the domain already holding the registration itself.
+        Err(DatabaseError::Conflict { .. }) => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Read which domain holds the registration of a configuration type.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `driver_type`: The registration type to look up.
+///
+/// # Returns
+/// - `Result<Option<String>, DomainConfigProviderError>` - The ID of the domain
+///   holding it, or `None` when nobody does.
+pub async fn read(
+    db: &DatabaseConnection,
+    driver_type: &str,
+) -> Result<Option<String>, DomainConfigProviderError> {
+    Ok(DbConfigRegister::find_by_id(driver_type)
+        .one(db)
+        .await
+        .context("reading a domain config registration")?
+        .map(|registration| registration.domain_id))
+}
+
+/// Release the registrations a domain holds.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain releasing them.
+/// - `driver_type`: The single type to release, or `None` for every type the
+///   domain holds. `None` is the only spelling of "every type": python-keystone
+///   tests its `type` argument for truth, so an empty string releases
+///   everything there, whereas here it selects the registration of the empty
+///   type, of which there is none.
+///
+/// # Returns
+/// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful.
+pub async fn release(
+    db: &DatabaseConnection,
+    domain_id: &str,
+    driver_type: Option<&str>,
+) -> Result<(), DomainConfigProviderError> {
+    // Always filtered by domain: releasing is only ever giving up what this
+    // domain holds, so a type registered to somebody else is left alone rather
+    // than stolen. Holding none of it is not an error either, as
+    // python-keystone's `release_registration` documents ("if it is not then do
+    // nothing - no exception is raised").
+    let mut query =
+        DbConfigRegister::delete_many().filter(config_register::Column::DomainId.eq(domain_id));
+    if let Some(driver_type) = driver_type {
+        query = query.filter(config_register::Column::Type.eq(driver_type));
+    }
+    query
+        .exec(db)
+        .await
+        .context("releasing a domain config registration")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, DbBackend, MockDatabase, MockExecResult, Schema, Transaction};
+
+    use super::*;
+    use crate::SqlBackend;
+    use openstack_keystone_core::SqlDriver;
+
+    /// A database with the driver's tables, for the paths whose behaviour is
+    /// the database enforcing the primary key rather than a statement.
+    async fn sqlite() -> DatabaseConnection {
+        let db = sea_orm::Database::connect("sqlite::memory:").await.unwrap();
+        let schema = Schema::new(DbBackend::Sqlite);
+        SqlBackend::default().setup(&db, &schema).await.unwrap();
+        db
+    }
+
+    #[tokio::test]
+    async fn test_obtain() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![config_register::Model {
+                r#type: "SQL".to_string(),
+                domain_id: "did".to_string(),
+            }]])
+            .into_connection();
+
+        assert!(obtain(&db, "did", "SQL").await.unwrap());
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"INSERT INTO "config_register" ("type", "domain_id") VALUES ($1, $2) RETURNING "type""#,
+                ["SQL".into(), "did".into()]
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_obtain_of_a_type_another_domain_holds() {
+        let db = sqlite().await;
+        assert!(obtain(&db, "did", "SQL").await.unwrap());
+
+        assert!(
+            !obtain(&db, "other", "SQL")
+                .await
+                .expect("a taken registration is an answer, not an error"),
+            "a type is registered to one domain at a time"
+        );
+        // The domain that got there first still holds it.
+        assert_eq!(read(&db, "SQL").await.unwrap(), Some("did".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_obtain_of_a_type_the_domain_already_holds() {
+        // python-keystone answers `False` here too: the caller asked to become
+        // the holder and nothing changed hands.
+        let db = sqlite().await;
+        assert!(obtain(&db, "did", "SQL").await.unwrap());
+
+        assert!(!obtain(&db, "did", "SQL").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_obtain_of_another_type() {
+        // The registration is exclusive per type, not per domain.
+        let db = sqlite().await;
+        assert!(obtain(&db, "did", "SQL").await.unwrap());
+
+        assert!(obtain(&db, "did", "LDAP").await.unwrap());
+        assert_eq!(read(&db, "LDAP").await.unwrap(), Some("did".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_read() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![config_register::Model {
+                r#type: "SQL".to_string(),
+                domain_id: "did".to_string(),
+            }]])
+            .into_connection();
+
+        assert_eq!(read(&db, "SQL").await.unwrap(), Some("did".to_string()));
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "config_register"."type", "config_register"."domain_id" FROM "config_register" WHERE "config_register"."type" = $1 LIMIT $2"#,
+                ["SQL".into(), 1u64.into()]
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_of_an_unregistered_type() {
+        let db = sqlite().await;
+
+        assert_eq!(read(&db, "SQL").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_release() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([MockExecResult {
+                rows_affected: 1,
+                ..Default::default()
+            }])
+            .into_connection();
+
+        release(&db, "did", Some("SQL")).await.unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"DELETE FROM "config_register" WHERE "config_register"."domain_id" = $1 AND "config_register"."type" = $2"#,
+                ["did".into(), "SQL".into()]
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_release_of_every_type_of_a_domain() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([MockExecResult {
+                rows_affected: 2,
+                ..Default::default()
+            }])
+            .into_connection();
+
+        release(&db, "did", None).await.unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"DELETE FROM "config_register" WHERE "config_register"."domain_id" = $1"#,
+                ["did".into()]
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_release_of_a_type_another_domain_holds_keeps_it() {
+        let db = sqlite().await;
+        assert!(obtain(&db, "did", "SQL").await.unwrap());
+
+        release(&db, "other", Some("SQL"))
+            .await
+            .expect("releasing what is not held is silent");
+
+        assert_eq!(read(&db, "SQL").await.unwrap(), Some("did".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_release_of_the_empty_type_releases_nothing() {
+        // Unlike python-keystone, where a falsey type means every type.
+        let db = sqlite().await;
+        assert!(obtain(&db, "did", "SQL").await.unwrap());
+
+        release(&db, "did", Some("")).await.unwrap();
+
+        assert_eq!(read(&db, "SQL").await.unwrap(), Some("did".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_release_frees_the_type_for_another_domain() {
+        let db = sqlite().await;
+        assert!(obtain(&db, "did", "SQL").await.unwrap());
+
+        release(&db, "did", Some("SQL")).await.unwrap();
+
+        assert!(obtain(&db, "other", "SQL").await.unwrap());
+        assert_eq!(read(&db, "SQL").await.unwrap(), Some("other".to_string()));
+    }
+}

--- a/crates/domain-config-driver-sql/src/update.rs
+++ b/crates/domain-config-driver-sql/src/update.rs
@@ -1,0 +1,569 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Merge changes into the stored configuration of a domain.
+//!
+//! An update never removes an option, so every write is an upsert: an option
+//! the domain already has is overwritten in place, one it does not have is
+//! added.
+//!
+//! The state a write returns is read back from `whitelisted_config` and the
+//! sensitive options *of that request*, never the ones already stored. It is
+//! what a caller just supplied, the same way [`crate::create`] returns it, so
+//! a caller that patches only `ldap.password` still sees a group that is not
+//! empty — but a caller that patches only `ldap.url` is never handed a secret
+//! it did not write, which is what the group scoped read guarantees too.
+
+use sea_orm::entity::*;
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{ConnectionTrait, DatabaseConnection, TransactionTrait};
+
+use openstack_keystone_core::error::DbContextExt;
+use openstack_keystone_core_types::domain_config::*;
+
+use crate::entity::prelude::{
+    SensitiveConfig as DbSensitiveConfig, WhitelistedConfig as DbWhitelistedConfig,
+};
+use crate::entity::{sensitive_config, whitelisted_config};
+use crate::{get, option};
+
+/// Merge changes into the whole configuration of a domain.
+///
+/// Backs `PATCH /v3/domains/{domain_id}/config`.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `config`: The options to change.
+///
+/// # Returns
+/// - `Result<DomainConfig, DomainConfigProviderError>` - The resulting
+///   configuration.
+pub async fn update_config(
+    db: &DatabaseConnection,
+    domain_id: &str,
+    config: DomainConfigUpdate,
+) -> Result<DomainConfig, DomainConfigProviderError> {
+    let config = config.into_inner();
+    config.validate()?;
+    // The values are decoded into the config sections they override, so a
+    // value no option can hold is refused rather than stored for every later
+    // read of the domain to trip over.
+    config.validate_values()?;
+    let options = config.to_options();
+
+    let txn = db.begin().await.context("starting the transaction")?;
+    upsert(&txn, domain_id, &options).await?;
+    let mut merged = get::load_whitelisted(&txn, domain_id, None, None).await?;
+    txn.commit().await.context("committing the transaction")?;
+
+    merged.extend(options.into_iter().filter(|option| option.sensitive()));
+    Ok(DomainConfig::from_options(merged))
+}
+
+/// Merge changes into a single configuration group of a domain.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `group`: The group to change.
+/// - `config`: The options to change; only `group` may be populated.
+///
+/// # Returns
+/// - `Result<DomainConfigGroup, DomainConfigProviderError>` - The resulting
+///   group, or [`DomainConfigProviderError::GroupMismatch`] when the payload
+///   does not address exactly the group of the request.
+pub async fn update_group(
+    db: &DatabaseConnection,
+    domain_id: &str,
+    group: DomainConfigGroupName,
+    config: DomainConfigUpdate,
+) -> Result<DomainConfigGroup, DomainConfigProviderError> {
+    let config = config.into_inner();
+    config.validate()?;
+    // The values are decoded into the config sections they override, so a
+    // value no option can hold is refused rather than stored for every later
+    // read of the domain to trip over.
+    config.validate_values()?;
+    if DomainConfigGroupName::ALL
+        .iter()
+        .any(|name| *name != group && config.group(*name).is_some())
+    {
+        return Err(DomainConfigProviderError::GroupMismatch(group.to_string()));
+    }
+    let options = config
+        .group(group)
+        .ok_or_else(|| DomainConfigProviderError::GroupMismatch(group.to_string()))?
+        .to_options();
+
+    let txn = db.begin().await.context("starting the transaction")?;
+    upsert(&txn, domain_id, &options).await?;
+    let mut merged = get::load_whitelisted(&txn, domain_id, Some(group), None).await?;
+    txn.commit().await.context("committing the transaction")?;
+
+    merged.extend(options.into_iter().filter(|option| option.sensitive()));
+    DomainConfigGroup::from_options(group, merged)
+}
+
+/// Change a single configuration option of a domain.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain.
+/// - `option`: The option to change, carrying its group, name and value.
+///
+/// # Returns
+/// - `Result<DomainConfigOption, DomainConfigProviderError>` - The stored
+///   option, or an error when it is not one a domain can hold; see
+///   [`option::assert_storable`].
+pub async fn update_option(
+    db: &DatabaseConnection,
+    domain_id: &str,
+    option: DomainConfigOption,
+) -> Result<DomainConfigOption, DomainConfigProviderError> {
+    option::assert_storable(&option)?;
+    upsert(db, domain_id, std::slice::from_ref(&option)).await?;
+    Ok(option)
+}
+
+/// Write options, overwriting the ones the domain already has.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The ID of the domain the options belong to.
+/// - `options`: The options to store.
+///
+/// # Returns
+/// - `Result<(), DomainConfigProviderError>` - `Ok(())` if successful.
+async fn upsert<C: ConnectionTrait>(
+    db: &C,
+    domain_id: &str,
+    options: &[DomainConfigOption],
+) -> Result<(), DomainConfigProviderError> {
+    let (whitelisted, sensitive) = option::to_rows(domain_id, options)?;
+    if !whitelisted.is_empty() {
+        DbWhitelistedConfig::insert_many(whitelisted)
+            .on_conflict(
+                OnConflict::columns([
+                    whitelisted_config::Column::DomainId,
+                    whitelisted_config::Column::Group,
+                    whitelisted_config::Column::Option,
+                ])
+                .update_column(whitelisted_config::Column::Value)
+                .to_owned(),
+            )
+            .exec(db)
+            .await
+            .context("updating domain config options")?;
+    }
+    if !sensitive.is_empty() {
+        DbSensitiveConfig::insert_many(sensitive)
+            .on_conflict(
+                OnConflict::columns([
+                    sensitive_config::Column::DomainId,
+                    sensitive_config::Column::Group,
+                    sensitive_config::Column::Option,
+                ])
+                .update_column(sensitive_config::Column::Value)
+                .to_owned(),
+            )
+            .exec(db)
+            .await
+            .context("updating sensitive domain config options")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DatabaseBackend, MockDatabase, Statement, Transaction};
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::tests::{domain_config, ldap_config, sensitive_row, whitelisted_row};
+
+    #[tokio::test]
+    async fn test_update_config() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .append_query_results([vec![sensitive_row(
+                "did",
+                "ldap",
+                "password",
+                r#""s3cr3t""#,
+            )]])
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .into_connection();
+
+        let config = update_config(&db, "did", DomainConfigUpdate(ldap_config()))
+            .await
+            .unwrap();
+        let ldap = config.group(DomainConfigGroupName::Ldap).unwrap();
+        assert_eq!(ldap.get("url"), Some(&json!("ldap://host")));
+        // The password of this very request, read back from nowhere.
+        assert!(ldap.get("password").is_some());
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::many(vec![
+                Statement::from_string(DatabaseBackend::Postgres, r#"BEGIN"#),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"INSERT INTO "whitelisted_config" ("domain_id", "group", "option", "value") VALUES ($1, $2, $3, $4) ON CONFLICT ("domain_id", "group", "option") DO UPDATE SET "value" = "excluded"."value" RETURNING "domain_id", "group", "option""#,
+                    [
+                        "did".into(),
+                        "ldap".into(),
+                        "url".into(),
+                        r#""ldap://host""#.into()
+                    ]
+                ),
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"INSERT INTO "sensitive_config" ("domain_id", "group", "option", "value") VALUES ($1, $2, $3, $4) ON CONFLICT ("domain_id", "group", "option") DO UPDATE SET "value" = "excluded"."value" RETURNING "domain_id", "group", "option""#,
+                    [
+                        "did".into(),
+                        "ldap".into(),
+                        "password".into(),
+                        r#""s3cr3t""#.into()
+                    ]
+                ),
+                // The read back never touches the sensitive table.
+                Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    r#"SELECT "whitelisted_config"."domain_id", "whitelisted_config"."group", "whitelisted_config"."option", "whitelisted_config"."value" FROM "whitelisted_config" WHERE "whitelisted_config"."domain_id" = $1 ORDER BY "whitelisted_config"."group" ASC, "whitelisted_config"."option" ASC"#,
+                    ["did".into()]
+                ),
+                Statement::from_string(DatabaseBackend::Postgres, r#"COMMIT"#),
+            ])]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_config_does_not_read_back_a_stored_secret() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .into_connection();
+
+        let config = update_config(
+            &db,
+            "did",
+            DomainConfigUpdate(domain_config(json!({"ldap": {"url": "ldap://host"}}))),
+        )
+        .await
+        .unwrap();
+        assert!(
+            config
+                .group(DomainConfigGroupName::Ldap)
+                .and_then(|group| group.get("password"))
+                .is_none(),
+            "a request that writes no secret must not be handed the stored one"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_config_rejects_a_value_the_option_cannot_hold() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let err = update_config(
+            &db,
+            "did",
+            DomainConfigUpdate(domain_config(json!({"ldap": {"use_tls": "maybe"}}))),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid value for option use_tls in group ldap: expected a boolean, got `\"maybe\"`"
+        );
+        assert_eq!(db.into_transaction_log(), []);
+    }
+
+    #[tokio::test]
+    async fn test_update_config_rejects_an_empty_payload() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let err = update_config(&db, "did", DomainConfigUpdate::default())
+            .await
+            .unwrap_err();
+        assert_eq!(err.to_string(), "no options specified");
+        assert_eq!(db.into_transaction_log(), []);
+    }
+
+    #[tokio::test]
+    async fn test_update_group() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "identity",
+                "driver",
+                r#""ldap""#,
+            )]])
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "identity",
+                "driver",
+                r#""ldap""#,
+            )]])
+            .into_connection();
+
+        let group = update_group(
+            &db,
+            "did",
+            DomainConfigGroupName::Identity,
+            DomainConfigUpdate(domain_config(json!({"identity": {"driver": "ldap"}}))),
+        )
+        .await
+        .unwrap();
+        assert_eq!(group.name(), DomainConfigGroupName::Identity);
+        assert_eq!(group.get("driver"), Some(&json!("ldap")));
+    }
+
+    #[tokio::test]
+    async fn test_update_group_does_not_read_back_a_stored_secret() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .into_connection();
+
+        let group = update_group(
+            &db,
+            "did",
+            DomainConfigGroupName::Ldap,
+            DomainConfigUpdate(domain_config(json!({"ldap": {"url": "ldap://host"}}))),
+        )
+        .await
+        .unwrap();
+        assert_eq!(group.name(), DomainConfigGroupName::Ldap);
+        assert!(
+            group.get("password").is_none(),
+            "a request that writes no secret must not be handed the stored one"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_group_returns_the_secret_of_the_request() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![sensitive_row(
+                "did",
+                "ldap",
+                "password",
+                r#""s3cr3t""#,
+            )]])
+            .append_query_results([Vec::<whitelisted_config::Model>::new()])
+            .into_connection();
+
+        let group = update_group(
+            &db,
+            "did",
+            DomainConfigGroupName::Ldap,
+            DomainConfigUpdate(domain_config(json!({"ldap": {"password": "s3cr3t"}}))),
+        )
+        .await
+        .unwrap();
+        assert_eq!(group.name(), DomainConfigGroupName::Ldap);
+        // Otherwise a patch of only the password would answer with an empty
+        // group.
+        assert!(group.get("password").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_update_group_rejects_another_group() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let err = update_group(
+            &db,
+            "did",
+            DomainConfigGroupName::Identity,
+            DomainConfigUpdate(ldap_config()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "trying to update group identity, so that, and only that, \
+             group must be specified in the config"
+        );
+        assert_eq!(db.into_transaction_log(), []);
+    }
+
+    #[tokio::test]
+    async fn test_update_group_rejects_a_payload_of_another_group_only() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let err = update_group(
+            &db,
+            "did",
+            DomainConfigGroupName::Ldap,
+            DomainConfigUpdate(domain_config(json!({"identity": {"driver": "ldap"}}))),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            DomainConfigProviderError::GroupMismatch(group) if group == "ldap"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_update_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://host""#,
+            )]])
+            .into_connection();
+
+        let stored = update_option(
+            &db,
+            "did",
+            DomainConfigOption::new(DomainConfigGroupName::Ldap, "url", "ldap://host"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(stored.value.as_str(), Some("ldap://host"));
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"INSERT INTO "whitelisted_config" ("domain_id", "group", "option", "value") VALUES ($1, $2, $3, $4) ON CONFLICT ("domain_id", "group", "option") DO UPDATE SET "value" = "excluded"."value" RETURNING "domain_id", "group", "option""#,
+                [
+                    "did".into(),
+                    "ldap".into(),
+                    "url".into(),
+                    r#""ldap://host""#.into()
+                ]
+            ),]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_a_sensitive_option_writes_the_sensitive_table_only() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![sensitive_row(
+                "did",
+                "ldap",
+                "password",
+                r#""s3cr3t""#,
+            )]])
+            .into_connection();
+
+        update_option(
+            &db,
+            "did",
+            DomainConfigOption::new(DomainConfigGroupName::Ldap, "password", "s3cr3t"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"INSERT INTO "sensitive_config" ("domain_id", "group", "option", "value") VALUES ($1, $2, $3, $4) ON CONFLICT ("domain_id", "group", "option") DO UPDATE SET "value" = "excluded"."value" RETURNING "domain_id", "group", "option""#,
+                [
+                    "did".into(),
+                    "ldap".into(),
+                    "password".into(),
+                    r#""s3cr3t""#.into()
+                ]
+            ),]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_option_rejects_an_unsupported_option() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let err = update_option(
+            &db,
+            "did",
+            DomainConfigOption::new(DomainConfigGroupName::Ldap, "bind_dn", "cn=admin"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "option bind_dn in group ldap is not supported for domain specific configurations"
+        );
+        assert_eq!(db.into_transaction_log(), []);
+    }
+
+    #[tokio::test]
+    async fn test_update_config_stores_a_substitution_reference_verbatim() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://%(user)s:%(password)s@host""#,
+            )]])
+            .append_query_results([vec![whitelisted_row(
+                "did",
+                "ldap",
+                "url",
+                r#""ldap://%(user)s:%(password)s@host""#,
+            )]])
+            .into_connection();
+
+        let config = update_config(
+            &db,
+            "did",
+            DomainConfigUpdate(domain_config(
+                json!({"ldap": {"url": "ldap://%(user)s:%(password)s@host"}}),
+            )),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            config
+                .group(DomainConfigGroupName::Ldap)
+                .and_then(|group| group.get("url")),
+            Some(&json!("ldap://%(user)s:%(password)s@host"))
+        );
+    }
+}

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -50,6 +50,7 @@ openstack-keystone-auth-plugin-identity-driver-raft.workspace = true
 openstack-keystone-core = { workspace = true, features = ["api"] }
 openstack-keystone-core-types.workspace = true
 openstack-keystone-distributed-storage.workspace = true
+openstack-keystone-domain-config-driver-sql.workspace = true
 openstack-keystone-storage-api.workspace = true
 openstack-keystone-federation-driver-sql.workspace = true
 openstack-keystone-k8s-auth-driver-sql.workspace = true


### PR DESCRIPTION
Phase 1 of #954: the SQL persistence for the
`/v3/domains/{domain_id}/config` API family.

Rebased onto `main` now that #1138 (Phase 0, the core types and the
backend trait) has merged, so this is a single commit against `main`.

There is still no service or handler, so nothing resolves a backend of
the `DomainConfigBackend` kind yet — the driver is reachable only through
the registry it submits itself to (`name: "sql"`), and its tables through
`keystone-manage db sync`.

## Storage

One row per option keyed by `(domain_id, group, option)`, value in a text
column as the JSON it was written as, matching python-keystone's
`JsonBlob` — whatever type a client writes is the type a later read
returns.

The tables are named `whitelisted_config` and `sensitive_config`, i.e.
python-keystone's names, rather than the `domain_config` /
`domain_config_sensitive` sketched in the issue. Every other `*-driver-sql`
crate in this workspace transcribes python-keystone's schema down to the
table and column names (`user`, `group`, `local_user`, …), and Phase 0's
core types already document these two by name.

They are part of the initial schema python-keystone installs, so this
driver ships **no migration** of its own (per review feedback): the tables
are created from their entities on `keystone-manage db sync`, like every
other natively-compatible provider. A test against a real SQLite database
covers that path, which also pins down that the reserved words `group` and
`option` are usable as column names.

## Registrations

A third table, `config_register`, holds no option at all (added per review
feedback): it records which domain holds the registration of a
configuration type — the lock python-keystone uses so that at most one
domain drives a given mechanism. python-keystone's schema again, `type
varchar(64)` as the primary key and `domain_id varchar(64) NOT NULL`;
`type` is a reserved word, so the field is `r#type` with an explicit
`column_name`, as in `policy-store-driver-sql`.

It backs the three methods the reviewer named, added to
`DomainConfigBackend` alongside it:

- `obtain_registration` inserts and lets the primary key decide, rather
  than reading the current holder and then writing, so two nodes claiming
  a type concurrently cannot both be told they hold it. Losing that race
  is the answer rather than a failure — the unique-constraint violation
  becomes `Ok(false)`, the way python-keystone swallows `DBDuplicateEntry`,
  including when the domain already holds the registration itself.
- `read_registration` answers `Option<String>` rather than raising, so
  `None` is python-keystone's `ConfigRegistrationNotFound` and the caller
  decides what it means.
- `release_registration` is always filtered by domain, so a type
  registered to another domain is left alone rather than stolen, and
  releasing what is not held is silent. Its `driver_type` is an `Option`,
  so `None` is the only spelling of "every type this domain holds":
  python-keystone tests that argument for truth, so `type=""` releases
  everything there, whereas here it selects the registration of the empty
  type, of which there is none. Documented and tested.

## Sensitive options

Keeping secrets in their own table is what makes the read paths safe by
construction rather than by filtering:

- the group and option scoped reads back the endpoints that hand options
  to a client, and they only ever select from `whitelisted_config`;
- the option scoped read answers a sensitive option with `None` without
  issuing a statement at all;
- only the whole-config read touches `sensitive_config`, because the
  identity backend has to be handed the bind password — and `DomainConfig`
  skips it on serialization, so it still cannot reach a response.

## Substitution

`%(option)s` references are stored verbatim and resolved by
`DomainConfig::substitute`, **not** on a driver read. Resolving them inside
`get_domain_config` would inline the bind password into `ldap.url`, which
that same read serves to the API; the resolved form is for the identity
backend alone, so it belongs to the resolution layer, where the issue also
lists it (Phase 3).

## Behaviour notes

- Reads are tolerant of drift, as the core types are: a row that is no
  longer configurable is skipped with a warning rather than failing the
  whole read, which would otherwise leave the domain unreadable — and its
  identity backend uninitializable — until an operator deleted the row.
  Both spellings of that drift, a group that is no longer configurable and
  an option that is no longer whitelisted, are dropped as the row is
  decoded, which is the one place every read passes through. Dropping the
  latter deeper down, where `DomainConfig::from_options` does it, would let
  it reach the emptiness check the reads make their `None` decision on — so
  a domain holding nothing but a drifted row would answer `200` with an
  empty configuration where a drifted *group* answers `404` — and the
  option scoped read, which has no later `from_options` to drop it, would
  serve it outright.
- A partial delete reports what is not there (404), as python-keystone's
  `delete_config` does; the row count answers that without a preceding
  read, and the transaction rolls back the half that did match. Deleting a
  whole configuration that is not there stays silent, also matching
  python-keystone's driver.
- The option scoped write rejects an option that is neither whitelisted
  nor sensitive: storing one would create a row every later read skips.
- Write paths return the merged state including sensitive options. They
  are what the caller just supplied and they are skipped on serialization,
  so echoing them back cannot put a secret on the wire, while a caller
  that patches only `ldap.password` still sees a group that is not empty.
  All of them answer with what was stored rather than what was asked for,
  the way python-keystone answers from the rows it wrote: the two differ
  over a group the whitelist emptied, which the request still carries and
  no later read would ever report.

## Outside the driver crate

- One additive error variant in `core-types`, `GroupMismatch`, for a group
  scoped write whose payload addresses another group (python-keystone's
  "trying to update group X, so that, and only that, …").
- `DomainConfigBackend` added to `PluginManager`'s backend registry so the
  driver's `inventory::submit!` has a registry to submit to. Resolving and
  holding the backend comes with the provider that consumes it — Phase 3/4.
- Three additive methods on the `DomainConfigBackend` trait,
  `obtain_registration`, `read_registration` and `release_registration`.
  They keep python-keystone's names rather than the CRUD prefixes the rest
  of the trait uses, since "obtain" and "release" are what the operations
  are; `get_default_*` already sits outside that pattern too.

## Testing

- `cargo test -p openstack-keystone-domain-config-driver-sql` — 62 tests,
  including nine against a real SQLite database, for the schema and for the
  registration paths whose behaviour is the database enforcing the primary
  key rather than a statement.
- `cargo test -p openstack-keystone-core-types -p openstack-keystone-core`
- `keystone-manage db sync` against a fresh SQLite database creates all
  three tables, with the composite primary key on the two option tables;
  `db up` still runs clean.
- `cargo clippy --all-targets` on the touched crates: no new warnings.

Part of #954. Closes #956.

