### PR TITLE
fix(logging): Surface 5xx causes at error level

### DIFF
--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -83,13 +83,27 @@ impl IntoResponse for KeystoneApiError {
             _ => StatusCode::BAD_REQUEST,
         };
 
-        tracing::debug!(
-            error_type = std::any::type_name::<KeystoneApiError>(),
-            status_code = status_code.as_u16(),
-            message = %self.to_string(),
-            source = ?self.source(),
-            "Returning API error response",
-        );
+        // 5xx must be visible under a default INFO deployment (nothing else
+        // in the request path logs the actual cause at INFO); 4xx are
+        // client-caused and stay at debug to avoid drowning out real
+        // problems.
+        if status_code.is_server_error() {
+            tracing::error!(
+                error_type = std::any::type_name::<KeystoneApiError>(),
+                status_code = status_code.as_u16(),
+                message = %self.to_string(),
+                source = ?self.source(),
+                "Returning API error response",
+            );
+        } else {
+            tracing::debug!(
+                error_type = std::any::type_name::<KeystoneApiError>(),
+                status_code = status_code.as_u16(),
+                message = %self.to_string(),
+                source = ?self.source(),
+                "Returning API error response",
+            );
+        }
 
         (
             status_code,

--- a/crates/api-types/src/v3/policy.rs
+++ b/crates/api-types/src/v3/policy.rs
@@ -19,8 +19,8 @@
 //! * **Requests** accept a `String` only, per `keystone/policy/schema.py`
 //!   (`{'blob': {'type': 'string'}}`). An object-valued `blob` is a 400.
 //! * **Responses** carry an arbitrary JSON value, because the stored column
-//!   round-trips whatever was written and rows created by older python
-//!   keystone releases may hold objects.
+//!   round-trips whatever was written and rows created by older python keystone
+//!   releases may hold objects.
 
 use std::collections::HashMap;
 

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -51,7 +51,7 @@ where
 {
     type Rejection = KeystoneApiError;
 
-    #[tracing::instrument(skip(state), err)]
+    #[tracing::instrument(skip(state, parts), err)]
     /// Try to authenticate the request
     ///
     /// Authenticate the request creating the `ValidatedSecurityContext` using

--- a/crates/core/src/revoke/service.rs
+++ b/crates/core/src/revoke/service.rs
@@ -79,7 +79,7 @@ impl RevokeApi for RevokeService {
         ctx: &ExecutionContext<'a>,
         token_security_context: &ValidatedSecurityContext,
     ) -> Result<bool, RevokeProviderError> {
-        tracing::info!("Checking for the revocation events");
+        tracing::debug!("Checking for the revocation events");
         self.backend_driver
             .is_token_revoked(ctx.state(), token_security_context)
             .await

--- a/crates/domain-config-driver-sql/src/get.rs
+++ b/crates/domain-config-driver-sql/src/get.rs
@@ -161,9 +161,9 @@ pub async fn get_config<C: ConnectionTrait>(
 /// - `group`: The group to read.
 ///
 /// # Returns
-/// - `Result<Option<DomainConfigGroup>, DomainConfigProviderError>` - The
-///   group without any sensitive option, or `None` when the domain has no
-///   readable option stored in it.
+/// - `Result<Option<DomainConfigGroup>, DomainConfigProviderError>` - The group
+///   without any sensitive option, or `None` when the domain has no readable
+///   option stored in it.
 pub async fn get_group<C: ConnectionTrait>(
     db: &C,
     domain_id: &str,

--- a/crates/domain-config-driver-sql/src/option.rs
+++ b/crates/domain-config-driver-sql/src/option.rs
@@ -152,8 +152,9 @@ where
 /// - `options`: The options to persist.
 ///
 /// # Returns
-/// - `Result<(Vec<whitelisted_config::ActiveModel>, Vec<sensitive_config::ActiveModel>), DomainConfigProviderError>` -
-///   The readable and the sensitive rows.
+/// - `Result<(Vec<whitelisted_config::ActiveModel>,
+///   Vec<sensitive_config::ActiveModel>), DomainConfigProviderError>` - The
+///   readable and the sensitive rows.
 #[allow(clippy::type_complexity)]
 pub(crate) fn to_rows<'a, I>(
     domain_id: &str,

--- a/crates/keystone/src/server/error_log.rs
+++ b/crates/keystone/src/server/error_log.rs
@@ -47,11 +47,21 @@ pub async fn log_error_body(req: Request, next: Next) -> Response {
     let (parts, body) = response.into_parts();
     match to_bytes(body, MAX_LOGGED_BODY_BYTES).await {
         Ok(bytes) => {
-            tracing::debug!(
-                status_code = status.as_u16(),
-                body = %String::from_utf8_lossy(&bytes),
-                "Returning error response",
-            );
+            // 5xx must be visible under a default INFO deployment; 4xx are
+            // client-caused and stay at debug.
+            if status.is_server_error() {
+                tracing::error!(
+                    status_code = status.as_u16(),
+                    body = %String::from_utf8_lossy(&bytes),
+                    "Returning error response",
+                );
+            } else {
+                tracing::debug!(
+                    status_code = status.as_u16(),
+                    body = %String::from_utf8_lossy(&bytes),
+                    "Returning error response",
+                );
+            }
             Response::from_parts(parts, Body::from(bytes))
         }
         Err(error) => {
@@ -60,11 +70,19 @@ pub async fn log_error_body(req: Request, next: Next) -> Response {
             // the original body can't be forwarded intact; log what we can
             // and fail closed with an empty body rather than send a
             // truncated/corrupt one.
-            tracing::debug!(
-                status_code = status.as_u16(),
-                %error,
-                "Failed to buffer error response body for logging",
-            );
+            if status.is_server_error() {
+                tracing::error!(
+                    status_code = status.as_u16(),
+                    %error,
+                    "Failed to buffer error response body for logging",
+                );
+            } else {
+                tracing::debug!(
+                    status_code = status.as_u16(),
+                    %error,
+                    "Failed to buffer error response body for logging",
+                );
+            }
             Response::from_parts(parts, Body::empty())
         }
     }

--- a/crates/revoke-driver-sql/src/list.rs
+++ b/crates/revoke-driver-sql/src/list.rs
@@ -37,7 +37,7 @@ use crate::entity::{
 fn build_query_filters(
     params: &RevocationEventListParameters,
 ) -> Result<Select<DbRevocationEvent>, RevokeProviderError> {
-    tracing::info!("Query parameters: {:?}", params);
+    tracing::debug!("Query parameters: {:?}", params);
     let mut select = DbRevocationEvent::find();
 
     //if let Some(val) = &params.access_token_id {

--- a/crates/trust-driver-sql/src/trust.rs
+++ b/crates/trust-driver-sql/src/trust.rs
@@ -41,14 +41,28 @@ impl TryFrom<db_trust::Model> for Trust {
             builder.deleted_at(val.and_utc());
         }
         if let Some(val) = value.expires_at_int {
-            builder.expires_at(
-                DateTime::from_timestamp_micros(val)
-                    .map(|val| val.to_utc())
-                    .ok_or_else(|| Self::Error::ExpirationDateTimeParse {
-                        id: value.id.clone(),
-                        expires_at: val,
-                    })?,
-            );
+            match DateTime::from_timestamp_micros(val).map(|val| val.to_utc()) {
+                Some(dt) => {
+                    builder.expires_at(dt);
+                }
+                None => {
+                    // `expires_at_int` is out of chrono's representable
+                    // range (corrupt write, bad migration, manual DB edit).
+                    // Hard-erroring here would 500 every read of this trust
+                    // forever; fall back to the legacy `expires_at` column
+                    // if it still holds a usable value, otherwise treat the
+                    // trust as non-expiring rather than making it
+                    // permanently unreadable.
+                    error!(
+                        trust_id = %value.id,
+                        expires_at_int = val,
+                        "trust.expires_at_int is out of range; falling back to expires_at"
+                    );
+                    if let Some(val) = value.expires_at {
+                        builder.expires_at(val.and_utc());
+                    }
+                }
+            }
         } else if let Some(val) = value.expires_at {
             builder.expires_at(val.and_utc());
         }

--- a/tests/api/src/macros.rs
+++ b/tests/api/src/macros.rs
@@ -93,8 +93,8 @@
 //! - `update`: private request struct, `RestEndpoint` impl (PATCH `path/{id}`,
 //!   JSON body under `body_key`), and `pub async fn <func>(tc, id,
 //!   <update_type>) -> Result<model>`. `update_put` is the identical arm
-//!   emitting `PUT` instead — every v4 update handler declares `put` where
-//!   its v3 counterpart declares `patch`, so v4 helpers need it.
+//!   emitting `PUT` instead — every v4 update handler declares `put` where its
+//!   v3 counterpart declares `patch`, so v4 helpers need it.
 //! - `list`: **public** request struct with `Option<String>` query fields,
 //!   `RestEndpoint` impl (GET `path`), and `pub async fn <func>(tc, params) ->
 //!   Result<Vec<model>>`.


### PR DESCRIPTION
- 5xx bodies/details logged at debug only; under default INFO
  deployment every 500 showed status with zero cause. Bump those two
  sites to error!, keep 4xx at debug.
- Auth::from_request_parts instrumented `parts` (full Parts incl. all
  headers) into every request's span at INFO; skip it instead of
  Debug-dumping headers on every request.
- revoke::service and revoke-driver-sql::list logged per-request
  check/query-struct dumps at INFO with no signal; drop to debug.
- trust get(): out-of-range expires_at_int hard-errored the whole
  trust read (permanent 500 on that row). Fall back to legacy
  expires_at column, or treat as non-expiring, logging the anomaly
  instead of failing closed.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
