### PR TITLE
fix(api-types): Remove invalid PartialEq from AppCred wrappers

### DIFF
--- a/crates/api-types/src/v3/application_credential/application_credential.rs
+++ b/crates/api-types/src/v3/application_credential/application_credential.rs
@@ -152,7 +152,12 @@ pub struct ApplicationCredentialResponse {
 }
 
 /// Wrapper for a create request body.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+///
+/// No `PartialEq`: `application_credential` may carry a plaintext `secret`
+/// (`ApplicationCredentialCreate.secret: Option<SecretString>`), and
+/// `secrecy::SecretString` deliberately does not implement `PartialEq` to
+/// discourage comparing secrets outside constant-time paths.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "validate", derive(validator::Validate))]
 pub struct ApplicationCredentialCreateRequest {
@@ -204,7 +209,11 @@ pub struct ApplicationCredentialCreated {
 }
 
 /// Wrapper for create response body.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+///
+/// No `PartialEq`: see [`ApplicationCredentialCreateRequest`] -- this
+/// wrapper carries `ApplicationCredentialCreated.secret: SecretString`,
+/// which deliberately has no `PartialEq` impl.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "validate", derive(validator::Validate))]
 pub struct ApplicationCredentialCreateResponse {


### PR DESCRIPTION
ApplicationCredentialCreateRequest/Response derived PartialEq while
wrapping ApplicationCredentialCreate/Created, whose secret field is a
secrecy::SecretString. SecretString deliberately has no PartialEq impl
(to discourage comparing secrets outside constant-time paths), so this
failed to compile with E0369 on the whole crate.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
