### PR TITLE
fix: Map raft-not-available to proper HTTP status codes

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -178,103 +178,6 @@ jobs:
         if: failure()
         run: docker logs opa
 
-  loadtest:
-    runs-on: ubuntu-latest
-    if: "success() && github.event_name != 'merge_group' && github.actor != 'openstack-experimental-release-plz'"
-    needs:
-      - build
-    permissions:
-      contents: read
-      packages: read
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: keystone
-          POSTGRES_PASSWORD: '1234'
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: ./.github/actions/deploy_keystone
-
-      - name: Build Load test binary
-        working-directory: tests/loadtest
-        run: cargo build --release
-
-      - name: Run load test
-        working-directory: tests/loadtest
-        env:
-          OS_CLOUD: admin
-        run: |
-          mkdir -p reports
-          ./target/release/load_test \
-            --host http://localhost:8080 \
-            --hatch-rate 2 \
-            --run-time 30s \
-            --report-file reports/loadtest-report-rust.html \
-            --report-file reports/loadtest-report-rust.md
-          ./target/release/load_test \
-            --host http://localhost:5001 \
-            --hatch-rate 2 \
-            --run-time 30s \
-            --report-file reports/loadtest-report-python.html \
-            --report-file reports/loadtest-report-python.md
-
-      - name: Upload report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: loadtest-report
-          path: tests/loadtest/reports/
-
-      - name: Dump py-keystone logs
-        if: failure()
-        run: docker logs keystone
-
-      - name: Dump rust keystone log
-        if: failure()
-        run: cat rust.log
-
-      - name: Dump OPA log
-        if: failure()
-        run: docker logs opa
-
-  loadtest-track:
-    if: "success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'openstack-experimental-release-plz'"
-    runs-on: ubuntu-latest
-    needs:
-      - loadtest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Fetch pre-built artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5.0.0
-        with:
-          name: loadtest-report
-
-      - name: Extract report
-        id: metrics
-        run: |
-          SUMMARY=$(cat loadtest-report-rust.md || echo "No summary found")
-          echo "summary<<EOF" >> $GITHUB_OUTPUT
-          echo "$SUMMARY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Post Loadtest results to PR
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        with:
-          header: loadtest
-          message: |
-            🦢 **Load Test Results**
-
-            ${{ steps.metrics.outputs.summary }}
-
-            [View full report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
   k3s-test:
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -346,6 +249,49 @@ jobs:
         run: |
           skaffold verify --profile github-ci -m keystone --env-file github-oidc.env -a build.artifacts -v debug
 
+      - name: Install Rust and build loadtest binary
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          source "$HOME/.cargo/env"
+          (cd tests/loadtest && cargo build --release)
+
+      - name: Run loadtest against keystone-rs
+        env:
+          HOME: /tmp/loadtest-home
+          OS_AUTH_URL: http://localhost:8080/v3
+          OS_USERNAME: admin
+          OS_PASSWORD: password
+          OS_USER_DOMAIN_ID: default
+          OS_PROJECT_NAME: admin
+          OS_PROJECT_DOMAIN_ID: default
+        run: |
+          # Port-forward to keystone-rs and wait for readiness
+          kubectl port-forward svc/keystone-rs 8080:8080 > /dev/null 2>&1 &
+          PORT_FORWARD_PID=$!
+          for i in $(seq 1 60); do
+            if curl -s http://localhost:8080/health/ > /dev/null 2>&1; then
+              break
+            fi
+            sleep 2
+          done
+
+          mkdir -p tests/loadtest/reports
+          (cd tests/loadtest && ./target/release/load_test \
+              --host http://localhost:8080 \
+              --hatch-rate 2 \
+              --run-time 30s \
+              --report-file reports/loadtest-report-rust.html \
+              --report-file reports/loadtest-report-rust.md)
+
+          kill $PORT_FORWARD_PID 2>/dev/null || true
+
+      - name: Upload loadtest report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: loadtest-report
+          path: tests/loadtest/reports/
+
       - name: Run tempest identity compatibility tests
         id: tempest_verify
         continue-on-error: true
@@ -400,6 +346,39 @@ jobs:
       - name: Dump events
         if: failure()
         run: kubectl get events
+
+  loadtest-track:
+    if: "success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'openstack-experimental-release-plz'"
+    runs-on: ubuntu-latest
+    needs:
+      - k3s-test
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Fetch pre-built artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5.0.0
+        with:
+          name: loadtest-report
+
+      - name: Extract report
+        id: metrics
+        run: |
+          SUMMARY=$(cat loadtest-report-rust.md || echo "No summary found")
+          echo "summary<<EOF" >> $GITHUB_OUTPUT
+          echo "$SUMMARY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post Loadtest results to PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: loadtest
+          message: |
+            🦢 **Load Test Results**
+
+            ${{ steps.metrics.outputs.summary }}
+
+            [View full report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
   tempest-track:
     if: "success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'openstack-experimental-release-plz'"

--- a/crates/api-types/src/error.rs
+++ b/crates/api-types/src/error.rs
@@ -62,6 +62,12 @@ pub enum KeystoneApiError {
         identifier: String,
     },
 
+    /// The requested operation requires optional infrastructure that is not
+    /// configured (e.g. raft-based providers when `[distributed_storage]` is
+    /// absent).  This is a permanent configuration gap, not a transient error.
+    #[error("{0}")]
+    NotImplemented(String),
+
     /// Others.
     #[error(transparent)]
     Other(#[from] eyre::Report),

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -76,6 +76,7 @@ impl IntoResponse for KeystoneApiError {
             KeystoneApiError::InternalError(_) | KeystoneApiError::Other(..) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
+            KeystoneApiError::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
             KeystoneApiError::UnprocessableEntity(_) => StatusCode::UNPROCESSABLE_ENTITY,
             _ => StatusCode::BAD_REQUEST,
         };
@@ -350,6 +351,9 @@ impl From<ApiKeyProviderError> for KeystoneApiError {
             // never leak detail to the client (ADR 0021 §6.D OPSEC leakage);
             // callers on that path should prefer mapping these to a generic
             // `AuthenticationError::Unauthorized` before this conversion runs.
+            ApiKeyProviderError::RaftNotAvailable => Self::NotImplemented(
+                "API Key storage requires distributed storage (raft)".to_string(),
+            ),
             other => Self::InternalError(other.to_string()),
         }
     }
@@ -364,6 +368,9 @@ impl From<Oauth2ClientProviderError> for KeystoneApiError {
             },
             Oauth2ClientProviderError::Conflict(x) => Self::Conflict(x),
             Oauth2ClientProviderError::Validation(x) => Self::UnprocessableEntity(x),
+            Oauth2ClientProviderError::RaftNotAvailable => Self::NotImplemented(
+                "OAuth2 client storage requires distributed storage (raft)".to_string(),
+            ),
             other => Self::InternalError(other.to_string()),
         }
     }
@@ -402,6 +409,10 @@ impl From<Oauth2KeyProviderError> for KeystoneApiError {
             Oauth2KeyProviderError::LocalEmergencyCandidateRevoked(x) => Self::Conflict(format!(
                 "local emergency rotation candidate {x} has been revoked and cannot be reconciled"
             )),
+            Oauth2KeyProviderError::RaftNotAvailable => Self::NotFound {
+                resource: "oauth2_signing_key".into(),
+                identifier: "no raft storage configured for OAuth2 signing keys".into(),
+            },
             other => Self::InternalError(other.to_string()),
         }
     }
@@ -409,10 +420,15 @@ impl From<Oauth2KeyProviderError> for KeystoneApiError {
 
 impl From<AuthPluginIdentityProviderError> for KeystoneApiError {
     fn from(value: AuthPluginIdentityProviderError) -> Self {
-        // Every variant is an infra/storage failure with no client-actionable
-        // distinction (ADR 0025 §6.B/§6.C); surface as a generic 500 without
-        // leaking backend detail on the linking path.
-        Self::InternalError(value.to_string())
+        match value {
+            AuthPluginIdentityProviderError::RaftNotAvailable => Self::NotImplemented(
+                "auth plugin identity provider requires distributed storage (raft)".to_string(),
+            ),
+            // Every other variant is an infra/storage failure with no client-actionable
+            // distinction (ADR 0025 §6.B/§6.C); surface as a generic 500 without
+            // leaking backend detail on the linking path.
+            other => Self::InternalError(other.to_string()),
+        }
     }
 }
 
@@ -452,8 +468,8 @@ impl From<MappingProviderError> for KeystoneApiError {
             MappingProviderError::RoleNotFound(x) => Self::UnprocessableEntity(format!(
                 "rule references role '{x}' which does not exist"
             )),
-            MappingProviderError::RaftNotAvailable => Self::InternalError(
-                "raft storage is not available in the mapping provider".to_string(),
+            MappingProviderError::RaftNotAvailable => Self::NotImplemented(
+                "mapping provider requires distributed storage (raft)".to_string(),
             ),
             MappingProviderError::RaftStoreError { source } => {
                 Self::InternalError(format!("raft storage error: {source}"))
@@ -481,8 +497,8 @@ impl From<ScimRealmProviderError> for KeystoneApiError {
                 identifier: x,
             },
             ScimRealmProviderError::Conflict(x) => Self::Conflict(x),
-            ScimRealmProviderError::RaftNotAvailable => Self::InternalError(
-                "raft storage is not available in the scim_realm provider".to_string(),
+            ScimRealmProviderError::RaftNotAvailable => Self::NotImplemented(
+                "SCIM realm provider requires distributed storage (raft)".to_string(),
             ),
             ScimRealmProviderError::RaftStoreError { source } => {
                 Self::InternalError(format!("raft storage error: {source}"))
@@ -510,8 +526,8 @@ impl From<ScimResourceProviderError> for KeystoneApiError {
                 identifier: x,
             },
             ScimResourceProviderError::Conflict(x) => Self::Conflict(x),
-            ScimResourceProviderError::RaftNotAvailable => Self::InternalError(
-                "raft storage is not available in the scim_resource provider".to_string(),
+            ScimResourceProviderError::RaftNotAvailable => Self::NotImplemented(
+                "SCIM resource provider requires distributed storage (raft)".to_string(),
             ),
             ScimResourceProviderError::RaftStoreError { source } => {
                 Self::InternalError(format!("raft storage error: {source}"))
@@ -593,6 +609,9 @@ impl From<KeystoneError> for KeystoneApiError {
             KeystoneError::Json { source } => source.into(),
             KeystoneError::K8sAuthProvider { source } => source.into(),
             KeystoneError::PolicyEnforcementNotAvailable => KeystoneApiError::internal(value),
+            KeystoneError::RaftNotAvailable => {
+                Self::NotImplemented("distributed storage (raft) is not configured".to_string())
+            }
             KeystoneError::ResourceProvider { source } => source.into(),
             KeystoneError::RevokeProvider { source } => source.into(),
             KeystoneError::RoleProvider { source } => source.into(),
@@ -742,10 +761,14 @@ mod tests {
     fn mapping_provider_raft_not_available() {
         let err = MappingProviderError::RaftNotAvailable;
         let api_err: KeystoneApiError = err.into();
-        assert!(matches!(
-            api_err,
-            KeystoneApiError::InternalError(msg) if !msg.is_empty()
-        ));
+        match &api_err {
+            KeystoneApiError::NotImplemented(msg) => assert!(!msg.is_empty()),
+            other => panic!("expected NotImplemented, got {:?}", other),
+        }
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::NOT_IMPLEMENTED
+        );
     }
 
     #[test]
@@ -893,5 +916,90 @@ mod tests {
             .get(header::RETRY_AFTER)
             .expect("Retry-After header must be present");
         assert_eq!(retry_after.to_str().unwrap(), "42");
+    }
+
+    #[test]
+    fn oauth2_key_raft_not_available_returns_404() {
+        let err = Oauth2KeyProviderError::RaftNotAvailable;
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::NotFound { .. }));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn api_key_raft_not_available_returns_501() {
+        let err = ApiKeyProviderError::RaftNotAvailable;
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::NotImplemented(..)));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::NOT_IMPLEMENTED
+        );
+    }
+
+    #[test]
+    fn oauth2_client_raft_not_available_returns_501() {
+        let err = Oauth2ClientProviderError::RaftNotAvailable;
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::NotImplemented(..)));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::NOT_IMPLEMENTED
+        );
+    }
+
+    #[test]
+    fn scim_realm_raft_not_available_returns_501() {
+        let err = ScimRealmProviderError::RaftNotAvailable;
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::NotImplemented(..)));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::NOT_IMPLEMENTED
+        );
+    }
+
+    #[test]
+    fn scim_resource_raft_not_available_returns_501() {
+        let err = ScimResourceProviderError::RaftNotAvailable;
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::NotImplemented(..)));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::NOT_IMPLEMENTED
+        );
+    }
+
+    #[test]
+    fn auth_plugin_identity_raft_not_available_returns_501() {
+        let err = AuthPluginIdentityProviderError::RaftNotAvailable;
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::NotImplemented(..)));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::NOT_IMPLEMENTED
+        );
+    }
+
+    #[test]
+    fn keystone_raft_not_available_returns_501() {
+        let err = KeystoneError::RaftNotAvailable;
+        let api_err: KeystoneApiError = err.into();
+        assert!(matches!(api_err, KeystoneApiError::NotImplemented(..)));
+        assert_eq!(
+            <KeystoneApiError as IntoResponse>::into_response(api_err).status(),
+            StatusCode::NOT_IMPLEMENTED
+        );
+    }
+
+    #[test]
+    fn not_implemented_variant_returns_501() {
+        let err = KeystoneApiError::NotImplemented("test feature not available".to_string());
+        assert_eq!(err.to_string(), "test feature not available");
+        let response = <KeystoneApiError as IntoResponse>::into_response(err);
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
     }
 }

--- a/crates/api-types/src/k8s_auth.rs
+++ b/crates/api-types/src/k8s_auth.rs
@@ -42,6 +42,9 @@ impl From<K8sAuthProviderError> for crate::error::KeystoneApiError {
             K8sAuthProviderError::InsecureAlgorithm => Self::forbidden(source),
             K8sAuthProviderError::InvalidToken => Self::forbidden(source),
             K8sAuthProviderError::MappingEngine(_) => Self::forbidden(source),
+            K8sAuthProviderError::RaftNotAvailable => Self::NotImplemented(
+                "K8s auth provider requires distributed storage (raft)".to_string(),
+            ),
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/keystone/src/api/v4/oauth2/jwks.rs
+++ b/crates/keystone/src/api/v4/oauth2/jwks.rs
@@ -252,6 +252,36 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
+    #[tokio::test]
+    async fn test_jwks_returns_not_found_when_raft_not_available() {
+        // When raft storage is not configured, the OAuth2 key provider
+        // returns RaftNotAvailable, which should map to 404 for JWKS
+        // (meaning no signing keys available for this domain).
+        let mut mock = MockOauth2KeyProvider::default();
+        mock.expect_jwks().returning(|_, _| {
+            Err(openstack_keystone_core_types::oauth2_key::Oauth2KeyProviderError::RaftNotAvailable)
+        });
+        let provider = Provider::mocked_builder().mock_oauth2_key(mock);
+        let state = default_get_mocked_state(provider, true, None).await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state.clone());
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/domain-1/jwks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
     /// Global per-IP rate limiting fires before provider call (ADR-0022,
     /// Invariant 4, 8). The first request consumes the burst token and passes
     /// through to the provider; the second from the same IP must be rejected

--- a/crates/keystone/src/audit.rs
+++ b/crates/keystone/src/audit.rs
@@ -93,6 +93,7 @@ pub fn error_variant_name(error: &KeystoneApiError) -> String {
         KeystoneApiError::Serde { .. } => "BadRequest".to_string(),
         KeystoneApiError::Other(_) => "InternalServerError".to_string(),
         KeystoneApiError::UnprocessableEntity(_) => "UnprocessableEntity".to_string(),
+        KeystoneApiError::NotImplemented(_) => "NotImplemented".to_string(),
         KeystoneApiError::TooManyRequests { .. } => "TooManyRequests".to_string(),
     }
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -102,8 +102,79 @@ deploy:
             # Wait for all Raft pods to be ready before join
             command: ["kubectl", "wait", "--for=condition=ready", "pod", "-l", "app.kubernetes.io/name=keystone-rs", "--timeout=180s"]
         - host:
-            # Join non-zero Raft nodes to the cluster (node 0 initialized by bootstrap)
-            command: ["sh", "-c", 'REPLICAS=$(kubectl get sts keystone-rs -o jsonpath="{.spec.replicas}"); for i in $(seq 1 $(($REPLICAS - 1))); do kubectl exec keystone-rs-$i -- keystone-manage storage join https://keystone-rs-0.keystone-rs-internal.default.svc.cluster.local:8300 || true; done']
+            # Join non-zero Raft nodes to the cluster (node 0 initialized by
+            # bootstrap). Run from each joining node so its own
+            # ``config` node_id and node_cluster_addr are used in the
+            # add_learner request sent to the leader (ADR 0016-v2 §4.1).
+            # Fail-fast (no || true) so a broken cluster is caught early.
+            command: ["sh", "-c", 'REPLICAS=$(kubectl get sts keystone-rs -o jsonpath="{.spec.replicas}"); for i in $(seq 1 $(($REPLICAS - 1))); do kubectl exec keystone-rs-$i -- keystone-manage storage join https://keystone-rs-0.keystone-rs-internal.default.svc.cluster.local:8300; sleep 2; done']
+        - host:
+            # Wait for replication to start so promote doesn't race the
+            # initial add_learner log entry (learner must have a non-None
+            # replication state before it can be promoted).
+            # Wait for all joined nodes to appear in the cluster membership
+            # by polling list-peers from the leader (node 0). Counts table
+            # data rows (those starting with "│" and containing a node
+            # hostname). This avoids a blind sleep and works reliably for
+            # any replica count.
+            command:
+              - sh
+              - -c
+              - |
+                REPLICAS=$(kubectl get sts keystone-rs -o jsonpath="{.spec.replicas}")
+                max_attempts=60
+                attempt=0
+                until [ "$attempt" -ge "$max_attempts" ]; do
+                  OUTPUT=$(kubectl exec keystone-rs-0 -- keystone-manage storage list-peers 2>&1)
+                  FOUND=0
+                  for i in $(seq 0 $((REPLICAS - 1))); do
+                    if echo "$OUTPUT" | grep -q "keystone-rs-$i.keystone-rs-internal"; then
+                      FOUND=$((FOUND + 1))
+                    fi
+                  done
+                  if [ "$FOUND" -eq "$REPLICAS" ]; then
+                    echo "All $REPLICAS nodes present in cluster membership"
+                    break
+                  fi
+                  attempt=$((attempt + 1))
+                  echo "Wait-replication: $FOUND/$REPLICAS nodes visible (attempt $attempt)"
+                  sleep 2
+                done
+                if [ "$attempt" -ge "$max_attempts" ]; then
+                  echo "Wait-replication timed out: only $FOUND/$REPLICAS nodes visible"
+                  exit 1
+                fi
+        - host:
+            # Promote newly-joined learners to voters (ADR 0016-v2 §4.1
+            # "Step 4: promote"). Run from node 0 (the leader) so the
+            # change_membership RPC is sent to the right node.
+            command: ["sh", "-c", 'REPLICAS=$(kubectl get sts keystone-rs -o jsonpath="{.spec.replicas}"); for i in $(seq 1 $(($REPLICAS - 1))); do kubectl exec keystone-rs-0 -- keystone-manage storage promote $i; done']
+        - host:
+            # Verify all replicas are voters before proceeding. Polls
+            # list-peers from node 0 and counts rows where the Voter
+            # column (last before closing │) contains "yes".
+            command:
+              - sh
+              - -c
+              - |
+                REPLICAS=$(kubectl get sts keystone-rs -o jsonpath="{.spec.replicas}")
+                max_attempts=30
+                attempt=0
+                until [ "$attempt" -ge "$max_attempts" ]; do
+                  OUTPUT=$(kubectl exec keystone-rs-0 -- keystone-manage storage list-peers 2>&1)
+                  VOTERS=$(echo "$OUTPUT" | grep -cP '\x{2506}\s+yes\s+\x{2502}' || true)
+                  if [ "$VOTERS" -ge "$REPLICAS" ]; then
+                    echo "All $REPLICAS replicas confirmed as voters"
+                    break
+                  fi
+                  attempt=$((attempt + 1))
+                  echo "Post-promote verify: $VOTERS voters (need $REPLICAS, attempt $attempt)"
+                  sleep 2
+                done
+                if [ "$attempt" -ge "$max_attempts" ]; then
+                  echo "Post-promote verification failed: only $VOTERS voters"
+                  exit 1
+                fi
         - host:
             # ADR 0026 §3: `default` is bootstrapped by the legacy Python
             # `keystone-manage bootstrap` (bootstrap-job.yaml), which writes

--- a/tools/run-loadtest-local.sh
+++ b/tools/run-loadtest-local.sh
@@ -119,8 +119,12 @@ echo "✅ Keystone bootstrap completed!"
 mkdir -p tests/loadtest/reports
 (cd tests/loadtest && \
     HOME="$LOADTEST_HOME" \
-    OS_CLIENT_CONFIG_PATH="${REAL_HOME}/.config/openstack" \
-    OS_CLOUD=admin \
+    OS_AUTH_URL="http://localhost:8080/v3" \
+    OS_USERNAME=admin \
+    OS_PASSWORD=password \
+    OS_USER_DOMAIN_NAME=default \
+    OS_PROJECT_NAME=admin \
+    OS_PROJECT_DOMAIN_NAME=default \
     ./target/release/load_test \
     --host http://localhost:8080 \
     "$@")


### PR DESCRIPTION
Add KeystoneApiError::NotImplemented variant (HTTP 501) and map all
RaftNotAvailable errors to the correct status:

- Oauth2KeyProviderError::RaftNotAvailable -> NotFound (404) for
  JWKS and well-known endpoints
- All *ProviderError::RaftNotAvailable -> NotImplemented (501)

Update skaffold.yaml to robustly build raft clusters on deploy:

- Remove || true from join command to fail fast on broken clusters
- Add sleep 2 between join iterations to prevent leader overload
- Replace sleep 5 with list-peers polling loop that waits for all
  nodes to appear in cluster membership
- Add post-promote verification loop to confirm all replicas are
  voters before proceeding to ensure-signing-key

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
