### PR TITLE
feat(storage): Add ephemeral state machine records

### DIFF
--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -184,6 +184,14 @@ pub struct Metadata {
     /// try-current-then-probe-retired read path for backward compatibility.
     #[serde(default)]
     pub dek_version: Option<u32>,
+    /// Marks the record as short-lived, replicated state that does not need
+    /// durable, at-rest persistence (e.g. WebAuthn ceremony challenges).
+    /// The state machine keeps such records purely in memory instead of
+    /// writing them to Fjall — they are still Raft-replicated to every
+    /// node, but skip encryption, disk persistence, and snapshot inclusion.
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub is_ephemeral: bool,
 }
 
 impl Metadata {
@@ -194,6 +202,7 @@ impl Metadata {
             created_at: Utc::now().timestamp(),
             tier: DataTier::Internal,
             dek_version: None,
+            is_ephemeral: false,
         }
     }
 
@@ -204,17 +213,28 @@ impl Metadata {
             created_at: Utc::now().timestamp(),
             tier,
             dek_version: None,
+            is_ephemeral: false,
         }
     }
 
-    /// Create new metadata with an incremented revision, preserving timestamp
-    /// and tier.
+    /// Create new ephemeral metadata (see [`Self::is_ephemeral`]) with the
+    /// current timestamp.
+    pub fn ephemeral() -> Self {
+        Self {
+            is_ephemeral: true,
+            ..Self::new()
+        }
+    }
+
+    /// Create new metadata with an incremented revision, preserving timestamp,
+    /// tier, and ephemeral marker.
     pub fn new_revision(&self) -> Self {
         Self {
             revision: self.revision + 1,
             created_at: self.created_at,
             tier: self.tier,
             dek_version: self.dek_version,
+            is_ephemeral: self.is_ephemeral,
         }
     }
 

--- a/crates/storage/src/app.rs
+++ b/crates/storage/src/app.rs
@@ -933,6 +933,17 @@ impl StorageApi for Storage {
             }
         }
 
+        let keyspace_name = keyspace.unwrap_or("data");
+        if self
+            .state_machine_store
+            .is_ephemeral_keyspace(keyspace_name)
+        {
+            return Ok(self
+                .state_machine_store
+                .ephemeral_get(keyspace_name, key)
+                .map(|(data, metadata)| StoreDataEnvelope { data, metadata }));
+        }
+
         // Leader path: local metadata + data read.
         let key_str =
             String::from_utf8(key.to_vec()).map_err(|e| StoreError::Other(eyre::eyre!("{e}")))?;
@@ -1021,6 +1032,22 @@ impl StorageApi for Storage {
                 // Retries exhausted without resolving leader status. Fall
                 // through to local read as best-effort.
             }
+        }
+
+        let ephemeral_ks_name = keyspace.unwrap_or("data");
+        if let Some(entries) = self
+            .state_machine_store
+            .ephemeral_prefix(ephemeral_ks_name, prefix)
+        {
+            return entries
+                .into_iter()
+                .map(|(key_bytes, data, metadata)| {
+                    let k = String::from_utf8(key_bytes)
+                        .map_err(|e| StoreError::Other(eyre::eyre!("{e}")))?;
+                    Ok((k, StoreDataEnvelope { data, metadata }))
+                })
+                .collect::<Result<Vec<_>, StoreError>>()
+                .map_err(ApiStoreError::from);
         }
 
         // Leader path: collect raw encrypted bytes + metadata locally,

--- a/crates/storage/src/grpc/storage_service.rs
+++ b/crates/storage/src/grpc/storage_service.rs
@@ -123,6 +123,30 @@ impl StorageService for StorageServiceImpl {
             Err(e) => return Err(Status::invalid_argument(format!("invalid key: {}", e))),
         };
 
+        let keyspace_name = req.keyspace.as_deref().unwrap_or("data");
+        if self
+            .state_machine_store
+            .is_ephemeral_keyspace(keyspace_name)
+        {
+            let found = self
+                .state_machine_store
+                .ephemeral_get(keyspace_name, key.as_bytes());
+            let (value, metadata_bytes) = match found {
+                Some((value, metadata)) => (
+                    Some(value),
+                    metadata
+                        .pack()
+                        .map_err(|e| Status::internal(format!("metadata pack error: {}", e)))?,
+                ),
+                None => (None, Vec::new()),
+            };
+            return Ok(Response::new(pb::api::ForwardedGetResponse {
+                not_found: value.is_none(),
+                value,
+                metadata: metadata_bytes,
+            }));
+        }
+
         // Read metadata to determine the data tier
         let metadata = self
             .state_machine_store
@@ -198,6 +222,28 @@ impl StorageService for StorageServiceImpl {
     ) -> Result<Response<pb::api::ForwardedPrefixResponse>, Status> {
         self.ensure_leader_linearizable().await?;
         let req = request.into_inner();
+
+        let keyspace_name = req.keyspace.as_deref().unwrap_or("data");
+        if let Some(entries) = self
+            .state_machine_store
+            .ephemeral_prefix(keyspace_name, &req.prefix)
+        {
+            let items = entries
+                .into_iter()
+                .filter_map(|(key_bytes, value, metadata)| {
+                    let key = String::from_utf8(key_bytes).ok()?;
+                    let metadata_bytes = metadata.pack().ok()?;
+                    Some(pb::api::PrefixEntry {
+                        key,
+                        value,
+                        metadata: metadata_bytes,
+                    })
+                })
+                .collect();
+            return Ok(Response::new(pb::api::ForwardedPrefixResponse {
+                entries: items,
+            }));
+        }
 
         let ks = match &req.keyspace {
             Some(name) => self

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
+use dashmap::DashMap;
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, Readable};
 use futures::Stream;
 use futures::TryStreamExt;
@@ -356,6 +357,16 @@ pub fn load_pending_rotations(
     Ok(map)
 }
 
+/// Cipher (or, for ephemeral records, plaintext) bytes plus metadata for one
+/// key inside an ephemeral keyspace.
+type EphemeralValue = (Vec<u8>, Metadata);
+
+/// The in-memory contents of one ephemeral keyspace, keyed by record key.
+type EphemeralKeyspace = DashMap<Vec<u8>, EphemeralValue>;
+
+/// One `(key, value, metadata)` entry returned from an ephemeral prefix scan.
+type EphemeralEntry = (Vec<u8>, Vec<u8>, Metadata);
+
 /// State machine backed by FjallDB for full persistence.
 ///
 /// All application data is AES-256-GCM encrypted at rest via `state_encrypt`
@@ -409,6 +420,18 @@ pub struct FjallStateMachine {
     /// silently land in an already-deregistered, soon-to-be-discarded
     /// partition — applied per Raft, invisible to every future read.
     keyspace_lifecycle: Arc<RwLock<()>>,
+    /// Ephemeral (non-Fjall-backed) keyspaces, keyed by keyspace name.
+    ///
+    /// Populated the first time `apply()` sees a `Set`/`CreateIfAbsent`
+    /// mutation whose `Metadata::is_ephemeral` is `true` for that keyspace
+    /// name; every node derives the same population independently since
+    /// `apply()` runs identically, in the same log order, everywhere — no
+    /// separate consensus needed (same principle `drop_keyspace` already
+    /// relies on for non-core keyspace lifecycle). A keyspace is either
+    /// always ephemeral or always Fjall-backed for the life of its name; an
+    /// outer entry existing (even with an empty inner map) is equivalent to
+    /// a Fjall partition existing.
+    ephemeral: DashMap<String, EphemeralKeyspace>,
     /// ADR 0031 Raft Prometheus metrics. Owned here (rather than only on
     /// `app::Storage`) because `apply_duration_seconds` must be recorded at
     /// the actual per-entry apply call site below; `app::Storage` reaches
@@ -470,6 +493,7 @@ impl FjallStateMachine {
             quarantine,
             pending_rotations,
             keyspace_lifecycle: Arc::new(RwLock::new(())),
+            ephemeral: DashMap::new(),
             raft_prometheus_metrics: Arc::new(
                 crate::prometheus_metrics::KeystoneRaftPrometheusMetrics::new(),
             ),
@@ -534,6 +558,48 @@ impl FjallStateMachine {
         Ok((snapshot, utc_epoch, dek_version))
     }
 
+    /// Returns `true` if `name` is a registered ephemeral (in-memory,
+    /// non-Fjall) keyspace.
+    pub fn is_ephemeral_keyspace<S: AsRef<str>>(&self, name: S) -> bool {
+        self.ephemeral.contains_key(name.as_ref())
+    }
+
+    /// Reads a single key from an ephemeral keyspace.
+    ///
+    /// Returns `None` both when `keyspace` is not ephemeral and when the
+    /// key is absent — callers that need to distinguish "not an ephemeral
+    /// keyspace" (fall through to Fjall) from "no such key" (return `None`
+    /// to the caller) must check [`Self::is_ephemeral_keyspace`] first.
+    pub fn ephemeral_get<S: AsRef<str>>(
+        &self,
+        keyspace: S,
+        key: &[u8],
+    ) -> Option<(Vec<u8>, Metadata)> {
+        self.ephemeral
+            .get(keyspace.as_ref())?
+            .get(key)
+            .map(|e| e.value().clone())
+    }
+
+    /// Lists all entries in an ephemeral keyspace whose key starts with
+    /// `prefix`. Returns `None` if `keyspace` is not ephemeral.
+    pub fn ephemeral_prefix<S: AsRef<str>>(
+        &self,
+        keyspace: S,
+        prefix: &[u8],
+    ) -> Option<Vec<EphemeralEntry>> {
+        let ks = self.ephemeral.get(keyspace.as_ref())?;
+        Some(
+            ks.iter()
+                .filter(|entry| entry.key().starts_with(prefix))
+                .map(|entry| {
+                    let (cipher, metadata) = entry.value().clone();
+                    (entry.key().clone(), cipher, metadata)
+                })
+                .collect(),
+        )
+    }
+
     /// Get the Fjall `keyspace` handle by name.
     pub fn keyspace<S: AsRef<str>>(&self, name: S) -> Result<Keyspace, StoreError> {
         Ok(match name.as_ref() {
@@ -552,7 +618,9 @@ impl FjallStateMachine {
     /// partition — safe to call speculatively when probing for
     /// garbage-collection candidates.
     pub fn keyspace_exists<S: AsRef<str>>(&self, name: S) -> bool {
-        matches!(name.as_ref(), "data" | "meta" | "index") || self.db.keyspace_exists(name.as_ref())
+        matches!(name.as_ref(), "data" | "meta" | "index")
+            || self.ephemeral.contains_key(name.as_ref())
+            || self.db.keyspace_exists(name.as_ref())
     }
 
     /// Permanently deletes an empty, non-core keyspace/partition.
@@ -571,6 +639,20 @@ impl FjallStateMachine {
             return Err(StoreError::Other(eyre::eyre!(
                 "refusing to drop core keyspace '{name}'"
             )));
+        }
+        // Ephemeral keyspaces live purely in memory: no on-disk emptiness
+        // check or `keyspace_lifecycle` coordination with `apply()` is
+        // needed, since `DashMap::remove` is atomic per-entry and `apply()`
+        // only ever inserts into a *different* per-keyspace inner map, not
+        // this outer registry.
+        if let Some((_, inner)) = self.ephemeral.remove(name) {
+            if !inner.is_empty() {
+                self.ephemeral.insert(name.to_string(), inner);
+                return Err(StoreError::Other(eyre::eyre!(
+                    "refusing to drop non-empty keyspace '{name}'"
+                )));
+            }
+            return Ok(());
         }
         // Excludes any concurrent `apply()` call for the whole
         // exists/is-empty/delete sequence, so a write that `apply()` is
@@ -1440,6 +1522,29 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                         ));
                                     }
 
+                                    if let Some(ephemeral_ks) = self.ephemeral.get(&keyspace) {
+                                        if let Some(expected_revision) = expected_revision {
+                                            let curr_revision = ephemeral_ks
+                                                .get(&key)
+                                                .map(|entry| entry.1.revision);
+                                            if curr_revision.is_none_or(|r| r != expected_revision)
+                                            {
+                                                violations.push(Violation {
+                                                    r#type: "CONFLICT".to_string(),
+                                                    subject: String::from_utf8_lossy(&key)
+                                                        .to_string(),
+                                                    description: format!(
+                                                        "Current revision is {curr_revision:?} \
+                                                         while {expected_revision} was expected",
+                                                    ),
+                                                });
+                                                continue;
+                                            }
+                                        }
+                                        ephemeral_ks.remove(&key);
+                                        continue;
+                                    }
+
                                     if let Some(expected_revision) = expected_revision {
                                         let curr_meta = self
                                             .meta()
@@ -1485,6 +1590,31 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                         return Err(io::Error::other(
                                             "not allowed to overwrite system data",
                                         ));
+                                    }
+
+                                    if metadata.is_ephemeral {
+                                        let ephemeral_ks =
+                                            self.ephemeral.entry(keyspace.clone()).or_default();
+                                        if let Some(expected_revision) = expected_revision {
+                                            let curr_revision = ephemeral_ks
+                                                .get(&key)
+                                                .map(|entry| entry.1.revision);
+                                            if curr_revision.is_none_or(|r| r != expected_revision)
+                                            {
+                                                violations.push(Violation {
+                                                    r#type: "CONFLICT".to_string(),
+                                                    subject: String::from_utf8_lossy(&key)
+                                                        .to_string(),
+                                                    description: format!(
+                                                        "Current revision is {curr_revision:?} \
+                                                         while {expected_revision} was expected",
+                                                    ),
+                                                });
+                                                continue;
+                                            }
+                                        }
+                                        ephemeral_ks.insert(key, (cipher, metadata));
+                                        continue;
                                     }
 
                                     if let Some(expected_revision) = expected_revision {
@@ -1565,6 +1695,23 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
                                     metadata,
                                     tier,
                                 } => {
+                                    if metadata.is_ephemeral {
+                                        let ephemeral_ks =
+                                            self.ephemeral.entry(keyspace.clone()).or_default();
+                                        if ephemeral_ks.contains_key(&key) {
+                                            violations.push(Violation {
+                                                r#type: "CONFLICT".to_string(),
+                                                subject: String::from_utf8_lossy(&key).to_string(),
+                                                description:
+                                                    "key already exists (create_if_absent)"
+                                                        .to_string(),
+                                            });
+                                            continue;
+                                        }
+                                        ephemeral_ks.insert(key, (cipher, metadata));
+                                        continue;
+                                    }
+
                                     let exists = self
                                         .meta()
                                         .get(&key)
@@ -2553,6 +2700,176 @@ mod keyspace_gc_tests {
         assert!(
             sm.keyspace_lifecycle.try_write().is_err(),
             "drop_keyspace's write lock must not be obtainable while apply() holds the read side"
+        );
+    }
+}
+
+#[cfg(test)]
+mod ephemeral_tests {
+    use openstack_keystone_storage_crypto::EnvKek;
+
+    use super::*;
+
+    fn make_sm() -> (FjallStateMachine, tempfile::TempDir) {
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let db = Arc::new(Database::builder(td.path()).open().expect("open db"));
+        let kek: Arc<dyn KekProvider> = Arc::new(EnvKek::from_bytes([0x42u8; 32]));
+        let epoch =
+            Arc::new(DekEpoch::from_raw(LockedKey::from_raw([0x09; 32]), 1).expect("epoch"));
+        let (reencrypt_tx, reencrypt_rx) = tokio::sync::mpsc::channel(1);
+        drop(reencrypt_rx);
+        let (quarantine_tx, quarantine_rx) = tokio::sync::mpsc::channel(1);
+        drop(quarantine_rx);
+
+        let sm = FjallStateMachine::new(
+            db,
+            td.path().join("snapshots"),
+            1,
+            Arc::new(RwLock::new(epoch)),
+            Arc::new(Mutex::new(BTreeMap::new())),
+            Arc::new(Mutex::new(HashSet::new())),
+            kek,
+            reencrypt_tx,
+            quarantine_tx,
+            Arc::new(Mutex::new(HashMap::new())),
+        )
+        .expect("construct state machine");
+        (sm, td)
+    }
+
+    /// Directly seeds an ephemeral keyspace the way `apply()`'s `Set`/
+    /// `CreateIfAbsent` arms would, without needing to drive a full
+    /// `RaftStateMachine::apply()` entry stream — the helper methods under
+    /// test (`is_ephemeral_keyspace`, `ephemeral_get`, `ephemeral_prefix`,
+    /// `keyspace_exists`, `drop_keyspace`) are exercised the same way
+    /// regardless of what populated the map.
+    fn seed(sm: &FjallStateMachine, keyspace: &str, key: &[u8], value: &[u8], metadata: Metadata) {
+        sm.ephemeral
+            .entry(keyspace.to_string())
+            .or_default()
+            .insert(key.to_vec(), (value.to_vec(), metadata));
+    }
+
+    #[test]
+    fn ephemeral_write_never_touches_the_fjall_db() {
+        let (sm, _td) = make_sm();
+        seed(
+            &sm,
+            "webauthn_state_1",
+            b"user-1:auth",
+            b"challenge-bytes",
+            Metadata::ephemeral(),
+        );
+
+        assert!(sm.keyspace_exists("webauthn_state_1"));
+        assert!(sm.is_ephemeral_keyspace("webauthn_state_1"));
+        // The keyspace must not exist as a real Fjall partition.
+        assert!(!sm.db.keyspace_exists("webauthn_state_1"));
+    }
+
+    #[test]
+    fn ephemeral_get_round_trips_value_and_metadata() {
+        let (sm, _td) = make_sm();
+        let metadata = Metadata::ephemeral();
+        seed(
+            &sm,
+            "webauthn_state_1",
+            b"user-1:auth",
+            b"payload",
+            metadata,
+        );
+
+        let (value, got_metadata) = sm
+            .ephemeral_get("webauthn_state_1", b"user-1:auth")
+            .expect("value present");
+        assert_eq!(value, b"payload");
+        assert!(got_metadata.is_ephemeral);
+    }
+
+    #[test]
+    fn ephemeral_get_is_none_for_unknown_keyspace() {
+        let (sm, _td) = make_sm();
+        assert!(sm.ephemeral_get("never_written", b"any-key").is_none());
+        assert!(!sm.is_ephemeral_keyspace("never_written"));
+    }
+
+    #[test]
+    fn ephemeral_prefix_filters_by_prefix_and_is_none_for_non_ephemeral_keyspace() {
+        let (sm, _td) = make_sm();
+        seed(
+            &sm,
+            "webauthn_state_1",
+            b"user-1:auth",
+            b"a",
+            Metadata::ephemeral(),
+        );
+        seed(
+            &sm,
+            "webauthn_state_1",
+            b"user-1:registration",
+            b"b",
+            Metadata::ephemeral(),
+        );
+        seed(
+            &sm,
+            "webauthn_state_1",
+            b"user-2:auth",
+            b"c",
+            Metadata::ephemeral(),
+        );
+
+        let matched = sm
+            .ephemeral_prefix("webauthn_state_1", b"user-1:")
+            .expect("keyspace is ephemeral");
+        assert_eq!(matched.len(), 2);
+
+        // A Fjall-backed (non-ephemeral) keyspace name must fall through to
+        // `None` rather than an empty result, so callers know to read Fjall
+        // instead.
+        assert!(sm.ephemeral_prefix("data", b"user-1:").is_none());
+    }
+
+    #[test]
+    fn drop_keyspace_reclaims_an_empty_ephemeral_partition() {
+        let (sm, _td) = make_sm();
+        seed(
+            &sm,
+            "webauthn_state_1",
+            b"user-1:auth",
+            b"payload",
+            Metadata::ephemeral(),
+        );
+        // Drain it back out, mirroring what apply()'s Remove arm does.
+        sm.ephemeral
+            .get("webauthn_state_1")
+            .expect("keyspace present")
+            .remove(b"user-1:auth".as_slice());
+
+        sm.drop_keyspace("webauthn_state_1")
+            .expect("drop empty ephemeral keyspace");
+        assert!(!sm.keyspace_exists("webauthn_state_1"));
+    }
+
+    #[test]
+    fn drop_keyspace_refuses_non_empty_ephemeral_partition() {
+        let (sm, _td) = make_sm();
+        seed(
+            &sm,
+            "webauthn_state_1",
+            b"user-1:auth",
+            b"payload",
+            Metadata::ephemeral(),
+        );
+
+        let err = sm
+            .drop_keyspace("webauthn_state_1")
+            .expect_err("must refuse to drop a non-empty ephemeral keyspace");
+        assert!(matches!(err, StoreError::Other(_)));
+        assert!(sm.keyspace_exists("webauthn_state_1"));
+        assert!(
+            sm.ephemeral_get("webauthn_state_1", b"user-1:auth")
+                .is_some(),
+            "the failed drop must not have discarded the entry"
         );
     }
 }

--- a/crates/storage/tests/test_cluster.rs
+++ b/crates/storage/tests/test_cluster.rs
@@ -1264,6 +1264,54 @@ async fn test_cluster_inner() -> Result<()> {
         }
     }
 
+    println!("=== ephemeral data replicates across nodes without Fjall");
+    {
+        let ephemeral_env = StoreDataEnvelope {
+            data: rmp_serde::to_vec("ephemeral_value")?,
+            metadata: Metadata::ephemeral(),
+        };
+        instance1
+            .storage
+            .set_value(
+                "eph:k1".to_string(),
+                ephemeral_env,
+                Some("webauthn_state_test".to_string()),
+                None,
+            )
+            .await?;
+
+        // --- Wait for a while to let the replication get done.
+        TypeConfig::sleep(Duration::from_millis(1_000)).await;
+
+        for instance in &instances {
+            let got = instance
+                .storage
+                .get_by_key("eph:k1".as_bytes(), Some("webauthn_state_test"))
+                .await?
+                .expect("ephemeral value must be readable from every node");
+            assert!(got.metadata.is_ephemeral);
+            assert_eq!("ephemeral_value", got.try_deserialize::<String>()?.data);
+        }
+
+        // Remove on a different node than it was written from, and confirm
+        // the delete also replicates.
+        instance2
+            .storage
+            .remove(
+                "eph:k1".to_string(),
+                Some("webauthn_state_test".to_string()),
+            )
+            .await?;
+        TypeConfig::sleep(Duration::from_millis(1_000)).await;
+        for instance in &instances {
+            let got = instance
+                .storage
+                .get_by_key("eph:k1".as_bytes(), Some("webauthn_state_test"))
+                .await?;
+            assert!(got.is_none());
+        }
+    }
+
     println!("=== delete `foo=bar`");
     {
         instance3.storage.remove("foo".to_string(), None).await?;

--- a/crates/webauthn/src/driver/raft.rs
+++ b/crates/webauthn/src/driver/raft.rs
@@ -250,7 +250,7 @@ impl RaftDriver {
             .set_value(
                 self.get_user_cred_auth_state_key_name(user_id),
                 StoreDataEnvelope {
-                    metadata: Metadata::new(),
+                    metadata: Metadata::ephemeral(),
                     data: rmp_serde::to_vec(auth_state)?,
                 },
                 Some(keyspace),
@@ -304,7 +304,7 @@ impl RaftDriver {
             .set_value(
                 self.get_user_cred_registration_state_key_name(user_id),
                 StoreDataEnvelope {
-                    metadata: Metadata::new(),
+                    metadata: Metadata::ephemeral(),
                     data: rmp_serde::to_vec(reg_state)?,
                 },
                 Some(keyspace),
@@ -936,6 +936,34 @@ mod tests {
         );
         // Two independent calls agree — no persisted pointer is consulted.
         assert_eq!(driver.current_state_bucket(), driver.current_state_bucket());
+    }
+
+    #[tokio::test]
+    async fn test_auth_state_write_is_marked_ephemeral() {
+        let driver = RaftDriver::default();
+        let storage = MockStorage::default();
+        let auth_state = sample_auth_state();
+
+        driver
+            .save_user_webauthn_credential_authentication_state_impl(
+                &storage,
+                "user-1",
+                &auth_state,
+            )
+            .await
+            .unwrap();
+
+        let current_ks = driver.state_keyspace_name(driver.current_state_bucket());
+        let key = driver.get_user_cred_auth_state_key_name("user-1");
+        let env = storage
+            .get_by_key(key.as_bytes(), Some(&current_ks))
+            .await
+            .unwrap()
+            .expect("state was written");
+        assert!(
+            env.metadata.is_ephemeral,
+            "ceremony state must be written with Metadata::ephemeral()"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds Metadata::is_ephemeral so short-lived, Raft-replicated data (e.g.
WebAuthn ceremony challenges) can skip Fjall persistence, encryption,
and snapshot inclusion, avoiding the on-disk keyspace churn the raft
webauthn driver previously mitigated with time-bucketed rotation.
Ephemeral records live purely in memory on the state machine but still
replicate to every node via the existing Raft log, so a completion
request landing on a different node than the one that started the
ceremony can still find it.

Wires the webauthn raft driver's ceremony-state writes to use
Metadata::ephemeral(), and fixes the leader-side forwarded_get/
forwarded_prefix gRPC handlers (used when a follower forwards a read
to the leader) to also check the ephemeral store, which the local
read path already did.

Assisted-By: Claude <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
