### PR TITLE
fix(policy): Bind credential listing to own user

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,6 +37,10 @@ behind each item.
       Gate I)
 - [ ] New list/collection endpoint? Does it re-check each item with the
       per-item read policy? (I8)
+- [ ] Same endpoint: can an unprivileged caller request the whole collection
+      and leave the per-item pass to sort it out? Is the value the
+      collection policy gates on the same one the driver actually filters
+      by? (I8a)
 - [ ] Does the change let a narrow auth method be broadened by a
       request-supplied scope? (I5)
 - [ ] Are there negative tests proving the escape is blocked, not just

--- a/crates/keystone/src/api/v3/credential/list.rs
+++ b/crates/keystone/src/api/v3/credential/list.rs
@@ -41,6 +41,15 @@ use openstack_keystone_core::policy::PolicyError;
 /// Pagination is applied *after* this per-item filtering, over the
 /// already-policy-approved set, matching the over-fetch-by-one convention
 /// used everywhere else.
+///
+/// The first phase is what keeps the second one cheap: unless the caller is
+/// a privileged lister (`admin`, or `reader` on the system scope),
+/// `identity/credential/list` demands a `user_id` filter naming the caller
+/// (issue #1117), so the driver narrows the query in SQL rather than
+/// handing the whole table to the per-item loop. The filter the policy
+/// approves and the filter the driver applies are the *same* value — both
+/// read `CredentialListParameters::user_id` off this one parsed struct — so
+/// the two cannot diverge.
 #[utoipa::path(
     get,
     path = "/",
@@ -323,13 +332,19 @@ mod tests {
     /// Gate B3 (security review V3a, issue #979): the per-item re-check
     /// (ADR 0019 §2, CVE-2019-19687) is where `list`'s delegation boundary
     /// (OSSA-2026-015) actually lives -- `identity/credential/list.rego`
-    /// itself lets any member attempt to list, so this drives a delegated
-    /// caller's list through the real `identity/credential/show.rego`
-    /// decision (via a real `opa run` subprocess) over a mixed batch: one
-    /// record bound to the delegation's own project (must survive), one
-    /// bound to a different project, and one unscoped (both must be
-    /// silently dropped, never surfaced as an error). Requires `opa` on
-    /// `PATH`.
+    /// has no resource project to anchor on, so it admits a delegated
+    /// caller filtering to their own `user_id` and leaves the project
+    /// boundary entirely to the re-check. This drives such a caller's list
+    /// through the real `identity/credential/show.rego` decision (via a
+    /// real `opa run` subprocess) over a mixed batch: one record bound to
+    /// the delegation's own project (must survive), one bound to a
+    /// different project, and one unscoped (both must be silently dropped,
+    /// never surfaced as an error). Requires `opa` on `PATH`.
+    ///
+    /// The `?user_id=u1` filter is load-bearing since issue #1117: the
+    /// caller holds only `member`, so an unfiltered list is now denied
+    /// outright by the collection-level check and would never reach the
+    /// per-item pass this test exists to exercise.
     #[tokio::test]
     async fn delegated_caller_list_is_filtered_to_own_project_by_real_policy() {
         let mut credential_mock = MockCredentialProvider::default();
@@ -375,7 +390,7 @@ mod tests {
             .as_service()
             .oneshot(
                 Request::builder()
-                    .uri("/")
+                    .uri("/?user_id=u1")
                     .extension(vsc)
                     .body(Body::empty())
                     .unwrap(),
@@ -393,6 +408,186 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["own-project"]
         );
+    }
+
+    /// Issue #1117, the negative case that is the whole point of the change:
+    /// an ordinary `member` may no longer scan the collection. Driven
+    /// through a real `opa run` subprocess, because the mocked enforcer used
+    /// by the tests above answers `allow` unconditionally and so cannot
+    /// distinguish the old rule from the new one.
+    ///
+    /// The backend mock deliberately sets no expectation for
+    /// `list_credentials`: the collection-level denial must short-circuit
+    /// *before* any row is fetched, so `mockall` fails the test if the
+    /// handler reaches the driver at all. That is the DoS property under
+    /// test -- a 403 that still scanned the table would fix nothing.
+    #[tokio::test]
+    async fn unfiltered_list_by_ordinary_member_is_denied_by_real_policy() {
+        let credential_mock = MockCredentialProvider::default();
+
+        let vsc = crate::api::tests::real_policy_fixtures::restricted_app_cred_vsc("u1", "p1");
+        let (state, _opa_guard) = crate::api::tests::get_state_with_real_policy(
+            Provider::mocked_builder().mock_credential(credential_mock),
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Issue #1117, the happy path the restriction must leave intact: an
+    /// ordinary, non-delegated `member` filtering to their own `user_id`
+    /// still gets their credentials back, and the filter reaches the driver
+    /// so the query is narrowed in SQL rather than in the per-item loop.
+    #[tokio::test]
+    async fn own_filtered_list_by_ordinary_member_is_allowed_by_real_policy() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock
+            .expect_list_credentials()
+            .withf(|_, qp: &CredentialListParameters| qp.user_id.as_deref() == Some("u1"))
+            .returning(|_, _| {
+                Ok(vec![
+                    CredentialBuilder::default()
+                        .id("own")
+                        .blob(r#"{"seed":"AAAA"}"#)
+                        .r#type("totp")
+                        .user_id("u1")
+                        .build()
+                        .unwrap(),
+                ])
+            });
+
+        let vsc = crate::api::tests::real_policy_fixtures::member_vsc("u1", "p1", &["member"]);
+        let (state, _opa_guard) = crate::api::tests::get_state_with_real_policy(
+            Provider::mocked_builder().mock_credential(credential_mock),
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?user_id=u1")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: CredentialList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            res.credentials
+                .iter()
+                .map(|c| c.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["own"]
+        );
+    }
+
+    /// Issue #1117 must not cost the privileged listers their cross-user
+    /// view: a system-scoped `reader` still lists the collection unfiltered.
+    #[tokio::test]
+    async fn unfiltered_list_by_system_reader_is_allowed_by_real_policy() {
+        let mut credential_mock = MockCredentialProvider::default();
+        credential_mock.expect_list_credentials().returning(|_, _| {
+            Ok(vec![
+                CredentialBuilder::default()
+                    .id("someone-elses")
+                    .blob(r#"{"seed":"AAAA"}"#)
+                    .r#type("totp")
+                    .user_id("u2")
+                    .build()
+                    .unwrap(),
+            ])
+        });
+
+        let vsc =
+            crate::api::tests::real_policy_fixtures::system_scoped_vsc("u1", "all", &["reader"]);
+        let (state, _opa_guard) = crate::api::tests::get_state_with_real_policy(
+            Provider::mocked_builder().mock_credential(credential_mock),
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let res: CredentialList = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            res.credentials
+                .iter()
+                .map(|c| c.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["someone-elses"]
+        );
+    }
+
+    /// Issue #1117: naming somebody else's `user_id` must not buy the scan
+    /// either -- otherwise the filter would be a formality rather than a
+    /// boundary. As above, the driver must never be reached.
+    #[tokio::test]
+    async fn list_filtered_to_another_user_is_denied_by_real_policy() {
+        let credential_mock = MockCredentialProvider::default();
+
+        let vsc = crate::api::tests::real_policy_fixtures::restricted_app_cred_vsc("u1", "p1");
+        let (state, _opa_guard) = crate::api::tests::get_state_with_real_policy(
+            Provider::mocked_builder().mock_credential(credential_mock),
+        )
+        .await;
+
+        let mut api = openapi_router()
+            .layer(TraceLayer::new_for_http())
+            .with_state(state);
+
+        let response = api
+            .as_service()
+            .oneshot(
+                Request::builder()
+                    .uri("/?user_id=u2")
+                    .extension(vsc)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
     /// Backend over-fetched (returned `limit + 1 == 2` rows): a `next` link

--- a/doc/src/adr/0019-credentials.md
+++ b/doc/src/adr/0019-credentials.md
@@ -181,6 +181,13 @@ Keystone-NG treats this table as read/write but never issues DDL against it.
     the wrong target (e.g. the caller's own attributes, or a cached target from
     the first item) would make the re-check a no-op and reintroduce a variant of
     CVE-2019-19687 rather than closing it.
+  - **The first phase must still narrow the query**: an unprivileged caller
+    reaching the per-item pass with no usable filter turns one request into a
+    full-collection scan plus an OPA round-trip per row. Matching Python
+    Keystone's `identity:list_credentials`, `identity/credential/list` therefore
+    requires a `user_id` filter naming the caller unless the caller is `admin`
+    or holds `reader` on the system scope. The accepted performance implication
+    above applies only to those privileged listers.
 
 #### Delegation Project Boundary (OSSA-2026-015)
 

--- a/doc/src/contributor/security-model.md
+++ b/doc/src/contributor/security-model.md
@@ -279,6 +279,30 @@ cannot read (CVE-2019-19687). **Where:**
 `crates/keystone/src/api/v3/credential/list.rs`,
 `crates/keystone/src/api/v3/policy/list.rs`.
 
+### I8a — A per-item re-check does not license a permissive collection filter
+
+**What:** the collection-level policy must still narrow the query to what the
+caller could plausibly read, using filter values the driver actually applies.
+An unprivileged caller must not be able to request the whole collection and
+have the per-item pass sort it out. **Why:** I8 makes a permissive collection
+filter *safe* (nothing leaks) but not *cheap* — every row still has to be
+fetched and OPA-evaluated before being discarded, so a single request
+becomes a full-table scan plus N policy round-trips. That is a
+resource-exhaustion amplifier available to any authenticated user, which is
+what issue #1117 found in `identity/credential/list`: it granted every `member`
+an unfiltered list. It now demands a `user_id` filter naming the caller unless
+the caller is a privileged lister (`admin`, or `reader` on the system scope).
+**Where:** `policy/credential/list.rego`, paired with the
+`AUTHORIZED_PAGE_SCAN_FACTOR` bound in `collect_authorized_page`
+(`crates/keystone/src/api/common.rs`), which caps the same cost for the
+privileged listers whose rows legitimately do get filtered.
+
+> When adding a collection endpoint, check that the value the policy is
+> gating on is the *same* value the driver filters by. If the policy approves
+> `?user_id=X` but the driver ignores `user_id`, the check is decorative: the
+> scan happens anyway. In `credential/list` both read a single parsed
+> `CredentialListParameters`, so they cannot diverge.
+
 ## 5. Delegated-auth specifics
 
 Trust, application-credential, and EC2 are authentication _methods_, each with
@@ -376,6 +400,10 @@ carries it, ticked by the reviewer, not just this prose reference.
 - [ ] Does any new data reaching OPA include **secrets/decrypted blobs** (I7)?
 - [ ] New list/collection endpoint? Does it **re-check each item** with the
       per-item read policy (I8)?
+- [ ] Same endpoint: can an **unprivileged caller request the whole
+      collection** and leave the per-item pass to sort it out? Is the value
+      the collection policy gates on the same one the **driver actually
+      filters by** (I8a)?
 - [ ] Does the change let a narrow auth method be **broadened by a
       request-supplied scope** (I5)?
 - [ ] Are there **negative tests** proving the escape is blocked, not just

--- a/policy/credential/list.rego
+++ b/policy/credential/list.rego
@@ -11,15 +11,38 @@ package identity.credential.list
 #
 # The `input.existing` is null
 #
-# This is only the first of the two policy checks required to list
+# An ordinary caller may list only their *own* credentials, and has to say
+# so explicitly: the request must carry a `user_id` filter naming the
+# caller (issue #1117). Granting every `member` an unfiltered list is not a
+# disclosure bug — the per-item re-check below drops the rows they may not
+# read — but it turns one cheap request into a full-collection scan plus
+# one OPA evaluation per row, a resource-exhaustion amplifier available to
+# any authenticated user. Demanding the filter up front lets the driver
+# narrow the query in SQL instead of materializing the whole table. This
+# mirrors python keystone's `user_id:%(target.credential.user_id)s`, which
+# likewise resolves against the query parameters and so denies an
+# unfiltered list to an unprivileged caller.
+#
+# Ownership alone suffices; no role is required.
+# `identity/credential/show` already grants a non-delegated caller their
+# own credential on ownership alone, and python keystone's rule carries no
+# role component either, so requiring `member` here would deny a
+# reader-scoped caller their own credentials for no security gain.
+#
+# This remains only the first of the two policy checks required to list
 # credentials safely (ADR 0019 §2, CVE-2019-19687): the API layer
 # additionally re-enforces `identity/credential/show` against every
-# individual record before returning it, so this rule only needs to gate
-# who may attempt a list at all. The delegation project boundary
-# (OSSA-2026-015) is therefore enforced entirely by that per-item
-# `identity/credential/show` re-check, not here — a delegated caller
-# passes this rule but has cross-project/unscoped records filtered out of
-# the result by the re-check.
+# individual record before returning it. That re-check still carries real
+# weight for the privileged listers below, who legitimately see other
+# users' rows.
+#
+# The delegation project boundary (OSSA-2026-015) is enforced entirely by
+# that per-item `identity/credential/show` re-check, not here. There is no
+# resource project to anchor on at this point — only query parameters — so
+# I2's `bound_to_own_delegation_project` has nothing to compare against
+# (see `doc/src/contributor/security-model.md` I2/I8). A delegated caller
+# filtering to their own `user_id` passes this rule and then has every
+# cross-project and unscoped record dropped by the re-check.
 #
 default allow := false
 
@@ -39,7 +62,14 @@ allow if {
 }
 
 # METADATA
-# description: "Any authenticated member may attempt to list; the per-item `identity/credential/show` re-check narrows the result to credentials they are actually allowed to read."
+# description: "Any caller may list their own credentials, provided the request is explicitly filtered to their own user ID. An omitted filter reaches OPA as JSON `null` (the handler serializes the absent `Option` rather than skipping the key) and is rejected, as is a filter naming anyone else."
 allow if {
-	"member" in input.credentials.roles
+	user_id_filter := object.get(input.target.credential, "user_id", null)
+	user_id_filter != null
+	user_id_filter == input.credentials.user_id
+}
+
+violation contains {"field": "user_id", "msg": msg} if {
+	not allow
+	msg := "listing credentials requires filtering by your own `user_id`, unless you hold the `admin` role or the `reader` role on the system scope."
 }

--- a/policy/credential/list_test.rego
+++ b/policy/credential/list_test.rego
@@ -4,11 +4,122 @@ import data.identity.credential.list
 
 test_allowed if {
 	list.allow with input as {"credentials": {"roles": ["admin"]}}
-	list.allow with input as {"credentials": {"roles": ["member"]}, "target": {"credential": {"user_id": "u1"}}}
+	list.allow with input as {"credentials": {"is_admin": true, "roles": []}}
 	list.allow with input as {"credentials": {"roles": ["reader"], "system": "all"}}
+}
+
+# A caller filtering to their own user ID may list, whatever roles they hold
+# (issue #1117) -- ownership alone is the grant, matching
+# `identity/credential/show` and python keystone.
+test_allowed_own_user_id if {
+	list.allow with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": {"credential": {"user_id": "u1", "type": null}},
+	}
+
+	list.allow with input as {
+		"credentials": {"roles": [], "user_id": "u1"},
+		"target": {"credential": {"user_id": "u1", "type": null}},
+	}
+
+	list.allow with input as {
+		"credentials": {"roles": ["reader"], "user_id": "u1"},
+		"target": {"credential": {"user_id": "u1", "type": "totp"}},
+	}
 }
 
 test_forbidden if {
 	not list.allow with input as {"credentials": {"roles": []}}
 	not list.allow with input as {"credentials": {"roles": ["reader"]}}
+}
+
+# The core of issue #1117: holding `member` is no longer enough to scan the
+# whole collection. Every shape of "no usable own-user filter" must deny.
+test_forbidden_unfiltered_list if {
+	# `user_id` omitted entirely (key absent).
+	not list.allow with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": {"credential": {"type": null}},
+	}
+
+	# `user_id` present but null -- the shape the handler actually emits for
+	# an absent `?user_id=`, since the `Option` is serialized, not skipped.
+	not list.allow with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": {"credential": {"user_id": null, "type": null}},
+	}
+
+	# `target.credential` missing altogether -- fail closed, never undefined.
+	not list.allow with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": {},
+	}
+
+	# A bare `?user_id=` deserializes to `Some("")`, which is not null and so
+	# clears the first guard -- the equality has to be what rejects it.
+	not list.allow with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": {"credential": {"user_id": "", "type": null}},
+	}
+
+	# `input.target` null outright. This handler never emits that shape, but
+	# the rule must not go undefined-and-therefore-permissive if one ever does.
+	not list.allow with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": null,
+	}
+
+	# No caller identity to compare against -- `Credentials.user_id` is
+	# non-optional today, so this only fires if that ever regresses.
+	not list.allow with input as {
+		"credentials": {"roles": ["member"]},
+		"target": {"credential": {"user_id": "u1", "type": null}},
+	}
+}
+
+# Filtering to somebody else's user ID must not grant the scan either.
+test_forbidden_other_user_id if {
+	not list.allow with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": {"credential": {"user_id": "u2", "type": null}},
+	}
+
+	# A non-system `reader` gets no exemption.
+	not list.allow with input as {
+		"credentials": {"roles": ["reader"], "user_id": "u1"},
+		"target": {"credential": {"user_id": "u2", "type": null}},
+	}
+
+	# `system` scoped to something other than `all` is not a privileged
+	# lister either.
+	not list.allow with input as {
+		"credentials": {"roles": ["reader"], "system": "other", "user_id": "u1"},
+		"target": {"credential": {"user_id": "u2", "type": null}},
+	}
+}
+
+# A privileged lister keeps the unfiltered collection view.
+test_allowed_privileged_unfiltered if {
+	list.allow with input as {
+		"credentials": {"roles": ["admin"], "user_id": "u1"},
+		"target": {"credential": {"user_id": null, "type": null}},
+	}
+
+	list.allow with input as {
+		"credentials": {"roles": ["reader"], "system": "all", "user_id": "u1"},
+		"target": {"credential": {"user_id": "u2", "type": null}},
+	}
+}
+
+# The denial carries an actionable message; an allowed request carries none.
+test_violation if {
+	count(list.violation) == 1 with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": {"credential": {"user_id": null, "type": null}},
+	}
+
+	count(list.violation) == 0 with input as {
+		"credentials": {"roles": ["member"], "user_id": "u1"},
+		"target": {"credential": {"user_id": "u1", "type": null}},
+	}
 }

--- a/tests/api/tests/api_v3/credential/list.rs
+++ b/tests/api/tests/api_v3/credential/list.rs
@@ -21,8 +21,33 @@ use uuid::Uuid;
 use openstack_keystone_api_types::v3::credential::*;
 use openstack_sdk::{AsyncOpenStack, config::CloudConfig};
 
+use test_api::asserts::assert_forbidden;
 use test_api::credential::{create_credential, list_credentials};
+use test_api::fixtures::{
+    ProjectScopedUser, cleanup_project_scoped_users, warn_on_cleanup_failure,
+};
 use test_api::guard::ResourceGuard;
+
+async fn admin_session() -> Result<Arc<AsyncOpenStack>> {
+    Ok(Arc::new(
+        AsyncOpenStack::new(&CloudConfig::from_env()?).await?,
+    ))
+}
+
+/// Two independent `member` users; `a` will attempt to list `b`'s
+/// credentials.
+async fn two_members(
+    admin: &Arc<AsyncOpenStack>,
+) -> Result<(ProjectScopedUser, ProjectScopedUser)> {
+    let a = ProjectScopedUser::provision(admin, "default", "member").await?;
+    match ProjectScopedUser::provision(admin, "default", "member").await {
+        Ok(b) => Ok((a, b)),
+        Err(error) => {
+            warn_on_cleanup_failure("member fixture", a.cleanup().await);
+            Err(error)
+        }
+    }
+}
 
 #[tokio::test]
 #[traced_test]
@@ -96,5 +121,87 @@ async fn test_list_filtered_by_user_id() -> Result<()> {
     assert!(filtered.iter().any(|c| c.id == guard.id));
 
     guard.delete().await?;
+    Ok(())
+}
+
+// --- issue #1117: an ordinary member may list only their own credentials ---
+//
+// The suite's ambient session is the bootstrap **admin**, which takes the
+// privileged branch of `identity/credential/list` and so cannot observe the
+// restriction at all; these cases act through a genuinely unprivileged
+// project-scoped `member` session instead.
+
+/// The happy path the restriction has to preserve: a `member` filtering to
+/// their own `user_id` still gets their own credentials back.
+#[tokio::test]
+#[traced_test]
+async fn test_list_own_user_id_allowed_for_member() -> Result<()> {
+    let admin = admin_session().await?;
+    let member = ProjectScopedUser::provision(&admin, "default", "member").await?;
+    let blob = format!(r#"{{"seed":"{}"}}"#, Uuid::new_v4().simple());
+
+    let guard = create_credential(
+        &member.session,
+        CredentialCreateBuilder::default()
+            .blob(blob)
+            .r#type("totp")
+            .build()?,
+    )
+    .await?;
+
+    let own = list_credentials(&member.session, None, Some(&member.user.id)).await?;
+    assert!(
+        own.iter().any(|c| c.id == guard.id),
+        "member filtering to their own user_id must see their own credential"
+    );
+    assert!(
+        own.iter().all(|c| c.user_id == member.user.id),
+        "the filter must be applied by the driver, not merely approved by policy"
+    );
+
+    guard.delete().await?;
+    member.cleanup().await?;
+    Ok(())
+}
+
+/// The bug itself (issue #1117): an unfiltered list let any `member` walk
+/// the whole credential table. The per-item `identity/credential/show`
+/// re-check meant nothing leaked, but the scan still happened — one cheap
+/// request per full-table scan plus an OPA round-trip per row.
+#[tokio::test]
+#[traced_test]
+async fn test_list_unfiltered_forbidden_for_member() -> Result<()> {
+    let admin = admin_session().await?;
+    let member = ProjectScopedUser::provision(&admin, "default", "member").await?;
+
+    assert_forbidden(
+        list_credentials(&member.session, None, None).await,
+        "member must not be able to list the whole credential collection",
+    );
+
+    // A `type` filter is not a way around the missing ownership filter.
+    assert_forbidden(
+        list_credentials(&member.session, Some("totp"), None).await,
+        "a type filter must not substitute for the user_id filter",
+    );
+
+    member.cleanup().await?;
+    Ok(())
+}
+
+/// Filtering to somebody else's `user_id` must not buy the scan either,
+/// otherwise the filter would be a formality rather than a boundary.
+#[tokio::test]
+#[traced_test]
+async fn test_list_other_user_id_forbidden_for_member() -> Result<()> {
+    let admin = admin_session().await?;
+    let (a, b) = two_members(&admin).await?;
+
+    assert_forbidden(
+        list_credentials(&a.session, None, Some(&b.user.id)).await,
+        "member must not be able to list another user's credentials",
+    );
+
+    cleanup_project_scoped_users([a, b]).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #1117.

`identity/credential/list` granted any caller holding `member` an unfiltered
list of every credential in the system.

Nothing leaked: the per-item `identity/credential/show` re-check (I8,
CVE-2019-19687) still dropped the rows the caller could not read. But the rows
were fetched and OPA-evaluated *before* being discarded, so one cheap request
became a full-collection scan plus one policy round-trip per row — a
resource-exhaustion amplifier available to any authenticated user.

The `member` rule is replaced by an ownership rule: the request must carry a
`user_id` filter naming the caller. `admin` and system-scoped `reader` keep the
unfiltered collection view. This mirrors python keystone's
`identity:list_credentials`:

```
(rule:admin_required) or (role:reader and system_scope:all)
  or user_id:%(target.credential.user_id)s
```

whose `user_id:%(target.credential.user_id)s` likewise resolves against the
query parameters and so denies an unfiltered list to an unprivileged caller. It
also matches `identity/user/application_credential/list`, which already gates
the sibling collection on the caller's own `user_id`.

**Ownership alone is the grant; no role is required.**
`identity/credential/show` already gives a non-delegated caller their own
credential on ownership alone, and python's rule carries no role component, so
demanding `member` would deny a reader-scoped caller their own credentials for
no security gain.

**The gate is not decorative.** The filter the policy approves and the filter
the driver applies are the same value — both read `user_id` off one parsed
`CredentialListParameters` — so a request cannot be approved on a filter the
query then ignores, which would leave the scan in place behind a check that
does nothing.

**The delegation boundary is unmoved.** OSSA-2026-015 stays where it was, in
the per-item re-check. This rule sees only query parameters, so I2's
`bound_to_own_delegation_project` has nothing to anchor on; a delegated caller
filtering to their own `user_id` passes here and still has every cross-project
and unscoped record dropped downstream. `show`'s delegated branch is unchanged.

Recorded as invariant **I8a** in the security model and in ADR 0019, with a
reviewer checklist entry: I8 makes a permissive collection filter *safe*, not
*cheap*, and the two properties need separate checks. The other I8 endpoint,
`/v3/policies`, is admin/system-reader only and already satisfies I8a.

### ⚠️ Behaviour change

`GET /v3/credentials` without a `user_id` filter now returns **403** for callers
who are neither `admin` nor system-scoped `reader`; they must pass
`?user_id=<their own id>`. Previously any `member` received a (correctly
filtered, often empty) 200. Python keystone already behaves this way, so this
closes a compatibility gap rather than opening one.

Based on `main` at #1127 (issue #1035), which is already merged — this is a
single commit against `main` with no stacked dependencies.

## Test plan

| check | result |
|---|---|
| `opa test policy/` | **366/366 pass** — 6 new/extended cases in `policy/credential/list_test.rego` |
| `cargo test -p openstack-keystone --lib` | **919/919 pass** |
| `cargo test -p openstack-keystone --lib api::v3::credential` | **39/39 pass** — 4 new handler tests |
| `cargo check -p test_api --tests` | clean — 3 new/rewritten live-API tests |
| `cargo fmt --all -- --check`, `opa fmt --diff` | clean |
| `cargo clippy --no-deps` on touched crates | no new diagnostics |

Repository security gates, all pass:
`check_rego_undefined_argument_footgun.py` (Gate E),
`check_policy_handler_coverage.py` (B1),
`check_security_checklist_sast.py` (Gate J),
`check_delegated_policy_scope_drift_tests.py` (Gate C),
`check_event_payload_no_secret_fields.py` (Gate I).

**Rego** (`policy/credential/list_test.rego`) — every shape of "no usable own-user
filter" denies: key absent, `null` (the shape the handler actually emits for an
absent `?user_id=`, since the `Option` is serialized rather than skipped),
`target.credential` missing, `target` null outright, `""` from a bare
`?user_id=`, and caller `user_id` missing. Plus: another user's id denies, a
non-system `reader` gets no exemption, `system` set to anything but `all` gets
no exemption, privileged listers keep the unfiltered view, and the violation
message fires exactly once on denial and not at all on allow.

**Handler** (`crates/keystone/src/api/v3/credential/list.rs`) — four tests driven
through a **real `opa run` subprocess**, since the mocked enforcer answers
`allow` unconditionally and cannot tell the old rule from the new one:

- `unfiltered_list_by_ordinary_member_is_denied_by_real_policy` — the backend
  mock deliberately sets **no expectation** for `list_credentials`, so `mockall`
  fails the test if the handler reaches the driver at all. That is the DoS
  property under test: a 403 that still scanned the table would fix nothing.
- `list_filtered_to_another_user_is_denied_by_real_policy` — same, for
  `?user_id=<someone else>`.
- `own_filtered_list_by_ordinary_member_is_allowed_by_real_policy` — asserts the
  filter reaches the driver via `withf`, proving the query is narrowed in SQL.
- `unfiltered_list_by_system_reader_is_allowed_by_real_policy` — privileged
  listers keep their cross-user view.

The pre-existing delegation test now sends `?user_id=u1`, which is load-bearing:
the caller holds only `member`, so an unfiltered list is denied outright by the
collection check and would never reach the per-item pass that test exists to
exercise.

**Live API** (`tests/api/tests/api_v3/credential/list.rs`) — the suite's ambient
session is the bootstrap admin, which takes the privileged branch and cannot
observe the restriction, so these act through a genuinely unprivileged
project-scoped `member` built with the shared `ProjectScopedUser` /
`two_members` / `cleanup_project_scoped_users` fixtures: own-`user_id` allowed,
unfiltered forbidden, `?type=totp` alone forbidden (a type filter is not a way
around the missing ownership filter), another user's id forbidden. Compile-
checked here; not executed, as the live suite needs the SPIRE + OPA harness.

## Security review checklist

- [x] Does any delegation/authorization decision read the **scope**
      (`project_id`, `ScopeInfo`) where it should read the **chain**
      (`authentication_context()`, delegation object)? (I1/I2) — no; the new
      branch reads only `input.credentials.user_id` (from the chain) and a
      query parameter. No scope field is consulted.
- [x] New delegation-sensitive policy rule? Is the fact it needs projected
      onto `Credentials` from the chain, and does the rule anchor on
      `delegated_project_id` + carry the scope-drift tripwire? (I2/I3) — the
      new branch is deliberately **not** delegation-sensitive: it sees only
      query parameters, so there is no resource project to anchor on. The
      OSSA-2026-015 boundary remains entirely in the per-item
      `identity/credential/show` re-check, which is unchanged, and Gate C
      confirms its scope-drift negative case still exists.
- [x] New scope shape or redemption path for a delegated auth? Are effective
      roles still bounded by the delegation? (I4) — n/a, no new scope shape or
      redemption path.
- [x] New `ScopeInfo` variant or auth method? (I5, Gate J) — n/a; Gate J passes.
- [x] New lookup by a client-derivable key (like `sha256(access)`)? (I6) — n/a.
- [x] Does any new data reaching OPA include secrets/decrypted blobs? (I7,
      Gate I) — no. The policy target is unchanged (`{"credential": <query
      params>}`, i.e. `type` and `user_id` only); no `blob` or `encrypted_blob`
      is involved. Gate I passes.
- [x] New list/collection endpoint? Does it re-check each item with the
      per-item read policy? (I8) — not new, and the per-item re-check is
      preserved verbatim, including propagating non-`Forbidden` policy errors
      rather than silently truncating.
- [x] Same endpoint: can an unprivileged caller request the whole collection
      and leave the per-item pass to sort it out? Is the value the collection
      policy gates on the same one the driver actually filters by? (I8a) —
      this is the bug being fixed; both read one parsed
      `CredentialListParameters`, and the handler tests assert the driver is
      never reached on denial.
- [x] Does the change let a narrow auth method be broadened by a
      request-supplied scope? (I5) — no; the change only narrows.
- [x] Are there negative tests proving the escape is blocked, not just
      positive tests proving the happy path works? — yes: 3 of the 4 new
      handler tests and 2 of the 3 new live-API tests are negative, plus the
      Rego denial matrix above.
- [x] Does the test drive `ValidatedSecurityContext::new_for_scope()`
      end-to-end, not just the inner helper in isolation? — the live-API tests
      drive the full password-auth path against a real server. The handler
      tests inject `ValidatedSecurityContext` fixtures from
      `real_policy_fixtures`, which is appropriate here: this PR changes no
      role calculation or scope validation, only the Rego decision, and those
      tests exercise it through a real `opa run`.