### PR TITLE
fix(trust): Match db fields to sINT for mysql

### DIFF
--- a/crates/api-types/src/v3/policy.rs
+++ b/crates/api-types/src/v3/policy.rs
@@ -19,8 +19,8 @@
 //! * **Requests** accept a `String` only, per `keystone/policy/schema.py`
 //!   (`{'blob': {'type': 'string'}}`). An object-valued `blob` is a 400.
 //! * **Responses** carry an arbitrary JSON value, because the stored column
-//!   round-trips whatever was written and rows created by older python
-//!   keystone releases may hold objects.
+//!   round-trips whatever was written and rows created by older python keystone
+//!   releases may hold objects.
 
 use std::collections::HashMap;
 

--- a/crates/domain-config-driver-sql/src/get.rs
+++ b/crates/domain-config-driver-sql/src/get.rs
@@ -161,9 +161,9 @@ pub async fn get_config<C: ConnectionTrait>(
 /// - `group`: The group to read.
 ///
 /// # Returns
-/// - `Result<Option<DomainConfigGroup>, DomainConfigProviderError>` - The
-///   group without any sensitive option, or `None` when the domain has no
-///   readable option stored in it.
+/// - `Result<Option<DomainConfigGroup>, DomainConfigProviderError>` - The group
+///   without any sensitive option, or `None` when the domain has no readable
+///   option stored in it.
 pub async fn get_group<C: ConnectionTrait>(
     db: &C,
     domain_id: &str,

--- a/crates/domain-config-driver-sql/src/option.rs
+++ b/crates/domain-config-driver-sql/src/option.rs
@@ -152,8 +152,9 @@ where
 /// - `options`: The options to persist.
 ///
 /// # Returns
-/// - `Result<(Vec<whitelisted_config::ActiveModel>, Vec<sensitive_config::ActiveModel>), DomainConfigProviderError>` -
-///   The readable and the sensitive rows.
+/// - `Result<(Vec<whitelisted_config::ActiveModel>,
+///   Vec<sensitive_config::ActiveModel>), DomainConfigProviderError>` - The
+///   readable and the sensitive rows.
 #[allow(clippy::type_complexity)]
 pub(crate) fn to_rows<'a, I>(
     domain_id: &str,

--- a/crates/trust-driver-sql/src/entity/trust.rs
+++ b/crates/trust-driver-sql/src/entity/trust.rs
@@ -27,12 +27,20 @@ pub struct Model {
     pub impersonation: bool,
     pub deleted_at: Option<DateTime>,
     pub expires_at: Option<DateTime>,
-    pub remaining_uses: Option<u32>,
+    // Deployed column is a signed `INT` (see `redelegation_count` comment
+    // below for why the Rust type has to match).
+    pub remaining_uses: Option<i32>,
     #[sea_orm(column_type = "Text", nullable)]
     pub extra: Option<String>,
     pub expires_at_int: Option<i64>,
     pub redelegated_trust_id: Option<String>,
-    pub redelegation_count: Option<u32>,
+    // Deployed column is a signed `INT` (predates this field, and `db
+    // sync` never alters existing columns), not the `INT UNSIGNED` that
+    // sea-orm's default codegen maps `u32` to -- sqlx's typed decode then
+    // rejects every non-null value on existing installs. Keep the Rust
+    // field signed to match what's actually on disk; convert to the
+    // domain's `u32` at the `TryFrom<Model>`/`create` boundary instead.
+    pub redelegation_count: Option<i32>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/trust-driver-sql/src/trust.rs
+++ b/crates/trust-driver-sql/src/trust.rs
@@ -65,19 +65,43 @@ impl TryFrom<db_trust::Model> for Trust {
             }
         }
 
+        if let Some(val) = value.redelegation_count {
+            match u32::try_from(val) {
+                Ok(val) => {
+                    builder.redelegation_count(val);
+                }
+                Err(_) => {
+                    error!(
+                        trust_id = %value.id,
+                        redelegation_count = val,
+                        "trust.redelegation_count is negative; treating as unset"
+                    );
+                }
+            }
+        }
+
+        if let Some(val) = value.remaining_uses {
+            match u32::try_from(val) {
+                Ok(val) => {
+                    builder.remaining_uses(val);
+                }
+                Err(_) => {
+                    error!(
+                        trust_id = %value.id,
+                        remaining_uses = val,
+                        "trust.remaining_uses is negative; treating as unset"
+                    );
+                }
+            }
+        }
+
         builder.id(value.id);
         builder.impersonation(value.impersonation);
         if let Some(val) = &value.project_id {
             builder.project_id(val);
         }
-        if let Some(val) = value.remaining_uses {
-            builder.remaining_uses(val);
-        }
         if let Some(val) = &value.redelegated_trust_id {
             builder.redelegated_trust_id(val);
-        }
-        if let Some(val) = value.redelegation_count {
-            builder.redelegation_count(val);
         }
         builder.trustor_user_id(value.trustor_user_id);
         builder.trustee_user_id(value.trustee_user_id);

--- a/crates/trust-driver-sql/src/trust/create.rs
+++ b/crates/trust-driver-sql/src/trust/create.rs
@@ -38,11 +38,16 @@ impl TryFrom<TrustCreate> for db_trust::ActiveModel {
             impersonation: Set(value.impersonation),
             deleted_at: NotSet,
             expires_at: NotSet,
-            remaining_uses: Set(value.remaining_uses),
+            // Column signed `INT` (see entity comment); remaining_uses is
+            // always small, cast never truncates in practice.
+            remaining_uses: Set(value.remaining_uses.map(|v| v as i32)),
             extra: Set(value.extra.map(|v| serde_json::to_string(&v)).transpose()?),
             expires_at_int: Set(value.expires_at.map(|v| v.timestamp_micros())),
             redelegated_trust_id: Set(value.redelegated_trust_id),
-            redelegation_count: Set(value.redelegation_count),
+            // Column is signed `INT` (see entity comment); `redelegation_count`
+            // is always small and bounded by `max_redelegation_count`
+            // config, so the cast never truncates in practice.
+            redelegation_count: Set(value.redelegation_count.map(|v| v as i32)),
         })
     }
 }

--- a/tests/api/src/macros.rs
+++ b/tests/api/src/macros.rs
@@ -93,8 +93,8 @@
 //! - `update`: private request struct, `RestEndpoint` impl (PATCH `path/{id}`,
 //!   JSON body under `body_key`), and `pub async fn <func>(tc, id,
 //!   <update_type>) -> Result<model>`. `update_put` is the identical arm
-//!   emitting `PUT` instead — every v4 update handler declares `put` where
-//!   its v3 counterpart declares `patch`, so v4 helpers need it.
+//!   emitting `PUT` instead — every v4 update handler declares `put` where its
+//!   v3 counterpart declares `patch`, so v4 helpers need it.
 //! - `list`: **public** request struct with `Option<String>` query fields,
 //!   `RestEndpoint` impl (GET `path`), and `pub async fn <func>(tc, params) ->
 //!   Result<Vec<model>>`.


### PR DESCRIPTION
sea-orm codegen mapped both fields to Option<u32>, which sqlx
type-checks against INT UNSIGNED at decode time. Deployed MySQL
schema (predates these fields, db sync never alters existing
columns) stores them as signed INT, so any row with a non-null
value hard-failed with a "mismatched types" decode error on every
read - 500ing GET/LIST trust for that row.

Keep the Rust field signed (Option<i32>) to match what's on disk;
convert to/from the domain's u32 at the TryFrom<Model>/create
boundary, logging and dropping to unset on the (should-never-happen)
negative case instead of hard-failing the whole read.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
