### PR TITLE
feat(assignment): add OpenFGA assignment driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,6 +4844,7 @@ dependencies = [
  "openstack-keystone-api-key-driver-raft",
  "openstack-keystone-api-types",
  "openstack-keystone-appcred-driver-sql",
+ "openstack-keystone-assignment-driver-openfga",
  "openstack-keystone-assignment-driver-sql",
  "openstack-keystone-audit",
  "openstack-keystone-auth-plugin-identity-driver-raft",
@@ -4973,6 +4974,29 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "openstack-keystone-assignment-driver-openfga"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "eyre",
+ "futures",
+ "httpmock",
+ "inventory",
+ "openstack-keystone-config",
+ "openstack-keystone-core",
+ "openstack-keystone-core-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "tracing-test",
+ "url",
+ "validator",
 ]
 
 [[package]]
@@ -5151,7 +5175,6 @@ dependencies = [
  "eyre",
  "governor",
  "hmac 0.13.0",
- "httpmock",
  "inventory",
  "ipnet",
  "jsonwebtoken",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/audit",
   "crates/appcred-driver-sql",
   "crates/assignment-driver-sql",
+  "crates/assignment-driver-openfga",
   "crates/catalog-driver-sql",
   "crates/config",
   "crates/core",
@@ -106,6 +107,7 @@ futures-util = { version = "0.3" }
 governor = "0.10"
 http-body-util = "0.1"
 http = { version = "1.5" }
+httpmock = { version = "0.8", features = ["http2"] }
 hyper = { version = "1.11" }
 hyper-util = { version = "0.1" }
 hkdf = { version = "0.13" }
@@ -125,6 +127,7 @@ openstack-keystone-api-key-driver-raft = { version = "0.1", path = "crates/api-k
 openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "crates/api-types" }
 openstack-keystone-audit = { version = "0.1.0", path = "crates/audit" }
 openstack-keystone-appcred-driver-sql = { version = "0.1", path = "crates/appcred-driver-sql/" }
+openstack-keystone-assignment-driver-openfga = { version = "0.1", path = "crates/assignment-driver-openfga/" }
 openstack-keystone-assignment-driver-sql = { version = "0.1", path = "crates/assignment-driver-sql/" }
 openstack-keystone-catalog-driver-sql = { version = "0.1", path = "crates/catalog-driver-sql/" }
 openstack-keystone-config = { version = "0.1.0", path = "crates/config"}

--- a/crates/api-types/src/error_conv.rs
+++ b/crates/api-types/src/error_conv.rs
@@ -219,6 +219,7 @@ impl From<AssignmentProviderError> for KeystoneApiError {
             ref err @ AssignmentProviderError::Validation { .. } => {
                 Self::BadRequest(err.to_string())
             }
+            AssignmentProviderError::NotImplemented(x) => Self::NotImplemented(x),
             other => Self::InternalError(other.to_string()),
         }
     }

--- a/crates/assignment-driver-openfga/Cargo.toml
+++ b/crates/assignment-driver-openfga/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "openstack-keystone-assignment-driver-openfga"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+exclude.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+futures.workspace = true
+inventory.workspace = true
+openstack-keystone-config.workspace = true
+openstack-keystone-core.workspace = true
+openstack-keystone-core-types.workspace = true
+reqwest = { workspace = true, features = ["json", "http2", "gzip", "deflate"] }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
+url.workspace = true
+validator.workspace = true
+
+[dev-dependencies]
+eyre.workspace = true
+httpmock.workspace = true
+openstack-keystone-core = { workspace = true, features = ["mock"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-test = { workspace = true, features = ["no-env-filter"] }
+url.workspace = true
+
+[lints]
+workspace = true

--- a/crates/assignment-driver-openfga/src/lib.rs
+++ b/crates/assignment-driver-openfga/src/lib.rs
@@ -1,0 +1,893 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Role assignment driver for OpenStack Keystone using OpenFGA
+//!
+//! Keystone role assignments are stored as OpenFGA relationship tuples. The
+//! Keystone role id is mapped to an OpenFGA relation name via the
+//! `[openfga] role_to_relation` config; actors and targets are mapped to
+//! OpenFGA objects by [`types::ObjectMapper`] (stateless, config-driven).
+//!
+//! `Assignment::inherited` is intentionally never encoded into a tuple: the
+//! OpenFGA authorization model performs the cascading itself, so every stored
+//! tuple is implicitly inheritable through the model's userset rewrite rules.
+//! `openfga_read` (raw tuple listing) therefore only surfaces the direct
+//! tuples that were written, while `check`/`batch-check` resolve direct and
+//! inherited grants alike.
+//!
+//! ## Authorization-model assumptions
+//!
+//! This driver does not resolve group membership or role implication itself.
+//! It assumes the OpenFGA authorization model does both:
+//!
+//! - **Group membership** must be represented in OpenFGA (e.g. a `member`
+//!   relation on the group type) so that a `check` for a user picks up grants
+//!   made to that user's groups. Keystone's identity backend is *not*
+//!   consulted here, and nothing in this driver syncs group membership into
+//!   OpenFGA - the deployment is responsible for that.
+//! - **Implied roles** must be expressed as relation rewrites in the model.
+//!
+//! ## `effective` selects the API family
+//!
+//! `list_assignments` keys off `RoleAssignmentListParameters::effective`:
+//!
+//! - **`effective == Some(true)`** - use the model-resolving APIs. An
+//!   actor+target query uses `check`/`batch-check`; an actor-only query uses
+//!   `streamed-list-objects` (the uncapped streaming form of `list-objects`).
+//!   Results include grants reached via group membership,
+//!   implied roles and project-tree inheritance, each reported as a direct
+//!   (`inherited: false`, `implied_via: None`) assignment. `resolve_implied_roles`
+//!   only takes effect in this mode (again, via the model).
+//! - **otherwise** - use a raw `read` of the stored tuples (direct grants
+//!   only). An actor-only query is rejected in this mode
+//!   (`ListingActorWithoutScopeRequiresEffective`): OpenFGA's `read` cannot
+//!   enumerate tuples by user alone.
+//!
+//! A **target-scoped** listing always uses `read` (direct only) even in
+//! effective mode - this driver does not call `list-users`, so group-derived
+//! grants on a target are not resolved. A `debug!` is logged when effective
+//! mode is asked for there.
+//!
+//! `create_grant` **rejects** `inherited: true`: every grant is stored as a
+//! single relationship tuple with no `inherited` marker, so an inherited grant
+//! could not be told apart from a direct one on read. Project-tree inheritance
+//! must be expressed in the OpenFGA authorization model instead.
+//!
+//! ## Concurrency
+//!
+//! An operation that fans out over several actor/target representations, target
+//! kinds or role relations issues its OpenFGA requests concurrently, with at
+//! most `[openfga] max_concurrency` (default 10) in flight. `read` continuation
+//! and `batch-check` chunking stay sequential.
+use std::future::{Future, ready};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use reqwest::{Client, RequestBuilder, Response, Url};
+use serde_json::{Value, json};
+use tracing::{debug, error, warn};
+
+use openstack_keystone_config::OpenFGAAssignmentDriver;
+use openstack_keystone_core::assignment::{AssignmentProviderError, backend::AssignmentBackend};
+use openstack_keystone_core::keystone::ServiceState;
+use openstack_keystone_core::plugin_manager::BackendRegistration;
+use openstack_keystone_core_types::assignment::*;
+
+mod types;
+use types::*;
+
+pub use types::OpenFGADriverError;
+
+/// OpenFGA `batch-check` caps a request at 50 items.
+const BATCH_CHECK_MAX: usize = 50;
+
+/// Safety bound on `read` pagination, in case a server keeps handing back a
+/// non-empty continuation token.
+const MAX_READ_PAGES: usize = 1000;
+
+/// Linkage anchor - see ADR-0018. Referenced by the `keystone` crate's
+/// `build.rs`-generated `_ANCHORS` static so the linker extracts `.rlib`
+/// members, keeping `inventory::submit!` sections visible at runtime.
+#[allow(dead_code)]
+pub fn anchor() {}
+
+inventory::submit! {
+    BackendRegistration::<dyn AssignmentBackend> {
+        name: "openfga",
+        selected: |_| true,
+        build: |cfg| {
+            let timeout = cfg.openfga.as_ref().and_then(|c| c.timeout);
+            Box::pin(async move {
+                Ok(Arc::new(OpenFGADriver::new(timeout)?) as Arc<dyn AssignmentBackend>)
+            })
+        },
+    }
+}
+
+pub struct OpenFGADriver {
+    openfga_client: Client,
+}
+
+impl Default for OpenFGADriver {
+    fn default() -> Self {
+        Self {
+            openfga_client: Client::new(),
+        }
+    }
+}
+
+impl OpenFGADriver {
+    /// Initialize the OpenFGA driver.
+    ///
+    /// `timeout_secs`, when set, is applied as a total per-request timeout on
+    /// the OpenFGA HTTP client.
+    pub fn new(timeout_secs: Option<u16>) -> Result<Self, OpenFGADriverError> {
+        let mut builder = Client::builder();
+        if let Some(secs) = timeout_secs {
+            builder = builder.timeout(Duration::from_secs(secs.into()));
+        }
+        Ok(Self {
+            openfga_client: builder.build()?,
+        })
+    }
+
+    /// Snapshot the `[openfga]` config section.
+    async fn config(
+        &self,
+        state: &ServiceState,
+    ) -> Result<OpenFGAAssignmentDriver, OpenFGADriverError> {
+        state
+            .config_manager
+            .config
+            .read()
+            .await
+            .openfga
+            .clone()
+            .ok_or(OpenFGADriverError::MissingConfiguration)
+    }
+
+    /// Build a POST to `stores/{store_id}/{path}` with auth and JSON body.
+    fn post(
+        &self,
+        cfg: &OpenFGAAssignmentDriver,
+        path: &str,
+        body: &Value,
+    ) -> Result<RequestBuilder, OpenFGADriverError> {
+        let url: Url = cfg
+            .api_url
+            .join(&format!("stores/{}/{}", cfg.store_id, path))?;
+        let mut rb = self.openfga_client.post(url).json(body);
+        if let Some(key) = &cfg.api_key {
+            rb = rb.bearer_auth(key);
+        }
+        Ok(rb)
+    }
+
+    /// POST to `stores/{store_id}/{path}`, retrying a transient failure
+    /// (connection error, timeout, HTTP 429 or 5xx) up to `cfg.max_retries`
+    /// times with exponential backoff from `cfg.retry_backoff_ms`. Returns a
+    /// 2xx response, or the last error once retries are exhausted. A 4xx
+    /// response other than 429 is returned immediately.
+    async fn send(
+        &self,
+        cfg: &OpenFGAAssignmentDriver,
+        path: &str,
+        body: &Value,
+    ) -> Result<Response, OpenFGADriverError> {
+        let attempts = u32::from(cfg.max_retries).saturating_add(1);
+        let mut backoff = Duration::from_millis(cfg.retry_backoff_ms);
+
+        for attempt in 1..=attempts {
+            if attempt > 1 {
+                debug!("openfga {path}: retry {}/{}", attempt - 1, attempts - 1);
+                tokio::time::sleep(backoff).await;
+                backoff = backoff.saturating_mul(2);
+            }
+            match self.post(cfg, path, body)?.send().await {
+                Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) => {
+                    let retryable = is_retryable_status(response.status());
+                    let err = openfga_error(response).await;
+                    if retryable && attempt < attempts {
+                        continue;
+                    }
+                    return Err(err);
+                }
+                Err(source) => {
+                    if is_retryable_error(&source) && attempt < attempts {
+                        continue;
+                    }
+                    return Err(source.into());
+                }
+            }
+        }
+        // Unreachable: the final attempt always returns from the match above.
+        Err(OpenFGADriverError::OpenFGAError(
+            "retry loop exhausted".into(),
+        ))
+    }
+
+    /// Run a single `check` call for one already-mapped tuple.
+    async fn openfga_check(
+        &self,
+        cfg: &OpenFGAAssignmentDriver,
+        user: &str,
+        relation: &str,
+        object: &str,
+    ) -> Result<bool, OpenFGADriverError> {
+        let mut body = json!({
+            "tuple_key": { "user": user, "relation": relation, "object": object }
+        });
+        add_model_id(&mut body, cfg);
+
+        let response = self.send(cfg, "check", &body).await?;
+        Ok(response.json::<OpenFGACheckResponse>().await?.allowed)
+    }
+
+    /// `batch-check` every `(role_id, relation)` pair for one already-mapped
+    /// `(user, object)`; returns the role ids whose relation is allowed.
+    async fn openfga_batch_check(
+        &self,
+        cfg: &OpenFGAAssignmentDriver,
+        user: &str,
+        object: &str,
+        role_relations: &[(String, String)],
+    ) -> Result<Vec<String>, OpenFGADriverError> {
+        let mut allowed: Vec<String> = Vec::new();
+        for chunk in role_relations.chunks(BATCH_CHECK_MAX) {
+            let checks: Vec<Value> = chunk
+                .iter()
+                .map(|(role_id, relation)| {
+                    json!({
+                        "tuple_key": { "user": user, "object": object, "relation": relation },
+                        "correlation_id": role_id,
+                    })
+                })
+                .collect();
+            let mut body = json!({ "checks": checks });
+            add_model_id(&mut body, cfg);
+
+            let response = self.send(cfg, "batch-check", &body).await?;
+            let parsed: OpenFGABatchCheckResponse = response.json().await?;
+            for (correlation_id, result) in parsed.result {
+                if result.allowed {
+                    allowed.push(correlation_id);
+                }
+            }
+        }
+        Ok(allowed)
+    }
+
+    /// Read every stored tuple matching `tuple_key`, following continuation
+    /// tokens.
+    async fn openfga_read(
+        &self,
+        cfg: &OpenFGAAssignmentDriver,
+        tuple_key: Value,
+    ) -> Result<Vec<OpenFGATuple>, OpenFGADriverError> {
+        let mut out: Vec<OpenFGATuple> = Vec::new();
+        let mut continuation: Option<String> = None;
+
+        for _ in 0..MAX_READ_PAGES {
+            let mut body = json!({ "tuple_key": tuple_key });
+            add_model_id(&mut body, cfg);
+            if let Some(token) = &continuation {
+                body["continuation_token"] = token.clone().into();
+            }
+
+            let response = self.send(cfg, "read", &body).await?;
+            let page: OpenFGAReadResponse = response.json().await?;
+            out.extend(page.tuples.into_iter().map(|k| k.tuple));
+
+            match page.continuation_token {
+                Some(token) if !token.is_empty() => continuation = Some(token),
+                _ => return Ok(out),
+            }
+        }
+
+        warn!("openfga read exceeded {MAX_READ_PAGES} pages; returning a truncated result");
+        Ok(out)
+    }
+
+    /// List every object of `object_type` on which `user` has `relation`
+    /// (direct or computed by the model).
+    ///
+    /// Uses `streamed-list-objects` rather than `list-objects`: the streaming
+    /// endpoint has no `OPENFGA_LIST_OBJECTS_MAX_RESULTS` cap (its only bound is
+    /// `OPENFGA_LIST_OBJECTS_DEADLINE`), so the result is not silently
+    /// truncated. The response is a sequence of newline-delimited JSON frames,
+    /// each `{"result":{"object":"type:id"}}`; frames without a `result` (an
+    /// end-of-stream marker, say) are ignored.
+    async fn openfga_list_objects(
+        &self,
+        cfg: &OpenFGAAssignmentDriver,
+        user: &str,
+        relation: &str,
+        object_type: &str,
+    ) -> Result<Vec<String>, OpenFGADriverError> {
+        let mut body = json!({ "type": object_type, "relation": relation, "user": user });
+        add_model_id(&mut body, cfg);
+
+        let response = self.send(cfg, "streamed-list-objects", &body).await?;
+        let stream_body = response.text().await?;
+        let mut objects = Vec::new();
+        for frame in
+            serde_json::Deserializer::from_str(&stream_body).into_iter::<OpenFGAStreamedFrame>()
+        {
+            if let Some(result) = frame?.result {
+                objects.push(result.object);
+            }
+        }
+        Ok(objects)
+    }
+
+    /// Write or delete a single already-mapped tuple.
+    async fn openfga_write(
+        &self,
+        cfg: &OpenFGAAssignmentDriver,
+        user: &str,
+        relation: &str,
+        object: &str,
+        delete: bool,
+    ) -> Result<(), OpenFGADriverError> {
+        let tuple = json!({ "user": user, "relation": relation, "object": object });
+        let mut body = if delete {
+            json!({ "deletes": { "tuple_keys": [tuple] } })
+        } else {
+            json!({ "writes": { "tuple_keys": [tuple] } })
+        };
+        add_model_id(&mut body, cfg);
+
+        self.send(cfg, "write", &body).await?;
+        Ok(())
+    }
+}
+
+/// HTTP statuses worth retrying: rate-limit and transient server errors.
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// Whether a transport-level error is transient enough to retry.
+fn is_retryable_error(err: &reqwest::Error) -> bool {
+    err.is_timeout() || err.is_connect() || err.is_request()
+}
+
+/// Drive `tasks` to completion with at most `limit` (>= 1) running at once,
+/// concatenating their per-task `Vec` outputs. Result order is not preserved.
+async fn fan_out<T, F>(limit: usize, tasks: Vec<F>) -> Result<Vec<T>, OpenFGADriverError>
+where
+    F: Future<Output = Result<Vec<T>, OpenFGADriverError>>,
+{
+    stream::iter(tasks)
+        .buffer_unordered(limit.max(1))
+        .try_concat()
+        .await
+}
+
+/// Drive `tasks` with at most `limit` (>= 1) running at once, discarding their
+/// outputs. Stops early on the first error.
+async fn run_all<F>(limit: usize, tasks: Vec<F>) -> Result<(), OpenFGADriverError>
+where
+    F: Future<Output = Result<(), OpenFGADriverError>>,
+{
+    stream::iter(tasks)
+        .buffer_unordered(limit.max(1))
+        .try_collect::<Vec<()>>()
+        .await?;
+    Ok(())
+}
+
+/// Drive `tasks` with at most `limit` (>= 1) running at once, returning `true`
+/// as soon as one yields `true` (remaining tasks are dropped). `false` only
+/// once every task has yielded `false`.
+async fn any_true<F>(limit: usize, tasks: Vec<F>) -> Result<bool, OpenFGADriverError>
+where
+    F: Future<Output = Result<bool, OpenFGADriverError>>,
+{
+    let hit = stream::iter(tasks)
+        .buffer_unordered(limit.max(1))
+        .try_filter(|allowed| ready(*allowed))
+        .try_next()
+        .await?;
+    Ok(hit.unwrap_or(false))
+}
+
+/// Insert `authorization_model_id` into a request body when pinned in config.
+fn add_model_id(body: &mut Value, cfg: &OpenFGAAssignmentDriver) {
+    if let Some(model_id) = &cfg.model_id {
+        body["authorization_model_id"] = model_id.clone().into();
+    }
+}
+
+/// Map the Keystone role id to its configured OpenFGA relation name.
+fn relation_for_role(
+    cfg: &OpenFGAAssignmentDriver,
+    role_id: &str,
+) -> Result<String, OpenFGADriverError> {
+    cfg.role_to_relation
+        .as_ref()
+        .and_then(|map| map.get(role_id).cloned())
+        .ok_or_else(|| OpenFGADriverError::RoleRelationNotConfigured(role_id.to_string()))
+}
+
+/// Reverse of [`relation_for_role`] - the Keystone role id for a relation.
+fn role_for_relation(cfg: &OpenFGAAssignmentDriver, relation: &str) -> Option<String> {
+    cfg.role_to_relation
+        .as_ref()?
+        .iter()
+        .find(|(_, configured)| configured.as_str() == relation)
+        .map(|(role_id, _)| role_id.clone())
+}
+
+/// All `(role_id, relation)` pairs from config.
+fn role_relations(cfg: &OpenFGAAssignmentDriver) -> Vec<(String, String)> {
+    cfg.role_to_relation
+        .as_ref()
+        .map(|map| {
+            map.iter()
+                .map(|(role_id, relation)| (role_id.clone(), relation.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Turn an OpenFGA error response body into a driver error, logging it.
+async fn openfga_error(response: Response) -> OpenFGADriverError {
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(source) => return OpenFGADriverError::from(source),
+    };
+    match serde_json::from_str::<OpenFGAErrorResponse>(&body) {
+        Ok(parsed) => {
+            error!("OpenFGA API error: {}", parsed.message);
+            OpenFGADriverError::OpenFGAError(parsed.message)
+        }
+        Err(_) => OpenFGADriverError::OpenFGAError(body),
+    }
+}
+
+/// Build an [`Assignment`] from an actor/target kind pair, or `None` when the
+/// pairing does not describe a valid grant (an actor kind in the target slot,
+/// etc.).
+fn make_assignment(
+    role_id: String,
+    actor_kind: Kind,
+    target_kind: Kind,
+    actor_id: &str,
+    target_id: &str,
+) -> Option<Assignment> {
+    Some(Assignment {
+        actor_id: actor_id.to_string(),
+        role_id,
+        role_name: None,
+        target_id: target_id.to_string(),
+        r#type: kinds_to_assignment_type(actor_kind, target_kind)?,
+        inherited: false,
+        implied_via: None,
+    })
+}
+
+/// Convert a raw stored tuple back into an [`Assignment`], or `None` (with a
+/// warning) when any part is not recognised by the current config.
+fn tuple_to_assignment(
+    cfg: &OpenFGAAssignmentDriver,
+    mapper: &ObjectMapper,
+    tuple: &OpenFGATuple,
+) -> Option<Assignment> {
+    let Some(role_id) = role_for_relation(cfg, &tuple.relation) else {
+        warn!(
+            "openfga tuple relation `{}` maps to no configured role; skipping",
+            tuple.relation
+        );
+        return None;
+    };
+    let Some((actor_kind, actor_id)) = mapper.parse_object(&tuple.user) else {
+        warn!(
+            "openfga tuple user `{}` has no configured type; skipping",
+            tuple.user
+        );
+        return None;
+    };
+    let Some((target_kind, target_id)) = mapper.parse_object(&tuple.object) else {
+        warn!(
+            "openfga tuple object `{}` has no configured type; skipping",
+            tuple.object
+        );
+        return None;
+    };
+    let Some(assignment_type) = kinds_to_assignment_type(actor_kind, target_kind) else {
+        warn!(
+            "openfga tuple `{}#{}@{}` does not describe an actor/target grant; skipping",
+            tuple.user, tuple.relation, tuple.object
+        );
+        return None;
+    };
+    Some(Assignment {
+        actor_id,
+        role_id,
+        role_name: None,
+        target_id,
+        r#type: assignment_type,
+        inherited: false,
+        implied_via: None,
+    })
+}
+
+#[async_trait]
+impl AssignmentBackend for OpenFGADriver {
+    /// Check whether a grant exists.
+    ///
+    /// Fans out over every configured representation of the actor and target
+    /// and returns `true` if any combination is allowed.
+    async fn check_grant(
+        &self,
+        state: &ServiceState,
+        assignment: &Assignment,
+    ) -> Result<bool, AssignmentProviderError> {
+        let cfg = self.config(state).await?;
+        let mapper = ObjectMapper::from_config(&cfg);
+        let relation = relation_for_role(&cfg, &assignment.role_id)?;
+        let (actor_kind, target_kind) = assignment_type_kinds(&assignment.r#type);
+
+        let users = mapper.objects_for(actor_kind, &assignment.actor_id);
+        let objects = mapper.objects_for(target_kind, &assignment.target_id);
+        let cfg_ref = &cfg;
+        let relation_ref = &relation;
+        let tasks: Vec<_> = users
+            .iter()
+            .flat_map(|user| objects.iter().map(move |object| (user, object)))
+            .map(|(user, object)| async move {
+                self.openfga_check(cfg_ref, user, relation_ref, object)
+                    .await
+            })
+            .collect();
+
+        Ok(any_true(cfg.max_concurrency, tasks).await?)
+    }
+
+    /// Create a grant by writing the canonical tuple.
+    async fn create_grant(
+        &self,
+        state: &ServiceState,
+        assignment: AssignmentCreate,
+    ) -> Result<Assignment, AssignmentProviderError> {
+        let cfg = self.config(state).await?;
+        let mapper = ObjectMapper::from_config(&cfg);
+        let relation = relation_for_role(&cfg, &assignment.role_id)?;
+        let (actor_kind, target_kind) = assignment_type_kinds(&assignment.r#type);
+
+        if assignment.inherited {
+            // A grant is stored as a single tuple with no `inherited` marker, so
+            // an inherited grant could not be distinguished from a direct one on
+            // read. Reject rather than silently downgrade (see the module docs);
+            // project-tree inheritance belongs in the authorization model.
+            return Err(OpenFGADriverError::InheritedGrantsNotSupported.into());
+        }
+
+        let user = mapper.canonical_object(actor_kind, &assignment.actor_id)?;
+        let object = mapper.canonical_object(target_kind, &assignment.target_id)?;
+        self.openfga_write(&cfg, &user, &relation, &object, false)
+            .await?;
+
+        Ok(Assignment {
+            actor_id: assignment.actor_id,
+            implied_via: None,
+            inherited: assignment.inherited,
+            r#type: assignment.r#type,
+            role_id: assignment.role_id,
+            role_name: None,
+            target_id: assignment.target_id,
+        })
+    }
+
+    /// List role assignments matching `params`.
+    async fn list_assignments(
+        &self,
+        state: &ServiceState,
+        params: &RoleAssignmentListParameters,
+    ) -> Result<Vec<Assignment>, AssignmentProviderError> {
+        let cfg = self.config(state).await?;
+        let mapper = ObjectMapper::from_config(&cfg);
+
+        // Whether the caller asked for the *effective* assignment set - grants
+        // reached via group membership, implied roles and project-tree
+        // inheritance. This driver never expands those itself; it relies on the
+        // OpenFGA authorization model. `effective` therefore selects between the
+        // model-resolving APIs (`check`/`batch-check`/`list-objects`) and a raw
+        // `read` of the stored tuples. See the module docs.
+        let effective = params.effective == Some(true);
+        if params.resolve_implied_roles && !effective {
+            debug!(
+                "openfga list_assignments: `resolve_implied_roles` is delegated to the \
+                 authorization model and only takes effect in effective mode"
+            );
+        }
+
+        let actor = actor_from_list_parameters(params);
+        let target = target_from_list_parameters(params);
+        // Resolve the role filter up front so an unknown role id fails fast.
+        let role_relation: Option<(String, String)> = match &params.role_id {
+            Some(role_id) => Some((role_id.clone(), relation_for_role(&cfg, role_id)?)),
+            None => None,
+        };
+
+        // Every fan-out below issues its OpenFGA calls concurrently, capped at
+        // `max_concurrency`. Rebind `cfg`/`mapper` as shared references so the
+        // per-task `async move` blocks copy the reference rather than moving the
+        // value.
+        let max_concurrency = cfg.max_concurrency;
+        let cfg = &cfg;
+        let mapper = &mapper;
+
+        let mut results: Vec<Assignment> = Vec::new();
+
+        match (actor, target) {
+            (Some((actor_kind, actor_id)), Some((target_kind, target_id))) => {
+                match &role_relation {
+                    // actor + target + role: is the grant present for any rep
+                    // pair? `check` in effective mode, a direct tuple `read`
+                    // otherwise.
+                    Some((role_id, relation)) => {
+                        let users = mapper.objects_for(actor_kind, actor_id);
+                        let objects = mapper.objects_for(target_kind, target_id);
+                        let tasks: Vec<_> = users
+                            .iter()
+                            .flat_map(|user| objects.iter().map(move |object| (user, object)))
+                            .map(|(user, object)| async move {
+                                if effective {
+                                    self.openfga_check(cfg, user, relation, object).await
+                                } else {
+                                    Ok(!self
+                                        .openfga_read(
+                                            cfg,
+                                            json!({
+                                                "user": user,
+                                                "relation": relation,
+                                                "object": object,
+                                            }),
+                                        )
+                                        .await?
+                                        .is_empty())
+                                }
+                            })
+                            .collect();
+                        if any_true(max_concurrency, tasks).await? {
+                            results.extend(make_assignment(
+                                role_id.clone(),
+                                actor_kind,
+                                target_kind,
+                                actor_id,
+                                target_id,
+                            ));
+                        }
+                    }
+                    // actor + target, no role (login path): every configured
+                    // role between the actor and the target. `batch-check` in
+                    // effective mode, a direct tuple `read` otherwise.
+                    None => {
+                        let pairs = role_relations(cfg);
+                        let pairs_ref = &pairs;
+                        let users = mapper.objects_for(actor_kind, actor_id);
+                        let objects = mapper.objects_for(target_kind, target_id);
+                        let tasks: Vec<_> = users
+                            .iter()
+                            .flat_map(|user| objects.iter().map(move |object| (user, object)))
+                            .map(|(user, object)| async move {
+                                let mut out: Vec<Assignment> = Vec::new();
+                                if effective {
+                                    for role_id in self
+                                        .openfga_batch_check(cfg, user, object, pairs_ref)
+                                        .await?
+                                    {
+                                        out.extend(make_assignment(
+                                            role_id,
+                                            actor_kind,
+                                            target_kind,
+                                            actor_id,
+                                            target_id,
+                                        ));
+                                    }
+                                } else {
+                                    for tuple in self
+                                        .openfga_read(
+                                            cfg,
+                                            json!({ "user": user, "object": object }),
+                                        )
+                                        .await?
+                                    {
+                                        if let Some(assignment) =
+                                            tuple_to_assignment(cfg, mapper, &tuple)
+                                        {
+                                            out.push(assignment);
+                                        }
+                                    }
+                                }
+                                Ok::<_, OpenFGADriverError>(out)
+                            })
+                            .collect();
+                        results.extend(fan_out(max_concurrency, tasks).await?);
+                    }
+                }
+            }
+            // actor without a target scope: enumerate the objects the actor
+            // holds each role relation on, per target kind. Only answerable in
+            // effective mode - OpenFGA's `read` cannot enumerate by user alone.
+            (Some((actor_kind, actor_id)), None) => {
+                if !effective {
+                    Err(OpenFGADriverError::ListingActorWithoutScopeRequiresEffective)?;
+                }
+                let pairs: Vec<(String, String)> = match &role_relation {
+                    Some(pair) => vec![pair.clone()],
+                    None => role_relations(cfg),
+                };
+                let users = mapper.objects_for(actor_kind, actor_id);
+                let mut tasks = Vec::new();
+                for user in &users {
+                    for tkind in [Kind::Project, Kind::Domain, Kind::System] {
+                        for object_type in mapper.types_for(tkind) {
+                            for (role_id, relation) in &pairs {
+                                tasks.push(async move {
+                                    let mut out: Vec<Assignment> = Vec::new();
+                                    for object in self
+                                        .openfga_list_objects(cfg, user, relation, object_type)
+                                        .await?
+                                    {
+                                        let Some((parsed_kind, target_id)) =
+                                            mapper.parse_object(&object)
+                                        else {
+                                            warn!(
+                                                "openfga list-objects returned `{object}` with \
+                                                 no configured type; skipping"
+                                            );
+                                            continue;
+                                        };
+                                        // `make_assignment` returns `None` for a
+                                        // nonsensical actor/target kind pairing.
+                                        out.extend(make_assignment(
+                                            role_id.clone(),
+                                            actor_kind,
+                                            parsed_kind,
+                                            actor_id,
+                                            &target_id,
+                                        ));
+                                    }
+                                    Ok::<_, OpenFGADriverError>(out)
+                                });
+                            }
+                        }
+                    }
+                }
+                results.extend(fan_out(max_concurrency, tasks).await?);
+            }
+            // target scope, maybe a role filter: read stored tuples per rep.
+            // Always direct - OpenFGA's `read` does not resolve group-derived
+            // grants on the target, and this driver does not call `list-users`.
+            (None, Some((target_kind, target_id))) => {
+                if effective {
+                    debug!(
+                        "openfga list_assignments: effective target-scoped listing returns \
+                         stored (direct) tuples only; group-derived grants on the target are \
+                         not resolved"
+                    );
+                }
+                let objects = mapper.objects_for(target_kind, target_id);
+                let role_relation_ref = &role_relation;
+                let tasks: Vec<_> = objects
+                    .iter()
+                    .map(|object| async move {
+                        let tuple_key = match role_relation_ref {
+                            Some((_, relation)) => {
+                                json!({ "relation": relation, "object": object })
+                            }
+                            None => json!({ "object": object }),
+                        };
+                        let mut out: Vec<Assignment> = Vec::new();
+                        for tuple in self.openfga_read(cfg, tuple_key).await? {
+                            if let Some(assignment) = tuple_to_assignment(cfg, mapper, &tuple) {
+                                out.push(assignment);
+                            }
+                        }
+                        Ok::<_, OpenFGADriverError>(out)
+                    })
+                    .collect();
+                results.extend(fan_out(max_concurrency, tasks).await?);
+            }
+            (None, None) => {
+                if role_relation.is_some() {
+                    Err(OpenFGADriverError::ListingAssignmentsByRoleNotSupported)?;
+                } else {
+                    Err(OpenFGADriverError::ListingAllAssignmentsNotSupported)?;
+                }
+            }
+        }
+
+        // No cursor is pushed into OpenFGA (results are a fan-out union across
+        // representations, target kinds and role relations). Pagination is
+        // applied post-fetch over the fully materialised set, mirroring the SQL
+        // driver: sort by the opaque marker, drop everything up to the caller's
+        // marker, then over-fetch by one so the service layer can tell there is
+        // a next page.
+        let mut results = dedupe_assignments(results);
+        results.sort_by_key(|a| a.pagination_marker());
+        if let Some(marker) = &params.pagination.marker {
+            if params.pagination.page_reverse {
+                results.retain(|x| x.pagination_marker().as_str() < marker.as_str());
+            } else {
+                results.retain(|x| x.pagination_marker().as_str() > marker.as_str());
+            }
+        }
+        if let Some(limit) = params.pagination.limit {
+            let limit = (limit + 1) as usize;
+            if params.pagination.page_reverse {
+                if results.len() > limit {
+                    results = results.split_off(results.len() - limit);
+                }
+            } else {
+                results.truncate(limit);
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Revoke a grant, fanning the delete out over every representation.
+    ///
+    /// Mirrors the SQL driver: revoking a grant that is not present is a no-op,
+    /// not an error. Each representation is probed with a direct `read` first so
+    /// OpenFGA's "tuple not found" delete error is never hit; only the
+    /// representations that actually hold the tuple are deleted. A real OpenFGA
+    /// error from either the `read` or the `delete` propagates as-is. The
+    /// representations are probed concurrently, capped at `max_concurrency`.
+    async fn revoke_grant(
+        &self,
+        state: &ServiceState,
+        assignment: &Assignment,
+    ) -> Result<(), AssignmentProviderError> {
+        let cfg = self.config(state).await?;
+        let mapper = ObjectMapper::from_config(&cfg);
+        let relation = relation_for_role(&cfg, &assignment.role_id)?;
+        let (actor_kind, target_kind) = assignment_type_kinds(&assignment.r#type);
+
+        let users = mapper.objects_for(actor_kind, &assignment.actor_id);
+        let objects = mapper.objects_for(target_kind, &assignment.target_id);
+        let cfg_ref = &cfg;
+        let relation_ref = &relation;
+        let tasks: Vec<_> = users
+            .iter()
+            .flat_map(|user| objects.iter().map(move |object| (user, object)))
+            .map(|(user, object)| async move {
+                let held = self
+                    .openfga_read(
+                        cfg_ref,
+                        json!({ "user": user, "relation": relation_ref, "object": object }),
+                    )
+                    .await?;
+                if held.is_empty() {
+                    return Ok(());
+                }
+                self.openfga_write(cfg_ref, user, relation_ref, object, true)
+                    .await
+            })
+            .collect();
+
+        run_all(cfg.max_concurrency, tasks).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/assignment-driver-openfga/src/tests.rs
+++ b/crates/assignment-driver-openfga/src/tests.rs
@@ -1,0 +1,1337 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OpenFGA assignment driver tests
+//!
+//! These exercise the driver against an `httpmock` OpenFGA. Actor/target
+//! mapping is now pure config, so there are no identity-provider mocks.
+
+use std::collections::HashMap;
+
+use eyre::Result;
+use httpmock::MockServer;
+use serde_json::json;
+use tracing_test::traced_test;
+use url::Url;
+
+use openstack_keystone_config::{Config, OpenFGAAssignmentDriver, OpenFGAIdTransform};
+use openstack_keystone_core::tests::get_mocked_state;
+
+use super::*;
+
+/// Default-shaped driver config pointing at `host`, with a single
+/// `role_id -> relation` mapping.
+fn driver_config(host: &str) -> OpenFGAAssignmentDriver {
+    OpenFGAAssignmentDriver {
+        api_url: Url::parse(host).expect("valid url"),
+        api_key: Some("secret".into()),
+        model_id: Some("model_id".into()),
+        store_id: "store_id".into(),
+        timeout: Some(5),
+        max_retries: 0,
+        retry_backoff_ms: 1,
+        max_concurrency: 10,
+        role_to_relation: Some(HashMap::from([("role_id".into(), "relation".into())])),
+        user_actor_types: vec!["user".into()],
+        group_actor_types: vec!["group".into()],
+        project_target_types: vec!["project".into()],
+        domain_target_types: vec!["domain".into()],
+        system_target_types: vec!["system".into()],
+        id_transform: OpenFGAIdTransform::None,
+    }
+}
+
+async fn state_with(cfg: OpenFGAAssignmentDriver) -> ServiceState {
+    let config = Config {
+        openfga: Some(cfg),
+        ..Default::default()
+    };
+    get_mocked_state(Some(config), None).await
+}
+
+fn driver() -> OpenFGADriver {
+    OpenFGADriver::new(None).expect("client builds")
+}
+
+fn user_project_assignment(actor: &str, role: &str, target: &str) -> Assignment {
+    Assignment {
+        actor_id: actor.into(),
+        role_id: role.into(),
+        role_name: None,
+        target_id: target.into(),
+        r#type: AssignmentType::UserProject,
+        inherited: false,
+        implied_via: None,
+    }
+}
+
+#[tokio::test]
+async fn new_rejects_absurd_timeout_but_accepts_normal() {
+    // Just make sure the timeout path builds a client.
+    assert!(OpenFGADriver::new(Some(30)).is_ok());
+    assert!(OpenFGADriver::new(None).is_ok());
+}
+
+#[tokio::test]
+async fn check_grant_maps_actor_and_target_and_returns_true() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    let mock = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/check")
+                .header("authorization", "Bearer secret")
+                .json_body(json!({
+                    "tuple_key": {
+                        "user": "user:actor_id",
+                        "relation": "relation",
+                        "object": "project:target_id",
+                    },
+                    "authorization_model_id": "model_id"
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({"allowed": true}));
+        })
+        .await;
+
+    let allowed = driver()
+        .check_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await?;
+
+    assert!(allowed);
+    mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn check_grant_returns_false_when_not_allowed() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST").path("/stores/store_id/check");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({"allowed": false}));
+    })
+    .await;
+
+    let allowed = driver()
+        .check_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await?;
+
+    assert!(!allowed);
+    Ok(())
+}
+
+#[tokio::test]
+async fn check_grant_fans_out_over_actor_representations() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.user_actor_types = vec!["user".into(), "account".into()];
+    let state = state_with(cfg).await;
+
+    // The `user:` representation is denied...
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/check")
+            .json_body(json!({
+                "tuple_key": {
+                    "user": "user:actor_id",
+                    "relation": "relation",
+                    "object": "project:target_id",
+                },
+                "authorization_model_id": "model_id"
+            }));
+        then.status(200).json_body(json!({"allowed": false}));
+    })
+    .await;
+    // ...the `account:` representation is allowed.
+    let hit = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/check")
+                .json_body(json!({
+                    "tuple_key": {
+                        "user": "account:actor_id",
+                        "relation": "relation",
+                        "object": "project:target_id",
+                    },
+                    "authorization_model_id": "model_id"
+                }));
+            then.status(200).json_body(json!({"allowed": true}));
+        })
+        .await;
+
+    let allowed = driver()
+        .check_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await?;
+
+    assert!(allowed, "grant found under the alternate representation");
+    hit.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn check_grant_errors_when_role_has_no_relation() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.role_to_relation = Some(HashMap::new());
+    let state = state_with(cfg).await;
+
+    match driver()
+        .check_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await
+    {
+        Err(AssignmentProviderError::Driver(msg)) => assert_eq!(
+            msg,
+            "role to relation mapping for the openfga driver is not configured for role `role_id`"
+        ),
+        other => panic!("expected a driver error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn check_grant_errors_when_config_missing() {
+    let state = get_mocked_state(Some(Config::default()), None).await;
+    match driver()
+        .check_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await
+    {
+        Err(AssignmentProviderError::Driver(msg)) => {
+            assert_eq!(msg, "openfga driver configuration missing")
+        }
+        other => panic!("expected a driver error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn create_grant_writes_canonical_tuple() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    let mock = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/write")
+                .header("authorization", "Bearer secret")
+                .json_body(json!({
+                    "writes": {
+                        "tuple_keys": [{
+                            "user": "user:actor_id",
+                            "relation": "relation",
+                            "object": "project:target_id",
+                        }],
+                    },
+                    "authorization_model_id": "model_id"
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({}));
+        })
+        .await;
+
+    let created = driver()
+        .create_grant(
+            &state,
+            AssignmentCreate {
+                actor_id: "actor_id".into(),
+                role_id: "role_id".into(),
+                role_name: None,
+                target_id: "target_id".into(),
+                r#type: AssignmentType::UserProject,
+                inherited: false,
+            },
+        )
+        .await?;
+
+    assert_eq!(created.actor_id, "actor_id");
+    assert_eq!(created.role_id, "role_id");
+    mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_grant_surfaces_openfga_error_message() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST").path("/stores/store_id/write");
+        then.status(400)
+            .header("content-type", "application/json")
+            .json_body(json!({"code": "validation_error", "message": "bar"}));
+    })
+    .await;
+
+    match driver()
+        .create_grant(
+            &state,
+            AssignmentCreate {
+                actor_id: "actor_id".into(),
+                role_id: "role_id".into(),
+                role_name: None,
+                target_id: "target_id".into(),
+                r#type: AssignmentType::UserProject,
+                inherited: false,
+            },
+        )
+        .await
+    {
+        Err(AssignmentProviderError::Driver(msg)) => {
+            assert_eq!(msg, "openfga http error: bar")
+        }
+        other => panic!("expected a driver error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_grant_uses_canonical_type_with_custom_actor_types() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.user_actor_types = vec!["user".into(), "account".into()];
+    let state = state_with(cfg).await;
+
+    let mock = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/write")
+                .json_body(json!({
+                    "writes": {
+                        "tuple_keys": [{
+                            "user": "user:actor_id",
+                            "relation": "relation",
+                            "object": "project:target_id",
+                        }],
+                    },
+                    "authorization_model_id": "model_id"
+                }));
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+
+    driver()
+        .create_grant(
+            &state,
+            AssignmentCreate {
+                actor_id: "actor_id".into(),
+                role_id: "role_id".into(),
+                role_name: None,
+                target_id: "target_id".into(),
+                r#type: AssignmentType::UserProject,
+                inherited: false,
+            },
+        )
+        .await?;
+
+    mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_grant_applies_uuid_dashes_transform() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.id_transform = OpenFGAIdTransform::UuidDashes;
+    let state = state_with(cfg).await;
+
+    let dashless_user = "0123456789abcdef0123456789abcdef";
+    let dashless_proj = "fedcba9876543210fedcba9876543210";
+
+    let mock = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/write")
+                .json_body(json!({
+                    "writes": {
+                        "tuple_keys": [{
+                            "user": "user:01234567-89ab-cdef-0123-456789abcdef",
+                            "relation": "relation",
+                            "object": "project:fedcba98-7654-3210-fedc-ba9876543210",
+                        }],
+                    },
+                    "authorization_model_id": "model_id"
+                }));
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+
+    driver()
+        .create_grant(
+            &state,
+            AssignmentCreate {
+                actor_id: dashless_user.into(),
+                role_id: "role_id".into(),
+                role_name: None,
+                target_id: dashless_proj.into(),
+                r#type: AssignmentType::UserProject,
+                inherited: false,
+            },
+        )
+        .await?;
+
+    mock.assert_async().await;
+    Ok(())
+}
+
+/// `read` body the revoke path issues to probe one representation.
+fn revoke_probe_body(user: &str) -> serde_json::Value {
+    json!({
+        "authorization_model_id": "model_id",
+        "tuple_key": { "user": user, "relation": "relation", "object": "project:target_id" }
+    })
+}
+
+fn held_tuple(user: &str) -> serde_json::Value {
+    json!({
+        "tuples": [
+            { "key": { "user": user, "relation": "relation", "object": "project:target_id" } }
+        ]
+    })
+}
+
+#[tokio::test]
+async fn revoke_grant_deletes_tuple() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    // The representation holds the tuple...
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(revoke_probe_body("user:actor_id"));
+        then.status(200).json_body(held_tuple("user:actor_id"));
+    })
+    .await;
+    // ...so it is deleted.
+    let del = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/write")
+                .json_body(json!({
+                    "deletes": {
+                        "tuple_keys": [{
+                            "user": "user:actor_id",
+                            "relation": "relation",
+                            "object": "project:target_id",
+                        }],
+                    },
+                    "authorization_model_id": "model_id"
+                }));
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+
+    driver()
+        .revoke_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await?;
+
+    del.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoke_grant_deletes_only_representations_that_hold_the_tuple() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.user_actor_types = vec!["user".into(), "account".into()];
+    let state = state_with(cfg).await;
+
+    // `user:` representation is empty, `account:` holds the tuple.
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(revoke_probe_body("user:actor_id"));
+        then.status(200).json_body(json!({ "tuples": [] }));
+    })
+    .await;
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(revoke_probe_body("account:actor_id"));
+        then.status(200).json_body(held_tuple("account:actor_id"));
+    })
+    .await;
+    // Only the `account:` tuple is deleted.
+    let del = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/write")
+                .json_body(json!({
+                    "deletes": {
+                        "tuple_keys": [{
+                            "user": "account:actor_id",
+                            "relation": "relation",
+                            "object": "project:target_id",
+                        }],
+                    },
+                    "authorization_model_id": "model_id"
+                }));
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+
+    driver()
+        .revoke_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await?;
+
+    del.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoke_grant_absent_tuple_is_a_noop() -> Result<()> {
+    // Mirrors the SQL driver: revoking a grant that is not present succeeds
+    // without issuing a delete.
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST").path("/stores/store_id/read");
+        then.status(200).json_body(json!({ "tuples": [] }));
+    })
+    .await;
+    let del = srv
+        .mock_async(|when, then| {
+            when.method("POST").path("/stores/store_id/write");
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+
+    driver()
+        .revoke_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await?;
+
+    assert_eq!(del.calls_async().await, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoke_grant_propagates_real_openfga_errors() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST").path("/stores/store_id/read");
+        then.status(500)
+            .json_body(json!({"code": "internal_error", "message": "boom"}));
+    })
+    .await;
+
+    match driver()
+        .revoke_grant(
+            &state,
+            &user_project_assignment("actor_id", "role_id", "target_id"),
+        )
+        .await
+    {
+        Err(AssignmentProviderError::Driver(msg)) => {
+            assert_eq!(msg, "openfga http error: boom")
+        }
+        other => panic!("expected a driver error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_unknown_role_filter_errors() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    match driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                project_id: Some("project_id".into()),
+                role_id: Some("wrong_role".into()),
+                ..Default::default()
+            },
+        )
+        .await
+    {
+        Err(AssignmentProviderError::Driver(msg)) => assert_eq!(
+            msg,
+            "role to relation mapping for the openfga driver is not configured for role `wrong_role`"
+        ),
+        other => panic!("expected a driver error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_actor_and_target_and_role_checks() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    let mock = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/check")
+                .json_body(json!({
+                    "authorization_model_id": "model_id",
+                    "tuple_key": {
+                        "object": "project:project_id",
+                        "relation": "relation",
+                        "user": "user:user_id"
+                    }
+                }));
+            then.status(200).json_body(json!({"allowed": true}));
+        })
+        .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                project_id: Some("project_id".into()),
+                role_id: Some("role_id".into()),
+                effective: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0].role_id, "role_id");
+    assert_eq!(res[0].actor_id, "user_id");
+    assert_eq!(res[0].target_id, "project_id");
+    assert_eq!(res[0].r#type, AssignmentType::UserProject);
+    mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_login_path_batch_checks_every_role() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.role_to_relation = Some(HashMap::from([
+        ("rid1".into(), "relation1".into()),
+        ("rid2".into(), "relation2".into()),
+        ("rid3".into(), "relation3".into()),
+    ]));
+    let state = state_with(cfg).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST").path("/stores/store_id/batch-check");
+        then.status(200).json_body(json!({
+            "result": {
+                "rid1": { "allowed": true },
+                "rid2": { "allowed": true },
+                "rid3": { "allowed": false },
+            }
+        }));
+    })
+    .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                project_id: Some("project_id".into()),
+                effective: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let roles: Vec<&str> = res.iter().map(|a| a.role_id.as_str()).collect();
+    assert!(roles.contains(&"rid1"));
+    assert!(roles.contains(&"rid2"));
+    assert!(!roles.contains(&"rid3"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_actor_without_scope_uses_streamed_list_objects() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    // One streamed-list-objects call per target kind; only `project` yields an
+    // object. The response body is newline-delimited JSON frames.
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/streamed-list-objects")
+            .json_body(json!({
+                "authorization_model_id": "model_id",
+                "type": "project",
+                "relation": "relation",
+                "user": "user:user_id"
+            }));
+        then.status(200)
+            .body("{\"result\":{\"object\":\"project:p1\"}}\n");
+    })
+    .await;
+    for target_type in ["domain", "system"] {
+        srv.mock_async(move |when, then| {
+            when.method("POST")
+                .path("/stores/store_id/streamed-list-objects")
+                .json_body(json!({
+                    "authorization_model_id": "model_id",
+                    "type": target_type,
+                    "relation": "relation",
+                    "user": "user:user_id"
+                }));
+            then.status(200).body("");
+        })
+        .await;
+    }
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                effective: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0].role_id, "role_id");
+    assert_eq!(res[0].actor_id, "user_id");
+    assert_eq!(res[0].target_id, "p1");
+    assert_eq!(res[0].r#type, AssignmentType::UserProject);
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_streamed_list_objects_reads_every_frame() -> Result<()> {
+    // The streamed endpoint has no result cap; every newline-delimited frame in
+    // the body is turned into an assignment (no silent truncation).
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/streamed-list-objects")
+            .json_body_includes(r#"{"type":"project"}"#);
+        then.status(200).body(concat!(
+            "{\"result\":{\"object\":\"project:p1\"}}\n",
+            "{\"result\":{\"object\":\"project:p2\"}}\n",
+            "{\"result\":{\"object\":\"project:p3\"}}\n",
+        ));
+    })
+    .await;
+    for target_type in ["domain", "system"] {
+        srv.mock_async(move |when, then| {
+            when.method("POST")
+                .path("/stores/store_id/streamed-list-objects")
+                .json_body_includes(format!(r#"{{"type":"{target_type}"}}"#));
+            then.status(200).body("");
+        })
+        .await;
+    }
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                effective: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let mut targets: Vec<&str> = res.iter().map(|a| a.target_id.as_str()).collect();
+    targets.sort_unstable();
+    assert_eq!(targets, ["p1", "p2", "p3"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_fan_out_is_serial_when_max_concurrency_is_one() -> Result<()> {
+    // `max_concurrency = 1` must still produce the full result set - it only
+    // constrains how many requests are in flight, not correctness.
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.max_concurrency = 1;
+    cfg.project_target_types = vec!["project".into(), "proj".into()];
+    let state = state_with(cfg).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(json!({
+                "authorization_model_id": "model_id",
+                "tuple_key": { "object": "project:project_id" }
+            }));
+        then.status(200).json_body(json!({
+            "tuples": [
+                { "key": { "user": "user:uid1", "object": "project:project_id", "relation": "relation" } }
+            ]
+        }));
+    })
+    .await;
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(json!({
+                "authorization_model_id": "model_id",
+                "tuple_key": { "object": "proj:project_id" }
+            }));
+        then.status(200).json_body(json!({
+            "tuples": [
+                { "key": { "user": "user:uid2", "object": "proj:project_id", "relation": "relation" } }
+            ]
+        }));
+    })
+    .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                project_id: Some("project_id".into()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let mut actors: Vec<&str> = res.iter().map(|a| a.actor_id.as_str()).collect();
+    actors.sort_unstable();
+    assert_eq!(actors, ["uid1", "uid2"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_actor_without_scope_honours_role_filter() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.role_to_relation = Some(HashMap::from([
+        ("rid1".into(), "relation1".into()),
+        ("rid2".into(), "relation2".into()),
+    ]));
+    let state = state_with(cfg).await;
+
+    // Only `relation1` (the filtered role) is ever queried.
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/streamed-list-objects")
+            .json_body_includes(r#"{"relation":"relation1"}"#);
+        then.status(200)
+            .body("{\"result\":{\"object\":\"project:p1\"}}\n");
+    })
+    .await;
+    let forbidden = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/streamed-list-objects")
+                .json_body_includes(r#"{"relation":"relation2"}"#);
+            then.status(200).body("");
+        })
+        .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                role_id: Some("rid1".into()),
+                effective: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert!(res.iter().all(|a| a.role_id == "rid1"));
+    assert_eq!(forbidden.calls_async().await, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_by_role_only_is_unsupported() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    match driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                role_id: Some("role_id".into()),
+                ..Default::default()
+            },
+        )
+        .await
+    {
+        Err(AssignmentProviderError::NotImplemented(msg)) => assert_eq!(
+            msg,
+            "listing assignments by only the role is not supported by the openfga"
+        ),
+        other => panic!("expected a not-implemented error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_no_parameters_is_unsupported() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    match driver()
+        .list_assignments(&state, &RoleAssignmentListParameters::default())
+        .await
+    {
+        Err(AssignmentProviderError::NotImplemented(msg)) => assert_eq!(
+            msg,
+            "listing all assignments is not supported by the openfga"
+        ),
+        other => panic!("expected a not-implemented error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+async fn list_assignments_project_only_reads_and_maps_tuples() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.role_to_relation = Some(HashMap::from([
+        ("rid1".into(), "relation1".into()),
+        ("rid2".into(), "relation2".into()),
+    ]));
+    let state = state_with(cfg).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(json!({
+                "authorization_model_id": "model_id",
+                "tuple_key": { "object": "project:project_id" }
+            }));
+        then.status(200).json_body(json!({
+            "tuples": [
+                { "key": { "user": "user:uid1", "object": "project:project_id", "relation": "relation1" } },
+                { "key": { "user": "group:gid2", "object": "project:project_id", "relation": "relation2" } },
+                { "key": { "user": "widget:w9", "object": "project:project_id", "relation": "relation1" } },
+                { "key": { "user": "user:uid3", "object": "project:project_id", "relation": "unmapped_relation" } }
+            ]
+        }));
+    })
+    .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                project_id: Some("project_id".into()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    // The `widget:` and `unmapped_relation` rows are skipped with a warning.
+    assert_eq!(res.len(), 2);
+    assert!(res.iter().any(|a| a.role_id == "rid1"
+        && a.actor_id == "uid1"
+        && a.r#type == AssignmentType::UserProject));
+    assert!(res.iter().any(|a| a.role_id == "rid2"
+        && a.actor_id == "gid2"
+        && a.r#type == AssignmentType::GroupProject));
+    assert!(logs_contain("has no configured type"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_project_only_follows_pagination() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    // Page 1: no continuation_token in the request body, token returned.
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(json!({
+                "authorization_model_id": "model_id",
+                "tuple_key": { "object": "project:project_id" }
+            }));
+        then.status(200).json_body(json!({
+            "tuples": [
+                { "key": { "user": "user:uid1", "object": "project:project_id", "relation": "relation" } }
+            ],
+            "continuation_token": "page-2"
+        }));
+    })
+    .await;
+    // Page 2: request carries the token, empty token ends the loop.
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(json!({
+                "authorization_model_id": "model_id",
+                "tuple_key": { "object": "project:project_id" },
+                "continuation_token": "page-2"
+            }));
+        then.status(200).json_body(json!({
+            "tuples": [
+                { "key": { "user": "user:uid2", "object": "project:project_id", "relation": "relation" } }
+            ],
+            "continuation_token": ""
+        }));
+    })
+    .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                project_id: Some("project_id".into()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let actors: Vec<&str> = res.iter().map(|a| a.actor_id.as_str()).collect();
+    assert!(actors.contains(&"uid1"));
+    assert!(actors.contains(&"uid2"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_project_only_reads_every_target_representation() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.project_target_types = vec!["project".into(), "proj".into()];
+    let state = state_with(cfg).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(json!({
+                "authorization_model_id": "model_id",
+                "tuple_key": { "object": "project:project_id" }
+            }));
+        then.status(200).json_body(json!({ "tuples": [] }));
+    })
+    .await;
+    let proj_mock = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/read")
+                .json_body(json!({
+                    "authorization_model_id": "model_id",
+                    "tuple_key": { "object": "proj:project_id" }
+                }));
+            then.status(200).json_body(json!({
+                "tuples": [
+                    { "key": { "user": "user:uid1", "object": "proj:project_id", "relation": "relation" } }
+                ]
+            }));
+        })
+        .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                project_id: Some("project_id".into()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0].actor_id, "uid1");
+    proj_mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_applies_pagination_limit_post_fetch() -> Result<()> {
+    use openstack_keystone_core_types::ListPagination;
+
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST").path("/stores/store_id/read");
+        then.status(200).json_body(json!({
+            "tuples": [
+                { "key": { "user": "user:uid1", "object": "project:project_id", "relation": "relation" } },
+                { "key": { "user": "user:uid2", "object": "project:project_id", "relation": "relation" } },
+                { "key": { "user": "user:uid3", "object": "project:project_id", "relation": "relation" } }
+            ]
+        }));
+    })
+    .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                project_id: Some("project_id".into()),
+                pagination: ListPagination {
+                    limit: Some(1),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    // Over-fetch by one (limit + 1), mirroring the SQL driver, so the service
+    // layer can detect that another page exists.
+    assert_eq!(res.len(), 2);
+    // Sorted by the opaque marker before truncation.
+    assert_eq!(res[0].actor_id, "uid1");
+    assert_eq!(res[1].actor_id, "uid2");
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_marker_drops_the_prior_page() -> Result<()> {
+    use openstack_keystone_core_types::ListPagination;
+
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    srv.mock_async(|when, then| {
+        when.method("POST").path("/stores/store_id/read");
+        then.status(200).json_body(json!({
+            "tuples": [
+                { "key": { "user": "user:uid1", "object": "project:project_id", "relation": "relation" } },
+                { "key": { "user": "user:uid2", "object": "project:project_id", "relation": "relation" } }
+            ]
+        }));
+    })
+    .await;
+
+    let first = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                project_id: Some("project_id".into()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    let marker = first[0].pagination_marker();
+
+    let rest = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                project_id: Some("project_id".into()),
+                pagination: ListPagination {
+                    marker: Some(marker),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(rest.len(), 1);
+    assert_eq!(rest[0].actor_id, "uid2");
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_grant_rejects_inherited() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    // No `write` must be issued: the request is rejected before any OpenFGA
+    // call.
+    let write = srv
+        .mock_async(|when, then| {
+            when.method("POST").path("/stores/store_id/write");
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+
+    let err = driver()
+        .create_grant(
+            &state,
+            AssignmentCreate {
+                actor_id: "actor_id".into(),
+                role_id: "role_id".into(),
+                role_name: None,
+                target_id: "target_id".into(),
+                r#type: AssignmentType::UserProject,
+                inherited: true,
+            },
+        )
+        .await
+        .unwrap_err();
+
+    // Maps to a validation error (HTTP 400), not a backend/driver error.
+    assert!(
+        matches!(err, AssignmentProviderError::Validation { .. }),
+        "got {err:?}"
+    );
+    assert_eq!(write.calls_async().await, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_actor_and_target_role_direct_mode_reads_tuple() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    let check = srv
+        .mock_async(|when, then| {
+            when.method("POST").path("/stores/store_id/check");
+            then.status(200).json_body(json!({ "allowed": true }));
+        })
+        .await;
+    let read = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/read")
+                .json_body(json!({
+                    "authorization_model_id": "model_id",
+                    "tuple_key": {
+                        "user": "user:user_id",
+                        "relation": "relation",
+                        "object": "project:project_id"
+                    }
+                }));
+            then.status(200).json_body(json!({
+                "tuples": [
+                    { "key": { "user": "user:user_id", "relation": "relation", "object": "project:project_id" } }
+                ]
+            }));
+        })
+        .await;
+
+    let res = driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                project_id: Some("project_id".into()),
+                role_id: Some("role_id".into()),
+                // No `effective` flag: the grant is proven by a direct tuple
+                // `read`, not a model-resolving `check`.
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0].role_id, "role_id");
+    assert_eq!(res[0].actor_id, "user_id");
+    assert_eq!(res[0].target_id, "project_id");
+    read.assert_async().await;
+    assert_eq!(check.calls_async().await, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_actor_without_scope_direct_mode_errors() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let state = state_with(driver_config(&srv.base_url())).await;
+
+    match driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                ..Default::default()
+            },
+        )
+        .await
+    {
+        Err(AssignmentProviderError::NotImplemented(msg)) => {
+            assert!(msg.contains("requires effective mode"), "got {msg:?}")
+        }
+        other => panic!("expected a not-implemented error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn send_retries_transient_server_error() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.max_retries = 2;
+    cfg.retry_backoff_ms = 1;
+    let state = state_with(cfg).await;
+
+    let m = srv
+        .mock_async(|when, then| {
+            when.method("POST").path("/stores/store_id/check");
+            then.status(503)
+                .json_body(json!({ "code": "internal_error", "message": "boom" }));
+        })
+        .await;
+
+    let err = driver()
+        .check_grant(&state, &user_project_assignment("a", "role_id", "t"))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, AssignmentProviderError::Driver(_)));
+    // 1 initial attempt + 2 retries.
+    assert_eq!(m.calls_async().await, 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn send_does_not_retry_client_error() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.max_retries = 3;
+    cfg.retry_backoff_ms = 1;
+    let state = state_with(cfg).await;
+
+    let m = srv
+        .mock_async(|when, then| {
+            when.method("POST").path("/stores/store_id/check");
+            then.status(400)
+                .json_body(json!({ "code": "validation_error", "message": "bad" }));
+        })
+        .await;
+
+    let err = driver()
+        .check_grant(&state, &user_project_assignment("a", "role_id", "t"))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, AssignmentProviderError::Driver(_)));
+    assert_eq!(m.calls_async().await, 1);
+    Ok(())
+}

--- a/crates/assignment-driver-openfga/src/types.rs
+++ b/crates/assignment-driver-openfga/src/types.rs
@@ -1,0 +1,602 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # OpenFGA object mapping
+//!
+//! Keystone entities are mapped onto OpenFGA objects purely from
+//! configuration (`[openfga]` opts) - there is no per-entity lookup and no
+//! reverse-mapping store. See `docs/design-actor-mapping.md` in the reference
+//! Python plugin for the rationale (Keystone's internal `id_mapping` table is
+//! a shared public<->local routing table and is the wrong mechanism here).
+//!
+//! A Keystone entity is `(kind, id)` with `kind` one of `user`, `group`,
+//! `project`, `domain`, `system`. Each kind has a list of OpenFGA type names:
+//! the first is *canonical* (used for writes) and every entry is consulted on
+//! reads, checks and deletes. The same id transform applies to actors and
+//! targets alike.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use openstack_keystone_config::{OpenFGAAssignmentDriver, OpenFGAIdTransform};
+use openstack_keystone_core::assignment::AssignmentProviderError;
+use openstack_keystone_core_types::assignment::*;
+
+/// A Keystone entity kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Kind {
+    User,
+    Group,
+    Project,
+    Domain,
+    System,
+}
+
+impl Kind {
+    /// All kinds, in a fixed order (used for reverse type-name lookup).
+    pub(crate) const ALL: [Kind; 5] = [
+        Kind::User,
+        Kind::Group,
+        Kind::Project,
+        Kind::Domain,
+        Kind::System,
+    ];
+
+    /// Whether this kind is an actor (`user`/`group`) rather than a target.
+    #[cfg(test)]
+    pub(crate) fn is_actor(&self) -> bool {
+        matches!(self, Kind::User | Kind::Group)
+    }
+
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Kind::User => "user",
+            Kind::Group => "group",
+            Kind::Project => "project",
+            Kind::Domain => "domain",
+            Kind::System => "system",
+        }
+    }
+}
+
+/// Split an [`AssignmentType`] into its `(actor kind, target kind)`.
+pub(crate) fn assignment_type_kinds(t: &AssignmentType) -> (Kind, Kind) {
+    match t {
+        AssignmentType::UserProject => (Kind::User, Kind::Project),
+        AssignmentType::UserDomain => (Kind::User, Kind::Domain),
+        AssignmentType::UserSystem => (Kind::User, Kind::System),
+        AssignmentType::GroupProject => (Kind::Group, Kind::Project),
+        AssignmentType::GroupDomain => (Kind::Group, Kind::Domain),
+        AssignmentType::GroupSystem => (Kind::Group, Kind::System),
+    }
+}
+
+/// Recombine an actor kind and a target kind into an [`AssignmentType`].
+///
+/// Returns `None` when the pairing is nonsensical (e.g. an actor kind in the
+/// target slot), which can happen for a hand-written OpenFGA tuple whose type
+/// names collide across the configured kind lists.
+pub(crate) fn kinds_to_assignment_type(actor: Kind, target: Kind) -> Option<AssignmentType> {
+    Some(match (actor, target) {
+        (Kind::User, Kind::Project) => AssignmentType::UserProject,
+        (Kind::User, Kind::Domain) => AssignmentType::UserDomain,
+        (Kind::User, Kind::System) => AssignmentType::UserSystem,
+        (Kind::Group, Kind::Project) => AssignmentType::GroupProject,
+        (Kind::Group, Kind::Domain) => AssignmentType::GroupDomain,
+        (Kind::Group, Kind::System) => AssignmentType::GroupSystem,
+        _ => return None,
+    })
+}
+
+/// The actor `(kind, id)` a listing is scoped to, if any.
+pub(crate) fn actor_from_list_parameters(
+    params: &RoleAssignmentListParameters,
+) -> Option<(Kind, &String)> {
+    if let Some(user_id) = &params.user_id {
+        Some((Kind::User, user_id))
+    } else {
+        params.group_id.as_ref().map(|g| (Kind::Group, g))
+    }
+}
+
+/// The target `(kind, id)` a listing is scoped to, if any.
+pub(crate) fn target_from_list_parameters(
+    params: &RoleAssignmentListParameters,
+) -> Option<(Kind, &String)> {
+    if let Some(project_id) = &params.project_id {
+        Some((Kind::Project, project_id))
+    } else if let Some(domain_id) = &params.domain_id {
+        Some((Kind::Domain, domain_id))
+    } else {
+        params.system_id.as_ref().map(|s| (Kind::System, s))
+    }
+}
+
+/// Stateless, config-driven mapping between Keystone `(kind, id)` and OpenFGA
+/// object strings (`"type:id"`).
+#[derive(Debug, Clone)]
+pub(crate) struct ObjectMapper {
+    user_types: Vec<String>,
+    group_types: Vec<String>,
+    project_types: Vec<String>,
+    domain_types: Vec<String>,
+    system_types: Vec<String>,
+    transform: OpenFGAIdTransform,
+}
+
+impl ObjectMapper {
+    pub(crate) fn from_config(cfg: &OpenFGAAssignmentDriver) -> Self {
+        Self {
+            user_types: cfg.user_actor_types.clone(),
+            group_types: cfg.group_actor_types.clone(),
+            project_types: cfg.project_target_types.clone(),
+            domain_types: cfg.domain_target_types.clone(),
+            system_types: cfg.system_target_types.clone(),
+            transform: cfg.id_transform,
+        }
+    }
+
+    pub(crate) fn types_for(&self, kind: Kind) -> &[String] {
+        match kind {
+            Kind::User => &self.user_types,
+            Kind::Group => &self.group_types,
+            Kind::Project => &self.project_types,
+            Kind::Domain => &self.domain_types,
+            Kind::System => &self.system_types,
+        }
+    }
+
+    /// Every OpenFGA object string a `(kind, id)` may be stored under.
+    pub(crate) fn objects_for(&self, kind: Kind, keystone_id: &str) -> Vec<String> {
+        let id = to_fga_id(self.transform, keystone_id);
+        self.types_for(kind)
+            .iter()
+            .map(|t| format!("{t}:{id}"))
+            .collect()
+    }
+
+    /// The single OpenFGA object string used when *writing* a `(kind, id)`.
+    pub(crate) fn canonical_object(
+        &self,
+        kind: Kind,
+        keystone_id: &str,
+    ) -> Result<String, OpenFGADriverError> {
+        let type_name = self
+            .types_for(kind)
+            .first()
+            .ok_or(OpenFGADriverError::NoTypeConfigured(kind.as_str()))?;
+        Ok(format!(
+            "{type_name}:{}",
+            to_fga_id(self.transform, keystone_id)
+        ))
+    }
+
+    /// Inverse mapping: recover `(kind, keystone_id)` from an OpenFGA object
+    /// string. `None` when the type name is not configured for any kind or the
+    /// id part is empty.
+    pub(crate) fn parse_object(&self, fga_object: &str) -> Option<(Kind, String)> {
+        let (type_name, raw_id) = fga_object.split_once(':')?;
+        if raw_id.is_empty() {
+            return None;
+        }
+        let kind = self.kind_for_type(type_name)?;
+        Some((kind, from_fga_id(self.transform, raw_id)))
+    }
+
+    /// The first kind whose configured type list contains `type_name`.
+    fn kind_for_type(&self, type_name: &str) -> Option<Kind> {
+        Kind::ALL
+            .into_iter()
+            .find(|kind| self.types_for(*kind).iter().any(|t| t == type_name))
+    }
+}
+
+fn is_32_hex(s: &str) -> bool {
+    s.len() == 32 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Keystone id -> OpenFGA id.
+fn to_fga_id(transform: OpenFGAIdTransform, id: &str) -> String {
+    match transform {
+        OpenFGAIdTransform::None => id.to_string(),
+        OpenFGAIdTransform::UuidDashes if is_32_hex(id) => format!(
+            "{}-{}-{}-{}-{}",
+            &id[0..8],
+            &id[8..12],
+            &id[12..16],
+            &id[16..20],
+            &id[20..32]
+        ),
+        OpenFGAIdTransform::UuidDashes => id.to_string(),
+    }
+}
+
+/// OpenFGA id -> Keystone id.
+fn from_fga_id(transform: OpenFGAIdTransform, id: &str) -> String {
+    match transform {
+        OpenFGAIdTransform::None => id.to_string(),
+        OpenFGAIdTransform::UuidDashes => {
+            let stripped: String = id.chars().filter(|c| *c != '-').collect();
+            // Only collapse dashes when the result is a 32-hex UUID; leave any
+            // other value (and its legitimate dashes) untouched.
+            if is_32_hex(&stripped) {
+                stripped
+            } else {
+                id.to_string()
+            }
+        }
+    }
+}
+
+/// Collapse representation duplicates to one assignment each.
+///
+/// `Assignment` derives `Hash`/`Eq` over every field; the fan-out paths only
+/// ever vary `actor_id`/`target_id`/`role_id`/`type` (the design's dedup key)
+/// and always set `role_name`/`inherited`/`implied_via` to the same values, so
+/// a plain set dedup is equivalent to keying on that tuple.
+pub(crate) fn dedupe_assignments(items: Vec<Assignment>) -> Vec<Assignment> {
+    let mut seen: HashSet<Assignment> = HashSet::new();
+    items
+        .into_iter()
+        .filter(|a| seen.insert(a.clone()))
+        .collect()
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGACheckResponse {
+    pub(crate) allowed: bool,
+    #[serde(default)]
+    pub(crate) resolution: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGABatchCheckSingleResult {
+    #[serde(default)]
+    pub(crate) allowed: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGABatchCheckResponse {
+    #[serde(default)]
+    pub(crate) result: std::collections::HashMap<String, OpenFGABatchCheckSingleResult>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGAErrorResponse {
+    #[serde(default)]
+    pub(crate) code: String,
+    pub(crate) message: String,
+}
+
+/// One newline-delimited frame of a `streamed-list-objects` response.
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGAStreamedFrame {
+    #[serde(default)]
+    pub(crate) result: Option<OpenFGAStreamedObject>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGAStreamedObject {
+    pub(crate) object: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGAReadResponse {
+    #[serde(default)]
+    pub(crate) tuples: Vec<OpenFGATupleKey>,
+    #[serde(default)]
+    pub(crate) continuation_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGATupleKey {
+    #[serde(rename = "key")]
+    pub(crate) tuple: OpenFGATuple,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct OpenFGATuple {
+    pub(crate) user: String,
+    pub(crate) relation: String,
+    pub(crate) object: String,
+}
+
+/// Assignment provider error.
+#[derive(Error, Debug)]
+pub enum OpenFGADriverError {
+    /// Missing configuration for the openfga driver.
+    #[error("openfga driver configuration missing")]
+    MissingConfiguration,
+
+    /// A kind has an empty OpenFGA type list, so no canonical object can be
+    /// formed.
+    #[error("no openfga type configured for kind `{0}`")]
+    NoTypeConfigured(&'static str),
+
+    /// Listing assignments knowing only the role is not supported.
+    #[error("listing assignments by only the role is not supported by the openfga")]
+    ListingAssignmentsByRoleNotSupported,
+
+    /// Listing assignments without parameters is not supported.
+    #[error("listing all assignments is not supported by the openfga")]
+    ListingAllAssignmentsNotSupported,
+
+    /// Listing an actor's assignments without a target scope, in non-effective
+    /// mode. OpenFGA's `read` cannot enumerate tuples by user alone, so this
+    /// query is only answerable via `list-objects` (i.e. `effective=true`).
+    #[error(
+        "listing an actor's assignments without a target scope requires effective mode \
+         on the openfga driver"
+    )]
+    ListingActorWithoutScopeRequiresEffective,
+
+    /// A `create_grant` asked for an inherited grant. The OpenFGA driver stores
+    /// every grant as a single relationship tuple with no `inherited` marker, so
+    /// an inherited grant would be indistinguishable from a direct one on read.
+    /// Project-tree inheritance must instead be expressed in the OpenFGA
+    /// authorization model; the request is rejected rather than silently
+    /// downgraded to a direct grant.
+    #[error("the openfga assignment driver does not support inherited grants")]
+    InheritedGrantsNotSupported,
+
+    /// An error response from the OpenFGA API. The payload is the parsed
+    /// `message` field when the body is a recognised error envelope, otherwise
+    /// the raw response body.
+    #[error("openfga http error: {0}")]
+    OpenFGAError(String),
+
+    /// (de)serialize error.
+    #[error(transparent)]
+    Serde {
+        #[from]
+        source: serde_json::Error,
+    },
+
+    /// Reqwest error.
+    #[error(transparent)]
+    Reqwest {
+        #[from]
+        source: reqwest::Error,
+    },
+
+    /// Role mapping not configured.
+    #[error("role to relation mapping for the openfga driver is not configured for role `{0}`")]
+    RoleRelationNotConfigured(String),
+
+    /// Url parsing error.
+    #[error(transparent)]
+    Url {
+        #[from]
+        source: url::ParseError,
+    },
+}
+
+impl From<OpenFGADriverError> for AssignmentProviderError {
+    fn from(source: OpenFGADriverError) -> Self {
+        match source {
+            // A client-supplied `inherited: true` is a bad request, not a
+            // backend fault - surface it as a 400, not a 500.
+            OpenFGADriverError::InheritedGrantsNotSupported => {
+                let mut errors = validator::ValidationErrors::new();
+                errors.add(
+                    "inherited",
+                    validator::ValidationError::new("inherited_grants_unsupported"),
+                );
+                Self::Validation { source: errors }
+            }
+            // Caller-shape limitations, not backend faults: the query is
+            // permanently unanswerable by this driver, regardless of retry.
+            // Surface as 501, not a 500 `Driver` error.
+            err @ (OpenFGADriverError::ListingActorWithoutScopeRequiresEffective
+            | OpenFGADriverError::ListingAssignmentsByRoleNotSupported
+            | OpenFGADriverError::ListingAllAssignmentsNotSupported) => {
+                Self::NotImplemented(err.to_string())
+            }
+            other => Self::Driver(other.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openstack_keystone_config::OpenFGAAssignmentDriver;
+    use url::Url;
+
+    use super::*;
+
+    fn cfg() -> OpenFGAAssignmentDriver {
+        OpenFGAAssignmentDriver {
+            api_url: Url::parse("http://localhost/").unwrap(),
+            api_key: None,
+            model_id: None,
+            store_id: "s".into(),
+            timeout: None,
+            max_retries: 0,
+            retry_backoff_ms: 100,
+            max_concurrency: 10,
+            role_to_relation: None,
+            user_actor_types: vec!["user".into()],
+            group_actor_types: vec!["group".into()],
+            project_target_types: vec!["project".into()],
+            domain_target_types: vec!["domain".into()],
+            system_target_types: vec!["system".into()],
+            id_transform: OpenFGAIdTransform::None,
+        }
+    }
+
+    #[test]
+    fn defaults_reproduce_legacy_prefixes() {
+        let m = ObjectMapper::from_config(&cfg());
+        assert_eq!(m.canonical_object(Kind::User, "u1").unwrap(), "user:u1");
+        assert_eq!(m.canonical_object(Kind::Group, "g1").unwrap(), "group:g1");
+        assert_eq!(
+            m.canonical_object(Kind::Project, "p1").unwrap(),
+            "project:p1"
+        );
+        assert_eq!(
+            m.canonical_object(Kind::Domain, "default").unwrap(),
+            "domain:default"
+        );
+        assert_eq!(
+            m.canonical_object(Kind::System, "all").unwrap(),
+            "system:all"
+        );
+    }
+
+    #[test]
+    fn round_trip_all_kinds_default() {
+        let m = ObjectMapper::from_config(&cfg());
+        for (kind, id) in [
+            (Kind::User, "u1"),
+            (Kind::Group, "g1"),
+            (Kind::Project, "p1"),
+            (Kind::Domain, "default"),
+            (Kind::System, "all"),
+        ] {
+            let obj = m.canonical_object(kind, id).unwrap();
+            assert_eq!(m.parse_object(&obj), Some((kind, id.to_string())));
+        }
+    }
+
+    #[test]
+    fn parse_object_rejects_unknown_type_and_empty_id() {
+        let m = ObjectMapper::from_config(&cfg());
+        assert_eq!(m.parse_object("account:u1"), None);
+        assert_eq!(m.parse_object("project:"), None);
+        assert_eq!(m.parse_object("no-colon"), None);
+    }
+
+    #[test]
+    fn custom_actor_types_fan_out_on_read_canonical_on_write() {
+        let mut c = cfg();
+        c.user_actor_types = vec!["user".into(), "account".into()];
+        let m = ObjectMapper::from_config(&c);
+
+        // write uses the first (canonical) type
+        assert_eq!(m.canonical_object(Kind::User, "u1").unwrap(), "user:u1");
+        // read fans out over every configured type
+        assert_eq!(
+            m.objects_for(Kind::User, "u1"),
+            vec!["user:u1".to_string(), "account:u1".to_string()]
+        );
+        // a tuple stored under the alternate type still maps back
+        assert_eq!(
+            m.parse_object("account:u1"),
+            Some((Kind::User, "u1".to_string()))
+        );
+    }
+
+    #[test]
+    fn custom_target_types_fan_out() {
+        let mut c = cfg();
+        c.project_target_types = vec!["project".into(), "proj".into()];
+        let m = ObjectMapper::from_config(&c);
+        assert_eq!(
+            m.objects_for(Kind::Project, "p1"),
+            vec!["project:p1".to_string(), "proj:p1".to_string()]
+        );
+        assert_eq!(
+            m.parse_object("proj:p1"),
+            Some((Kind::Project, "p1".to_string()))
+        );
+    }
+
+    #[test]
+    fn uuid_dashes_transform_both_directions() {
+        let mut c = cfg();
+        c.id_transform = OpenFGAIdTransform::UuidDashes;
+        let m = ObjectMapper::from_config(&c);
+
+        let dashless = "0123456789abcdef0123456789abcdef";
+        let dashed = "01234567-89ab-cdef-0123-456789abcdef";
+
+        assert_eq!(
+            m.canonical_object(Kind::User, dashless).unwrap(),
+            format!("user:{dashed}")
+        );
+        assert_eq!(
+            m.parse_object(&format!("user:{dashed}")),
+            Some((Kind::User, dashless.to_string()))
+        );
+    }
+
+    #[test]
+    fn uuid_dashes_passes_non_uuid_ids_through() {
+        let mut c = cfg();
+        c.id_transform = OpenFGAIdTransform::UuidDashes;
+        let m = ObjectMapper::from_config(&c);
+
+        assert_eq!(
+            m.canonical_object(Kind::Domain, "default").unwrap(),
+            "domain:default"
+        );
+        assert_eq!(
+            m.parse_object("domain:default"),
+            Some((Kind::Domain, "default".to_string()))
+        );
+        assert_eq!(
+            m.canonical_object(Kind::System, "all").unwrap(),
+            "system:all"
+        );
+    }
+
+    #[test]
+    fn empty_type_list_has_no_canonical_object() {
+        let mut c = cfg();
+        c.system_target_types = vec![];
+        let m = ObjectMapper::from_config(&c);
+        assert!(matches!(
+            m.canonical_object(Kind::System, "all"),
+            Err(OpenFGADriverError::NoTypeConfigured("system"))
+        ));
+    }
+
+    #[test]
+    fn kinds_round_trip_through_assignment_type() {
+        for t in [
+            AssignmentType::UserProject,
+            AssignmentType::UserDomain,
+            AssignmentType::UserSystem,
+            AssignmentType::GroupProject,
+            AssignmentType::GroupDomain,
+            AssignmentType::GroupSystem,
+        ] {
+            let (a, tgt) = assignment_type_kinds(&t);
+            assert!(a.is_actor());
+            assert_eq!(kinds_to_assignment_type(a, tgt), Some(t));
+        }
+    }
+
+    #[test]
+    fn kinds_to_assignment_type_rejects_bad_pairing() {
+        assert_eq!(kinds_to_assignment_type(Kind::Project, Kind::User), None);
+        assert_eq!(kinds_to_assignment_type(Kind::User, Kind::Group), None);
+    }
+
+    #[test]
+    fn dedupe_collapses_representation_duplicates() {
+        let a = Assignment {
+            actor_id: "u1".into(),
+            role_id: "r1".into(),
+            role_name: None,
+            target_id: "p1".into(),
+            r#type: AssignmentType::UserProject,
+            inherited: false,
+            implied_via: None,
+        };
+        let out = dedupe_assignments(vec![a.clone(), a.clone(), a]);
+        assert_eq!(out.len(), 1);
+    }
+}

--- a/crates/config/src/assignment.rs
+++ b/crates/config/src/assignment.rs
@@ -11,7 +11,10 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+use std::collections::HashMap;
+
 use serde::Deserialize;
+use url::Url;
 
 use crate::common::default_sql_driver;
 use crate::pagination::ListLimitConfig;
@@ -35,4 +38,115 @@ impl Default for AssignmentProvider {
             list_limit: ListLimitConfig::default(),
         }
     }
+}
+
+fn default_user_actor_types() -> Vec<String> {
+    vec!["user".to_string()]
+}
+fn default_group_actor_types() -> Vec<String> {
+    vec!["group".to_string()]
+}
+fn default_project_target_types() -> Vec<String> {
+    vec!["project".to_string()]
+}
+fn default_domain_target_types() -> Vec<String> {
+    vec!["domain".to_string()]
+}
+fn default_system_target_types() -> Vec<String> {
+    vec!["system".to_string()]
+}
+fn default_retry_backoff_ms() -> u64 {
+    100
+}
+fn default_max_concurrency() -> usize {
+    10
+}
+
+/// Transform applied between Keystone entity ids and OpenFGA object ids.
+///
+/// Applied to every kind (actors and targets alike).
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OpenFGAIdTransform {
+    /// The Keystone id is used verbatim as the OpenFGA object id.
+    #[default]
+    None,
+    /// Keystone stores dashless UUIDs; OpenFGA stores them dashed. The
+    /// Keystone -> OpenFGA direction inserts canonical `8-4-4-4-12` dashes
+    /// into 32-hex ids, the reverse strips every `-`. Non-hex ids (`default`,
+    /// `all`, ...) pass through unchanged in both directions.
+    UuidDashes,
+}
+
+/// OpenFGA assignment driver.
+///
+/// Keystone entities are mapped onto OpenFGA objects purely from this
+/// configuration - no per-entity lookup or reverse-mapping store. Each kind
+/// (`user`, `group`, `project`, `domain`, `system`) has a list of OpenFGA
+/// type names; the first is canonical (used for writes) and every entry is
+/// consulted on reads, checks and deletes.
+#[derive(Debug, Deserialize, Clone)]
+pub struct OpenFGAAssignmentDriver {
+    /// Base OpenFGA API url. Must end with `/` for the relative
+    /// `stores/{id}/...` paths to resolve without dropping a path prefix.
+    pub api_url: Url,
+
+    /// Bearer token presented to OpenFGA. Omit for an unauthenticated store.
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Authorization model id. The store's latest model is used when unset.
+    pub model_id: Option<String>,
+
+    /// OpenFGA store id.
+    pub store_id: String,
+
+    /// Per-request timeout in seconds applied to the OpenFGA HTTP client.
+    pub timeout: Option<u16>,
+
+    /// How many times to retry an OpenFGA request that failed with a transient
+    /// error (connection failure, timeout, HTTP 429 or 5xx). `0` (the default)
+    /// disables retries. 4xx responses other than 429 are never retried.
+    #[serde(default)]
+    pub max_retries: u8,
+
+    /// Base delay in milliseconds before the first retry; doubled on each
+    /// subsequent attempt (exponential backoff). Ignored when `max_retries`
+    /// is `0`.
+    #[serde(default = "default_retry_backoff_ms")]
+    pub retry_backoff_ms: u64,
+
+    /// Maximum number of OpenFGA requests issued concurrently when a single
+    /// operation fans out over multiple actor/target representations, target
+    /// kinds or role relations. `1` forces fully sequential calls. Defaults
+    /// to `10`.
+    #[serde(default = "default_max_concurrency")]
+    pub max_concurrency: usize,
+
+    /// Keystone role id -> OpenFGA relation name.
+    pub role_to_relation: Option<HashMap<String, String>>,
+
+    /// OpenFGA type names a Keystone user may be represented by.
+    #[serde(default = "default_user_actor_types")]
+    pub user_actor_types: Vec<String>,
+
+    /// OpenFGA type names a Keystone group may be represented by.
+    #[serde(default = "default_group_actor_types")]
+    pub group_actor_types: Vec<String>,
+
+    /// OpenFGA type names a Keystone project may be represented by.
+    #[serde(default = "default_project_target_types")]
+    pub project_target_types: Vec<String>,
+
+    /// OpenFGA type names a Keystone domain may be represented by.
+    #[serde(default = "default_domain_target_types")]
+    pub domain_target_types: Vec<String>,
+
+    /// OpenFGA type names a Keystone system scope may be represented by.
+    #[serde(default = "default_system_target_types")]
+    pub system_target_types: Vec<String>,
+
+    /// Id format transform applied between Keystone and OpenFGA.
+    #[serde(default)]
+    pub id_transform: OpenFGAIdTransform,
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -257,6 +257,10 @@ pub struct Config {
     #[validate(nested)]
     pub oauth2: Oauth2Provider,
 
+    /// OpenFGA assignment driver configuration.
+    #[serde(default)]
+    pub openfga: Option<OpenFGAAssignmentDriver>,
+
     /// `[oslo_middleware]` configuration (proxy header parsing).
     #[serde(default)]
     pub oslo_middleware: OsloMiddleware,

--- a/crates/core-types/src/assignment/error.rs
+++ b/crates/core-types/src/assignment/error.rs
@@ -45,6 +45,13 @@ pub enum AssignmentProviderError {
     #[error("{0}")]
     InvalidAssignmentType(String),
 
+    /// The request shape is not supported by the configured backend driver
+    /// (e.g. a query the OpenFGA driver cannot answer without a target
+    /// scope). A permanent, driver-specific limitation - not a transient
+    /// failure - so it is kept distinct from [`Self::Driver`].
+    #[error("{0}")]
+    NotImplemented(String),
+
     /// Resource provider error.
     #[error(transparent)]
     ResourceProvider {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -61,7 +61,6 @@ subtle = "2.6.1"
 axum = { workspace = true, default-features = false, features = ["json", "tokio"] }
 config = { workspace = true }
 openstack-keystone-auth-plugin-runtime.workspace = true
-httpmock = { version = "0.8", features = ["http2"] }
 mockall.workspace = true
 openstack-keystone-api-types = { workspace = true, features = ["builder", "conv"] }
 openstack-keystone-audit = { workspace = true, features = ["testing"] }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -127,7 +127,7 @@ pub mod trust;
 #[cfg(any(test, feature = "mock"))]
 pub mod mocks;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "mock"))]
 pub mod tests;
 
 #[async_trait]

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -12,6 +12,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //! # Test related functionality
+//!
+//! Compiled both under `#[cfg(test)]` and the `mock` feature so downstream
+//! driver crates can reuse `get_mocked_state`. `clippy.toml`'s
+//! `allow-unwrap-in-tests` only covers `#[cfg(test)]` builds, so the
+//! `unwrap`/`expect` allowances are restated here for the `mock`-feature build.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use std::sync::Arc;
 
 use sea_orm::DatabaseConnection;

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -41,6 +41,7 @@ openstack-keystone-api-key-driver-raft.workspace = true
 openstack-keystone-api-types = { workspace = true, features = ["openapi", "validate", "conv"]}
 openstack-keystone-audit.workspace = true
 openstack-keystone-appcred-driver-sql.workspace = true
+openstack-keystone-assignment-driver-openfga = { workspace = true, optional = true }
 openstack-keystone-assignment-driver-sql.workspace = true
 openstack-keystone-auth-plugin-runtime.workspace = true
 openstack-keystone-catalog-driver-sql.workspace = true
@@ -128,6 +129,7 @@ url.workspace = true
 
 [features]
 default = []
+openfga = ["dep:openstack-keystone-assignment-driver-openfga"]
 
 [lints]
 workspace = true

--- a/crates/keystone/build.rs
+++ b/crates/keystone/build.rs
@@ -49,9 +49,36 @@ fn main() {
         }
     };
 
+    // Optional dependencies are only linked into the build when the feature
+    // that activates them (`dep:<name>`) is enabled; anchoring them
+    // unconditionally would reference a crate that was never compiled in.
+    let enabled_optional_deps: std::collections::HashSet<String> = parsed
+        .get("features")
+        .and_then(|v| v.as_table())
+        .map(|features| {
+            features
+                .iter()
+                .filter(|(name, _)| {
+                    let env_name =
+                        format!("CARGO_FEATURE_{}", name.to_uppercase().replace('-', "_"));
+                    env::var(env_name).is_ok()
+                })
+                .flat_map(|(_, activations)| {
+                    activations
+                        .as_array()
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|v| v.as_str())
+                        .filter_map(|v| v.strip_prefix("dep:"))
+                        .map(String::from)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     let mut plugin_deps = Vec::new();
 
-    for key in deps.keys() {
+    for (key, spec) in deps {
         // Only include openstack-keystone-* crates
         if !key.starts_with("openstack-keystone-") {
             continue;
@@ -59,6 +86,14 @@ fn main() {
 
         // Only anchor driver crates and webauthn
         if !key.contains("-driver-") && !key.starts_with("openstack-keystone-webauthn") {
+            continue;
+        }
+
+        let is_optional = spec
+            .get("optional")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if is_optional && !enabled_optional_deps.contains(key) {
             continue;
         }
 

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -122,3 +122,4 @@
     - [Per-Request Cache via tokio::task_local!](adr/0030-per-request-cache.md)
     - [Prometheus Metrics Catalog](adr/0031-prometheus-metrics.md)
     - [Vendor Data JWT Attestation](adr/0032-vendor-data-jwt.md)
+    - [OpenFGA Assignment Driver](adr/0033-openfga-assignment-driver.md)

--- a/doc/src/adr/0033-openfga-assignment-driver.md
+++ b/doc/src/adr/0033-openfga-assignment-driver.md
@@ -1,0 +1,275 @@
+# 33. OpenFGA Assignment Driver
+
+**Date:** 2026-09-04
+
+## Status
+
+Accepted. Implemented in `crates/assignment-driver-openfga`
+(`openstack-keystone-assignment-driver-openfga`), selectable via
+`[assignment] driver = "openfga"` plus an `[openfga]` config section
+(`crates/config/src/assignment.rs`, `OpenFGAAssignmentDriver`). Linked into the
+`keystone` binary only when the `openfga` cargo feature is enabled.
+
+## Context
+
+Keystone's role assignments (who has which role on which project / domain /
+system) are a natural relationship graph. [OpenFGA](https://openfga.dev) is a
+Zanzibar-style relationship-based authorization store that models exactly this
+kind of graph and answers "does user U have relation R on object O?" with group
+expansion and userset rewrites built in.
+
+Operators already running OpenFGA as their central authorization service want
+Keystone role assignments to live there too, so that a single authorization
+model governs both OpenStack and non-OpenStack resources, and so that group
+membership and role implication are resolved once, by the model, rather than
+separately in each consumer.
+
+The existing SQL driver (`crates/assignment-driver-sql`) stores assignments in
+local tables and expands inheritance / group membership itself. The OpenFGA
+driver is an alternative `AssignmentBackend` that delegates that expansion to
+the relationship store.
+
+### Impedance mismatch
+
+The `AssignmentBackend` trait (`check_grant`, `create_grant`,
+`list_assignments`, `revoke_grant`) is shaped by the SQL model. OpenFGA differs
+in ways this ADR has to reconcile:
+
+- OpenFGA has no notion of a Keystone entity id. A mapping from
+  `(kind, keystone_id)` to an OpenFGA object string (`type:id`) is needed, and
+  it must be reversible for listing.
+- OpenFGA's `read` (raw tuple listing) matches on a tuple filter; it **cannot**
+  enumerate tuples by user alone. Only the model-resolving APIs (`check`,
+  `batch-check`, `list-objects`) answer "everything U can do".
+- OpenFGA stores one flat relationship tuple per grant. There is no column for
+  Keystone's `inherited` flag.
+- Group membership and implied roles are the model's job, not the driver's.
+
+## Decision
+
+### 1. Crate structure
+
+Follows the ADR-0018 naming convention:
+`openstack-keystone-assignment-driver-openfga`, with the usual
+`#[allow(dead_code)] pub fn anchor() {}` linker anchor and an
+`inventory::submit! { BackendRegistration::<dyn AssignmentBackend> { name: "openfga", .. } }`
+registration.
+
+```
+crates/assignment-driver-openfga/
+  Cargo.toml
+  src/
+    lib.rs      # OpenFGADriver, AssignmentBackend impl, HTTP + retry + fan-out
+    types.rs    # ObjectMapper, Kind, request/response structs, error enum
+    tests.rs    # httpmock-based unit tests
+```
+
+### 2. Entity ↔ object mapping is pure config
+
+`ObjectMapper` (in `types.rs`) is stateless and built entirely from the
+`[openfga]` section — **no** per-entity lookup table and **no** reverse-mapping
+store (Keystone's `id_mapping` table is a public↔local routing table for a
+different purpose and is deliberately not reused).
+
+Each Keystone kind (`user`, `group`, `project`, `domain`, `system`) has a list
+of OpenFGA type names. The first is _canonical_ (used for writes); every entry
+is consulted on reads / checks / deletes, so a store that already holds tuples
+under an alternate type name (`account:` instead of `user:`, say) still
+resolves. An optional `id_transform` (`uuid-dashes`) inserts/strips canonical
+UUID dashes, since Keystone stores dashless UUIDs and OpenFGA stores dashed.
+
+The Keystone role id ↔ OpenFGA relation name mapping is an explicit
+`role_to_relation` table in config. An unmapped role id fails fast with
+`RoleRelationNotConfigured`.
+
+### 3. `effective` selects the API family
+
+`list_assignments` branches on `RoleAssignmentListParameters::effective`:
+
+| Query shape               | `effective == Some(true)`              | otherwise                                                  |
+| ------------------------- | -------------------------------------- | ---------------------------------------------------------- |
+| actor + target + role     | `check` (model-resolved)               | `read` of the exact tuple                                  |
+| actor + target, no role   | `batch-check` over every role relation | `read {user,object}`, map relations back to roles          |
+| actor, no target          | `streamed-list-objects` fan-out        | **501** — `ListingActorWithoutScopeRequiresEffective`      |
+| no actor, target (± role) | `read` (see below)                     | `read`                                                     |
+| no actor, role only, no target | **501** — `ListingAssignmentsByRoleNotSupported`  | **501** — `ListingAssignmentsByRoleNotSupported`           |
+| no actor, no target, no role | **501** — `ListingAllAssignmentsNotSupported`     | **501** — `ListingAllAssignmentsNotSupported`               |
+
+`resolve_implied_roles` has no independent effect; implication is a model
+rewrite and therefore only visible in effective mode. A `debug!` records this
+when the flag is set outside effective mode. Every assignment this driver
+returns — direct or effective — is reported with `inherited: false` and
+`implied_via: None`: the driver has no way to tell a directly-stored tuple
+from one the model resolved via inheritance or implication. See the Negative
+consequences.
+
+A **target-scoped** listing always uses `read` even in effective mode: this
+driver does not call `list-users`, so group-derived grants _on the target_ are
+not resolved. A `debug!` records the limitation when effective mode is asked for
+there. This `read` also never walks the Keystone project tree, in either mode:
+a project-scoped listing (`domain_id`/`system_id` have no tree to walk) only
+ever sees tuples stored directly on that project. Unlike the SQL driver — which
+adds each ancestor project as an `inherited = true` target via
+`get_project_parents` regardless of `effective` — a grant made on a parent
+project is invisible here even in non-effective mode. Project-tree inheritance
+on this driver only exists to the extent the OpenFGA model encodes it as a
+rewrite (see §4 and the Negative consequences below).
+
+`check_grant` always calls OpenFGA's model-resolving `check` API — it has no
+`effective` parameter, so it cannot restrict itself to a direct tuple the way
+`assignment-driver-sql`'s `check` does. See the Negative consequences.
+
+### 4. `inherited: true` is rejected on create
+
+Because a grant is one tuple with no `inherited` marker, an inherited grant
+would be indistinguishable from a direct one on read. `create_grant` returns
+`InheritedGrantsNotSupported`, which maps to
+`AssignmentProviderError::Validation` → HTTP 400, rather than silently storing
+it as a direct grant. Project-tree inheritance must be expressed as a relation
+rewrite in the OpenFGA authorization model.
+
+### 5. Revoke mirrors the SQL driver's idempotence
+
+`revoke_grant` probes each representation with a direct `read` and issues a
+delete only for the ones that actually hold the tuple. Revoking a grant that is
+not present is a no-op returning `Ok(())`, matching `assignment-driver-sql`.
+This also avoids OpenFGA's "tuple not found" delete error. A real error from
+either the `read` or the `delete` propagates.
+
+### 6. Listing has no server-side cursor; pagination is post-fetch
+
+A single `list_assignments` call is a fan-out union across representations,
+target kinds and role relations, so no opaque cursor can be pushed into OpenFGA.
+Results are fully materialised, de-duplicated, sorted by the assignment
+pagination marker, then sliced (`marker` / `limit` / `page_reverse`), mirroring
+the SQL driver's post-fetch pagination.
+
+To keep individual OpenFGA calls from truncating silently:
+
+- `read` follows `continuation_token` to completion (bounded by
+  `MAX_READ_PAGES = 1000`, with a `warn!` if hit).
+- object enumeration uses **`streamed-list-objects`**, not `list-objects`.
+  `list-objects` caps its result at `OPENFGA_LIST_OBJECTS_MAX_RESULTS`
+  (default 1000) with no continuation token, so a full page silently drops
+  assignments. The streaming form is bounded only by
+  `OPENFGA_LIST_OBJECTS_DEADLINE`; the driver parses its newline-delimited
+  `{"result":{"object":...}}` frames.
+
+### 7. Resiliency: configurable retry
+
+`send()` wraps every OpenFGA call. Transient failures — connection errors,
+timeouts, HTTP 429, HTTP 5xx — are retried up to `max_retries` times (default
+`0`, i.e. off) with exponential backoff from `retry_backoff_ms` (default 100). A
+4xx other than 429 is returned immediately.
+
+### 8. Concurrency: bounded fan-out
+
+Every fan-out (over actor/target representations, target kinds, role relations)
+issues its OpenFGA requests concurrently via `buffer_unordered`, capped at
+`max_concurrency` (default 10). `read` continuation and `batch-check` chunking
+stay sequential. `max_concurrency = 1` forces fully serial calls without
+changing results.
+
+### 9. No caching
+
+`check_grant` / `list_assignments` results are not cached in the driver. OpenFGA
+is the source of truth and has its own consistency controls; a Keystone-side
+cache would add a staleness window on authorization decisions for no clear
+benefit at current call volumes. Revisit if profiling shows OpenFGA round-trips
+dominating auth latency.
+
+### 10. Error mapping
+
+`OpenFGADriverError` (in `types.rs`) converts to `AssignmentProviderError`:
+`InheritedGrantsNotSupported` → `Validation` (400); the three unsupported-listing
+variants (`ListingActorWithoutScopeRequiresEffective`,
+`ListingAssignmentsByRoleNotSupported`, `ListingAllAssignmentsNotSupported`) →
+`AssignmentProviderError::NotImplemented` → HTTP 501; everything else → `Driver`
+(500). The unsupported-listing shapes are a permanent property of the query
+(no target scope, only a role filter, or no filter at all), not a transient
+backend fault, so they are kept out of the 500 path: a 501 tells the caller
+"this driver can't answer this", where a 500 would read as a bug and page an
+operator. `GET /v3/role_assignments` reaches all three from public,
+policy-gated query parameters (`role.id` alone, or no parameters at all, or
+`user.id`/`group.id` without `effective=true` and without a target scope).
+
+## Consequences
+
+### Positive
+
+- A single authorization model spans OpenStack and non-OpenStack resources;
+  group expansion and role implication are resolved once, by OpenFGA.
+- No new persistence: the driver is stateless, the mapping is config, and there
+  is no schema to migrate.
+- Alternate type names and UUID-format differences are absorbed by config, so
+  the driver can point at a pre-existing OpenFGA store.
+- Retry and concurrency are tunable per deployment; both default to conservative
+  behaviour (retry off, modest parallelism).
+
+### Negative
+
+- **Authorization-model coupling.** The driver is only correct if the OpenFGA
+  model encodes group membership (e.g. a `member` relation) and implied roles as
+  rewrites. Nothing syncs Keystone identity group membership into OpenFGA — the
+  deployment owns that. This is not limited to `GET /v3/role_assignments`:
+  every scoped-token issue path
+  (`resolve_project_default_roles`/`resolve_domain_roles`/`resolve_system_roles`
+  in `crates/core/src/auth.rs`) calls `list_assignments` with
+  `effective = true`, which on this driver is a `batch-check` against the
+  model with no Keystone-side group expansion (the SQL driver expands
+  `list_groups_of_user` itself before querying). **A deployment that switches
+  `driver = "openfga"` without first building that membership sync issues
+  tokens missing every group-derived role**, silently, from the first request
+  onward.
+- **Asymmetric listing.** Actor-only listing needs `effective = true`;
+  target-scoped listing never resolves group-derived grants; a non-effective
+  project-scoped listing does not walk the project tree either (see the
+  `read`-only target-scoped path in §3) — parent-project `inherited = true`
+  grants that the SQL driver surfaces via `get_project_parents` are simply
+  absent. Callers relying on the SQL driver's fully-symmetric listing may see
+  different results.
+- **`check_grant` is always model-resolved.** Unlike the SQL driver's `check`
+  (an exact match on actor/target/role **and** the `inherited` flag), this
+  driver's `check_grant` calls OpenFGA's `check` API, so it also returns `true`
+  for a grant reached via group membership, implication or inheritance, with
+  no way to ask for "direct only" (the method takes no `effective` flag).
+  Harmless today — `check_grant` has no production caller (the `HEAD
+  /v3/projects/{id}/users/{id}/roles/{id}` handler goes through
+  `list_role_assignments` instead) — but a future caller wiring `check_grant`
+  directly will get a different answer per driver.
+- **`implied_via` provenance is lost.** Effective-mode results always report
+  `implied_via: None`, even for a role the model only granted through
+  implication. `GET /v3/role_assignments?include_names` therefore cannot show
+  which grant implied which role on this driver, unlike the SQL driver.
+- **No cursor.** Large assignment sets are materialised in memory before
+  pagination. Acceptable for realistic per-actor / per-target scopes; not for a
+  hypothetical "all assignments" query (which is unsupported anyway).
+- **Actor-only effective listing fans out per role.** `(actor, no target)` in
+  effective mode issues one `streamed-list-objects` graph walk per
+  `(representation, target kind, role relation)` combination — roughly
+  `users × 3 × role count` calls, each a full graph traversal, bounded only by
+  `max_concurrency` in flight, not in total. `GET /v3/auth/projects` (an
+  unscoped→scoped token flow step, e.g. Horizon's project picker) takes this
+  path. The SQL driver answers the equivalent query with two table scans.
+  Acceptable at a handful of configured roles; worth profiling before pointing
+  this driver at a large `role_to_relation` table.
+- **`inherited` grants are unavailable** through this driver. Deployments that
+  depend on Keystone project-tree inheritance must model it in OpenFGA or stay
+  on the SQL driver.
+- **New dependency surface:** `reqwest` to talk to OpenFGA, plus `futures` for
+  the bounded fan-out.
+
+### Testing
+
+`crates/assignment-driver-openfga/src/tests.rs` exercises every path against an
+`httpmock` OpenFGA: actor/target mapping and representation fan-out, the
+`effective` branch matrix, streamed object enumeration (multi-frame, no
+truncation), retry (retries a 503, does not retry a 400), idempotent revoke,
+`inherited` rejection, and post-fetch pagination. Config parsing is covered by
+`openstack-keystone-config`. A live-OpenFGA functional suite is reasonable
+follow-up work and is not part of this change. Also follow-up, not part of
+this change: profiling the actor-only effective fan-out call count
+(`users × target kinds × role relations`, see Negative consequences) against a
+realistic `role_to_relation` table size, and — if group-membership sync into
+OpenFGA gets built — an integration test asserting a scoped token actually
+carries a group-derived role end to end.


### PR DESCRIPTION
Keystone role assignments are a relationship graph; OpenFGA models that
natively, letting deployments that already run it as their central authz
store put OpenStack and non-OpenStack resources under one model with
group/implication resolution done once, not per-consumer.

- Config-only entity<->object mapping (crates/config), no new
  Keystone-side mapping table
- listing shapes this driver structurally cannot answer (no actor and no
  target, or role-only) return 501 via a new
AssignmentProviderError::NotImplement, not backend faults
- object enumeration uses streamed-list-objects instead of list-objects
  to avoid its silent 1000-result truncation
- bounded concurrency (max_concurrency, default 10) on every fan-out
  over actor/target representations and role relations
- retry with exponential backoff on 429/5xx/transient transport errors

See doc/src/adr/0033-openfga-assignment-driver.md, including the
Negative consequences: this driver does not sync Keystone group
membership into OpenFGA, so effective-mode token issuance needs that
pipeline built externally before switching drivers.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
