### PR TITLE
chore: Rename tracing params

### DIFF
--- a/crates/keystone/src/server/access_log.rs
+++ b/crates/keystone/src/server/access_log.rs
@@ -49,8 +49,8 @@ pub async fn log_request(req: Request, next: Next) -> Response {
     let latency_us = start.elapsed().as_micros();
 
     tracing::info!(
-        %method,
-        %uri,
+        http_method=%method,
+        http_uri=%uri,
         %request_id,
         %status,
         latency_us,


### PR DESCRIPTION
Exposed "method" and "uri" params are resulting with duplicated args in
journald what is then breaking graylog integration that reads journalctl
entries. method -> http_method, uri -> http_uri

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
