### PR TITLE
feat(domain-config): Dispatch identity ops per domain

### DIFF
--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -361,6 +361,9 @@ impl From<IdentityProviderError> for KeystoneApiError {
             // identity driver, ADR-0027) is a permissions statement, not a
             // server fault.
             err @ IdentityProviderError::Readonly(..) => Self::forbidden(err),
+            // A membership across two identity backends is a policy statement,
+            // not a server fault (python-keystone `CrossBackendNotAllowed`).
+            err @ IdentityProviderError::CrossBackendNotAllowed { .. } => Self::forbidden(err),
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/core-types/src/identity/error.rs
+++ b/crates/core-types/src/identity/error.rs
@@ -35,6 +35,19 @@ pub enum IdentityProviderError {
     #[error("conflict: {0}")]
     Conflict(String),
 
+    /// A group membership was requested between a user and a group that live
+    /// in different identity backends. Mirrors python-keystone's
+    /// `CrossBackendNotAllowed` (surfaced as 403).
+    #[error(
+        "cannot add user {user_id} to group {group_id}: they belong to different identity backends"
+    )]
+    CrossBackendNotAllowed {
+        /// The user's public id.
+        user_id: String,
+        /// The group's public id.
+        group_id: String,
+    },
+
     /// Credential provider error, surfaced when cascading a user deletion
     /// into `delete_credentials_for_user` (ADR 0019 §3).
     #[error(transparent)]

--- a/crates/core/src/auth_metrics.rs
+++ b/crates/core/src/auth_metrics.rs
@@ -255,6 +255,7 @@ pub fn identity_failure_reason(e: &IdentityProviderError) -> &'static str {
     match e {
         IdentityProviderError::Authentication { source } => auth_failure_reason(source),
         IdentityProviderError::Conflict(_) => "Conflict",
+        IdentityProviderError::CrossBackendNotAllowed { .. } => "CrossBackendNotAllowed",
         IdentityProviderError::CredentialProvider { .. } => "ProviderError",
         IdentityProviderError::DateError => "DateError",
         IdentityProviderError::Driver(_) => "Driver",

--- a/crates/core/src/domain_config/resolver.rs
+++ b/crates/core/src/domain_config/resolver.rs
@@ -99,6 +99,16 @@ impl DomainConfigResolver {
         }
     }
 
+    /// A resolver wired directly to explicit sources, bypassing the plugin
+    /// manager. Test-only.
+    #[cfg(test)]
+    pub(crate) fn from_sources(
+        file: Option<Arc<dyn DomainConfigBackend>>,
+        database: Option<Arc<dyn DomainConfigBackend>>,
+    ) -> Self {
+        Self { file, database }
+    }
+
     /// The effective stored configuration for a domain: the file source
     /// overlaid by the database source.
     ///

--- a/crates/core/src/domain_config/service.rs
+++ b/crates/core/src/domain_config/service.rs
@@ -36,20 +36,31 @@ use crate::plugin_manager::PluginManagerApi;
 /// written through the API.
 const API_BACKEND: &str = "sql";
 
+/// The registration type claimed by the domain whose stored `identity/driver`
+/// is `sql`. Matches python-keystone's `SQL` registration key.
+const SQL_REGISTRATION: &str = "SQL";
+
 /// Domain configuration provider service.
 ///
-/// A thin pass-through to the `sql` domain-config backend; every method
-/// forwards verbatim.
+/// A near pass-through to the `sql` domain-config backend. The only logic it
+/// adds is the single-domain SQL identity-driver registration lock
+/// (issue #960): while `[identity] domain_configurations_from_database` is on,
+/// at most one domain may have `identity/driver = sql` in its stored config.
 pub struct DomainConfigService {
     backend_driver: Arc<dyn DomainConfigBackend>,
+    /// `[identity] domain_configurations_from_database`. The registration lock
+    /// is enforced only while this is set; otherwise the stored configuration
+    /// never drives identity-backend selection and there is nothing to guard.
+    domain_configurations_from_database: bool,
 }
 
 impl DomainConfigService {
     /// Create a new `DomainConfigService`.
     ///
     /// # Parameters
-    /// - `_config`: The service configuration (unused: the API backend is
-    ///   always `sql`).
+    /// - `config`: The service configuration; only
+    ///   `[identity] domain_configurations_from_database` is read, to decide
+    ///   whether the registration lock is enforced.
     /// - `plugin_manager`: The plugin manager used to resolve the backend
     ///   driver.
     ///
@@ -58,13 +69,106 @@ impl DomainConfigService {
     ///   or [`DomainConfigProviderError::UnsupportedDriver`] when the `sql`
     ///   backend is not registered.
     pub fn new<P: PluginManagerApi>(
-        _config: &Config,
+        config: &Config,
         plugin_manager: &P,
     ) -> Result<Self, DomainConfigProviderError> {
         let backend_driver = plugin_manager
             .get_domain_config_backend(API_BACKEND)?
             .clone();
-        Ok(Self { backend_driver })
+        Ok(Self {
+            backend_driver,
+            domain_configurations_from_database: config
+                .identity
+                .domain_configurations_from_database,
+        })
+    }
+
+    /// The `identity/driver` a domain configuration sets, if any.
+    fn identity_driver(config: &DomainConfig) -> Option<String> {
+        config
+            .clone()
+            .into_group(DomainConfigGroupName::Identity)
+            .and_then(|group| {
+                group
+                    .get("driver")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_owned)
+            })
+    }
+
+    /// Claim the SQL identity-driver registration for `domain_id`, or fail the
+    /// write when another domain already holds it. No-op unless
+    /// configurations come from the database.
+    async fn claim_sql_registration(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<(), DomainConfigProviderError> {
+        if !self.domain_configurations_from_database {
+            return Ok(());
+        }
+        let obtained = self
+            .backend_driver
+            .obtain_registration(state, domain_id, SQL_REGISTRATION)
+            .await?;
+        if !obtained
+            && self
+                .backend_driver
+                .read_registration(state, SQL_REGISTRATION)
+                .await?
+                .as_deref()
+                != Some(domain_id)
+        {
+            return Err(DomainConfigProviderError::Conflict(
+                "the SQL identity driver is already registered to another domain".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Give up the SQL identity-driver registration `domain_id` may hold.
+    /// No-op unless configurations come from the database.
+    async fn release_sql_registration(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+    ) -> Result<(), DomainConfigProviderError> {
+        if !self.domain_configurations_from_database {
+            return Ok(());
+        }
+        self.backend_driver
+            .release_registration(state, domain_id, Some(SQL_REGISTRATION))
+            .await
+    }
+
+    /// Reconcile the SQL registration with the `identity/driver` a write is
+    /// about to store: `Some("sql")` must claim it (before the write, so a
+    /// conflict blocks the write), any other value releases it (after), and
+    /// `None` — the write does not touch `identity/driver` — leaves it alone.
+    async fn reconcile_registration_before(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        driver: Option<&str>,
+    ) -> Result<(), DomainConfigProviderError> {
+        if driver == Some("sql") {
+            self.claim_sql_registration(state, domain_id).await?;
+        }
+        Ok(())
+    }
+
+    async fn reconcile_registration_after(
+        &self,
+        state: &ServiceState,
+        domain_id: &str,
+        driver: Option<&str>,
+    ) -> Result<(), DomainConfigProviderError> {
+        if let Some(driver) = driver
+            && driver != "sql"
+        {
+            self.release_sql_registration(state, domain_id).await?;
+        }
+        Ok(())
     }
 }
 
@@ -76,9 +180,16 @@ impl DomainConfigApi for DomainConfigService {
         domain_id: &'a str,
         config: DomainConfigCreate,
     ) -> Result<DomainConfig, DomainConfigProviderError> {
-        self.backend_driver
+        let driver = Self::identity_driver(&config.0);
+        self.reconcile_registration_before(state, domain_id, driver.as_deref())
+            .await?;
+        let stored = self
+            .backend_driver
             .create_domain_config(state, domain_id, config)
-            .await
+            .await?;
+        self.reconcile_registration_after(state, domain_id, driver.as_deref())
+            .await?;
+        Ok(stored)
     }
 
     async fn get_domain_config<'a>(
@@ -120,9 +231,16 @@ impl DomainConfigApi for DomainConfigService {
         domain_id: &'a str,
         config: DomainConfigUpdate,
     ) -> Result<DomainConfig, DomainConfigProviderError> {
-        self.backend_driver
+        let driver = Self::identity_driver(&config.0);
+        self.reconcile_registration_before(state, domain_id, driver.as_deref())
+            .await?;
+        let stored = self
+            .backend_driver
             .update_domain_config(state, domain_id, config)
-            .await
+            .await?;
+        self.reconcile_registration_after(state, domain_id, driver.as_deref())
+            .await?;
+        Ok(stored)
     }
 
     async fn update_domain_config_group<'a>(
@@ -132,9 +250,18 @@ impl DomainConfigApi for DomainConfigService {
         group: DomainConfigGroupName,
         config: DomainConfigUpdate,
     ) -> Result<DomainConfigGroup, DomainConfigProviderError> {
-        self.backend_driver
+        let driver = (group == DomainConfigGroupName::Identity)
+            .then(|| Self::identity_driver(&config.0))
+            .flatten();
+        self.reconcile_registration_before(state, domain_id, driver.as_deref())
+            .await?;
+        let stored = self
+            .backend_driver
             .update_domain_config_group(state, domain_id, group, config)
-            .await
+            .await?;
+        self.reconcile_registration_after(state, domain_id, driver.as_deref())
+            .await?;
+        Ok(stored)
     }
 
     async fn update_domain_config_option<'a>(
@@ -143,9 +270,18 @@ impl DomainConfigApi for DomainConfigService {
         domain_id: &'a str,
         option: DomainConfigOption,
     ) -> Result<DomainConfigOption, DomainConfigProviderError> {
-        self.backend_driver
+        let driver = (option.group == DomainConfigGroupName::Identity && option.option == "driver")
+            .then(|| option.value.as_value().as_str().map(str::to_owned))
+            .flatten();
+        self.reconcile_registration_before(state, domain_id, driver.as_deref())
+            .await?;
+        let stored = self
+            .backend_driver
             .update_domain_config_option(state, domain_id, option)
-            .await
+            .await?;
+        self.reconcile_registration_after(state, domain_id, driver.as_deref())
+            .await?;
+        Ok(stored)
     }
 
     async fn delete_domain_config<'a>(
@@ -155,7 +291,8 @@ impl DomainConfigApi for DomainConfigService {
     ) -> Result<(), DomainConfigProviderError> {
         self.backend_driver
             .delete_domain_config(state, domain_id)
-            .await
+            .await?;
+        self.release_sql_registration(state, domain_id).await
     }
 
     async fn delete_domain_config_group<'a>(
@@ -166,7 +303,11 @@ impl DomainConfigApi for DomainConfigService {
     ) -> Result<(), DomainConfigProviderError> {
         self.backend_driver
             .delete_domain_config_group(state, domain_id, group)
-            .await
+            .await?;
+        if group == DomainConfigGroupName::Identity {
+            self.release_sql_registration(state, domain_id).await?;
+        }
+        Ok(())
     }
 
     async fn delete_domain_config_option<'a>(
@@ -178,7 +319,11 @@ impl DomainConfigApi for DomainConfigService {
     ) -> Result<(), DomainConfigProviderError> {
         self.backend_driver
             .delete_domain_config_option(state, domain_id, group, option)
-            .await
+            .await?;
+        if group == DomainConfigGroupName::Identity && option == "driver" {
+            self.release_sql_registration(state, domain_id).await?;
+        }
+        Ok(())
     }
 
     async fn get_default_config(
@@ -205,5 +350,176 @@ impl DomainConfigApi for DomainConfigService {
         self.backend_driver
             .get_default_option(state, group, option)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::domain_config::backend::MockDomainConfigBackend;
+    use crate::tests::get_mocked_state;
+
+    /// A `DomainConfigService` over `backend`, with the registration lock
+    /// enforced when `from_database`.
+    fn service(backend: MockDomainConfigBackend, from_database: bool) -> DomainConfigService {
+        DomainConfigService {
+            backend_driver: Arc::new(backend),
+            domain_configurations_from_database: from_database,
+        }
+    }
+
+    /// A `DomainConfig` from a request-shaped body.
+    fn config(body: serde_json::Value) -> DomainConfig {
+        DomainConfig::from_value(body).expect("a valid domain configuration")
+    }
+
+    /// A `create_domain_config` that echoes back an `identity/driver = sql`
+    /// configuration.
+    fn expect_create(backend: &mut MockDomainConfigBackend) {
+        backend
+            .expect_create_domain_config()
+            .returning(|_, _, _| Ok(config(json!({"identity": {"driver": "sql"}}))));
+    }
+
+    #[tokio::test]
+    async fn the_lock_is_skipped_when_configs_do_not_come_from_the_database() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend.expect_obtain_registration().never();
+        backend.expect_release_registration().never();
+        expect_create(&mut backend);
+
+        service(backend, false)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({"identity": {"driver": "sql"}}))),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_sql_driver_claims_the_free_registration_then_writes() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_obtain_registration()
+            .withf(|_, domain_id, driver_type| domain_id == "d1" && driver_type == "SQL")
+            .returning(|_, _, _| Ok(true));
+        backend.expect_release_registration().never();
+        expect_create(&mut backend);
+
+        service(backend, true)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({"identity": {"driver": "sql"}}))),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_registration_held_by_another_domain_blocks_the_write() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_obtain_registration()
+            .returning(|_, _, _| Ok(false));
+        backend
+            .expect_read_registration()
+            .returning(|_, _| Ok(Some("other-domain".to_string())));
+        backend.expect_create_domain_config().never();
+
+        let error = service(backend, true)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({"identity": {"driver": "sql"}}))),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, DomainConfigProviderError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn a_registration_already_held_by_this_domain_lets_the_write_through() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_obtain_registration()
+            .returning(|_, _, _| Ok(false));
+        backend
+            .expect_read_registration()
+            .returning(|_, _| Ok(Some("d1".to_string())));
+        expect_create(&mut backend);
+
+        service(backend, true)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({"identity": {"driver": "sql"}}))),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn switching_to_a_non_sql_driver_releases_the_registration_after_the_write() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend.expect_obtain_registration().never();
+        backend
+            .expect_update_domain_config()
+            .returning(|_, _, _| Ok(config(json!({"identity": {"driver": "ldap"}}))));
+        backend
+            .expect_release_registration()
+            .withf(|_, domain_id, driver_type| domain_id == "d1" && *driver_type == Some("SQL"))
+            .returning(|_, _, _| Ok(()));
+
+        service(backend, true)
+            .update_domain_config(
+                &state,
+                "d1",
+                DomainConfigUpdate(config(json!({"identity": {"driver": "ldap"}}))),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn deleting_the_configuration_releases_the_registration() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_delete_domain_config()
+            .returning(|_, _| Ok(()));
+        backend
+            .expect_release_registration()
+            .withf(|_, domain_id, driver_type| domain_id == "d1" && *driver_type == Some("SQL"))
+            .returning(|_, _, _| Ok(()));
+
+        service(backend, true)
+            .delete_domain_config(&state, "d1")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn deleting_the_configuration_is_a_plain_passthrough_without_database_configs() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_delete_domain_config()
+            .returning(|_, _| Ok(()));
+        backend.expect_release_registration().never();
+
+        service(backend, false)
+            .delete_domain_config(&state, "d1")
+            .await
+            .unwrap();
     }
 }

--- a/crates/core/src/identity/backend.rs
+++ b/crates/core/src/identity/backend.rs
@@ -26,6 +26,18 @@ use crate::keystone::ServiceState;
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait IdentityBackend: Send + Sync {
+    /// Whether this backend can represent more than one domain.
+    ///
+    /// Mirrors python-keystone's `IdentityDriverBase.is_domain_aware`. A
+    /// domain-aware backend (SQL) stores `domain_id` per entity and can serve
+    /// every domain from one instance; a non-domain-aware one (LDAP) maps a
+    /// single directory to a single domain, so routing a foreign domain to it
+    /// as the global default is rejected (see
+    /// `IdentityService::driver_for`).
+    fn is_domain_aware(&self) -> bool {
+        true
+    }
+
     /// Add the user to the group.
     ///
     /// # Parameters

--- a/crates/core/src/identity/service.rs
+++ b/crates/core/src/identity/service.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use openstack_keystone_config::Config;
+use openstack_keystone_core_types::domain_config::DomainConfigGroupName;
 use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::identity::*;
 
@@ -31,8 +32,10 @@ use crate::auth::{
     AuthenticationContext, AuthenticationError, AuthenticationResult, AuthenticationResultBuilder,
     ExecutionContext, IdentityInfo, PrincipalInfo, UserIdentityInfoBuilder, scope_domain_id,
 };
+use crate::domain_config::DomainConfigResolver;
 use crate::events::AuditDispatchError;
 use crate::identity::{IdentityApi, IdentityProviderError, backend::IdentityBackend};
+use crate::keystone::ServiceState;
 use crate::plugin_manager::PluginManagerApi;
 use crate::request_cache::{cache_get, cache_remove, cache_set};
 use crate::resource::error::ResourceProviderError;
@@ -44,7 +47,29 @@ const GROUP_CACHE_NS: &str = "identity.group";
 
 /// Identity provider.
 pub struct IdentityService {
+    /// The global identity driver, used for every domain unless per-domain
+    /// drivers are enabled and a domain's stored config selects another one.
     backend_driver: Arc<dyn IdentityBackend>,
+    /// Name of [`Self::backend_driver`] in [`Self::backends`] (the global
+    /// `[identity] driver`). Empty for [`Self::from_driver`], which has no
+    /// named registry.
+    default_driver_name: String,
+    /// `[identity] default_domain_id`. A non-domain-aware global driver is
+    /// allowed to serve this one domain even without its own stored config.
+    default_domain_id: String,
+    /// Every registered identity backend by name. Holds just the global driver
+    /// unless `[identity] domain_specific_drivers_enabled`, in which case it
+    /// also holds the backends a domain config may select (`sql` + `ldap`).
+    backends: HashMap<String, Arc<dyn IdentityBackend>>,
+    /// Resolves a domain's effective stored configuration. `Some` only when
+    /// `[identity] domain_specific_drivers_enabled`; `None` disables all
+    /// per-domain dispatch and every operation uses [`Self::backend_driver`].
+    domain_config_resolver: Option<Arc<DomainConfigResolver>>,
+    /// Cache of `domain_id` to resolved identity driver name. An empty value
+    /// means "no per-domain override, use the global driver". No invalidation:
+    /// a change to a domain's `identity/driver` through the config API is
+    /// picked up only after a restart (issue #960 follow-up).
+    resolved_driver_cache: RwLock<HashMap<String, String>>,
     /// Caching flag. When enabled certain data can be cached (i.e. `domain_id`
     /// by `user_id`).
     caching: bool,
@@ -67,8 +92,21 @@ impl IdentityService {
         let backend_driver = plugin_manager
             .get_identity_backend(config.identity.driver.clone())?
             .clone();
+        let domain_config_resolver = if config.identity.domain_specific_drivers_enabled {
+            Some(Arc::new(
+                DomainConfigResolver::new(config, plugin_manager)
+                    .map_err(|e| IdentityProviderError::Driver(e.to_string()))?,
+            ))
+        } else {
+            None
+        };
         Ok(Self {
             backend_driver,
+            default_driver_name: config.identity.driver.clone(),
+            default_domain_id: config.identity.default_domain_id.clone(),
+            backends: plugin_manager.identity_backends().clone(),
+            domain_config_resolver,
+            resolved_driver_cache: HashMap::new().into(),
             caching: config.identity.caching,
             user_id_domain_id_cache: HashMap::new().into(),
         })
@@ -76,14 +114,226 @@ impl IdentityService {
 
     /// Create an IdentityService from a backend driver.
     ///
+    /// Per-domain dispatch is off (`domain_config_resolver` is `None`), so
+    /// every operation goes to `driver`; this keeps the unit tests that build a
+    /// service from a single mock backend working unchanged.
+    ///
     /// # Parameters
     /// - `driver`: The backend driver.
     pub fn from_driver<I: IdentityBackend + 'static>(driver: I) -> Self {
         Self {
             backend_driver: Arc::new(driver),
+            default_driver_name: String::new(),
+            default_domain_id: String::new(),
+            backends: HashMap::new(),
+            domain_config_resolver: None,
+            resolved_driver_cache: HashMap::new().into(),
             caching: false,
             user_id_domain_id_cache: HashMap::new().into(),
         }
+    }
+
+    /// Build a service with an explicit backend registry and resolver.
+    /// Test-only; production code goes through [`Self::new`].
+    #[cfg(test)]
+    pub(crate) fn from_backends(
+        default_driver_name: impl Into<String>,
+        backend_driver: Arc<dyn IdentityBackend>,
+        backends: HashMap<String, Arc<dyn IdentityBackend>>,
+        domain_config_resolver: Option<Arc<DomainConfigResolver>>,
+    ) -> Self {
+        Self {
+            backend_driver,
+            default_driver_name: default_driver_name.into(),
+            default_domain_id: "default".to_string(),
+            backends,
+            domain_config_resolver,
+            resolved_driver_cache: HashMap::new().into(),
+            caching: false,
+            user_id_domain_id_cache: HashMap::new().into(),
+        }
+    }
+
+    /// Test-only override for `[identity] default_domain_id`, so a test can
+    /// prove the non-domain-aware guard keys on the configured value rather
+    /// than a literal `"default"`.
+    #[cfg(test)]
+    pub(crate) fn with_default_domain_id(mut self, domain_id: impl Into<String>) -> Self {
+        self.default_domain_id = domain_id.into();
+        self
+    }
+
+    /// The identity backend that serves `domain_id`.
+    ///
+    /// The global driver when per-domain drivers are off, `domain_id` is
+    /// `None`, the domain's stored config names no `identity/driver`, or it
+    /// names one with no registered backend. Otherwise the backend the
+    /// resolved `identity/driver` selects. The resolution is cached per domain.
+    ///
+    /// Errors with `DomainNotFound` (404) when the request would fall back to
+    /// a global driver that is not domain aware (e.g. `[identity] driver =
+    /// ldap`) for a domain other than `[identity] default_domain_id` — a
+    /// single LDAP directory cannot represent multiple domains. Mirrors
+    /// python-keystone's `Manager._select_identity_driver`.
+    async fn driver_for(
+        &self,
+        state: &ServiceState,
+        domain_id: Option<&str>,
+    ) -> Result<Arc<dyn IdentityBackend>, IdentityProviderError> {
+        let (Some(resolver), Some(domain_id)) = (&self.domain_config_resolver, domain_id) else {
+            return Ok(self.backend_driver.clone());
+        };
+
+        let name = if let Some(name) = self
+            .resolved_driver_cache
+            .read()
+            .await
+            .get(domain_id)
+            .cloned()
+        {
+            name
+        } else {
+            let name = match resolver.effective_config(state, domain_id).await {
+                Ok(config) => config
+                    .into_group(DomainConfigGroupName::Identity)
+                    .and_then(|group| {
+                        group
+                            .get("driver")
+                            .and_then(|value| value.as_str())
+                            .map(str::to_owned)
+                    })
+                    .unwrap_or_default(),
+                Err(error) => {
+                    tracing::warn!(
+                        %domain_id,
+                        %error,
+                        "domain config resolution failed; using the global identity driver"
+                    );
+                    String::new()
+                }
+            };
+            self.resolved_driver_cache
+                .write()
+                .await
+                .insert(domain_id.to_owned(), name.clone());
+            name
+        };
+
+        let backend = self.backend_by_name(&name);
+        if Arc::ptr_eq(&backend, &self.backend_driver)
+            && !backend.is_domain_aware()
+            && domain_id != self.default_domain_id
+        {
+            tracing::warn!(
+                %domain_id,
+                "the global identity driver is not domain aware; a non-default \
+                 domain cannot be mapped onto it"
+            );
+            return Err(ResourceProviderError::DomainNotFound(domain_id.to_owned()).into());
+        }
+        Ok(backend)
+    }
+
+    /// The registered backend called `name`, or the global driver when `name`
+    /// is empty (no per-domain override) or unknown.
+    fn backend_by_name(&self, name: &str) -> Arc<dyn IdentityBackend> {
+        if name.is_empty() || name == self.default_driver_name {
+            return self.backend_driver.clone();
+        }
+        self.backends
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| self.backend_driver.clone())
+    }
+
+    /// The identity backend that serves the user `user_id`.
+    ///
+    /// Mirrors python-keystone's `_get_domain_driver_and_entity_id`: the id
+    /// mapping is the authoritative record of which backend owns an entity.
+    async fn driver_for_user<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        user_id: &str,
+    ) -> Result<Arc<dyn IdentityBackend>, IdentityProviderError> {
+        self.driver_for_public_id(ctx, user_id).await
+    }
+
+    /// The identity backend that serves the group `group_id`. Same id-mapping
+    /// lookup as [`Self::driver_for_user`].
+    async fn driver_for_group<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        group_id: &str,
+    ) -> Result<Arc<dyn IdentityBackend>, IdentityProviderError> {
+        self.driver_for_public_id(ctx, group_id).await
+    }
+
+    /// Resolve the backend for a user or group public id.
+    ///
+    /// python-keystone (`_get_domain_driver_and_entity_id`): while per-domain
+    /// drivers are enabled, look the public id up in the id mapping first. A
+    /// mapping row exists for every entity a non-default backend owns; a hit
+    /// dispatches to that domain's driver. A miss means the default driver
+    /// owns the id (default-SQL entities carry no mapping row), so fall back
+    /// to the global driver rather than re-deriving a domain that would
+    /// mis-route the entity.
+    async fn driver_for_public_id<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        public_id: &str,
+    ) -> Result<Arc<dyn IdentityBackend>, IdentityProviderError> {
+        if self.domain_config_resolver.is_none() {
+            return Ok(self.backend_driver.clone());
+        }
+        let domain_id = match ctx
+            .state()
+            .provider
+            .get_idmapping_provider()
+            .get_by_public_id(ctx, public_id)
+            .await
+        {
+            Ok(Some(mapping)) => mapping.domain_id,
+            _ => return Ok(self.backend_driver.clone()),
+        };
+        self.driver_for(ctx.state(), Some(&domain_id)).await
+    }
+
+    /// Resolve the user's and the group's backends and require them to be the
+    /// same instance before a group-membership mutation.
+    ///
+    /// Mirrors python-keystone's
+    /// `Manager._assert_user_and_group_in_same_backend`: a membership that
+    /// spans two identity backends is rejected with `CrossBackendNotAllowed`
+    /// (403), after confirming both entities actually exist (a bogus id
+    /// surfaces as its own `UserNotFound`/`GroupNotFound` 404 first).
+    async fn membership_backend<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        user_id: &str,
+        group_id: &str,
+    ) -> Result<Arc<dyn IdentityBackend>, IdentityProviderError> {
+        let user_backend = self.driver_for_user(ctx, user_id).await?;
+        if self.domain_config_resolver.is_none() {
+            return Ok(user_backend);
+        }
+        let group_backend = self.driver_for_group(ctx, group_id).await?;
+        if Arc::ptr_eq(&user_backend, &group_backend) {
+            return Ok(user_backend);
+        }
+        if user_backend.get_user(ctx.state(), user_id).await?.is_none() {
+            return Err(IdentityProviderError::UserNotFound(user_id.to_owned()));
+        }
+        if group_backend
+            .get_group(ctx.state(), group_id)
+            .await?
+            .is_none()
+        {
+            return Err(IdentityProviderError::GroupNotFound(group_id.to_owned()));
+        }
+        Err(IdentityProviderError::CrossBackendNotAllowed {
+            user_id: user_id.to_owned(),
+            group_id: group_id.to_owned(),
+        })
     }
 
     /// The actual password-authentication implementation, split out of the
@@ -128,9 +378,11 @@ impl IdentityService {
         // performs any password verification (Invariants 4 and 8). The
         // throttle lives here at the provider level so every backend driver
         // shares a single implementation.
+        let driver = self
+            .driver_for(state, auth.domain.as_ref().and_then(|d| d.id.as_deref()))
+            .await?;
         if state.rate_limiters.user_auth_enabled() {
-            match self
-                .backend_driver
+            match driver
                 .check_user_exist(
                     state,
                     auth.id.as_deref(),
@@ -155,9 +407,7 @@ impl IdentityService {
             }
         }
 
-        self.backend_driver
-            .authenticate_by_password(state, &auth)
-            .await
+        driver.authenticate_by_password(state, &auth).await
     }
 }
 
@@ -175,6 +425,7 @@ impl IdentityApi for IdentityService {
         user_id: &'a str,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
+        let backend_driver = self.membership_backend(ctx, user_id, group_id).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -187,14 +438,14 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .add_user_to_group(ctx.state(), user_id, group_id)
                         .await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .add_user_to_group(ctx.state(), user_id, group_id)
                 .await?;
             ctx.state()
@@ -225,6 +476,7 @@ impl IdentityApi for IdentityService {
         group_id: &'a str,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
+        let backend_driver = self.membership_backend(ctx, user_id, group_id).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -237,14 +489,14 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .add_user_to_group_expiring(ctx.state(), user_id, group_id, idp_id)
                         .await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .add_user_to_group_expiring(ctx.state(), user_id, group_id, idp_id)
                 .await?;
             ctx.state()
@@ -279,6 +531,10 @@ impl IdentityApi for IdentityService {
                 memberships.iter().map(|(_, g)| g.to_string()).collect(),
             )
         };
+        let backend_driver = match memberships.first() {
+            Some((user_id, _)) => self.driver_for_user(ctx, user_id).await?,
+            None => self.backend_driver.clone(),
+        };
         if let Some(vsc) = ctx.ctx() {
             let memberships_clone = memberships
                 .iter()
@@ -295,7 +551,7 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .add_users_to_groups(
                             ctx.state(),
                             memberships_clone
@@ -308,7 +564,7 @@ impl IdentityApi for IdentityService {
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .add_users_to_groups(ctx.state(), memberships)
                 .await?;
             ctx.state()
@@ -345,6 +601,10 @@ impl IdentityApi for IdentityService {
                 memberships.iter().map(|(_, g)| g.to_string()).collect(),
             )
         };
+        let backend_driver = match memberships.first() {
+            Some((user_id, _)) => self.driver_for_user(ctx, user_id).await?,
+            None => self.backend_driver.clone(),
+        };
         if let Some(vsc) = ctx.ctx() {
             let memberships_clone = memberships
                 .iter()
@@ -362,7 +622,7 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .add_users_to_groups_expiring(
                             ctx.state(),
                             memberships_clone
@@ -376,7 +636,7 @@ impl IdentityApi for IdentityService {
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .add_users_to_groups_expiring(ctx.state(), memberships, idp_id)
                 .await?;
             ctx.state()
@@ -462,7 +722,8 @@ impl IdentityApi for IdentityService {
         // probe shared with password authentication resolves the reference to
         // the canonical user ID and rejects disabled accounts.
         let user_id = match self
-            .backend_driver
+            .driver_for(state, auth.domain.as_ref().and_then(|d| d.id.as_deref()))
+            .await?
             .check_user_exist(
                 state,
                 auth.id.as_deref(),
@@ -559,8 +820,9 @@ impl IdentityApi for IdentityService {
             res.id = Some(gid.clone());
             gid
         };
+        let backend_driver = self.driver_for(ctx.state(), Some(&res.domain_id)).await?;
         let group = if let Some(vsc) = ctx.ctx() {
-            let backend_driver = &self.backend_driver;
+            let backend_driver = &backend_driver;
             let state = ctx.state();
             let res_clone = res.clone();
             let dispatch = crate::audited_op! {
@@ -577,7 +839,7 @@ impl IdentityApi for IdentityService {
             };
             dispatch?
         } else {
-            let group = self.backend_driver.create_group(ctx.state(), res).await?;
+            let group = backend_driver.create_group(ctx.state(), res).await?;
             ctx.state()
                 .event_dispatcher
                 .emit(Event::new(
@@ -623,8 +885,11 @@ impl IdentityApi for IdentityService {
             let cfg = ctx.state().config_manager.config.read().await;
             cfg.security_compliance.validate_password(password)?;
         }
+        let backend_driver = self
+            .driver_for(ctx.state(), mod_user.domain_id.as_deref())
+            .await?;
         let user = if let Some(vsc) = ctx.ctx() {
-            let backend_driver = &self.backend_driver;
+            let backend_driver = &backend_driver;
             let state = ctx.state();
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -639,10 +904,7 @@ impl IdentityApi for IdentityService {
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?
         } else {
-            let user = self
-                .backend_driver
-                .create_user(ctx.state(), mod_user)
-                .await?;
+            let user = backend_driver.create_user(ctx.state(), mod_user).await?;
             ctx.state()
                 .event_dispatcher
                 .emit(Event::new(
@@ -668,6 +930,7 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
+        let backend_driver = self.driver_for_group(ctx, group_id).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -677,15 +940,13 @@ impl IdentityApi for IdentityService {
                     EventPayload::Group { id: group_id.to_string() },
                 ),
                 operation: async {
-                    self.backend_driver.delete_group(ctx.state(), group_id).await?;
+                    backend_driver.delete_group(ctx.state(), group_id).await?;
                     Ok::<(), IdentityProviderError>(())
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
-                .delete_group(ctx.state(), group_id)
-                .await?;
+            backend_driver.delete_group(ctx.state(), group_id).await?;
             ctx.state()
                 .event_dispatcher
                 .emit(Event::new(
@@ -711,6 +972,7 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
+        let backend_driver = self.driver_for_user(ctx, user_id).await?;
         if let Some(vsc) = ctx.ctx() {
             // Audited delete – fail‐closed on pre‐audit failure.
             crate::audited_op! {
@@ -721,7 +983,7 @@ impl IdentityApi for IdentityService {
                     EventPayload::User { id: user_id.to_string() },
                 ),
                 operation: async {
-                    self.backend_driver.delete_user(ctx.state(), user_id).await?;
+                    backend_driver.delete_user(ctx.state(), user_id).await?;
                     if self.caching {
                         self.user_id_domain_id_cache
                             .write()
@@ -739,9 +1001,7 @@ impl IdentityApi for IdentityService {
             }?;
         } else {
             // No validated context – perform operation and emit on perimeter.
-            self.backend_driver
-                .delete_user(ctx.state(), user_id)
-                .await?;
+            backend_driver.delete_user(ctx.state(), user_id).await?;
             if self.caching {
                 self.user_id_domain_id_cache.write().await.remove(user_id);
             }
@@ -782,7 +1042,11 @@ impl IdentityApi for IdentityService {
         if let Some(user) = cache_get::<UserResponse>(USER_CACHE_NS, user_id) {
             return Ok(Some(user));
         }
-        let user = self.backend_driver.get_user(ctx.state(), user_id).await?;
+        let user = self
+            .driver_for_user(ctx, user_id)
+            .await?
+            .get_user(ctx.state(), user_id)
+            .await?;
         if let Some(user) = &user {
             if self.caching {
                 self.user_id_domain_id_cache
@@ -816,7 +1080,8 @@ impl IdentityApi for IdentityService {
                 return Ok(domain_id.clone());
             } else {
                 let domain_id = self
-                    .backend_driver
+                    .driver_for_user(ctx, user_id)
+                    .await?
                     .get_user_domain_id(ctx.state(), user_id)
                     .await?;
                 self.user_id_domain_id_cache
@@ -827,7 +1092,8 @@ impl IdentityApi for IdentityService {
             }
         } else {
             Ok(self
-                .backend_driver
+                .driver_for_user(ctx, user_id)
+                .await?
                 .get_user_domain_id(ctx.state(), user_id)
                 .await?)
         }
@@ -839,7 +1105,8 @@ impl IdentityApi for IdentityService {
         domain_id: &'a str,
         name: &'a str,
     ) -> Result<Option<String>, IdentityProviderError> {
-        self.backend_driver
+        self.driver_for(ctx.state(), Some(domain_id))
+            .await?
             .find_user_by_name_ci(ctx.state(), domain_id, name)
             .await
     }
@@ -875,7 +1142,10 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         params: &UserListParameters,
     ) -> Result<Vec<UserResponse>, IdentityProviderError> {
-        self.backend_driver.list_users(ctx.state(), params).await
+        self.driver_for(ctx.state(), params.domain_id.as_deref())
+            .await?
+            .list_users(ctx.state(), params)
+            .await
     }
 
     /// List groups.
@@ -888,7 +1158,10 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         params: &GroupListParameters,
     ) -> Result<Vec<Group>, IdentityProviderError> {
-        self.backend_driver.list_groups(ctx.state(), params).await
+        self.driver_for(ctx.state(), params.domain_id.as_deref())
+            .await?
+            .list_groups(ctx.state(), params)
+            .await
     }
 
     /// Get single group.
@@ -908,7 +1181,11 @@ impl IdentityApi for IdentityService {
         if let Some(group) = cache_get::<Group>(GROUP_CACHE_NS, group_id) {
             return Ok(Some(group));
         }
-        let group = self.backend_driver.get_group(ctx.state(), group_id).await?;
+        let group = self
+            .driver_for_group(ctx, group_id)
+            .await?
+            .get_group(ctx.state(), group_id)
+            .await?;
         if let Some(group) = &group {
             cache_set(GROUP_CACHE_NS, group_id, group.clone());
         }
@@ -925,7 +1202,8 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<Vec<Group>, IdentityProviderError> {
-        self.backend_driver
+        self.driver_for_user(ctx, user_id)
+            .await?
             .list_groups_of_user(ctx.state(), user_id)
             .await
     }
@@ -940,7 +1218,8 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         group_id: &'a str,
     ) -> Result<Vec<String>, IdentityProviderError> {
-        self.backend_driver
+        self.driver_for_group(ctx, group_id)
+            .await?
             .list_users_of_group(ctx.state(), group_id)
             .await
     }
@@ -958,7 +1237,8 @@ impl IdentityApi for IdentityService {
         domain_id: &'a str,
         name: &'a str,
     ) -> Result<Option<String>, IdentityProviderError> {
-        self.backend_driver
+        self.driver_for(ctx.state(), Some(domain_id))
+            .await?
             .find_group_by_name_ci(ctx.state(), domain_id, name)
             .await
     }
@@ -975,8 +1255,9 @@ impl IdentityApi for IdentityService {
         group_id: &'a str,
         group: GroupUpdate,
     ) -> Result<Group, IdentityProviderError> {
+        let backend_driver = self.driver_for_group(ctx, group_id).await?;
         let group = if let Some(vsc) = ctx.ctx() {
-            let backend_driver = &self.backend_driver;
+            let backend_driver = &backend_driver;
             let state = ctx.state();
             let group_id_clone = group_id.to_string();
             crate::audited_op! {
@@ -992,8 +1273,7 @@ impl IdentityApi for IdentityService {
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?
         } else {
-            let group = self
-                .backend_driver
+            let group = backend_driver
                 .update_group(ctx.state(), group_id, group)
                 .await?;
             ctx.state()
@@ -1024,6 +1304,7 @@ impl IdentityApi for IdentityService {
         user_id: &'a str,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
+        let backend_driver = self.membership_backend(ctx, user_id, group_id).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -1036,14 +1317,14 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .remove_user_from_group(ctx.state(), user_id, group_id)
                         .await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .remove_user_from_group(ctx.state(), user_id, group_id)
                 .await?;
             ctx.state()
@@ -1074,6 +1355,7 @@ impl IdentityApi for IdentityService {
         group_id: &'a str,
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
+        let backend_driver = self.membership_backend(ctx, user_id, group_id).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -1086,14 +1368,14 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .remove_user_from_group_expiring(ctx.state(), user_id, group_id, idp_id)
                         .await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .remove_user_from_group_expiring(ctx.state(), user_id, group_id, idp_id)
                 .await?;
             ctx.state()
@@ -1123,6 +1405,7 @@ impl IdentityApi for IdentityService {
         group_ids: HashSet<&'a str>,
     ) -> Result<(), IdentityProviderError> {
         let group_ids_vec: Vec<String> = group_ids.iter().copied().map(|s| s.to_string()).collect();
+        let backend_driver = self.driver_for_user(ctx, user_id).await?;
         if let Some(vsc) = ctx.ctx() {
             let group_ids_clone = group_ids_vec.clone();
             let user_id_str = user_id.to_string();
@@ -1137,14 +1420,14 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .remove_user_from_groups(ctx.state(), &user_id_str, group_ids.iter().copied().collect())
                         .await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .remove_user_from_groups(ctx.state(), user_id, group_ids)
                 .await?;
             ctx.state()
@@ -1176,6 +1459,7 @@ impl IdentityApi for IdentityService {
         idp_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
         let group_ids_vec: Vec<String> = group_ids.iter().copied().map(|s| s.to_string()).collect();
+        let backend_driver = self.driver_for_user(ctx, user_id).await?;
         if let Some(vsc) = ctx.ctx() {
             let group_ids_clone = group_ids_vec.clone();
             let user_id_str = user_id.to_string();
@@ -1191,14 +1475,14 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .remove_user_from_groups_expiring(ctx.state(), &user_id_str, group_ids.iter().copied().collect(), &idp_id_str)
                         .await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .remove_user_from_groups_expiring(ctx.state(), user_id, group_ids, idp_id)
                 .await?;
             ctx.state()
@@ -1228,6 +1512,7 @@ impl IdentityApi for IdentityService {
         group_ids: HashSet<&'a str>,
     ) -> Result<(), IdentityProviderError> {
         let group_ids_vec: Vec<String> = group_ids.iter().copied().map(|s| s.to_string()).collect();
+        let backend_driver = self.driver_for_user(ctx, user_id).await?;
         if let Some(vsc) = ctx.ctx() {
             let group_ids_clone = group_ids_vec.clone();
             let user_id_str = user_id.to_string();
@@ -1242,14 +1527,14 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .set_user_groups(ctx.state(), &user_id_str, group_ids.iter().copied().collect())
                         .await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .set_user_groups(ctx.state(), user_id, group_ids)
                 .await?;
             ctx.state()
@@ -1284,8 +1569,9 @@ impl IdentityApi for IdentityService {
             let cfg = ctx.state().config_manager.config.read().await;
             cfg.security_compliance.validate_password(password)?;
         }
+        let backend_driver = self.driver_for_user(ctx, user_id).await?;
         let user = if let Some(vsc) = ctx.ctx() {
-            let backend_driver = &self.backend_driver;
+            let backend_driver = &backend_driver;
             let state = ctx.state();
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -1300,8 +1586,7 @@ impl IdentityApi for IdentityService {
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?
         } else {
-            let user = self
-                .backend_driver
+            let user = backend_driver
                 .update_user(ctx.state(), user_id, user)
                 .await?;
             ctx.state()
@@ -1336,8 +1621,9 @@ impl IdentityApi for IdentityService {
     ) -> Result<(), IdentityProviderError> {
         let cfg = ctx.state().config_manager.config.read().await;
         cfg.security_compliance.validate_password(&new_password)?;
+        let backend_driver = self.driver_for_user(ctx, user_id).await?;
         if let Some(vsc) = ctx.ctx() {
-            let backend_driver = &self.backend_driver;
+            let backend_driver = &backend_driver;
             let state = ctx.state();
             let user_id = user_id.to_string();
             let orig_pwd = original_password.clone();
@@ -1355,7 +1641,7 @@ impl IdentityApi for IdentityService {
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .update_user_password(ctx.state(), user_id, original_password, new_password)
                 .await?;
             ctx.state()
@@ -1389,6 +1675,7 @@ impl IdentityApi for IdentityService {
         last_verified: Option<&'a DateTime<Utc>>,
     ) -> Result<(), IdentityProviderError> {
         let group_ids_vec: Vec<String> = group_ids.iter().copied().map(|s| s.to_string()).collect();
+        let backend_driver = self.driver_for_user(ctx, user_id).await?;
         if let Some(vsc) = ctx.ctx() {
             let group_ids_clone = group_ids_vec.clone();
             let user_id_str = user_id.to_string();
@@ -1404,14 +1691,14 @@ impl IdentityApi for IdentityService {
                     },
                 ),
                 operation: async {
-                    self.backend_driver
+                    backend_driver
                         .set_user_groups_expiring(ctx.state(), &user_id_str, group_ids.iter().copied().collect(), &idp_id_str, last_verified)
                         .await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            self.backend_driver
+            backend_driver
                 .set_user_groups_expiring(ctx.state(), user_id, group_ids, idp_id, last_verified)
                 .await?;
             ctx.state()
@@ -1430,1181 +1717,5 @@ impl IdentityApi for IdentityService {
 }
 
 #[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use openstack_keystone_config::Config;
-    use openstack_keystone_core_types::credential::{Credential, CredentialBuilder};
-    use openstack_keystone_core_types::identity::{
-        UserCreateBuilder, UserResponseBuilder, UserUpdateBuilder,
-    };
-
-    use super::*;
-    use crate::auth::ValidatedSecurityContext;
-    use crate::credential::MockCredentialProvider;
-    use crate::identity::backend::MockIdentityBackend;
-    use crate::provider::Provider;
-    use crate::resource::MockResourceProvider;
-    use crate::tests::get_mocked_state;
-    use openstack_keystone_core_types::auth::{
-        AuthenticationContext, AuthzInfoBuilder, IdentityInfo, PrincipalInfo, ScopeInfo,
-        SecurityContext, UserIdentityInfoBuilder,
-    };
-    use openstack_keystone_core_types::resource::DomainBuilder as ResourceDomainBuilder;
-
-    fn make_vsc_scoped(scope: ScopeInfo) -> ValidatedSecurityContext {
-        let user = UserIdentityInfoBuilder::default()
-            .user_id("test-user-id".to_string())
-            .build()
-            .unwrap();
-        let authz = AuthzInfoBuilder::default().scope(scope).build().unwrap();
-        let sc = SecurityContext::test_build()
-            .authentication_context(AuthenticationContext::Password)
-            .principal(PrincipalInfo {
-                identity: IdentityInfo::User(user),
-            })
-            .authorization(authz)
-            .build();
-        ValidatedSecurityContext::test_new(sc)
-    }
-
-    fn make_domain(id: &str) -> openstack_keystone_core_types::resource::Domain {
-        ResourceDomainBuilder::default()
-            .id(id)
-            .name(format!("{id}-name"))
-            .enabled(true)
-            .build()
-            .unwrap()
-    }
-
-    fn get_config_with_password_regex(regex_str: &str) -> Config {
-        let mut config = Config::default();
-        config.security_compliance.password_regex = Some(regex_str.to_string());
-        // Compile the regex as Config::load_all would do.
-        config.security_compliance.compile_regex().unwrap();
-        config
-    }
-
-    #[tokio::test]
-    async fn test_create_user() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend.expect_create_user().returning(|_, _| {
-            Ok(UserResponseBuilder::default()
-                .id("id")
-                .domain_id("domain_id")
-                .enabled(true)
-                .name("name")
-                .build()
-                .unwrap())
-        });
-        let provider = IdentityService::from_driver(backend);
-
-        assert_eq!(
-            provider
-                .create_user(
-                    &ExecutionContext::internal(&state),
-                    UserCreateBuilder::default()
-                        .name("uname")
-                        .domain_id("did")
-                        .build()
-                        .unwrap()
-                )
-                .await
-                .unwrap(),
-            UserResponseBuilder::default()
-                .domain_id("domain_id")
-                .enabled(true)
-                .id("id")
-                .name("name")
-                .build()
-                .unwrap()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_create_user_defaults_domain_id_from_scope() {
-        // Real clients (tempest, python-openstackclient) omit `domain_id` on
-        // user create and expect the server to infer it from the caller's
-        // token scope, matching python-keystone. Regression test for the
-        // 422 "missing field `domain_id`" compatibility gap.
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_create_user()
-            .withf(|_, user| user.domain_id.as_deref() == Some("scoped-did"))
-            .returning(|_, _| {
-                Ok(UserResponseBuilder::default()
-                    .id("id")
-                    .domain_id("scoped-did")
-                    .enabled(true)
-                    .name("uname")
-                    .build()
-                    .unwrap())
-            });
-        let provider = IdentityService::from_driver(backend);
-        let vsc = make_vsc_scoped(ScopeInfo::Domain(make_domain("scoped-did")));
-        let ctx = ExecutionContext::from_auth(&state, &vsc);
-
-        let created = provider
-            .create_user(
-                &ctx,
-                UserCreateBuilder::default().name("uname").build().unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(created.domain_id, "scoped-did");
-    }
-
-    #[tokio::test]
-    async fn test_get_user() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_user()
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| {
-                Ok(Some(
-                    UserResponseBuilder::default()
-                        .id("id")
-                        .domain_id("domain_id")
-                        .enabled(true)
-                        .name("name")
-                        .build()
-                        .unwrap(),
-                ))
-            });
-        let provider = IdentityService::from_driver(backend);
-
-        assert_eq!(
-            provider
-                .get_user(&ExecutionContext::internal(&state), "uid")
-                .await
-                .unwrap()
-                .expect("user should be there"),
-            UserResponseBuilder::default()
-                .domain_id("domain_id")
-                .enabled(true)
-                .id("id")
-                .name("name")
-                .build()
-                .unwrap(),
-        );
-    }
-
-    #[tokio::test]
-    async fn test_get_user_domain_id() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_user_domain_id()
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .times(2) // only 2 times
-            .returning(|_, _| Ok("did".into()));
-        backend
-            .expect_get_user_domain_id()
-            .withf(|_, uid: &'_ str| uid == "missing")
-            .returning(|_, _| Err(IdentityProviderError::UserNotFound("missing".into())));
-        let mut provider = IdentityService::from_driver(backend);
-        provider.caching = true;
-
-        assert_eq!(
-            provider
-                .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
-                .await
-                .unwrap(),
-            "did"
-        );
-        assert_eq!(
-            provider
-                .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
-                .await
-                .unwrap(),
-            "did",
-            "second time data extracted from cache"
-        );
-        assert!(
-            provider
-                .get_user_domain_id(&ExecutionContext::internal(&state), "missing")
-                .await
-                .is_err()
-        );
-        provider.caching = false;
-        assert_eq!(
-            provider
-                .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
-                .await
-                .unwrap(),
-            "did",
-            "third time backend is again triggered causing total of 2 invocations"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_delete_user() {
-        let mut credential_mock = MockCredentialProvider::default();
-        credential_mock
-            .expect_delete_credentials_for_user()
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(()));
-        let state = get_mocked_state(
-            None,
-            Some(Provider::mocked_builder().mock_credential(credential_mock)),
-        )
-        .await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_delete_user()
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(()));
-        let provider = IdentityService::from_driver(backend);
-
-        assert!(
-            provider
-                .delete_user(&ExecutionContext::internal(&state), "uid")
-                .await
-                .is_ok()
-        );
-    }
-
-    /// RFC 6238 Appendix B seed/passcode used across the TOTP tests below,
-    /// with an oversized `period` so the resulting HOTP counter (`now /
-    /// period`) stays `0` for the foreseeable future regardless of the
-    /// wall-clock time the test actually runs at.
-    fn totp_credential(user_id: &str) -> Credential {
-        CredentialBuilder::default()
-            .id("cred_id")
-            .blob(
-                json!({
-                    "seed": "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ",
-                    "digits": 8,
-                    "period": 10_000_000_000u64,
-                })
-                .to_string(),
-            )
-            .r#type("totp")
-            .user_id(user_id)
-            .build()
-            .unwrap()
-    }
-
-    const TOTP_PASSCODE_COUNTER_0: &str = "84755224";
-
-    fn totp_user(user_id: &str, domain_id: &str, enabled: bool) -> UserResponse {
-        UserResponseBuilder::default()
-            .id(user_id)
-            .domain_id(domain_id)
-            .enabled(enabled)
-            .name("uname")
-            .build()
-            .unwrap()
-    }
-
-    #[tokio::test]
-    async fn test_authenticate_by_totp_success_by_id() {
-        let mut credential_mock = MockCredentialProvider::default();
-        credential_mock
-            .expect_list_credentials_for_user()
-            .withf(|_, uid: &'_ str, r#type: &Option<&str>| uid == "uid" && *r#type == Some("totp"))
-            .returning(|_, _, _| Ok(vec![totp_credential("uid")]));
-        let state = get_mocked_state(
-            None,
-            Some(Provider::mocked_builder().mock_credential(credential_mock)),
-        )
-        .await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .withf(|_, id, name, domain| *id == Some("uid") && name.is_none() && domain.is_none())
-            .returning(|_, _, _, _| Ok("uid".to_string()));
-        backend
-            .expect_get_user()
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(Some(totp_user("uid", "did", true))));
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_totp(
-                &ExecutionContext::internal(&state),
-                &UserTotpAuthRequestBuilder::default()
-                    .id("uid")
-                    .passcode(TOTP_PASSCODE_COUNTER_0)
-                    .build()
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(result.context, AuthenticationContext::Totp);
-        assert_eq!(result.principal.get_user_id(), "uid");
-    }
-
-    /// ADR-0022 Invariants 4 and 8 on the TOTP path: the per-user bucket is
-    /// keyed on the confirmed user ID and fires before any credential is
-    /// listed or passcode verified. The bucket is exhausted directly through
-    /// `check_user` (simulating a prior authentication attempt) so timing
-    /// cannot replenish it mid-test.
-    #[tokio::test]
-    async fn test_authenticate_by_totp_rate_limited() {
-        let mut credential_mock = MockCredentialProvider::default();
-        // Rejected before verification: credentials must never be listed.
-        credential_mock.expect_list_credentials_for_user().times(0);
-        let mut config = openstack_keystone_config::Config::default();
-        config.rate_limit_user_auth = openstack_keystone_config::RateLimitSection {
-            enabled: true,
-            burst_size: 1,
-            replenish_rate_per_second: 1,
-        };
-        let state = get_mocked_state(
-            Some(config),
-            Some(Provider::mocked_builder().mock_credential(credential_mock)),
-        )
-        .await;
-        assert!(state.rate_limiters.check_user("uid").is_ok());
-
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .returning(|_, _, _, _| Ok("uid".to_string()));
-        // Rejected before the full user is ever loaded.
-        backend.expect_get_user().times(0);
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_totp(
-                &ExecutionContext::internal(&state),
-                &UserTotpAuthRequestBuilder::default()
-                    .id("uid")
-                    .passcode(TOTP_PASSCODE_COUNTER_0)
-                    .build()
-                    .unwrap(),
-            )
-            .await;
-
-        assert!(matches!(
-            result,
-            Err(IdentityProviderError::TooManyRequests { retry_after_secs }) if retry_after_secs >= 1
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_authenticate_by_totp_wrong_passcode() {
-        let mut credential_mock = MockCredentialProvider::default();
-        credential_mock
-            .expect_list_credentials_for_user()
-            .returning(|_, _, _| Ok(vec![totp_credential("uid")]));
-        let state = get_mocked_state(
-            None,
-            Some(Provider::mocked_builder().mock_credential(credential_mock)),
-        )
-        .await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .returning(|_, _, _, _| Ok("uid".to_string()));
-        backend
-            .expect_get_user()
-            .returning(|_, _| Ok(Some(totp_user("uid", "did", true))));
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_totp(
-                &ExecutionContext::internal(&state),
-                &UserTotpAuthRequestBuilder::default()
-                    .id("uid")
-                    .passcode("00000000")
-                    .build()
-                    .unwrap(),
-            )
-            .await;
-
-        assert!(matches!(
-            result,
-            Err(IdentityProviderError::Authentication {
-                source: AuthenticationError::TotpPasscodeInvalid
-            })
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_authenticate_by_totp_no_credentials() {
-        let mut credential_mock = MockCredentialProvider::default();
-        credential_mock
-            .expect_list_credentials_for_user()
-            .returning(|_, _, _| Ok(vec![]));
-        let state = get_mocked_state(
-            None,
-            Some(Provider::mocked_builder().mock_credential(credential_mock)),
-        )
-        .await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .returning(|_, _, _, _| Ok("uid".to_string()));
-        backend
-            .expect_get_user()
-            .returning(|_, _| Ok(Some(totp_user("uid", "did", true))));
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_totp(
-                &ExecutionContext::internal(&state),
-                &UserTotpAuthRequestBuilder::default()
-                    .id("uid")
-                    .passcode(TOTP_PASSCODE_COUNTER_0)
-                    .build()
-                    .unwrap(),
-            )
-            .await;
-
-        assert!(matches!(
-            result,
-            Err(IdentityProviderError::Authentication {
-                source: AuthenticationError::TotpPasscodeInvalid
-            })
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_authenticate_by_totp_user_disabled() {
-        let mut credential_mock = MockCredentialProvider::default();
-        credential_mock.expect_list_credentials_for_user().times(0);
-        let state = get_mocked_state(
-            None,
-            Some(Provider::mocked_builder().mock_credential(credential_mock)),
-        )
-        .await;
-        let mut backend = MockIdentityBackend::default();
-        // The cheap probe rejects the disabled account before any credential
-        // work; the full user is never loaded.
-        backend
-            .expect_check_user_exist()
-            .returning(|_, _, _, _| Err(AuthenticationError::UserDisabled("uid".into()).into()));
-        backend.expect_get_user().times(0);
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_totp(
-                &ExecutionContext::internal(&state),
-                &UserTotpAuthRequestBuilder::default()
-                    .id("uid")
-                    .passcode(TOTP_PASSCODE_COUNTER_0)
-                    .build()
-                    .unwrap(),
-            )
-            .await;
-
-        assert!(matches!(
-            result,
-            Err(IdentityProviderError::Authentication {
-                source: AuthenticationError::UserDisabled(id)
-            }) if id == "uid"
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_authenticate_by_totp_user_not_found() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .returning(|_, _, _, _| Err(IdentityProviderError::UserNotFound("uid".into())));
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_totp(
-                &ExecutionContext::internal(&state),
-                &UserTotpAuthRequestBuilder::default()
-                    .id("uid")
-                    .passcode(TOTP_PASSCODE_COUNTER_0)
-                    .build()
-                    .unwrap(),
-            )
-            .await;
-
-        assert!(matches!(
-            result,
-            Err(IdentityProviderError::Authentication {
-                source: AuthenticationError::TotpPasscodeInvalid
-            })
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_authenticate_by_totp_success_by_name_and_domain() {
-        let mut credential_mock = MockCredentialProvider::default();
-        credential_mock
-            .expect_list_credentials_for_user()
-            .withf(|_, uid: &'_ str, r#type: &Option<&str>| uid == "uid" && *r#type == Some("totp"))
-            .returning(|_, _, _| Ok(vec![totp_credential("uid")]));
-        let mut resource_mock = MockResourceProvider::default();
-        resource_mock
-            .expect_find_domain_by_name()
-            .withf(|_, name: &'_ str| name == "dname")
-            .returning(|_, _| {
-                Ok(Some(openstack_keystone_core_types::resource::Domain {
-                    id: "did".into(),
-                    enabled: true,
-                    ..Default::default()
-                }))
-            });
-        let state = get_mocked_state(
-            None,
-            Some(
-                Provider::mocked_builder()
-                    .mock_credential(credential_mock)
-                    .mock_resource(resource_mock),
-            ),
-        )
-        .await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .withf(|_, id, name, domain| {
-                id.is_none() && *name == Some("uname_lookup") && *domain == Some("did")
-            })
-            .returning(|_, _, _, _| Ok("uid".to_string()));
-        backend
-            .expect_get_user()
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(Some(totp_user("uid", "did", true))));
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_totp(
-                &ExecutionContext::internal(&state),
-                &UserTotpAuthRequestBuilder::default()
-                    .name("uname_lookup")
-                    .domain(DomainBuilder::default().name("dname").build().unwrap())
-                    .passcode(TOTP_PASSCODE_COUNTER_0)
-                    .build()
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(result.context, AuthenticationContext::Totp);
-        assert_eq!(result.principal.get_user_id(), "uid");
-    }
-
-    /// ADR-0022 Invariants 4 and 8 at the provider level: the enabled
-    /// per-user bucket is keyed on the ID resolved by the cheap probe and
-    /// fires before the backend performs any password verification. The
-    /// bucket is exhausted directly through `check_user` (simulating a prior
-    /// attempt) so timing cannot replenish it mid-test.
-    #[tokio::test]
-    async fn test_authenticate_by_password_rate_limited() {
-        let mut config = openstack_keystone_config::Config::default();
-        config.rate_limit_user_auth = openstack_keystone_config::RateLimitSection {
-            enabled: true,
-            burst_size: 1,
-            replenish_rate_per_second: 1,
-        };
-        let state = get_mocked_state(Some(config), None).await;
-        assert!(state.rate_limiters.check_user("uid").is_ok());
-
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .withf(|_, id, name, domain| *id == Some("uid") && name.is_none() && domain.is_none())
-            .returning(|_, _, _, _| Ok("uid".to_string()));
-        // The expensive backend authentication must never be reached.
-        backend.expect_authenticate_by_password().times(0);
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_password(
-                &ExecutionContext::internal(&state),
-                &UserPasswordAuthRequest {
-                    id: Some("uid".into()),
-                    password: "pass".into(),
-                    ..Default::default()
-                },
-            )
-            .await;
-
-        assert!(matches!(
-            result,
-            Err(IdentityProviderError::TooManyRequests { retry_after_secs }) if retry_after_secs >= 1
-        ));
-    }
-
-    /// ADR-0022 Invariant 8: unknown users never touch the limiter store.
-    /// The probe misses and the request falls through to the backend, which
-    /// keeps the uniform dummy-hash credentials error — never a 429 — no
-    /// matter how often it is retried.
-    #[tokio::test]
-    async fn test_authenticate_by_password_unknown_user_uniform_error() {
-        let mut config = openstack_keystone_config::Config::default();
-        config.rate_limit_user_auth = openstack_keystone_config::RateLimitSection {
-            enabled: true,
-            burst_size: 1,
-            replenish_rate_per_second: 1,
-        };
-        let state = get_mocked_state(Some(config), None).await;
-
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .returning(|_, _, _, _| Err(IdentityProviderError::UserNotFound("ghost".into())));
-        backend
-            .expect_authenticate_by_password()
-            .times(2)
-            .returning(|_, _| Err(AuthenticationError::UserNameOrPasswordWrong.into()));
-        let provider = IdentityService::from_driver(backend);
-
-        for _ in 0..2 {
-            let result = provider
-                .authenticate_by_password(
-                    &ExecutionContext::internal(&state),
-                    &UserPasswordAuthRequest {
-                        id: Some("ghost".into()),
-                        password: "pass".into(),
-                        ..Default::default()
-                    },
-                )
-                .await;
-            assert!(matches!(
-                result,
-                Err(IdentityProviderError::Authentication {
-                    source: AuthenticationError::UserNameOrPasswordWrong
-                })
-            ));
-        }
-    }
-
-    /// With the bucket disabled (the default), the probe is skipped
-    /// entirely: rate limiting adds no extra query to the authentication
-    /// hot path.
-    #[tokio::test]
-    async fn test_authenticate_by_password_probe_skipped_when_disabled() {
-        let state = get_mocked_state(None, None).await;
-
-        let mut backend = MockIdentityBackend::default();
-        backend.expect_check_user_exist().times(0);
-        backend
-            .expect_authenticate_by_password()
-            .once()
-            .returning(|_, _| Err(AuthenticationError::UserNameOrPasswordWrong.into()));
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_password(
-                &ExecutionContext::internal(&state),
-                &UserPasswordAuthRequest {
-                    id: Some("uid".into()),
-                    password: "pass".into(),
-                    ..Default::default()
-                },
-            )
-            .await;
-        assert!(matches!(
-            result,
-            Err(IdentityProviderError::Authentication {
-                source: AuthenticationError::UserNameOrPasswordWrong
-            })
-        ));
-    }
-
-    /// Within quota the request proceeds to the backend normally.
-    #[tokio::test]
-    async fn test_authenticate_by_password_within_quota_reaches_backend() {
-        let mut config = openstack_keystone_config::Config::default();
-        config.rate_limit_user_auth = openstack_keystone_config::RateLimitSection {
-            enabled: true,
-            burst_size: 100,
-            replenish_rate_per_second: 10,
-        };
-        let state = get_mocked_state(Some(config), None).await;
-
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_check_user_exist()
-            .returning(|_, _, _, _| Ok("uid".to_string()));
-        backend
-            .expect_authenticate_by_password()
-            .once()
-            .returning(|_, _| Err(AuthenticationError::UserNameOrPasswordWrong.into()));
-        let provider = IdentityService::from_driver(backend);
-
-        let result = provider
-            .authenticate_by_password(
-                &ExecutionContext::internal(&state),
-                &UserPasswordAuthRequest {
-                    id: Some("uid".into()),
-                    password: "pass".into(),
-                    ..Default::default()
-                },
-            )
-            .await;
-        assert!(matches!(
-            result,
-            Err(IdentityProviderError::Authentication {
-                source: AuthenticationError::UserNameOrPasswordWrong
-            })
-        ));
-    }
-
-    /// Password regex rejects invalid password on user creation.
-    #[tokio::test]
-    async fn test_create_user_password_regex_rejected() {
-        let config = get_config_with_password_regex(r"^.{7,}$");
-        let state = get_mocked_state(Some(config), None).await;
-        let provider = IdentityService::from_driver(MockIdentityBackend::default());
-
-        let result = provider
-            .create_user(
-                &ExecutionContext::internal(&state),
-                UserCreateBuilder::default()
-                    .name("uname")
-                    .domain_id("did")
-                    .password("short")
-                    .build()
-                    .unwrap(),
-            )
-            .await;
-
-        assert!(
-            matches!(result, Err(IdentityProviderError::SecurityCompliance(..))),
-            "expected SecurityCompliance error for invalid password"
-        );
-    }
-
-    /// Password regex accepts valid password on user creation and backend is
-    /// invoked.
-    #[tokio::test]
-    async fn test_create_user_password_regex_accepted() {
-        let config = get_config_with_password_regex(r"^.{3,}$");
-        let state = get_mocked_state(Some(config), None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend.expect_create_user().returning(|_, _| {
-            Ok(UserResponseBuilder::default()
-                .id("id")
-                .domain_id("domain_id")
-                .enabled(true)
-                .name("name")
-                .build()
-                .unwrap())
-        });
-        let provider = IdentityService::from_driver(backend);
-
-        assert!(
-            provider
-                .create_user(
-                    &ExecutionContext::internal(&state),
-                    UserCreateBuilder::default()
-                        .name("uname")
-                        .domain_id("did")
-                        .password("Abc1")
-                        .build()
-                        .unwrap(),
-                )
-                .await
-                .is_ok(),
-            "password matching regex should reach backend"
-        );
-    }
-
-    /// No password on user creation skips validation and backend is invoked.
-    #[tokio::test]
-    async fn test_create_user_no_password() {
-        let config = get_config_with_password_regex(r"^.{7,}$");
-        let state = get_mocked_state(Some(config), None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend.expect_create_user().returning(|_, _| {
-            Ok(UserResponseBuilder::default()
-                .id("id")
-                .domain_id("domain_id")
-                .enabled(true)
-                .name("name")
-                .build()
-                .unwrap())
-        });
-        let provider = IdentityService::from_driver(backend);
-
-        assert!(
-            provider
-                .create_user(
-                    &ExecutionContext::internal(&state),
-                    UserCreateBuilder::default()
-                        .name("uname")
-                        .domain_id("did")
-                        .build()
-                        .unwrap(),
-                )
-                .await
-                .is_ok(),
-            "no password should skip validation"
-        );
-    }
-
-    /// Password regex rejects invalid password on user update.
-    #[tokio::test]
-    async fn test_update_user_password_regex_rejected() {
-        let config = get_config_with_password_regex(r"^.{7,}$");
-        let state = get_mocked_state(Some(config), None).await;
-        let provider = IdentityService::from_driver(MockIdentityBackend::default());
-
-        let result = provider
-            .update_user(
-                &ExecutionContext::internal(&state),
-                "uid",
-                UserUpdateBuilder::default()
-                    .password("short")
-                    .build()
-                    .unwrap(),
-            )
-            .await;
-
-        assert!(
-            matches!(result, Err(IdentityProviderError::SecurityCompliance(..))),
-            "expected SecurityCompliance error for invalid password on update"
-        );
-    }
-
-    /// Password regex accepts valid password on user update and backend is
-    /// invoked.
-    #[tokio::test]
-    async fn test_update_user_password_regex_accepted() {
-        let config = get_config_with_password_regex(r"^.{3,}$");
-        let state = get_mocked_state(Some(config), None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_update_user()
-            .returning(|_, _: &'_ str, _: UserUpdate| {
-                Ok(UserResponseBuilder::default()
-                    .id("id")
-                    .domain_id("domain_id")
-                    .enabled(true)
-                    .name("name")
-                    .build()
-                    .unwrap())
-            });
-        let provider = IdentityService::from_driver(backend);
-
-        assert!(
-            provider
-                .update_user(
-                    &ExecutionContext::internal(&state),
-                    "uid",
-                    UserUpdateBuilder::default()
-                        .password("Abc1")
-                        .build()
-                        .unwrap(),
-                )
-                .await
-                .is_ok(),
-            "password matching regex on update should reach backend"
-        );
-    }
-
-    /// No password on user update skips validation and backend is invoked.
-    #[tokio::test]
-    async fn test_update_user_no_password() {
-        let config = get_config_with_password_regex(r"^.{7,}$");
-        let state = get_mocked_state(Some(config), None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_update_user()
-            .returning(|_, _: &'_ str, _: UserUpdate| {
-                Ok(UserResponseBuilder::default()
-                    .id("id")
-                    .domain_id("domain_id")
-                    .enabled(true)
-                    .name("name")
-                    .build()
-                    .unwrap())
-            });
-        let provider = IdentityService::from_driver(backend);
-
-        assert!(
-            provider
-                .update_user(
-                    &ExecutionContext::internal(&state),
-                    "uid",
-                    UserUpdateBuilder::default()
-                        .name("new_name")
-                        .build()
-                        .unwrap(),
-                )
-                .await
-                .is_ok(),
-            "no password on update should skip validation"
-        );
-    }
-
-    // --- Per-request cache (ADR 0030) -------------------------------------
-
-    use openstack_keystone_core_types::identity::{GroupBuilder, GroupUpdate};
-
-    fn make_user(id: &str) -> UserResponse {
-        UserResponseBuilder::default()
-            .id(id)
-            .domain_id("did")
-            .enabled(true)
-            .name(format!("{id}-name"))
-            .build()
-            .unwrap()
-    }
-
-    fn make_group(id: &str) -> Group {
-        GroupBuilder::default()
-            .id(id)
-            .domain_id("did")
-            .name(format!("{id}-name"))
-            .build()
-            .unwrap()
-    }
-
-    #[tokio::test]
-    async fn test_get_user_hits_backend_once_across_repeated_calls() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_user()
-            .times(1)
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(Some(make_user("uid"))));
-        let provider = IdentityService::from_driver(backend);
-
-        crate::request_cache::RequestCache::scope(async {
-            let ctx = ExecutionContext::internal(&state);
-            let first = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
-            let second = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
-            assert_eq!(first, second);
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_get_user_not_cached_outside_request_scope() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_user()
-            .times(2)
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(Some(make_user("uid"))));
-        let provider = IdentityService::from_driver(backend);
-
-        let ctx = ExecutionContext::internal(&state);
-        provider.get_user(&ctx, "uid").await.unwrap();
-        provider.get_user(&ctx, "uid").await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_update_user_refreshes_cache_instead_of_refetching() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_user()
-            .times(1)
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(Some(make_user("uid"))));
-        backend
-            .expect_update_user()
-            .withf(|_, uid: &'_ str, _| uid == "uid")
-            .returning(|_, _, update| {
-                let mut u = make_user("uid");
-                if let Some(name) = update.name {
-                    u.name = name;
-                }
-                Ok(u)
-            });
-        let provider = IdentityService::from_driver(backend);
-
-        crate::request_cache::RequestCache::scope(async {
-            let ctx = ExecutionContext::internal(&state);
-            provider.get_user(&ctx, "uid").await.unwrap();
-
-            let updated = provider
-                .update_user(
-                    &ctx,
-                    "uid",
-                    UserUpdateBuilder::default()
-                        .name("renamed".to_string())
-                        .build()
-                        .unwrap(),
-                )
-                .await
-                .unwrap();
-            assert_eq!(updated.name, "renamed");
-
-            let refetched = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
-            assert_eq!(refetched.name, "renamed");
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_delete_user_invalidates_cache() {
-        let mut credential_mock = MockCredentialProvider::default();
-        credential_mock
-            .expect_delete_credentials_for_user()
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(()));
-        let state = get_mocked_state(
-            None,
-            Some(Provider::mocked_builder().mock_credential(credential_mock)),
-        )
-        .await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_user()
-            .times(2)
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(Some(make_user("uid"))));
-        backend
-            .expect_delete_user()
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(()));
-        let provider = IdentityService::from_driver(backend);
-
-        crate::request_cache::RequestCache::scope(async {
-            let ctx = ExecutionContext::internal(&state);
-            provider.get_user(&ctx, "uid").await.unwrap();
-            provider.delete_user(&ctx, "uid").await.unwrap();
-            provider.get_user(&ctx, "uid").await.unwrap();
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_update_user_password_invalidates_cache() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_user()
-            .times(2)
-            .withf(|_, uid: &'_ str| uid == "uid")
-            .returning(|_, _| Ok(Some(make_user("uid"))));
-        backend
-            .expect_update_user_password()
-            .withf(|_, uid: &'_ str, _, _| uid == "uid")
-            .returning(|_, _, _, _| Ok(()));
-        let provider = IdentityService::from_driver(backend);
-
-        crate::request_cache::RequestCache::scope(async {
-            let ctx = ExecutionContext::internal(&state);
-            provider.get_user(&ctx, "uid").await.unwrap();
-            provider
-                .update_user_password(
-                    &ctx,
-                    "uid",
-                    SecretString::from("orig".to_string()),
-                    SecretString::from("newpassword".to_string()),
-                )
-                .await
-                .unwrap();
-            // `update_user_password` doesn't return a fresh `UserResponse`
-            // to refresh the cache with -- the cached entry must instead be
-            // invalidated so `password_expires_at` isn't served stale.
-            provider.get_user(&ctx, "uid").await.unwrap();
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_get_group_hits_backend_once_across_repeated_calls() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_group()
-            .times(1)
-            .withf(|_, gid: &'_ str| gid == "gid")
-            .returning(|_, _| Ok(Some(make_group("gid"))));
-        let provider = IdentityService::from_driver(backend);
-
-        crate::request_cache::RequestCache::scope(async {
-            let ctx = ExecutionContext::internal(&state);
-            let first = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
-            let second = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
-            assert_eq!(first, second);
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_get_group_not_cached_outside_request_scope() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_group()
-            .times(2)
-            .withf(|_, gid: &'_ str| gid == "gid")
-            .returning(|_, _| Ok(Some(make_group("gid"))));
-        let provider = IdentityService::from_driver(backend);
-
-        let ctx = ExecutionContext::internal(&state);
-        provider.get_group(&ctx, "gid").await.unwrap();
-        provider.get_group(&ctx, "gid").await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_update_group_refreshes_cache_instead_of_refetching() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_group()
-            .times(1)
-            .withf(|_, gid: &'_ str| gid == "gid")
-            .returning(|_, _| Ok(Some(make_group("gid"))));
-        backend
-            .expect_update_group()
-            .withf(|_, gid: &'_ str, _| gid == "gid")
-            .returning(|_, _, update| {
-                let mut g = make_group("gid");
-                if let Some(name) = update.name {
-                    g.name = name;
-                }
-                Ok(g)
-            });
-        let provider = IdentityService::from_driver(backend);
-
-        crate::request_cache::RequestCache::scope(async {
-            let ctx = ExecutionContext::internal(&state);
-            provider.get_group(&ctx, "gid").await.unwrap();
-
-            let updated = provider
-                .update_group(
-                    &ctx,
-                    "gid",
-                    GroupUpdate {
-                        name: Some("renamed".into()),
-                        ..Default::default()
-                    },
-                )
-                .await
-                .unwrap();
-            assert_eq!(updated.name, "renamed");
-
-            let refetched = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
-            assert_eq!(refetched.name, "renamed");
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_delete_group_invalidates_cache() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockIdentityBackend::default();
-        backend
-            .expect_get_group()
-            .times(2)
-            .withf(|_, gid: &'_ str| gid == "gid")
-            .returning(|_, _| Ok(Some(make_group("gid"))));
-        backend
-            .expect_delete_group()
-            .withf(|_, gid: &'_ str| gid == "gid")
-            .returning(|_, _| Ok(()));
-        let provider = IdentityService::from_driver(backend);
-
-        crate::request_cache::RequestCache::scope(async {
-            let ctx = ExecutionContext::internal(&state);
-            provider.get_group(&ctx, "gid").await.unwrap();
-            provider.delete_group(&ctx, "gid").await.unwrap();
-            provider.get_group(&ctx, "gid").await.unwrap();
-        })
-        .await;
-    }
-}
+#[path = "service/tests.rs"]
+mod tests;

--- a/crates/core/src/identity/service/tests.rs
+++ b/crates/core/src/identity/service/tests.rs
@@ -1,0 +1,1199 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for [`super::IdentityService`].
+//!
+//! Split out of `service.rs` to keep the implementation file short and the
+//! test suites structurally isolated. Per-domain driver dispatch lives in the
+//! [`per_domain_dispatch`] submodule.
+
+use serde_json::json;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core_types::credential::{Credential, CredentialBuilder};
+use openstack_keystone_core_types::identity::{
+    UserCreateBuilder, UserResponseBuilder, UserUpdateBuilder,
+};
+
+use super::*;
+use crate::auth::ValidatedSecurityContext;
+use crate::credential::MockCredentialProvider;
+use crate::identity::backend::MockIdentityBackend;
+use crate::provider::Provider;
+use crate::resource::MockResourceProvider;
+use crate::tests::get_mocked_state;
+use openstack_keystone_core_types::auth::{
+    AuthenticationContext, AuthzInfoBuilder, IdentityInfo, PrincipalInfo, ScopeInfo,
+    SecurityContext, UserIdentityInfoBuilder,
+};
+use openstack_keystone_core_types::resource::DomainBuilder as ResourceDomainBuilder;
+
+fn make_vsc_scoped(scope: ScopeInfo) -> ValidatedSecurityContext {
+    let user = UserIdentityInfoBuilder::default()
+        .user_id("test-user-id".to_string())
+        .build()
+        .unwrap();
+    let authz = AuthzInfoBuilder::default().scope(scope).build().unwrap();
+    let sc = SecurityContext::test_build()
+        .authentication_context(AuthenticationContext::Password)
+        .principal(PrincipalInfo {
+            identity: IdentityInfo::User(user),
+        })
+        .authorization(authz)
+        .build();
+    ValidatedSecurityContext::test_new(sc)
+}
+
+fn make_domain(id: &str) -> openstack_keystone_core_types::resource::Domain {
+    ResourceDomainBuilder::default()
+        .id(id)
+        .name(format!("{id}-name"))
+        .enabled(true)
+        .build()
+        .unwrap()
+}
+
+fn get_config_with_password_regex(regex_str: &str) -> Config {
+    let mut config = Config::default();
+    config.security_compliance.password_regex = Some(regex_str.to_string());
+    // Compile the regex as Config::load_all would do.
+    config.security_compliance.compile_regex().unwrap();
+    config
+}
+
+#[tokio::test]
+async fn test_create_user() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend.expect_create_user().returning(|_, _| {
+        Ok(UserResponseBuilder::default()
+            .id("id")
+            .domain_id("domain_id")
+            .enabled(true)
+            .name("name")
+            .build()
+            .unwrap())
+    });
+    let provider = IdentityService::from_driver(backend);
+
+    assert_eq!(
+        provider
+            .create_user(
+                &ExecutionContext::internal(&state),
+                UserCreateBuilder::default()
+                    .name("uname")
+                    .domain_id("did")
+                    .build()
+                    .unwrap()
+            )
+            .await
+            .unwrap(),
+        UserResponseBuilder::default()
+            .domain_id("domain_id")
+            .enabled(true)
+            .id("id")
+            .name("name")
+            .build()
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_create_user_defaults_domain_id_from_scope() {
+    // Real clients (tempest, python-openstackclient) omit `domain_id` on
+    // user create and expect the server to infer it from the caller's
+    // token scope, matching python-keystone. Regression test for the
+    // 422 "missing field `domain_id`" compatibility gap.
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_create_user()
+        .withf(|_, user| user.domain_id.as_deref() == Some("scoped-did"))
+        .returning(|_, _| {
+            Ok(UserResponseBuilder::default()
+                .id("id")
+                .domain_id("scoped-did")
+                .enabled(true)
+                .name("uname")
+                .build()
+                .unwrap())
+        });
+    let provider = IdentityService::from_driver(backend);
+    let vsc = make_vsc_scoped(ScopeInfo::Domain(make_domain("scoped-did")));
+    let ctx = ExecutionContext::from_auth(&state, &vsc);
+
+    let created = provider
+        .create_user(
+            &ctx,
+            UserCreateBuilder::default().name("uname").build().unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.domain_id, "scoped-did");
+}
+
+#[tokio::test]
+async fn test_get_user() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_user()
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| {
+            Ok(Some(
+                UserResponseBuilder::default()
+                    .id("id")
+                    .domain_id("domain_id")
+                    .enabled(true)
+                    .name("name")
+                    .build()
+                    .unwrap(),
+            ))
+        });
+    let provider = IdentityService::from_driver(backend);
+
+    assert_eq!(
+        provider
+            .get_user(&ExecutionContext::internal(&state), "uid")
+            .await
+            .unwrap()
+            .expect("user should be there"),
+        UserResponseBuilder::default()
+            .domain_id("domain_id")
+            .enabled(true)
+            .id("id")
+            .name("name")
+            .build()
+            .unwrap(),
+    );
+}
+
+#[tokio::test]
+async fn test_get_user_domain_id() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_user_domain_id()
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .times(2) // only 2 times
+        .returning(|_, _| Ok("did".into()));
+    backend
+        .expect_get_user_domain_id()
+        .withf(|_, uid: &'_ str| uid == "missing")
+        .returning(|_, _| Err(IdentityProviderError::UserNotFound("missing".into())));
+    let mut provider = IdentityService::from_driver(backend);
+    provider.caching = true;
+
+    assert_eq!(
+        provider
+            .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
+            .await
+            .unwrap(),
+        "did"
+    );
+    assert_eq!(
+        provider
+            .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
+            .await
+            .unwrap(),
+        "did",
+        "second time data extracted from cache"
+    );
+    assert!(
+        provider
+            .get_user_domain_id(&ExecutionContext::internal(&state), "missing")
+            .await
+            .is_err()
+    );
+    provider.caching = false;
+    assert_eq!(
+        provider
+            .get_user_domain_id(&ExecutionContext::internal(&state), "uid")
+            .await
+            .unwrap(),
+        "did",
+        "third time backend is again triggered causing total of 2 invocations"
+    );
+}
+
+#[tokio::test]
+async fn test_delete_user() {
+    let mut credential_mock = MockCredentialProvider::default();
+    credential_mock
+        .expect_delete_credentials_for_user()
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(()));
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_credential(credential_mock)),
+    )
+    .await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_delete_user()
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(()));
+    let provider = IdentityService::from_driver(backend);
+
+    assert!(
+        provider
+            .delete_user(&ExecutionContext::internal(&state), "uid")
+            .await
+            .is_ok()
+    );
+}
+
+/// RFC 6238 Appendix B seed/passcode used across the TOTP tests below,
+/// with an oversized `period` so the resulting HOTP counter (`now /
+/// period`) stays `0` for the foreseeable future regardless of the
+/// wall-clock time the test actually runs at.
+fn totp_credential(user_id: &str) -> Credential {
+    CredentialBuilder::default()
+        .id("cred_id")
+        .blob(
+            json!({
+                "seed": "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ",
+                "digits": 8,
+                "period": 10_000_000_000u64,
+            })
+            .to_string(),
+        )
+        .r#type("totp")
+        .user_id(user_id)
+        .build()
+        .unwrap()
+}
+
+const TOTP_PASSCODE_COUNTER_0: &str = "84755224";
+
+fn totp_user(user_id: &str, domain_id: &str, enabled: bool) -> UserResponse {
+    UserResponseBuilder::default()
+        .id(user_id)
+        .domain_id(domain_id)
+        .enabled(enabled)
+        .name("uname")
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_authenticate_by_totp_success_by_id() {
+    let mut credential_mock = MockCredentialProvider::default();
+    credential_mock
+        .expect_list_credentials_for_user()
+        .withf(|_, uid: &'_ str, r#type: &Option<&str>| uid == "uid" && *r#type == Some("totp"))
+        .returning(|_, _, _| Ok(vec![totp_credential("uid")]));
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_credential(credential_mock)),
+    )
+    .await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .withf(|_, id, name, domain| *id == Some("uid") && name.is_none() && domain.is_none())
+        .returning(|_, _, _, _| Ok("uid".to_string()));
+    backend
+        .expect_get_user()
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(Some(totp_user("uid", "did", true))));
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_totp(
+            &ExecutionContext::internal(&state),
+            &UserTotpAuthRequestBuilder::default()
+                .id("uid")
+                .passcode(TOTP_PASSCODE_COUNTER_0)
+                .build()
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.context, AuthenticationContext::Totp);
+    assert_eq!(result.principal.get_user_id(), "uid");
+}
+
+/// ADR-0022 Invariants 4 and 8 on the TOTP path: the per-user bucket is
+/// keyed on the confirmed user ID and fires before any credential is
+/// listed or passcode verified. The bucket is exhausted directly through
+/// `check_user` (simulating a prior authentication attempt) so timing
+/// cannot replenish it mid-test.
+#[tokio::test]
+async fn test_authenticate_by_totp_rate_limited() {
+    let mut credential_mock = MockCredentialProvider::default();
+    // Rejected before verification: credentials must never be listed.
+    credential_mock.expect_list_credentials_for_user().times(0);
+    let mut config = openstack_keystone_config::Config::default();
+    config.rate_limit_user_auth = openstack_keystone_config::RateLimitSection {
+        enabled: true,
+        burst_size: 1,
+        replenish_rate_per_second: 1,
+    };
+    let state = get_mocked_state(
+        Some(config),
+        Some(Provider::mocked_builder().mock_credential(credential_mock)),
+    )
+    .await;
+    assert!(state.rate_limiters.check_user("uid").is_ok());
+
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .returning(|_, _, _, _| Ok("uid".to_string()));
+    // Rejected before the full user is ever loaded.
+    backend.expect_get_user().times(0);
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_totp(
+            &ExecutionContext::internal(&state),
+            &UserTotpAuthRequestBuilder::default()
+                .id("uid")
+                .passcode(TOTP_PASSCODE_COUNTER_0)
+                .build()
+                .unwrap(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(IdentityProviderError::TooManyRequests { retry_after_secs }) if retry_after_secs >= 1
+    ));
+}
+
+#[tokio::test]
+async fn test_authenticate_by_totp_wrong_passcode() {
+    let mut credential_mock = MockCredentialProvider::default();
+    credential_mock
+        .expect_list_credentials_for_user()
+        .returning(|_, _, _| Ok(vec![totp_credential("uid")]));
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_credential(credential_mock)),
+    )
+    .await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .returning(|_, _, _, _| Ok("uid".to_string()));
+    backend
+        .expect_get_user()
+        .returning(|_, _| Ok(Some(totp_user("uid", "did", true))));
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_totp(
+            &ExecutionContext::internal(&state),
+            &UserTotpAuthRequestBuilder::default()
+                .id("uid")
+                .passcode("00000000")
+                .build()
+                .unwrap(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(IdentityProviderError::Authentication {
+            source: AuthenticationError::TotpPasscodeInvalid
+        })
+    ));
+}
+
+#[tokio::test]
+async fn test_authenticate_by_totp_no_credentials() {
+    let mut credential_mock = MockCredentialProvider::default();
+    credential_mock
+        .expect_list_credentials_for_user()
+        .returning(|_, _, _| Ok(vec![]));
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_credential(credential_mock)),
+    )
+    .await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .returning(|_, _, _, _| Ok("uid".to_string()));
+    backend
+        .expect_get_user()
+        .returning(|_, _| Ok(Some(totp_user("uid", "did", true))));
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_totp(
+            &ExecutionContext::internal(&state),
+            &UserTotpAuthRequestBuilder::default()
+                .id("uid")
+                .passcode(TOTP_PASSCODE_COUNTER_0)
+                .build()
+                .unwrap(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(IdentityProviderError::Authentication {
+            source: AuthenticationError::TotpPasscodeInvalid
+        })
+    ));
+}
+
+#[tokio::test]
+async fn test_authenticate_by_totp_user_disabled() {
+    let mut credential_mock = MockCredentialProvider::default();
+    credential_mock.expect_list_credentials_for_user().times(0);
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_credential(credential_mock)),
+    )
+    .await;
+    let mut backend = MockIdentityBackend::default();
+    // The cheap probe rejects the disabled account before any credential
+    // work; the full user is never loaded.
+    backend
+        .expect_check_user_exist()
+        .returning(|_, _, _, _| Err(AuthenticationError::UserDisabled("uid".into()).into()));
+    backend.expect_get_user().times(0);
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_totp(
+            &ExecutionContext::internal(&state),
+            &UserTotpAuthRequestBuilder::default()
+                .id("uid")
+                .passcode(TOTP_PASSCODE_COUNTER_0)
+                .build()
+                .unwrap(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(IdentityProviderError::Authentication {
+            source: AuthenticationError::UserDisabled(id)
+        }) if id == "uid"
+    ));
+}
+
+#[tokio::test]
+async fn test_authenticate_by_totp_user_not_found() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .returning(|_, _, _, _| Err(IdentityProviderError::UserNotFound("uid".into())));
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_totp(
+            &ExecutionContext::internal(&state),
+            &UserTotpAuthRequestBuilder::default()
+                .id("uid")
+                .passcode(TOTP_PASSCODE_COUNTER_0)
+                .build()
+                .unwrap(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(IdentityProviderError::Authentication {
+            source: AuthenticationError::TotpPasscodeInvalid
+        })
+    ));
+}
+
+#[tokio::test]
+async fn test_authenticate_by_totp_success_by_name_and_domain() {
+    let mut credential_mock = MockCredentialProvider::default();
+    credential_mock
+        .expect_list_credentials_for_user()
+        .withf(|_, uid: &'_ str, r#type: &Option<&str>| uid == "uid" && *r#type == Some("totp"))
+        .returning(|_, _, _| Ok(vec![totp_credential("uid")]));
+    let mut resource_mock = MockResourceProvider::default();
+    resource_mock
+        .expect_find_domain_by_name()
+        .withf(|_, name: &'_ str| name == "dname")
+        .returning(|_, _| {
+            Ok(Some(openstack_keystone_core_types::resource::Domain {
+                id: "did".into(),
+                enabled: true,
+                ..Default::default()
+            }))
+        });
+    let state = get_mocked_state(
+        None,
+        Some(
+            Provider::mocked_builder()
+                .mock_credential(credential_mock)
+                .mock_resource(resource_mock),
+        ),
+    )
+    .await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .withf(|_, id, name, domain| {
+            id.is_none() && *name == Some("uname_lookup") && *domain == Some("did")
+        })
+        .returning(|_, _, _, _| Ok("uid".to_string()));
+    backend
+        .expect_get_user()
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(Some(totp_user("uid", "did", true))));
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_totp(
+            &ExecutionContext::internal(&state),
+            &UserTotpAuthRequestBuilder::default()
+                .name("uname_lookup")
+                .domain(DomainBuilder::default().name("dname").build().unwrap())
+                .passcode(TOTP_PASSCODE_COUNTER_0)
+                .build()
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.context, AuthenticationContext::Totp);
+    assert_eq!(result.principal.get_user_id(), "uid");
+}
+
+/// ADR-0022 Invariants 4 and 8 at the provider level: the enabled
+/// per-user bucket is keyed on the ID resolved by the cheap probe and
+/// fires before the backend performs any password verification. The
+/// bucket is exhausted directly through `check_user` (simulating a prior
+/// attempt) so timing cannot replenish it mid-test.
+#[tokio::test]
+async fn test_authenticate_by_password_rate_limited() {
+    let mut config = openstack_keystone_config::Config::default();
+    config.rate_limit_user_auth = openstack_keystone_config::RateLimitSection {
+        enabled: true,
+        burst_size: 1,
+        replenish_rate_per_second: 1,
+    };
+    let state = get_mocked_state(Some(config), None).await;
+    assert!(state.rate_limiters.check_user("uid").is_ok());
+
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .withf(|_, id, name, domain| *id == Some("uid") && name.is_none() && domain.is_none())
+        .returning(|_, _, _, _| Ok("uid".to_string()));
+    // The expensive backend authentication must never be reached.
+    backend.expect_authenticate_by_password().times(0);
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_password(
+            &ExecutionContext::internal(&state),
+            &UserPasswordAuthRequest {
+                id: Some("uid".into()),
+                password: "pass".into(),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(IdentityProviderError::TooManyRequests { retry_after_secs }) if retry_after_secs >= 1
+    ));
+}
+
+/// ADR-0022 Invariant 8: unknown users never touch the limiter store.
+/// The probe misses and the request falls through to the backend, which
+/// keeps the uniform dummy-hash credentials error — never a 429 — no
+/// matter how often it is retried.
+#[tokio::test]
+async fn test_authenticate_by_password_unknown_user_uniform_error() {
+    let mut config = openstack_keystone_config::Config::default();
+    config.rate_limit_user_auth = openstack_keystone_config::RateLimitSection {
+        enabled: true,
+        burst_size: 1,
+        replenish_rate_per_second: 1,
+    };
+    let state = get_mocked_state(Some(config), None).await;
+
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .returning(|_, _, _, _| Err(IdentityProviderError::UserNotFound("ghost".into())));
+    backend
+        .expect_authenticate_by_password()
+        .times(2)
+        .returning(|_, _| Err(AuthenticationError::UserNameOrPasswordWrong.into()));
+    let provider = IdentityService::from_driver(backend);
+
+    for _ in 0..2 {
+        let result = provider
+            .authenticate_by_password(
+                &ExecutionContext::internal(&state),
+                &UserPasswordAuthRequest {
+                    id: Some("ghost".into()),
+                    password: "pass".into(),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(IdentityProviderError::Authentication {
+                source: AuthenticationError::UserNameOrPasswordWrong
+            })
+        ));
+    }
+}
+
+/// With the bucket disabled (the default), the probe is skipped
+/// entirely: rate limiting adds no extra query to the authentication
+/// hot path.
+#[tokio::test]
+async fn test_authenticate_by_password_probe_skipped_when_disabled() {
+    let state = get_mocked_state(None, None).await;
+
+    let mut backend = MockIdentityBackend::default();
+    backend.expect_check_user_exist().times(0);
+    backend
+        .expect_authenticate_by_password()
+        .once()
+        .returning(|_, _| Err(AuthenticationError::UserNameOrPasswordWrong.into()));
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_password(
+            &ExecutionContext::internal(&state),
+            &UserPasswordAuthRequest {
+                id: Some("uid".into()),
+                password: "pass".into(),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(IdentityProviderError::Authentication {
+            source: AuthenticationError::UserNameOrPasswordWrong
+        })
+    ));
+}
+
+/// Within quota the request proceeds to the backend normally.
+#[tokio::test]
+async fn test_authenticate_by_password_within_quota_reaches_backend() {
+    let mut config = openstack_keystone_config::Config::default();
+    config.rate_limit_user_auth = openstack_keystone_config::RateLimitSection {
+        enabled: true,
+        burst_size: 100,
+        replenish_rate_per_second: 10,
+    };
+    let state = get_mocked_state(Some(config), None).await;
+
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_check_user_exist()
+        .returning(|_, _, _, _| Ok("uid".to_string()));
+    backend
+        .expect_authenticate_by_password()
+        .once()
+        .returning(|_, _| Err(AuthenticationError::UserNameOrPasswordWrong.into()));
+    let provider = IdentityService::from_driver(backend);
+
+    let result = provider
+        .authenticate_by_password(
+            &ExecutionContext::internal(&state),
+            &UserPasswordAuthRequest {
+                id: Some("uid".into()),
+                password: "pass".into(),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(IdentityProviderError::Authentication {
+            source: AuthenticationError::UserNameOrPasswordWrong
+        })
+    ));
+}
+
+/// Password regex rejects invalid password on user creation.
+#[tokio::test]
+async fn test_create_user_password_regex_rejected() {
+    let config = get_config_with_password_regex(r"^.{7,}$");
+    let state = get_mocked_state(Some(config), None).await;
+    let provider = IdentityService::from_driver(MockIdentityBackend::default());
+
+    let result = provider
+        .create_user(
+            &ExecutionContext::internal(&state),
+            UserCreateBuilder::default()
+                .name("uname")
+                .domain_id("did")
+                .password("short")
+                .build()
+                .unwrap(),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(IdentityProviderError::SecurityCompliance(..))),
+        "expected SecurityCompliance error for invalid password"
+    );
+}
+
+/// Password regex accepts valid password on user creation and backend is
+/// invoked.
+#[tokio::test]
+async fn test_create_user_password_regex_accepted() {
+    let config = get_config_with_password_regex(r"^.{3,}$");
+    let state = get_mocked_state(Some(config), None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend.expect_create_user().returning(|_, _| {
+        Ok(UserResponseBuilder::default()
+            .id("id")
+            .domain_id("domain_id")
+            .enabled(true)
+            .name("name")
+            .build()
+            .unwrap())
+    });
+    let provider = IdentityService::from_driver(backend);
+
+    assert!(
+        provider
+            .create_user(
+                &ExecutionContext::internal(&state),
+                UserCreateBuilder::default()
+                    .name("uname")
+                    .domain_id("did")
+                    .password("Abc1")
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .is_ok(),
+        "password matching regex should reach backend"
+    );
+}
+
+/// No password on user creation skips validation and backend is invoked.
+#[tokio::test]
+async fn test_create_user_no_password() {
+    let config = get_config_with_password_regex(r"^.{7,}$");
+    let state = get_mocked_state(Some(config), None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend.expect_create_user().returning(|_, _| {
+        Ok(UserResponseBuilder::default()
+            .id("id")
+            .domain_id("domain_id")
+            .enabled(true)
+            .name("name")
+            .build()
+            .unwrap())
+    });
+    let provider = IdentityService::from_driver(backend);
+
+    assert!(
+        provider
+            .create_user(
+                &ExecutionContext::internal(&state),
+                UserCreateBuilder::default()
+                    .name("uname")
+                    .domain_id("did")
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .is_ok(),
+        "no password should skip validation"
+    );
+}
+
+/// Password regex rejects invalid password on user update.
+#[tokio::test]
+async fn test_update_user_password_regex_rejected() {
+    let config = get_config_with_password_regex(r"^.{7,}$");
+    let state = get_mocked_state(Some(config), None).await;
+    let provider = IdentityService::from_driver(MockIdentityBackend::default());
+
+    let result = provider
+        .update_user(
+            &ExecutionContext::internal(&state),
+            "uid",
+            UserUpdateBuilder::default()
+                .password("short")
+                .build()
+                .unwrap(),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(IdentityProviderError::SecurityCompliance(..))),
+        "expected SecurityCompliance error for invalid password on update"
+    );
+}
+
+/// Password regex accepts valid password on user update and backend is
+/// invoked.
+#[tokio::test]
+async fn test_update_user_password_regex_accepted() {
+    let config = get_config_with_password_regex(r"^.{3,}$");
+    let state = get_mocked_state(Some(config), None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_update_user()
+        .returning(|_, _: &'_ str, _: UserUpdate| {
+            Ok(UserResponseBuilder::default()
+                .id("id")
+                .domain_id("domain_id")
+                .enabled(true)
+                .name("name")
+                .build()
+                .unwrap())
+        });
+    let provider = IdentityService::from_driver(backend);
+
+    assert!(
+        provider
+            .update_user(
+                &ExecutionContext::internal(&state),
+                "uid",
+                UserUpdateBuilder::default()
+                    .password("Abc1")
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .is_ok(),
+        "password matching regex on update should reach backend"
+    );
+}
+
+/// No password on user update skips validation and backend is invoked.
+#[tokio::test]
+async fn test_update_user_no_password() {
+    let config = get_config_with_password_regex(r"^.{7,}$");
+    let state = get_mocked_state(Some(config), None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_update_user()
+        .returning(|_, _: &'_ str, _: UserUpdate| {
+            Ok(UserResponseBuilder::default()
+                .id("id")
+                .domain_id("domain_id")
+                .enabled(true)
+                .name("name")
+                .build()
+                .unwrap())
+        });
+    let provider = IdentityService::from_driver(backend);
+
+    assert!(
+        provider
+            .update_user(
+                &ExecutionContext::internal(&state),
+                "uid",
+                UserUpdateBuilder::default()
+                    .name("new_name")
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .is_ok(),
+        "no password on update should skip validation"
+    );
+}
+
+// --- Per-request cache (ADR 0030) -------------------------------------
+
+use openstack_keystone_core_types::identity::{GroupBuilder, GroupUpdate};
+
+fn make_user(id: &str) -> UserResponse {
+    UserResponseBuilder::default()
+        .id(id)
+        .domain_id("did")
+        .enabled(true)
+        .name(format!("{id}-name"))
+        .build()
+        .unwrap()
+}
+
+fn make_group(id: &str) -> Group {
+    GroupBuilder::default()
+        .id(id)
+        .domain_id("did")
+        .name(format!("{id}-name"))
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_get_user_hits_backend_once_across_repeated_calls() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_user()
+        .times(1)
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(Some(make_user("uid"))));
+    let provider = IdentityService::from_driver(backend);
+
+    crate::request_cache::RequestCache::scope(async {
+        let ctx = ExecutionContext::internal(&state);
+        let first = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
+        let second = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
+        assert_eq!(first, second);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_get_user_not_cached_outside_request_scope() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_user()
+        .times(2)
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(Some(make_user("uid"))));
+    let provider = IdentityService::from_driver(backend);
+
+    let ctx = ExecutionContext::internal(&state);
+    provider.get_user(&ctx, "uid").await.unwrap();
+    provider.get_user(&ctx, "uid").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_update_user_refreshes_cache_instead_of_refetching() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_user()
+        .times(1)
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(Some(make_user("uid"))));
+    backend
+        .expect_update_user()
+        .withf(|_, uid: &'_ str, _| uid == "uid")
+        .returning(|_, _, update| {
+            let mut u = make_user("uid");
+            if let Some(name) = update.name {
+                u.name = name;
+            }
+            Ok(u)
+        });
+    let provider = IdentityService::from_driver(backend);
+
+    crate::request_cache::RequestCache::scope(async {
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_user(&ctx, "uid").await.unwrap();
+
+        let updated = provider
+            .update_user(
+                &ctx,
+                "uid",
+                UserUpdateBuilder::default()
+                    .name("renamed".to_string())
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated.name, "renamed");
+
+        let refetched = provider.get_user(&ctx, "uid").await.unwrap().unwrap();
+        assert_eq!(refetched.name, "renamed");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_delete_user_invalidates_cache() {
+    let mut credential_mock = MockCredentialProvider::default();
+    credential_mock
+        .expect_delete_credentials_for_user()
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(()));
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_credential(credential_mock)),
+    )
+    .await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_user()
+        .times(2)
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(Some(make_user("uid"))));
+    backend
+        .expect_delete_user()
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(()));
+    let provider = IdentityService::from_driver(backend);
+
+    crate::request_cache::RequestCache::scope(async {
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_user(&ctx, "uid").await.unwrap();
+        provider.delete_user(&ctx, "uid").await.unwrap();
+        provider.get_user(&ctx, "uid").await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_update_user_password_invalidates_cache() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_user()
+        .times(2)
+        .withf(|_, uid: &'_ str| uid == "uid")
+        .returning(|_, _| Ok(Some(make_user("uid"))));
+    backend
+        .expect_update_user_password()
+        .withf(|_, uid: &'_ str, _, _| uid == "uid")
+        .returning(|_, _, _, _| Ok(()));
+    let provider = IdentityService::from_driver(backend);
+
+    crate::request_cache::RequestCache::scope(async {
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_user(&ctx, "uid").await.unwrap();
+        provider
+            .update_user_password(
+                &ctx,
+                "uid",
+                SecretString::from("orig".to_string()),
+                SecretString::from("newpassword".to_string()),
+            )
+            .await
+            .unwrap();
+        // `update_user_password` doesn't return a fresh `UserResponse`
+        // to refresh the cache with -- the cached entry must instead be
+        // invalidated so `password_expires_at` isn't served stale.
+        provider.get_user(&ctx, "uid").await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_get_group_hits_backend_once_across_repeated_calls() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_group()
+        .times(1)
+        .withf(|_, gid: &'_ str| gid == "gid")
+        .returning(|_, _| Ok(Some(make_group("gid"))));
+    let provider = IdentityService::from_driver(backend);
+
+    crate::request_cache::RequestCache::scope(async {
+        let ctx = ExecutionContext::internal(&state);
+        let first = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
+        let second = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
+        assert_eq!(first, second);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_get_group_not_cached_outside_request_scope() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_group()
+        .times(2)
+        .withf(|_, gid: &'_ str| gid == "gid")
+        .returning(|_, _| Ok(Some(make_group("gid"))));
+    let provider = IdentityService::from_driver(backend);
+
+    let ctx = ExecutionContext::internal(&state);
+    provider.get_group(&ctx, "gid").await.unwrap();
+    provider.get_group(&ctx, "gid").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_update_group_refreshes_cache_instead_of_refetching() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_group()
+        .times(1)
+        .withf(|_, gid: &'_ str| gid == "gid")
+        .returning(|_, _| Ok(Some(make_group("gid"))));
+    backend
+        .expect_update_group()
+        .withf(|_, gid: &'_ str, _| gid == "gid")
+        .returning(|_, _, update| {
+            let mut g = make_group("gid");
+            if let Some(name) = update.name {
+                g.name = name;
+            }
+            Ok(g)
+        });
+    let provider = IdentityService::from_driver(backend);
+
+    crate::request_cache::RequestCache::scope(async {
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_group(&ctx, "gid").await.unwrap();
+
+        let updated = provider
+            .update_group(
+                &ctx,
+                "gid",
+                GroupUpdate {
+                    name: Some("renamed".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated.name, "renamed");
+
+        let refetched = provider.get_group(&ctx, "gid").await.unwrap().unwrap();
+        assert_eq!(refetched.name, "renamed");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_delete_group_invalidates_cache() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockIdentityBackend::default();
+    backend
+        .expect_get_group()
+        .times(2)
+        .withf(|_, gid: &'_ str| gid == "gid")
+        .returning(|_, _| Ok(Some(make_group("gid"))));
+    backend
+        .expect_delete_group()
+        .withf(|_, gid: &'_ str| gid == "gid")
+        .returning(|_, _| Ok(()));
+    let provider = IdentityService::from_driver(backend);
+
+    crate::request_cache::RequestCache::scope(async {
+        let ctx = ExecutionContext::internal(&state);
+        provider.get_group(&ctx, "gid").await.unwrap();
+        provider.delete_group(&ctx, "gid").await.unwrap();
+        provider.get_group(&ctx, "gid").await.unwrap();
+    })
+    .await;
+}
+
+#[path = "tests/per_domain_dispatch.rs"]
+mod per_domain_dispatch;

--- a/crates/core/src/identity/service/tests/per_domain_dispatch.rs
+++ b/crates/core/src/identity/service/tests/per_domain_dispatch.rs
@@ -1,0 +1,757 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-domain identity driver dispatch unit tests.
+//!
+//! Split out of `service.rs::tests`. Covers `DomainConfigResolver` consultation,
+//! per-domain resolution caching, the id-mapping public-id lookup, the two
+//! ported python-keystone guards (`is_domain_aware`/`DomainNotFound`,
+//! `CrossBackendNotAllowed`), and password-auth dispatch.
+
+use openstack_keystone_core_types::domain_config::DomainConfig;
+
+use super::*;
+use crate::domain_config::DomainConfigResolver;
+use crate::domain_config::backend::MockDomainConfigBackend;
+use crate::domain_config::error::DomainConfigProviderError;
+
+/// A domain-config `sql` source whose `get_domain_config` answers
+/// `answer` (cloned) every call, expected `calls` times.
+fn config_source(
+    answer: Result<Option<DomainConfig>, DomainConfigProviderError>,
+    calls: usize,
+) -> Arc<dyn crate::domain_config::backend::DomainConfigBackend> {
+    let mut mock = MockDomainConfigBackend::new();
+    mock.expect_get_domain_config()
+        .times(calls)
+        .returning(move |_, _| match &answer {
+            Ok(maybe) => Ok(maybe.clone()),
+            Err(err) => Err(DomainConfigProviderError::Driver(err.to_string())),
+        });
+    Arc::new(mock)
+}
+
+/// A resolver whose database source is `source`.
+fn resolver(
+    source: Arc<dyn crate::domain_config::backend::DomainConfigBackend>,
+) -> Arc<DomainConfigResolver> {
+    Arc::new(DomainConfigResolver::from_sources(None, Some(source)))
+}
+
+/// An identity list backend that only ever answers an empty list, and
+/// only when `calls` says it should be reached.
+fn identity_backend(calls: usize) -> Arc<dyn IdentityBackend> {
+    let mut mock = MockIdentityBackend::default();
+    mock.expect_is_domain_aware().return_const(true);
+    mock.expect_list_users()
+        .times(calls)
+        .returning(|_, _| Ok(Vec::new()));
+    Arc::new(mock)
+}
+
+fn list_params(domain_id: &str) -> UserListParameters {
+    UserListParametersBuilder::default()
+        .domain_id(Some(domain_id.to_owned()))
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn resolver_absent_uses_the_global_driver() {
+    // `from_driver` leaves `domain_config_resolver` `None`: even a
+    // domain-scoped list must never touch a resolver.
+    let state = get_mocked_state(None, None).await;
+    let provider = IdentityService::from_driver(identity_backend_owned());
+    provider
+        .list_users(&ExecutionContext::internal(&state), &list_params("d1"))
+        .await
+        .unwrap();
+}
+
+fn identity_backend_owned() -> MockIdentityBackend {
+    let mut mock = MockIdentityBackend::default();
+    mock.expect_is_domain_aware().return_const(true);
+    mock.expect_list_users().returning(|_, _| Ok(Vec::new()));
+    mock
+}
+
+#[tokio::test]
+async fn stored_driver_selects_the_named_backend() {
+    let state = get_mocked_state(None, None).await;
+    let sql = identity_backend(0);
+    let ldap = identity_backend(1);
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider = IdentityService::from_backends(
+        "sql",
+        sql,
+        backends,
+        Some(resolver(config_source(
+            Ok(Some(
+                DomainConfig::from_value(json!({"identity": {"driver": "ldap"}}))
+                    .expect("valid config"),
+            )),
+            1,
+        ))),
+    );
+
+    provider
+        .list_users(&ExecutionContext::internal(&state), &list_params("d-ldap"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn empty_stored_config_uses_the_global_driver() {
+    let state = get_mocked_state(None, None).await;
+    let sql = identity_backend(1);
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    let provider = IdentityService::from_backends(
+        "sql",
+        sql,
+        backends,
+        Some(resolver(config_source(Ok(None), 1))),
+    );
+
+    provider
+        .list_users(&ExecutionContext::internal(&state), &list_params("d-none"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn the_resolution_is_cached_per_domain() {
+    let state = get_mocked_state(None, None).await;
+    let sql = identity_backend(0);
+    let ldap = identity_backend(2);
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    // The source is expected exactly once for two identical lists.
+    let provider = IdentityService::from_backends(
+        "sql",
+        sql,
+        backends,
+        Some(resolver(config_source(
+            Ok(Some(
+                DomainConfig::from_value(json!({"identity": {"driver": "ldap"}}))
+                    .expect("valid config"),
+            )),
+            1,
+        ))),
+    );
+
+    let ctx = ExecutionContext::internal(&state);
+    provider
+        .list_users(&ctx, &list_params("d-ldap"))
+        .await
+        .unwrap();
+    provider
+        .list_users(&ctx, &list_params("d-ldap"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_resolver_error_falls_back_to_the_global_driver() {
+    let state = get_mocked_state(None, None).await;
+    let sql = identity_backend(1);
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    let provider = IdentityService::from_backends(
+        "sql",
+        sql,
+        backends,
+        Some(resolver(config_source(
+            Err(DomainConfigProviderError::Driver("boom".to_string())),
+            1,
+        ))),
+    );
+
+    provider
+        .list_users(
+            &ExecutionContext::internal(&state),
+            &list_params("d-broken"),
+        )
+        .await
+        .unwrap();
+}
+
+use openstack_keystone_core_types::idmapping::{IdMapping, IdMappingEntityType};
+
+use crate::idmapping::MockIdMappingProvider;
+
+/// An identity backend that only ever answers `get_user` -> `None`,
+/// and only when `calls` says it should be reached.
+fn get_user_backend(calls: usize) -> Arc<dyn IdentityBackend> {
+    let mut mock = MockIdentityBackend::default();
+    mock.expect_is_domain_aware().return_const(true);
+    mock.expect_get_user()
+        .times(calls)
+        .returning(|_, _| Ok(None));
+    Arc::new(mock)
+}
+
+/// A state whose id-mapping provider answers `get_by_public_id` with
+/// `answer` (cloned) every call.
+async fn state_with_idmapping(answer: Option<IdMapping>) -> ServiceState {
+    let mut mock = MockIdMappingProvider::default();
+    mock.expect_get_by_public_id()
+        .returning(move |_, _| Ok(answer.clone()));
+    get_mocked_state(None, Some(Provider::mocked_builder().mock_idmapping(mock))).await
+}
+
+#[tokio::test]
+async fn an_unmapped_id_uses_the_global_driver() {
+    // python-keystone `_get_domain_driver_and_entity_id`: a public id
+    // with no id-mapping row is owned by the default driver. The
+    // domain's stored `ldap` config must not be consulted and the
+    // entity must not be re-routed by re-deriving its domain.
+    let state = state_with_idmapping(None).await;
+    let sql = get_user_backend(1);
+    let ldap = get_user_backend(0);
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider = IdentityService::from_backends(
+        "sql",
+        sql,
+        backends,
+        Some(resolver(config_source(
+            Ok(Some(
+                DomainConfig::from_value(json!({"identity": {"driver": "ldap"}}))
+                    .expect("valid config"),
+            )),
+            0,
+        ))),
+    );
+
+    provider
+        .get_user(&ExecutionContext::internal(&state), "u-sql")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_mapped_id_uses_its_domain_driver() {
+    // A public id carried in the id mapping is owned by that domain's
+    // configured driver.
+    let state = state_with_idmapping(Some(IdMapping {
+        domain_id: "d-ldap".to_string(),
+        entity_type: IdMappingEntityType::User,
+        local_id: "local".to_string(),
+        public_id: "pub-id".to_string(),
+    }))
+    .await;
+    let sql = get_user_backend(0);
+    let ldap = get_user_backend(1);
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider = IdentityService::from_backends(
+        "sql",
+        sql,
+        backends,
+        Some(resolver(config_source(
+            Ok(Some(
+                DomainConfig::from_value(json!({"identity": {"driver": "ldap"}}))
+                    .expect("valid config"),
+            )),
+            1,
+        ))),
+    );
+
+    provider
+        .get_user(&ExecutionContext::internal(&state), "pub-id")
+        .await
+        .unwrap();
+}
+
+/// A global identity backend that is not domain aware (LDAP-like) and
+/// answers `list_users` only `list_calls` times.
+fn non_domain_aware_backend(list_calls: usize) -> Arc<dyn IdentityBackend> {
+    let mut mock = MockIdentityBackend::default();
+    mock.expect_is_domain_aware().return_const(false);
+    mock.expect_list_users()
+        .times(list_calls)
+        .returning(|_, _| Ok(Vec::new()));
+    Arc::new(mock)
+}
+
+#[tokio::test]
+async fn a_foreign_domain_on_a_non_domain_aware_global_driver_is_rejected() {
+    // python-keystone `_select_identity_driver`: a single non-domain
+    // aware directory (LDAP) as the global driver cannot represent a
+    // domain other than `default`.
+    let state = get_mocked_state(None, None).await;
+    let ldap = non_domain_aware_backend(0);
+    let mut backends = HashMap::new();
+    backends.insert("ldap".to_string(), ldap.clone());
+    let provider = IdentityService::from_backends(
+        "ldap",
+        ldap,
+        backends,
+        Some(resolver(config_source(Ok(None), 1))),
+    );
+
+    let error = provider
+        .list_users(&ExecutionContext::internal(&state), &list_params("d2"))
+        .await
+        .expect_err("a foreign domain must be rejected");
+    assert!(
+        matches!(
+            error,
+            IdentityProviderError::ResourceProvider {
+                source: ResourceProviderError::DomainNotFound(_)
+            }
+        ),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_default_domain_on_a_non_domain_aware_global_driver_is_allowed() {
+    let state = get_mocked_state(None, None).await;
+    let ldap = non_domain_aware_backend(1);
+    let mut backends = HashMap::new();
+    backends.insert("ldap".to_string(), ldap.clone());
+    let provider = IdentityService::from_backends(
+        "ldap",
+        ldap,
+        backends,
+        Some(resolver(config_source(Ok(None), 1))),
+    );
+
+    // `from_backends` sets `default_domain_id` to "default".
+    provider
+        .list_users(&ExecutionContext::internal(&state), &list_params("default"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_cross_backend_membership_is_rejected() {
+    // python-keystone `_assert_user_and_group_in_same_backend`: the
+    // user resolves to LDAP (mapped), the group to the global SQL
+    // driver (unmapped) -> 403 CrossBackendNotAllowed, after both
+    // entities are confirmed to exist.
+    let mut idmapping = MockIdMappingProvider::default();
+    idmapping
+        .expect_get_by_public_id()
+        .returning(|_, public_id| {
+            Ok((public_id == "u").then(|| IdMapping {
+                domain_id: "d-ldap".to_string(),
+                entity_type: IdMappingEntityType::User,
+                local_id: "u".to_string(),
+                public_id: "u".to_string(),
+            }))
+        });
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_idmapping(idmapping)),
+    )
+    .await;
+
+    let mut sql_mock = MockIdentityBackend::default();
+    sql_mock.expect_is_domain_aware().return_const(true);
+    sql_mock.expect_get_group().returning(|_, group_id| {
+        Ok(Some(
+            openstack_keystone_core_types::identity::GroupBuilder::default()
+                .id(group_id)
+                .domain_id("default")
+                .name("g-name")
+                .build()
+                .expect("valid group"),
+        ))
+    });
+    let sql: Arc<dyn IdentityBackend> = Arc::new(sql_mock);
+
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(false);
+    ldap_mock.expect_get_user().returning(|_, user_id| {
+        Ok(Some(
+            UserResponseBuilder::default()
+                .id(user_id)
+                .domain_id("d-ldap")
+                .enabled(true)
+                .name("u-name")
+                .build()
+                .expect("valid user"),
+        ))
+    });
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider = IdentityService::from_backends(
+        "sql",
+        sql,
+        backends,
+        Some(resolver(config_source(
+            Ok(Some(
+                DomainConfig::from_value(json!({"identity": {"driver": "ldap"}}))
+                    .expect("valid config"),
+            )),
+            1,
+        ))),
+    );
+
+    let error = provider
+        .add_user_to_group(&ExecutionContext::internal(&state), "u", "g")
+        .await
+        .expect_err("a cross-backend membership must be rejected");
+    assert!(
+        matches!(error, IdentityProviderError::CrossBackendNotAllowed { .. }),
+        "unexpected error: {error:?}"
+    );
+}
+
+/// Build a state whose id-mapping provider answers `get_by_public_id`
+/// by calling `f` with the queried public id.
+async fn state_with_mapping_fn(
+    f: impl Fn(&str) -> Option<IdMapping> + Send + Sync + 'static,
+) -> ServiceState {
+    let mut mock = MockIdMappingProvider::default();
+    mock.expect_get_by_public_id()
+        .returning(move |_, public_id| Ok(f(public_id)));
+    get_mocked_state(None, Some(Provider::mocked_builder().mock_idmapping(mock))).await
+}
+
+/// An `IdMapping` row binding `public_id` to `domain_id`.
+fn user_mapping(domain_id: &str, public_id: &str) -> IdMapping {
+    IdMapping {
+        domain_id: domain_id.to_string(),
+        entity_type: IdMappingEntityType::User,
+        local_id: public_id.to_string(),
+        public_id: public_id.to_string(),
+    }
+}
+
+/// A domain-config `sql` source whose overlay is `identity/driver =
+/// ldap`, expected `calls` times.
+fn ldap_config_source(calls: usize) -> Arc<dyn crate::domain_config::backend::DomainConfigBackend> {
+    config_source(
+        Ok(Some(
+            DomainConfig::from_value(json!({"identity": {"driver": "ldap"}}))
+                .expect("valid config"),
+        )),
+        calls,
+    )
+}
+
+/// An identity backend that only ever answers `get_group` -> `None`,
+/// and only when `calls` says it should be reached.
+fn get_group_backend(calls: usize) -> Arc<dyn IdentityBackend> {
+    let mut mock = MockIdentityBackend::default();
+    mock.expect_is_domain_aware().return_const(true);
+    mock.expect_get_group()
+        .times(calls)
+        .returning(|_, _| Ok(None));
+    Arc::new(mock)
+}
+
+#[tokio::test]
+async fn a_mapped_id_with_no_domain_driver_uses_the_global_driver() {
+    // python-keystone `_get_domain_driver_and_entity_id`: a mapped id
+    // whose domain carries no domain-specific `identity/driver` is
+    // served by the default driver, never rejected.
+    let state =
+        state_with_mapping_fn(|id| (id == "seg-user").then(|| user_mapping("d-empty", "seg-user")))
+            .await;
+    let sql = get_user_backend(1);
+    let ldap = get_user_backend(0);
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider = IdentityService::from_backends(
+        "sql",
+        sql,
+        backends,
+        Some(resolver(config_source(Ok(None), 1))),
+    );
+
+    provider
+        .get_user(&ExecutionContext::internal(&state), "seg-user")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_mapped_group_id_uses_its_domain_driver() {
+    // Group dispatch mirrors user dispatch: a mapped group public id
+    // is served by its domain's configured driver.
+    let state = state_with_mapping_fn(|id| {
+        (id == "grp").then(|| IdMapping {
+            domain_id: "d-ldap".to_string(),
+            entity_type: IdMappingEntityType::Group,
+            local_id: "grp".to_string(),
+            public_id: "grp".to_string(),
+        })
+    })
+    .await;
+    let sql = get_group_backend(0);
+    let ldap = get_group_backend(1);
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(1))));
+
+    provider
+        .get_group(&ExecutionContext::internal(&state), "grp")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_shared_backend_serves_membership_across_two_domains() {
+    // python-keystone: two domains backed by the same driver (domain3
+    // and domain4 in `test_domain_segregation`) may hold a membership
+    // between them. Here the user resolves via `d-a`, the group via
+    // `d-b`, both to the same `ldap` backend instance -> the
+    // `Arc::ptr_eq` fast path returns without any existence probe.
+    let state = state_with_mapping_fn(|id| match id {
+        "u" => Some(user_mapping("d-a", "u")),
+        "g" => Some(user_mapping("d-b", "g")),
+        _ => None,
+    })
+    .await;
+
+    let sql = identity_backend(0);
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(true);
+    ldap_mock.expect_get_user().times(0);
+    ldap_mock.expect_get_group().times(0);
+    ldap_mock
+        .expect_add_user_to_group()
+        .once()
+        .returning(|_, _, _| Ok(()));
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(2))));
+
+    provider
+        .add_user_to_group(&ExecutionContext::internal(&state), "u", "g")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_same_domain_membership_through_a_per_domain_driver_is_allowed() {
+    // User and group both mapped to `d-ldap`: one resolver hit
+    // (cached), both resolve to `ldap`, membership proceeds.
+    let state =
+        state_with_mapping_fn(|id| matches!(id, "u" | "g").then(|| user_mapping("d-ldap", id)))
+            .await;
+
+    let sql = identity_backend(0);
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(true);
+    ldap_mock.expect_get_user().times(0);
+    ldap_mock.expect_get_group().times(0);
+    ldap_mock
+        .expect_add_user_to_group()
+        .once()
+        .returning(|_, _, _| Ok(()));
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(1))));
+
+    provider
+        .add_user_to_group(&ExecutionContext::internal(&state), "u", "g")
+        .await
+        .unwrap();
+}
+
+/// A provider + state for the cross-backend membership scenario: `u`
+/// is mapped to `d-ldap` (LDAP), `g` is unmapped (global SQL). Both
+/// entities exist. Every membership mutation must reject with
+/// `CrossBackendNotAllowed`.
+async fn cross_backend_fixture() -> (IdentityService, ServiceState) {
+    let state = state_with_mapping_fn(|id| (id == "u").then(|| user_mapping("d-ldap", "u"))).await;
+
+    let mut sql_mock = MockIdentityBackend::default();
+    sql_mock.expect_is_domain_aware().return_const(true);
+    sql_mock.expect_get_group().returning(|_, group_id| {
+        Ok(Some(
+            openstack_keystone_core_types::identity::GroupBuilder::default()
+                .id(group_id)
+                .domain_id("default")
+                .name("g-name")
+                .build()
+                .expect("valid group"),
+        ))
+    });
+    let sql: Arc<dyn IdentityBackend> = Arc::new(sql_mock);
+
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(false);
+    ldap_mock.expect_get_user().returning(|_, user_id| {
+        Ok(Some(
+            UserResponseBuilder::default()
+                .id(user_id)
+                .domain_id("d-ldap")
+                .enabled(true)
+                .name("u-name")
+                .build()
+                .expect("valid user"),
+        ))
+    });
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(1))));
+    (provider, state)
+}
+
+#[tokio::test]
+async fn remove_user_from_group_rejects_a_cross_backend_membership() {
+    let (provider, state) = cross_backend_fixture().await;
+    let error = provider
+        .remove_user_from_group(&ExecutionContext::internal(&state), "u", "g")
+        .await
+        .expect_err("a cross-backend membership must be rejected");
+    assert!(
+        matches!(error, IdentityProviderError::CrossBackendNotAllowed { .. }),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn add_user_to_group_expiring_rejects_a_cross_backend_membership() {
+    let (provider, state) = cross_backend_fixture().await;
+    let error = provider
+        .add_user_to_group_expiring(&ExecutionContext::internal(&state), "u", "g", "idp")
+        .await
+        .expect_err("a cross-backend membership must be rejected");
+    assert!(
+        matches!(error, IdentityProviderError::CrossBackendNotAllowed { .. }),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn remove_user_from_group_expiring_rejects_a_cross_backend_membership() {
+    let (provider, state) = cross_backend_fixture().await;
+    let error = provider
+        .remove_user_from_group_expiring(&ExecutionContext::internal(&state), "u", "g", "idp")
+        .await
+        .expect_err("a cross-backend membership must be rejected");
+    assert!(
+        matches!(error, IdentityProviderError::CrossBackendNotAllowed { .. }),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn authenticate_by_password_uses_the_resolved_per_domain_driver() {
+    // python-keystone `test_authenticate_to_each_domain`: password auth
+    // is served by the driver the request's domain resolves to.
+    let state = get_mocked_state(None, None).await;
+
+    let mut sql_mock = MockIdentityBackend::default();
+    sql_mock.expect_is_domain_aware().return_const(true);
+    sql_mock.expect_authenticate_by_password().times(0);
+    let sql: Arc<dyn IdentityBackend> = Arc::new(sql_mock);
+
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(true);
+    ldap_mock.expect_check_user_exist().times(0);
+    ldap_mock
+        .expect_authenticate_by_password()
+        .once()
+        .returning(|_, _| Err(AuthenticationError::UserNameOrPasswordWrong.into()));
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(1))));
+
+    let result = provider
+        .authenticate_by_password(
+            &ExecutionContext::internal(&state),
+            &UserPasswordAuthRequest {
+                id: Some("u".into()),
+                password: "pw".into(),
+                domain: Some(Domain {
+                    id: Some("d-ldap".into()),
+                    name: None,
+                }),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(
+        matches!(
+            result,
+            Err(IdentityProviderError::Authentication {
+                source: AuthenticationError::UserNameOrPasswordWrong
+            })
+        ),
+        "unexpected result: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_non_domain_aware_guard_honours_a_custom_default_domain_id() {
+    // The guard compares against `[identity] default_domain_id`, not a
+    // literal "default": the configured primary domain is allowed onto
+    // the non-domain-aware global driver, every other domain is not.
+    let state = get_mocked_state(None, None).await;
+    let ldap = non_domain_aware_backend(1);
+    let mut backends = HashMap::new();
+    backends.insert("ldap".to_string(), ldap.clone());
+    let provider = IdentityService::from_backends(
+        "ldap",
+        ldap,
+        backends,
+        Some(resolver(config_source(Ok(None), 2))),
+    )
+    .with_default_domain_id("d-primary");
+
+    let ctx = ExecutionContext::internal(&state);
+    provider
+        .list_users(&ctx, &list_params("d-primary"))
+        .await
+        .unwrap();
+    let error = provider
+        .list_users(&ctx, &list_params("default"))
+        .await
+        .expect_err("a non-primary domain must be rejected");
+    assert!(
+        matches!(
+            error,
+            IdentityProviderError::ResourceProvider {
+                source: ResourceProviderError::DomainNotFound(_)
+            }
+        ),
+        "unexpected error: {error:?}"
+    );
+}

--- a/crates/core/src/plugin_manager.rs
+++ b/crates/core/src/plugin_manager.rs
@@ -287,6 +287,16 @@ pub trait PluginManagerApi {
         name: S,
     ) -> Result<&Arc<dyn IdentityBackend>, IdentityProviderError>;
 
+    /// Every registered identity backend, keyed by driver name.
+    ///
+    /// The identity provider clones this map to dispatch operations to a
+    /// per-domain driver (issue #960); with `domain_specific_drivers_enabled`
+    /// it holds both `"sql"` and `"ldap"`.
+    ///
+    /// # Returns
+    /// - `&HashMap<String, Arc<dyn IdentityBackend>>` - The registry.
+    fn identity_backends(&self) -> &HashMap<String, Arc<dyn IdentityBackend>>;
+
     /// Get registered idmapping backend.
     ///
     /// # Parameters

--- a/crates/identity-driver-ldap/src/lib.rs
+++ b/crates/identity-driver-ldap/src/lib.rs
@@ -115,7 +115,12 @@ pub fn anchor() {}
 inventory::submit! {
     BackendRegistration::<dyn IdentityBackend> {
         name: "ldap",
-        selected: |cfg: &Config| cfg.identity.driver == "ldap",
+        // Registered whenever it is the global driver, or whenever per-domain
+        // drivers are on: with `domain_specific_drivers_enabled` a domain's
+        // stored config may select `ldap` even though the global driver is not.
+        selected: |cfg: &Config| {
+            cfg.identity.driver == "ldap" || cfg.identity.domain_specific_drivers_enabled
+        },
         build: |cfg: &Config| {
             let ldap_cfg = cfg.ldap.clone();
             Box::pin(async move {
@@ -127,6 +132,12 @@ inventory::submit! {
 
 #[async_trait]
 impl IdentityBackend for LdapBackend {
+    /// LDAP maps one directory to one domain (python-keystone parity: the
+    /// LDAP driver is not domain aware).
+    fn is_domain_aware(&self) -> bool {
+        false
+    }
+
     async fn add_user_to_group<'a>(
         &self,
         _state: &ServiceState,

--- a/crates/keystone/src/plugin_manager.rs
+++ b/crates/keystone/src/plugin_manager.rs
@@ -299,6 +299,10 @@ impl PluginManagerApi for PluginManager {
             ))
     }
 
+    fn identity_backends(&self) -> &HashMap<String, Arc<dyn IdentityBackend>> {
+        &self.identity_backends
+    }
+
     /// Get registered idmapping backend.
     ///
     /// # Parameters

--- a/tests/integration/src/domain_config.rs
+++ b/tests/integration/src/domain_config.rs
@@ -1,0 +1,153 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Per-domain identity driver dispatch (SQL only)
+//!
+//! Exercises `[identity] domain_specific_drivers_enabled` end to end through
+//! the full `Provider` stack: the `DomainConfigResolver` is consulted for a
+//! domain's stored `identity/driver`, and `DomainConfigService` enforces the
+//! single-domain SQL identity-driver registration lock on config writes.
+//!
+//! Both the global and the per-domain driver here are `sql`, so these do not
+//! cover cross-backend routing, the `_select_identity_driver` `DomainNotFound`
+//! guard, or `CrossBackendNotAllowed` -- those need a second, non-domain-aware
+//! backend and are a follow-up (real LDAP harness).
+
+use eyre::Result;
+use serde_json::json;
+use tracing_test::traced_test;
+use uuid::Uuid;
+
+use openstack_keystone_config::Config;
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core::domain_config::DomainConfigProviderError;
+use openstack_keystone_core_types::domain_config::{DomainConfig, DomainConfigCreate};
+use openstack_keystone_core_types::identity::*;
+
+use crate::common::get_state_with_config;
+
+/// Turn on per-domain identity drivers with the database as the config source.
+fn enable_domain_specific(cfg: &mut Config) {
+    cfg.identity.domain_specific_drivers_enabled = true;
+    cfg.identity.domain_configurations_from_database = true;
+}
+
+/// A stored configuration pinning a domain to the `sql` identity driver.
+fn sql_identity_config() -> DomainConfigCreate {
+    DomainConfigCreate(
+        DomainConfig::from_value(json!({"identity": {"driver": "sql"}}))
+            .expect("valid domain configuration"),
+    )
+}
+
+/// A domain whose stored config names `identity/driver = sql` resolves through
+/// `DomainConfigResolver` to the (same) global SQL backend, and ordinary user
+/// CRUD scoped to that domain still works.
+#[tokio::test]
+#[traced_test]
+async fn a_domain_pinned_to_the_sql_driver_serves_user_crud() -> Result<()> {
+    let (state, _tmp) = get_state_with_config(enable_domain_specific).await?;
+    let ctx = ExecutionContext::internal(&state);
+    let domain = crate::create_domain!(state)?;
+
+    // Seed the stored config BEFORE the first identity call for this domain:
+    // `driver_for` caches the resolved driver name per domain with no
+    // invalidation.
+    state
+        .provider
+        .get_domain_config_provider()
+        .create_domain_config(&state, &domain.id, sql_identity_config())
+        .await?;
+
+    let name = Uuid::new_v4().to_string();
+    state
+        .provider
+        .get_identity_provider()
+        .create_user(
+            &ctx,
+            UserCreateBuilder::default()
+                .name(name.clone())
+                .domain_id(domain.id.clone())
+                .enabled(true)
+                .build()?,
+        )
+        .await?;
+
+    let users: Vec<UserResponse> = state
+        .provider
+        .get_identity_provider()
+        .list_users(
+            &ctx,
+            &UserListParameters {
+                domain_id: Some(domain.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?
+        .into_iter()
+        .collect();
+
+    assert_eq!(users.len(), 1, "the domain-scoped user should be listed");
+    assert_eq!(users[0].name, name);
+    Ok(())
+}
+
+/// At most one domain may hold `identity/driver = sql` while configurations
+/// come from the database: the second claim is rejected `Conflict`, and the
+/// write does not land.
+#[tokio::test]
+#[traced_test]
+async fn the_sql_identity_driver_registration_is_single_domain() -> Result<()> {
+    let (state, _tmp) = get_state_with_config(enable_domain_specific).await?;
+    let first = crate::create_domain!(state)?;
+    let second = crate::create_domain!(state)?;
+    let dc = state.provider.get_domain_config_provider();
+
+    dc.create_domain_config(&state, &first.id, sql_identity_config())
+        .await?;
+
+    let err = dc
+        .create_domain_config(&state, &second.id, sql_identity_config())
+        .await
+        .expect_err("a second domain must not claim the SQL identity driver");
+    assert!(
+        matches!(err, DomainConfigProviderError::Conflict(_)),
+        "expected Conflict, got {err:?}"
+    );
+
+    assert!(
+        dc.get_domain_config(&state, &second.id).await?.is_none(),
+        "the rejected config must not have been stored"
+    );
+    Ok(())
+}
+
+/// Deleting the owning domain's configuration releases the SQL registration,
+/// letting another domain claim it.
+#[tokio::test]
+#[traced_test]
+async fn deleting_a_domain_config_frees_the_sql_registration() -> Result<()> {
+    let (state, _tmp) = get_state_with_config(enable_domain_specific).await?;
+    let first = crate::create_domain!(state)?;
+    let second = crate::create_domain!(state)?;
+    let dc = state.provider.get_domain_config_provider();
+
+    dc.create_domain_config(&state, &first.id, sql_identity_config())
+        .await?;
+    dc.delete_domain_config(&state, &first.id).await?;
+
+    // Registration is free again.
+    dc.create_domain_config(&state, &second.id, sql_identity_config())
+        .await?;
+    Ok(())
+}

--- a/tests/integration/src/integration.rs
+++ b/tests/integration/src/integration.rs
@@ -22,6 +22,7 @@ mod audit;
 mod catalog;
 mod common;
 mod credential;
+mod domain_config;
 mod federation;
 mod identity;
 mod k8s_auth;


### PR DESCRIPTION
## What

Phase 5 of #954 (issue **#960**): wire the domain configuration resolution
layer into identity backend selection. Until now `DomainConfigResolver` was
constructed on the provider but nothing consulted it — `IdentityService` held a
single global `backend_driver` chosen once from `[identity] driver`.

## Changes

- **`IdentityService`** carries the full registered-backend map and an optional
  `DomainConfigResolver` (`Some` only when `domain_specific_drivers_enabled`).
  Every backend call site (~50 — user/group CRUD, auth, list, password,
  membership) now routes through `driver_for` / `driver_for_user` /
  `driver_for_group`, which resolve a domain's stored `identity/driver` and
  dispatch to the named backend. Fallback to the global driver when per-domain
  drivers are off, the domain is unknown, no `identity/driver` is stored, or
  resolution errors.
- Per-domain resolution is **cached with no invalidation** — a driver change
  through the config API takes effect on restart (follow-up issue to be filed).
- `IdentityService::from_driver` keeps a `None` resolver, so the existing
  single-mock unit tests are unchanged.
- **LDAP identity backend** registers whenever per-domain drivers are enabled,
  not only when it is the global driver. Writes to an LDAP-backed domain surface
  the existing read-only error.
- **SQL identity-driver registration lock** (deferred from #959):
  `DomainConfigService` claims the `SQL` registration before storing an
  `identity/driver = sql` configuration and releases it when the driver changes
  away or the config is deleted, while `domain_configurations_from_database` is
  on. A second domain claiming it gets HTTP 409.

## Out of scope

- Resolved-driver cache invalidation on config API writes (follow-up).
- `keystone-manage domain_config_upload` / `mapping_purge` CLI (follow-up).

## Tests

- `identity/service.rs`: per-domain dispatch — resolver absent → global driver
  regression; stored `identity/driver` selects the named backend; empty config →
  global; resolution cached per domain; resolver error → global fallback.
- `domain_config/service.rs`: registration lock — skipped without database
  configs; `sql` claims a free registration then writes; held by another domain
  → 409, no write; held by self → write proceeds; switch to non-`sql` releases
  after the write; delete releases.
- Full suites green: `openstack-keystone-core` (757), `openstack-keystone`
  (991), `openstack-keystone-core-types` domain_config (79), ldap crate;
  `cargo build -p openstack-keystone`; `opa test policy/domain_config` 15/15;
  `cargo fmt --all -- --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)