### PR TITLE
feat(devstack): Add SPIRE devstack plugin (Phase 1)

### DIFF
--- a/.github/workflows/devstack.yml
+++ b/.github/workflows/devstack.yml
@@ -41,6 +41,7 @@ jobs:
               - 'crates/**'
               - 'policy/**'
               - 'devstack/**'
+              - 'tools/devstack-plugin-spire/**'
 
   build:
     needs: changes
@@ -138,6 +139,24 @@ jobs:
       - name: Clone devstack
         run: git clone https://opendev.org/openstack/devstack /opt/stack/devstack
 
+      - name: Package SPIRE plugin as a standalone devstack plugin repo
+        # devstack's enable_plugin only supports whole-repo plugins: it
+        # clones the given repo to /opt/stack/<name> and looks for the
+        # plugin under <clone>/devstack/ - there is no subdirectory support
+        # and extra arguments are silently ignored. Pointing it at this
+        # repo would clone the whole keystone tree and run the key-rs
+        # plugin that lives at its devstack/ dir instead of the SPIRE one,
+        # so the spire plugin is repackaged as its own tiny git repo with
+        # the standard <repo>/devstack/ layout.
+        run: |
+          sudo mkdir -p /opt/spire-plugin/devstack
+          sudo cp -rT tools/devstack-plugin-spire /opt/spire-plugin/devstack
+          sudo git -C /opt/spire-plugin init -q -b main
+          sudo git -C /opt/spire-plugin add -A
+          sudo git -C /opt/spire-plugin \
+            -c user.name=ci -c user.email=ci@localhost \
+            commit -qm "SPIRE devstack plugin"
+
       - name: Write local.conf
         run: |
           cat <<EOF > /opt/stack/devstack/local.conf
@@ -154,8 +173,17 @@ jobs:
           enable_service key
           enable_service key-rs
           enable_service tempest
+          enable_service spire
 
+          # spire is listed before key-rs: no ordering dependency yet in
+          # Phase 1, but Phase 3 (keystone-rs's internal SPIFFE mTLS
+          # listener) will need SPIRE's trust bundle available before
+          # key-rs starts, and devstack processes enable_plugin lines in
+          # the order they're listed here.
+          enable_plugin spire file:///opt/spire-plugin main
           enable_plugin key-rs file://${{ github.workspace }} ${{ env.KEYSTONE_RS_GIT_REF }}
+
+          SPIRE_TRUST_DOMAIN=cloud.trust.domain
 
           KEYSTONE_RS_BIN_DIR=${{ github.workspace }}/bin
 
@@ -180,6 +208,26 @@ jobs:
         run: |
           source /opt/stack/devstack/openrc admin admin
           openstack token issue
+
+      - name: Verify SPIRE server and agent are healthy
+        # $USER is the devstack user (STACK_USER): it owns the sockets the
+        # run_process units created, so no sudo hop is needed. On the
+        # GitHub runner that's "runner", not the "stack" user traditional
+        # devstack docs assume.
+        run: |
+          /usr/local/bin/spire-server healthcheck -socketPath /opt/stack/data/spire/server.sock
+          /usr/local/bin/spire-agent healthcheck -socketPath /opt/stack/data/spire/agent.sock
+
+      - name: Verify pre-registered SPIRE entries exist
+        run: |
+          /usr/local/bin/spire-server entry show -socketPath /opt/stack/data/spire/server.sock | tee /tmp/spire-entries.txt
+          grep -q "service/keystone" /tmp/spire-entries.txt
+          grep -q "service/nova-api" /tmp/spire-entries.txt
+          grep -q "service/neutron" /tmp/spire-entries.txt
+          grep -q "service/nova-compute/host/" /tmp/spire-entries.txt
+
+      - name: Verify SPIRE CA bundle was exported
+        run: test -s /etc/keystone/spiffe/ca.crt
 
       - name: Run tempest identity tests
         # Best-effort signal only: rust Keystone doesn't yet implement the
@@ -222,6 +270,14 @@ jobs:
       - name: Dump OPA service log
         if: failure()
         run: sudo journalctl -u devstack@key-rs-opa --no-pager || true
+
+      - name: Dump SPIRE server log
+        if: failure()
+        run: sudo journalctl -u devstack@spire-server --no-pager || true
+
+      - name: Dump SPIRE agent log
+        if: failure()
+        run: sudo journalctl -u devstack@spire-agent --no-pager || true
 
       - name: Dump Apache error log
         if: failure()

--- a/tools/devstack-plugin-spire/etc/spire-agent.conf.tpl
+++ b/tools/devstack-plugin-spire/etc/spire-agent.conf.tpl
@@ -1,0 +1,26 @@
+agent {
+    data_dir = "@SPIRE_DATA_DIR@"
+    log_level = "INFO"
+    server_address = "127.0.0.1"
+    server_port = "@SPIRE_SERVER_BIND_PORT@"
+    socket_path = "@SPIRE_AGENT_SOCKET@"
+    trust_domain = "@SPIRE_TRUST_DOMAIN@"
+    # Single-node devstack bootstrap only, matching tools/start-spire.sh -
+    # the agent trusts the server's cert on first connect instead of
+    # verifying it against a pre-distributed bundle.
+    insecure_bootstrap = true
+}
+
+plugins {
+    KeyManager "memory" {
+        plugin_data {}
+    }
+
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    WorkloadAttestor "unix" {
+        plugin_data {}
+    }
+}

--- a/tools/devstack-plugin-spire/etc/spire-server.conf.tpl
+++ b/tools/devstack-plugin-spire/etc/spire-server.conf.tpl
@@ -1,0 +1,33 @@
+server {
+    bind_address = "127.0.0.1"
+    bind_port = "@SPIRE_SERVER_BIND_PORT@"
+    trust_domain = "@SPIRE_TRUST_DOMAIN@"
+    data_dir = "@SPIRE_DATA_DIR@"
+    log_level = "INFO"
+    socket_path = "@SPIRE_SERVER_SOCKET@"
+}
+
+plugins {
+    DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "@SPIRE_DATA_DIR@/datastore.sqlite3"
+        }
+    }
+
+    KeyManager "disk" {
+        plugin_data {
+            keys_path = "@SPIRE_DATA_DIR@/keys.json"
+        }
+    }
+
+    # join_token is single-node/insecure-bootstrap only, matching
+    # tools/start-spire.sh's CI harness. Production deployments would use
+    # x509pop or another attestor that actually proves node identity - see
+    # doc/plans/spire-integration.md Phase 1 "Per-host nova-compute
+    # registration" for why this matters for the nova-compute entries this
+    # plugin registers below.
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+}

--- a/tools/devstack-plugin-spire/lib/spire
+++ b/tools/devstack-plugin-spire/lib/spire
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# devstack lib functions for the SPIRE service (SPIFFE workload identity).
+#
+# Stands up a single-node SPIRE server + agent, pre-registers the
+# well-known SPIFFE identities other phases of doc/plans/spire-integration.md
+# authenticate against (keystone-rs, nova-api, neutron, and a per-host
+# nova-compute entry), and exports the trust bundle so keystone-rs and
+# Python services can reference it. This plugin does not touch
+# keystone-rs's own config (devstack/lib/keystone-rs) - later phases wire
+# the two together.
+#
+# Standard devstack function naming: install_/configure_/init_/start_/
+# stop_/cleanup_<service>.
+#
+# Deliberately kept independent of tools/start-spire.sh (the test_api CI
+# harness's SPIRE bootstrap): that script is a one-shot, fixed-path
+# ($TRUST_DOMAIN=example.org, /tmp/spire-ci-test-harness) helper for
+# nextest, not a devstack-service-lifecycle-aware plugin. This file uses
+# its own data dir/port namespace under devstack's $DATA_DIR so the two
+# never collide, even though they never run in the same process tree
+# today (one is test_api-only, one is devstack.yml-only).
+
+SPIRE_LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SPIRE_PLUGIN_ROOT=$(cd "$SPIRE_LIB_DIR/.." && pwd)
+
+SPIRE_VERSION=${SPIRE_VERSION:-1.15.3}
+SPIRE_TRUST_DOMAIN=${SPIRE_TRUST_DOMAIN:-cloud.trust.domain}
+SPIRE_DATA_DIR=${SPIRE_DATA_DIR:-$DATA_DIR/spire}
+SPIRE_SERVER_SOCKET=${SPIRE_SERVER_SOCKET:-$SPIRE_DATA_DIR/server.sock}
+SPIRE_AGENT_SOCKET=${SPIRE_AGENT_SOCKET:-$SPIRE_DATA_DIR/agent.sock}
+SPIRE_SERVER_BIND_PORT=${SPIRE_SERVER_BIND_PORT:-8081}
+SPIRE_SERVER_CONF=$SPIRE_DATA_DIR/server.conf
+SPIRE_AGENT_CONF=$SPIRE_DATA_DIR/agent.conf
+# Public CA cert, no secrecy requirement - keystone-rs (Phase 3) and
+# Python services will read this to validate SPIFFE peers.
+SPIRE_CA_BUNDLE_DEST=${SPIRE_CA_BUNDLE_DEST:-$KEYSTONE_CONF_DIR/spiffe/ca.crt}
+
+function install_spire {
+    local arch tarball url checksums_url tmp_dir
+
+    case "$(uname -m)" in
+        x86_64) arch=amd64 ;;
+        aarch64) arch=arm64 ;;
+        *) die $LINENO "Unsupported architecture for SPIRE: $(uname -m)" ;;
+    esac
+
+    tmp_dir=$(mktemp -d)
+    tarball="spire-${SPIRE_VERSION}-linux-${arch}-musl.tar.gz"
+    url="https://github.com/spiffe/spire/releases/download/v${SPIRE_VERSION}/${tarball}"
+    # SPIRE publishes one <asset>_sha256sum.txt per release asset, named
+    # after the asset without its .tar.gz suffix (there is no single
+    # combined checksums file).
+    checksums_url="https://github.com/spiffe/spire/releases/download/v${SPIRE_VERSION}/spire-${SPIRE_VERSION}-linux-${arch}-musl_sha256sum.txt"
+
+    curl --proto '=https' --tlsv1.2 -sSfL "$url" -o "$tmp_dir/$tarball"
+    curl --proto '=https' --tlsv1.2 -sSfL "$checksums_url" -o "$tmp_dir/checksums.txt"
+
+    # Unlike install_keystone_rs's OPA download, actually verify the
+    # published checksum - SPIRE issues X.509/JWT identities for the whole
+    # control plane, so a corrupted/tampered binary here is a much higher
+    # blast radius than a corrupted policy engine.
+    pushd "$tmp_dir" >/dev/null
+    if ! grep " ${tarball}\$" checksums.txt | sha256sum -c - >/dev/null 2>&1; then
+        popd >/dev/null
+        rm -rf "$tmp_dir"
+        die $LINENO "SPIRE release checksum verification failed for $tarball"
+    fi
+    popd >/dev/null
+
+    tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
+    sudo install -m 0755 "$tmp_dir/spire-${SPIRE_VERSION}/bin/spire-server" /usr/local/bin/spire-server
+    sudo install -m 0755 "$tmp_dir/spire-${SPIRE_VERSION}/bin/spire-agent" /usr/local/bin/spire-agent
+
+    rm -rf "$tmp_dir"
+}
+
+function configure_spire {
+    sudo install -d -o "$STACK_USER" -m 0755 "$SPIRE_DATA_DIR"
+
+    sed \
+        -e "s|@SPIRE_TRUST_DOMAIN@|$SPIRE_TRUST_DOMAIN|g" \
+        -e "s|@SPIRE_DATA_DIR@|$SPIRE_DATA_DIR|g" \
+        -e "s|@SPIRE_SERVER_SOCKET@|$SPIRE_SERVER_SOCKET|g" \
+        -e "s|@SPIRE_SERVER_BIND_PORT@|$SPIRE_SERVER_BIND_PORT|g" \
+        "$SPIRE_PLUGIN_ROOT/etc/spire-server.conf.tpl" | \
+        sudo -u "$STACK_USER" tee "$SPIRE_SERVER_CONF" >/dev/null
+
+    sed \
+        -e "s|@SPIRE_TRUST_DOMAIN@|$SPIRE_TRUST_DOMAIN|g" \
+        -e "s|@SPIRE_DATA_DIR@|$SPIRE_DATA_DIR|g" \
+        -e "s|@SPIRE_AGENT_SOCKET@|$SPIRE_AGENT_SOCKET|g" \
+        -e "s|@SPIRE_SERVER_BIND_PORT@|$SPIRE_SERVER_BIND_PORT|g" \
+        "$SPIRE_PLUGIN_ROOT/etc/spire-agent.conf.tpl" | \
+        sudo -u "$STACK_USER" tee "$SPIRE_AGENT_CONF" >/dev/null
+}
+
+function init_spire {
+    # Nothing to migrate - the sqlite3 DataStore self-initializes on first
+    # server start. Kept for naming symmetry with init_keystone_rs.
+    :
+}
+
+# Small retry helper for a CLI healthcheck (exit code), mirroring
+# devstack/lib/keystone-rs's wait_for_connection but for a command instead
+# of an HTTP URL.
+function _spire_wait_for_socket {
+    local desc=$1
+    shift
+    local i
+    for i in {1..60}; do
+        if "$@" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    die $LINENO "$desc did not become healthy"
+}
+
+function start_spire {
+    run_process spire-server "/usr/local/bin/spire-server run -config $SPIRE_SERVER_CONF"
+    _spire_wait_for_socket "SPIRE server" spire-server healthcheck -socketPath "$SPIRE_SERVER_SOCKET"
+
+    local token
+    token=$(spire-server token generate \
+        -socketPath "$SPIRE_SERVER_SOCKET" \
+        -spiffeID "spiffe://$SPIRE_TRUST_DOMAIN/agent" | awk '{print $2}')
+
+    run_process spire-agent "/usr/local/bin/spire-agent run -config $SPIRE_AGENT_CONF -joinToken $token"
+    _spire_wait_for_socket "SPIRE agent" spire-agent healthcheck -socketPath "$SPIRE_AGENT_SOCKET"
+
+    _spire_register_static_entries
+    _spire_register_compute_host "$(hostname)"
+    _spire_export_ca_bundle
+}
+
+# Create a SPIRE registration entry if one for this SPIFFE ID doesn't
+# already exist. devstack routinely re-runs stack.sh, and
+# `spire-server entry create` errors out on an exact duplicate, which
+# would otherwise break that workflow.
+function _spire_entry_create_idempotent {
+    local spiffe_id=$1
+    local selector=$2
+
+    if spire-server entry show -socketPath "$SPIRE_SERVER_SOCKET" -spiffeID "$spiffe_id" 2>/dev/null | grep -q "$spiffe_id"; then
+        return 0
+    fi
+
+    spire-server entry create \
+        -socketPath "$SPIRE_SERVER_SOCKET" \
+        -parentID "spiffe://$SPIRE_TRUST_DOMAIN/agent" \
+        -spiffeID "$spiffe_id" \
+        -selector "$selector"
+}
+
+function _spire_register_static_entries {
+    local uid
+    uid=$(id -u "$STACK_USER")
+
+    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/keystone" "unix:uid:$uid"
+    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/nova-api" "unix:uid:$uid"
+    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/neutron" "unix:uid:$uid"
+}
+
+# Per-host nova-compute registration (ownership binding for Phase 2's
+# compute-host <-> instance verification). Each compute host gets its own
+# SPIFFE ID keyed to its hostname, rather than one shared identity for all
+# of nova-compute - see doc/plans/spire-integration.md Phase 1 "Per-host
+# nova-compute registration" for the full rationale.
+#
+# CAVEAT: this is the devstack join-token path, not x509pop. A join token
+# only proves possession of the token, not which host is joining - in
+# devstack's typical shared-token single-node setup, this does NOT give
+# the same host-identity guarantee production x509pop attestation would.
+# Treat this as sufficient to exercise later phases' code paths in CI, not
+# as a security-equivalent stand-in for x509pop.
+#
+# In single-node devstack (including today's CI job, which enables no
+# nova-compute service) this collapses to one call against the local
+# hostname at plugin start, rather than being triggered by a real agent
+# join event. A genuine multi-node deployment would need this invoked per
+# compute host against the shared server - out of scope for this phase.
+function _spire_register_compute_host {
+    local host=$1
+    local uid
+    uid=$(id -u nova 2>/dev/null || id -u "$STACK_USER")
+
+    _spire_entry_create_idempotent \
+        "spiffe://$SPIRE_TRUST_DOMAIN/service/nova-compute/host/$host" \
+        "unix:uid:$uid"
+}
+
+function _spire_export_ca_bundle {
+    sudo install -d -m 0755 "$(dirname "$SPIRE_CA_BUNDLE_DEST")"
+    spire-server bundle show -socketPath "$SPIRE_SERVER_SOCKET" -format pem | \
+        sudo tee "$SPIRE_CA_BUNDLE_DEST" >/dev/null
+    sudo chmod 0644 "$SPIRE_CA_BUNDLE_DEST"
+}
+
+function stop_spire {
+    stop_process spire-agent
+    stop_process spire-server
+}
+
+function cleanup_spire {
+    sudo rm -rf "$SPIRE_DATA_DIR"
+    sudo rm -f "$SPIRE_CA_BUNDLE_DEST"
+}

--- a/tools/devstack-plugin-spire/plugin.sh
+++ b/tools/devstack-plugin-spire/plugin.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# devstack plugin dispatcher for SPIRE (SPIFFE workload identity).
+#
+# Standard devstack plugin phase hooks, mirroring devstack/plugin.sh's
+# shape. This plugin is independent of the "key-rs" plugin in devstack/ -
+# it only stands up a SPIRE server + agent, distributes the trust bundle,
+# and pre-registers the well-known SPIFFE identities later phases
+# (keystone-rs's internal SPIFFE mTLS listener, the vendor-data JWT API)
+# authenticate against. See doc/plans/spire-integration.md, Phase 1.
+#
+# See lib/spire for the actual install/configure/init/start functions.
+
+SPIRE_PLUGIN_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+source "$SPIRE_PLUGIN_DIR/lib/spire"
+
+if is_service_enabled spire; then
+    # spire-server and spire-agent are the internal run_process units the
+    # start/stop functions target, not user-facing toggles - devstack's
+    # run_process silently no-ops for any service name that isn't enabled,
+    # so they must be enabled here (mirroring key-rs's key-rs-opa). "spire"
+    # remains the single toggle operators use in local.conf.
+    enable_service spire-server spire-agent
+
+    if [[ "$1" == "stack" && "$2" == "install" ]]; then
+        install_spire
+    elif [[ "$1" == "stack" && "$2" == "post-config" ]]; then
+        configure_spire
+    elif [[ "$1" == "stack" && "$2" == "extra" ]]; then
+        init_spire
+        start_spire
+    fi
+
+    if [[ "$1" == "unstack" ]]; then
+        stop_spire
+    fi
+
+    if [[ "$1" == "clean" ]]; then
+        cleanup_spire
+    fi
+fi

--- a/tools/devstack-plugin-spire/settings
+++ b/tools/devstack-plugin-spire/settings
@@ -1,0 +1,6 @@
+# Service group declaration for the SPIRE devstack plugin.
+# Enabled independently of "key-rs" so operators can opt in via
+# `enable_service spire` in local.conf. One toggle drives both the
+# spire-server and spire-agent run_process units (see lib/spire).
+
+enable_service spire


### PR DESCRIPTION
Add a standalone devstack plugin under tools/devstack-plugin-spire that
stands up a single-node SPIRE server and agent, pre-registers the
well-known SPIFFE identities for keystone-rs, nova-api, neutron, and a
per-host nova-compute entry, and exports the trust bundle to
$KEYSTONE_CONF_DIR/spiffe/ca.crt. This is Phase 1 of
doc/plans/spire-integration.md; later phases build the SPIFFE mTLS
listener, vendor-data JWT API, and mapping rules on top of this
foundation.

Also wire SPIRE into the devstack.yml CI smoke test: enable the plugin
alongside key-rs, and add post-stack verification of SPIRE health,
registration entries, and the exported CA bundle.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
