### PR TITLE
fix: register UserType in OpenAPI components schema

### DIFF
--- a/crates/api-types/src/v3/application_credential/application_credential.rs
+++ b/crates/api-types/src/v3/application_credential/application_credential.rs
@@ -161,7 +161,8 @@ pub struct ApplicationCredentialCreateRequest {
     pub application_credential: ApplicationCredentialCreate,
 }
 
-/// Application credential as returned by create — includes secret (shown once only).
+/// Application credential as returned by create — includes secret (shown once
+/// only).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "validate", derive(validator::Validate))]

--- a/crates/api-types/src/v3/application_credential_conv.rs
+++ b/crates/api-types/src/v3/application_credential_conv.rs
@@ -154,6 +154,7 @@ impl PartialEq for api_types_application_credential::ApplicationCredentialCreate
             && self.name == other.name
             && self.roles == other.roles
             && self.unrestricted == other.unrestricted
-        // secret is intentionally excluded — SecretBox does not implement PartialEq
+        // secret is intentionally excluded — SecretBox does not implement
+        // PartialEq
     }
 }

--- a/crates/core-types/src/domain_config.rs
+++ b/crates/core-types/src/domain_config.rs
@@ -24,8 +24,8 @@
 //!   each holding a flat set of *options*,
 //! - an option is only storable when it is explicitly listed as either
 //!   whitelisted or sensitive (see [`whitelisted_options`] /
-//!   [`sensitive_options`]); anything else is dropped with a warning, so
-//!   making a new option domain-configurable is always a deliberate act,
+//!   [`sensitive_options`]); anything else is dropped with a warning, so making
+//!   a new option domain-configurable is always a deliberate act,
 //! - sensitive options (today only `ldap.password`) are stored separately and
 //!   are never returned by the API: they are stripped on serialization and
 //!   redacted in `Debug`.

--- a/crates/core-types/src/domain_config/config.rs
+++ b/crates/core-types/src/domain_config/config.rs
@@ -25,8 +25,8 @@
 //! [`openstack_keystone_config::LdapProvider`]:
 //!
 //! - [`DomainConfig::resolve_identity`] / [`DomainConfig::resolve_ldap`]
-//!   overlay a domain's options onto the global section and hand back the
-//!   very struct the identity backend is configured with;
+//!   overlay a domain's options onto the global section and hand back the very
+//!   struct the identity backend is configured with;
 //! - [`DomainConfig::defaults`] serializes the global sections and keeps the
 //!   whitelisted keys, which is what the `/v3/domains/config/…/default`
 //!   endpoints answer;
@@ -453,8 +453,8 @@ impl DomainConfig {
     /// outside the whitelist is left empty on purpose, and stores nothing.
     ///
     /// # Returns
-    /// - `Result<(), DomainConfigProviderError>` - `Ok(())` when the payload
-    ///   is usable, otherwise [`DomainConfigProviderError::EmptyConfig`].
+    /// - `Result<(), DomainConfigProviderError>` - `Ok(())` when the payload is
+    ///   usable, otherwise [`DomainConfigProviderError::EmptyConfig`].
     pub fn validate(&self) -> Result<(), DomainConfigProviderError> {
         if self.groups.is_empty() {
             return Err(DomainConfigProviderError::EmptyConfig);

--- a/crates/core-types/src/domain_config/error.rs
+++ b/crates/core-types/src/domain_config/error.rs
@@ -24,8 +24,8 @@ use crate::error::BuilderError;
 /// `InvalidDomainConfig`, which the v3 API reports as `403 Forbidden` (see
 /// `api-ref/source/v3/domains-config-v3.inc`: "If you try to create or update
 /// configuration options for groups other than the `identity` or `ldap`
-/// groups, the `Forbidden (403)` response code is returned"). [`Self::NotFound`]
-/// corresponds to `DomainConfigNotFound` (`404`).
+/// groups, the `Forbidden (403)` response code is returned").
+/// [`Self::NotFound`] corresponds to `DomainConfigNotFound` (`404`).
 #[derive(Error, Debug)]
 pub enum DomainConfigProviderError {
     /// Conflict.

--- a/crates/core/src/domain_config/backend.rs
+++ b/crates/core/src/domain_config/backend.rs
@@ -155,8 +155,8 @@ pub trait DomainConfigBackend: Send + Sync {
     /// - `config`: The options to change; only `group` may be populated.
     ///
     /// # Returns
-    /// - `Result<DomainConfigGroup, DomainConfigProviderError>` - The
-    ///   resulting group, or an error.
+    /// - `Result<DomainConfigGroup, DomainConfigProviderError>` - The resulting
+    ///   group, or an error.
     async fn update_domain_config_group<'a>(
         &self,
         state: &ServiceState,

--- a/crates/keystone/src/api/v3/user/application_credential/create.rs
+++ b/crates/keystone/src/api/v3/user/application_credential/create.rs
@@ -68,7 +68,8 @@ pub(super) async fn create(
 
     let mut target = serde_json::to_value(&payload.application_credential)?;
     target["user_id"] = json!(user_id);
-    // Check payload has secret field,if yes copy target variable and remove secret from copied variable and pass it to policy enforcer
+    // Check payload has secret field,if yes copy target variable and remove secret
+    // from copied variable and pass it to policy enforcer
     let mut target_for_policy = target.clone();
     if let Some(obj) = target_for_policy.as_object_mut() {
         obj.remove("secret");

--- a/crates/keystone/src/api/v4/user/mod.rs
+++ b/crates/keystone/src/api/v4/user/mod.rs
@@ -34,6 +34,7 @@ use utoipa::OpenApi;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::keystone::ServiceState;
+use openstack_keystone_api_types::v4::user::UserType;
 
 pub mod types;
 
@@ -52,7 +53,8 @@ mod update;
 
 User management endpoints for creating, retrieving, updating, and deleting users.
         "#),
-    )
+    ),
+    components(schemas(UserType)),
 )]
 pub struct ApiDoc;
 

--- a/crates/keystone/src/api/v4/user/types.rs
+++ b/crates/keystone/src/api/v4/user/types.rs
@@ -17,4 +17,4 @@ pub use crate::api::v3::user::types::{
     Federation, FederationProtocol, User, UserCreate, UserCreateRequest, UserList, UserOptions,
     UserResponse, UserUpdateRequest,
 };
-pub use openstack_keystone_api_types::v4::user::UserListParameters;
+pub use openstack_keystone_api_types::v4::user::{UserListParameters, UserType};

--- a/tests/api/src/macros.rs
+++ b/tests/api/src/macros.rs
@@ -30,12 +30,12 @@
 //!
 //! - `parent = ("users", user_id)` prefixes the endpoint with a parent
 //!   collection and its ID, for sub-resources such as
-//!   `users/{user_id}/credentials/OS-EC2`. The request struct gains a
-//!   `user_id` field and every generated wrapper takes it as the first
-//!   argument after `tc`.
+//!   `users/{user_id}/credentials/OS-EC2`. The request struct gains a `user_id`
+//!   field and every generated wrapper takes it as the first argument after
+//!   `tc`.
 //! - Omitting `body_key` from a `create` block serializes `create_type`
-//!   unwrapped at the request root, for legacy bodies that are not nested
-//!   under a resource key.
+//!   unwrapped at the request root, for legacy bodies that are not nested under
+//!   a resource key.
 //!
 //! Canonical field order per operation (all fields required, see arms
 //! below):


### PR DESCRIPTION
UserType derives utoipa::ToSchema but was not registered in the v4
user ApiDoc, causing the generated spec to reference a nonexistent
component (#/components/schemas/UserType).

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
