### PR TITLE
feat(api): Log response body for all 4xx/5xx errors

### DIFF
--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -35,5 +35,8 @@ url = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4"], optional = true }
 tracing.workspace = true
 
+[dev-dependencies]
+serde_urlencoded.workspace = true
+
 [lints]
 workspace = true

--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -64,6 +64,29 @@ pub fn default_true() -> bool {
     true
 }
 
+/// Deserialize an `Option<bool>` query parameter leniently.
+///
+/// OpenStack's python keystone (via `oslo.utils.strutils.bool_from_string`)
+/// accepts `1`/`0`, `yes`/`no`, `on`/`off`, and `true`/`false` (any case) for
+/// boolean query params like `nocatalog`/`allow_expired`. Plain
+/// `Option<bool>` only accepts `true`/`false` and 400s on anything else
+/// (e.g. `allow_expired=1`), which is what real clients send. Use as
+/// `#[serde(default, deserialize_with = "deserialize_lenient_bool_opt")]`
+/// on `Option<bool>` query fields.
+pub fn deserialize_lenient_bool_opt<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    match raw.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(Some(true)),
+        "0" | "false" | "no" | "off" => Ok(Some(false)),
+        other => Err(serde::de::Error::custom(format!(
+            "invalid boolean value: `{other}`"
+        ))),
+    }
+}
+
 /// Default `limit` when the client does not supply one: **`None`**.
 ///
 /// Deliberately not a hard-coded page size. ADR 0029's precedence chain is

--- a/crates/api-types/src/v3/auth/token.rs
+++ b/crates/api-types/src/v3/auth/token.rs
@@ -401,6 +401,7 @@ fn validate_token_auth_secret(value: &TokenAuth) -> Result<(), validator::Valida
 pub struct CreateTokenParameters {
     /// The authentication response excludes the service catalog. By default,
     /// the response includes the service catalog.
+    #[serde(default, deserialize_with = "crate::deserialize_lenient_bool_opt")]
     pub nocatalog: Option<bool>,
 }
 
@@ -410,9 +411,11 @@ pub struct CreateTokenParameters {
 pub struct ValidateTokenParameters {
     /// The authentication response excludes the service catalog. By default,
     /// the response includes the service catalog.
+    #[serde(default, deserialize_with = "crate::deserialize_lenient_bool_opt")]
     pub nocatalog: Option<bool>,
     /// Allow fetching a token that has expired. By default expired tokens
     /// return a 404 exception.
+    #[serde(default, deserialize_with = "crate::deserialize_lenient_bool_opt")]
     pub allow_expired: Option<bool>,
 }
 
@@ -440,6 +443,29 @@ mod tests {
     use super::*;
 
     const PWD: &str = "hunter2-plaintext";
+
+    #[test]
+    fn validate_token_parameters_accepts_lenient_bool_query_values() {
+        for (raw, expected) in [
+            ("allow_expired=1", Some(true)),
+            ("allow_expired=0", Some(false)),
+            ("allow_expired=true", Some(true)),
+            ("allow_expired=false", Some(false)),
+            ("allow_expired=yes", Some(true)),
+            ("allow_expired=no", Some(false)),
+        ] {
+            let params: ValidateTokenParameters = serde_urlencoded::from_str(raw)
+                .unwrap_or_else(|e| panic!("failed to parse `{raw}`: {e}"));
+            assert_eq!(params.allow_expired, expected, "input: {raw}");
+        }
+    }
+
+    #[test]
+    fn validate_token_parameters_rejects_garbage_bool_query_value() {
+        let err = serde_urlencoded::from_str::<ValidateTokenParameters>("allow_expired=maybe")
+            .unwrap_err();
+        assert!(err.to_string().contains("invalid boolean value"));
+    }
 
     #[test]
     fn user_password_deserializes_plaintext_and_debug_never_leaks() {

--- a/crates/keystone/src/bin/keystone.rs
+++ b/crates/keystone/src/bin/keystone.rs
@@ -84,6 +84,7 @@ use openstack_keystone::revoke::RevokeHook;
 use openstack_keystone::role::RoleHook;
 use openstack_keystone::scim;
 use openstack_keystone::server::access_log::log_request;
+use openstack_keystone::server::error_log::log_error_body;
 use openstack_keystone::server::http_metrics::format_prometheus_text as format_http_metrics_text;
 use openstack_keystone::server::http_metrics::{HttpMetrics, record_http_metrics};
 use openstack_keystone::server::listener::{raft_grpc, spiffe_tls, spiffe_tls_uds};
@@ -981,6 +982,11 @@ async fn build_router(
         // on them. Must stay layered after TraceLayer so it runs inside the
         // request span.
         .layer(middleware::from_fn(log_request))
+        // Logs the body of any 4xx/5xx response (not just `KeystoneApiError`
+        // ones — extractor rejections build their own response and never
+        // reach handler code). Must stay layered before `.compression()` so
+        // it reads the body while it's still plain JSON.
+        .layer(middleware::from_fn(log_error_body))
         // Compress responses
         .compression()
         .sensitive_response_headers(sensitive_headers)

--- a/crates/keystone/src/server.rs
+++ b/crates/keystone/src/server.rs
@@ -13,6 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # Keystone server listeners
 pub mod access_log;
+pub mod error_log;
 pub mod http_metrics;
 pub mod listener;
 pub mod proxy_headers;

--- a/crates/keystone/src/server/error_log.rs
+++ b/crates/keystone/src/server/error_log.rs
@@ -1,0 +1,132 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Error response body logging middleware
+//!
+//! `KeystoneApiError::into_response` logs its own diagnostic fields (see
+//! `error_conv.rs`), but that only covers responses produced by handler code
+//! that actually returns a `KeystoneApiError`. Extractor rejections (e.g.
+//! `Query<T>`/`Json<T>`/`Path<T>` failing to deserialize) never reach the
+//! handler and build their own response directly, bypassing that log
+//! entirely — the body (which carries the only diagnostic detail, e.g. which
+//! field failed to parse and why) was otherwise visible only to the client.
+//!
+//! This middleware logs the response body for any 4xx/5xx response,
+//! regardless of where in the stack it was produced. Must be layered before
+//! the compression layer (outside it, i.e. closer to the handler) so it
+//! reads the body while it's still plain JSON.
+
+use axum::body::{Body, to_bytes};
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+
+/// Cap on how much of an error body we buffer for logging. Error bodies in
+/// this codebase are small, hand-built JSON objects; a generous cap avoids
+/// ever truncating a real one while still bounding memory use against a
+/// pathological body.
+const MAX_LOGGED_BODY_BYTES: usize = 64 * 1024;
+
+pub async fn log_error_body(req: Request, next: Next) -> Response {
+    let response = next.run(req).await;
+    let status = response.status();
+    if !status.is_client_error() && !status.is_server_error() {
+        return response;
+    }
+
+    let (parts, body) = response.into_parts();
+    match to_bytes(body, MAX_LOGGED_BODY_BYTES).await {
+        Ok(bytes) => {
+            tracing::debug!(
+                status_code = status.as_u16(),
+                body = %String::from_utf8_lossy(&bytes),
+                "Returning error response",
+            );
+            Response::from_parts(parts, Body::from(bytes))
+        }
+        Err(error) => {
+            // Body couldn't be fully buffered (e.g. exceeded the cap above).
+            // The stream is already partially consumed at this point, so
+            // the original body can't be forwarded intact; log what we can
+            // and fail closed with an empty body rather than send a
+            // truncated/corrupt one.
+            tracing::debug!(
+                status_code = status.as_u16(),
+                %error,
+                "Failed to buffer error response body for logging",
+            );
+            Response::from_parts(parts, Body::empty())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Router;
+    use axum::http::StatusCode;
+    use axum::routing::get;
+    use tower::ServiceExt as _;
+
+    use super::*;
+
+    async fn ok_handler() -> &'static str {
+        "fine"
+    }
+
+    async fn err_handler() -> Response {
+        Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::from(r#"{"error":{"message":"bad"}}"#))
+            .expect("valid response")
+    }
+
+    #[tokio::test]
+    async fn passes_through_success_body_unchanged() {
+        let app = Router::new()
+            .route("/ok", get(ok_handler))
+            .layer(axum::middleware::from_fn(log_error_body));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ok")
+                    .body(Body::empty())
+                    .expect("req"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+        assert_eq!(&body[..], b"fine");
+    }
+
+    #[tokio::test]
+    async fn preserves_error_body_after_logging() {
+        let app = Router::new()
+            .route("/err", get(err_handler))
+            .layer(axum::middleware::from_fn(log_error_body));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/err")
+                    .body(Body::empty())
+                    .expect("req"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+        assert_eq!(&body[..], br#"{"error":{"message":"bad"}}"#);
+    }
+}


### PR DESCRIPTION
KeystoneApiError::IntoResponse already logs its own diagnostics, but
extractor rejections (Query/Json/Path failing to deserialize) never
reach handler code and build their own response directly, bypassing
that log entirely — the body was the only place the actual failure
reason showed up, and it only reached the client.

Add log_error_body middleware, layered before compression so it
reads the body while still plain JSON.

allow_expired/nocatalog only accepted `true`/`false`, 400ing on
`allow_expired=1` from real clients (python-keystoneclient). Add
deserialize_lenient_bool_opt accepting 1/0, yes/no, on/off, true/false
case-insensitively, matching python-keystone's
strutils.bool_from_string behavior.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
