### PR TITLE
feat(api): Log error details in IntoResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4946,6 +4946,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "thiserror 2.0.19",
+ "tracing",
  "url",
  "utoipa",
  "uuid",

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -33,6 +33,7 @@ validator = { workspace = true, features = ["derive"], optional = true }
 webauthn-rs-proto.workspace = true
 url = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4"], optional = true }
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -20,6 +20,7 @@ use {
         response::{IntoResponse, Response},
     },
     serde_json::json,
+    std::error::Error,
 };
 
 use openstack_keystone_core_types::api_key::ApiKeyProviderError;
@@ -81,6 +82,14 @@ impl IntoResponse for KeystoneApiError {
             KeystoneApiError::UnprocessableEntity(_) => StatusCode::UNPROCESSABLE_ENTITY,
             _ => StatusCode::BAD_REQUEST,
         };
+
+        tracing::debug!(
+            error_type = std::any::type_name::<KeystoneApiError>(),
+            status_code = status_code.as_u16(),
+            message = %self.to_string(),
+            source = ?self.source(),
+            "Returning API error response",
+        );
 
         (
             status_code,


### PR DESCRIPTION
Every KeystoneApiError now emits a structured debug log before
converting to an HTTP response, capturing error_type, status_code,
message, and source. This surfaces the diagnostic payload that was
previously only visible in the response body, which is critical for
debugging 400 Bad Request responses where the error body contains
context not otherwise visible in server logs.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
