### PR TITLE
fix: Ensure appcred are unique over name+user_id

### DIFF
--- a/crates/appcred-driver-sql/src/entity/application_credential.rs
+++ b/crates/appcred-driver-sql/src/entity/application_credential.rs
@@ -22,10 +22,12 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub internal_id: i32,
     pub id: String,
+    #[sea_orm(unique_key = "duplicate_app_cred_constraint")]
     pub name: String,
     pub secret_hash: String,
     #[sea_orm(column_type = "Text", nullable)]
     pub description: Option<String>,
+    #[sea_orm(unique_key = "duplicate_app_cred_constraint")]
     pub user_id: String,
     pub project_id: Option<String>,
     pub expires_at: Option<i64>,

--- a/tests/integration/src/application_credential/create.rs
+++ b/tests/integration/src/application_credential/create.rs
@@ -208,3 +208,38 @@ async fn test_create_role() -> Result<(), Report> {
     );
     Ok(())
 }
+
+#[tokio::test]
+#[traced_test]
+async fn test_create_duplicate() -> Result<(), Report> {
+    let (state, _) = get_state().await?;
+    let domain = create_domain!(state)?;
+    let project = create_project!(state, domain.id.clone())?;
+    let user = create_user!(state, domain.id.clone())?;
+    let sot = ApplicationCredentialCreate {
+        id: Some(Uuid::new_v4().to_string()),
+        name: Uuid::new_v4().to_string(),
+        project_id: project.id.clone(),
+        roles: vec![],
+        user_id: user.id.clone(),
+        ..Default::default()
+    };
+    state
+        .provider
+        .get_application_credential_provider()
+        .create_application_credential(&ExecutionContext::internal(&state), sot.clone())
+        .await?;
+
+    let res = state
+        .provider
+        .get_application_credential_provider()
+        .create_application_credential(&ExecutionContext::internal(&state), sot.clone())
+        .await;
+
+    if let Err(ApplicationCredentialProviderError::Conflict(_)) = res {
+    } else {
+        panic!("creating duplicated application credential must fail");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
python keystone defines unique constraint for application credentials
over the user_id+name.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
