### PR TITLE
feat(identity): Resolve local/public ids for non-default backends

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -109,19 +109,20 @@ store-failure-output = true
 # Spins up a throwaway local `slapd` (no Docker daemon required; see
 # tools/start-ldap-test.sh), seeds it from
 # crates/identity-driver-ldap/tests/fixtures/base.ldif, and runs the
-# `live_tests` module's functional tests against it. Those tests skip
-# themselves (rather than fail) under any other profile, since
-# KEYSTONE_LDAP_TEST_URL is only set here.
+# `live_tests` module's functional tests, plus test_integration's
+# `domain_config::cross_backend` module (real SQL+LDAP per-domain identity
+# dispatch), against it. Those tests skip themselves (rather than fail)
+# under any other profile, since KEYSTONE_LDAP_TEST_URL is only set here.
 [profile.ldap]
 
 [[profile.ldap.scripts]]
-filter = "package(openstack-keystone-identity-driver-ldap)"
+filter = "package(openstack-keystone-identity-driver-ldap) + binary(integration)"
 setup = "start-ldap-test"
 
 [profile.ci-ldap]
 inherits = "ldap"
 [[profile.ci-ldap.scripts]]
-filter = "package(openstack-keystone-identity-driver-ldap)"
+filter = "package(openstack-keystone-identity-driver-ldap) + binary(integration)"
 setup = "start-ldap-test"
 [profile.ci-ldap.junit]
 path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,10 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         run: cargo nextest run -p openstack-keystone-identity-driver-ldap --profile ci-ldap
 
+      - name: Run cross-backend (SQL+LDAP) domain config tests
+        if: needs.changes.outputs.code == 'true'
+        run: cargo nextest run -p test_integration --profile ci-ldap --test integration -- domain_config::cross_backend
+
       # Compile-only: catches rot in the TPM sample without requiring a
       # real/virtual TPM in CI (ADR 0016-v2 §2.5.2 test/sample scope decision
       # — real/virtual TPM availability in CI runners isn't reliable enough

--- a/crates/core-types/src/identity/error.rs
+++ b/crates/core-types/src/identity/error.rs
@@ -19,6 +19,7 @@ use openstack_keystone_config::SecurityComplianceError;
 use crate::auth::AuthenticationError;
 use crate::credential::CredentialProviderError;
 use crate::error::BuilderError;
+use crate::idmapping::IdMappingProviderError;
 use crate::resource::ResourceProviderError;
 
 /// Identity provider error.
@@ -58,6 +59,14 @@ pub enum IdentityProviderError {
 
     #[error("Date calculation error")]
     DateError,
+
+    /// Id-mapping provider error, surfaced when a domain-specific-driver
+    /// create/delete cascades into `create_id_mapping`/`delete_id_mapping`.
+    #[error(transparent)]
+    IdMappingProvider {
+        #[from]
+        source: IdMappingProviderError,
+    },
 
     /// Driver error.
     #[error("backend driver error: {0}")]

--- a/crates/core-types/src/resource/error.rs
+++ b/crates/core-types/src/resource/error.rs
@@ -15,6 +15,7 @@
 use thiserror::Error;
 
 use crate::credential::CredentialProviderError;
+use crate::idmapping::IdMappingProviderError;
 use crate::oauth2_key::Oauth2KeyProviderError;
 
 #[derive(Error, Debug)]
@@ -29,6 +30,14 @@ pub enum ResourceProviderError {
     CredentialProvider {
         #[from]
         source: CredentialProviderError,
+    },
+
+    /// Id-mapping provider error, surfaced when cascading a domain deletion
+    /// into `delete_mappings_for_domain`.
+    #[error(transparent)]
+    IdMappingProvider {
+        #[from]
+        source: IdMappingProviderError,
     },
 
     /// Domain not found.

--- a/crates/core/src/auth_metrics.rs
+++ b/crates/core/src/auth_metrics.rs
@@ -260,6 +260,7 @@ pub fn identity_failure_reason(e: &IdentityProviderError) -> &'static str {
         IdentityProviderError::DateError => "DateError",
         IdentityProviderError::Driver(_) => "Driver",
         IdentityProviderError::GroupNotFound(_) => "GroupNotFound",
+        IdentityProviderError::IdMappingProvider { .. } => "ProviderError",
         IdentityProviderError::Join { .. } => "ProviderError",
         IdentityProviderError::LdapConnection(_) => "LdapConnection",
         IdentityProviderError::LdapFilterBuild(_) => "LdapFilterBuild",

--- a/crates/core/src/identity/service.rs
+++ b/crates/core/src/identity/service.rs
@@ -27,6 +27,7 @@ use openstack_keystone_config::Config;
 use openstack_keystone_core_types::domain_config::DomainConfigGroupName;
 use openstack_keystone_core_types::events::{Event, EventPayload, Operation};
 use openstack_keystone_core_types::identity::*;
+use openstack_keystone_core_types::idmapping::IdMappingEntityType;
 
 use crate::auth::{
     AuthenticationContext, AuthenticationError, AuthenticationResult, AuthenticationResultBuilder,
@@ -282,20 +283,128 @@ impl IdentityService {
         ctx: &ExecutionContext<'a>,
         public_id: &str,
     ) -> Result<Arc<dyn IdentityBackend>, IdentityProviderError> {
+        Ok(self.resolve_public_id(ctx, public_id).await?.0)
+    }
+
+    /// Resolve a public id to the backend that owns it and the local id to
+    /// use when calling into that backend.
+    ///
+    /// Mirrors python-keystone's `_get_domain_driver_and_entity_id`: a
+    /// mapping hit means a non-default backend owns the entity, under a
+    /// (possibly different) local id; a miss means the default backend
+    /// owns it and `public_id` doubles as the local id, used as-is.
+    async fn resolve_public_id<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        public_id: &str,
+    ) -> Result<(Arc<dyn IdentityBackend>, String), IdentityProviderError> {
         if self.domain_config_resolver.is_none() {
-            return Ok(self.backend_driver.clone());
+            return Ok((self.backend_driver.clone(), public_id.to_string()));
         }
-        let domain_id = match ctx
+        match ctx
             .state()
             .provider
             .get_idmapping_provider()
             .get_by_public_id(ctx, public_id)
             .await
         {
-            Ok(Some(mapping)) => mapping.domain_id,
-            _ => return Ok(self.backend_driver.clone()),
-        };
-        self.driver_for(ctx.state(), Some(&domain_id)).await
+            Ok(Some(mapping)) => {
+                let backend = self
+                    .driver_for(ctx.state(), Some(&mapping.domain_id))
+                    .await?;
+                Ok((backend, mapping.local_id))
+            }
+            _ => Ok((self.backend_driver.clone(), public_id.to_string())),
+        }
+    }
+
+    /// Record an id-mapping row for an entity just created on a non-default
+    /// backend, so a later [`Self::driver_for_public_id`] lookup by its id
+    /// dispatches back to that same backend instead of falling through to
+    /// the global driver.
+    ///
+    /// A no-op when `backend_driver` is the global driver itself: entities
+    /// there need no mapping, since a lookup miss already falls back to it.
+    /// The local id and the public id are the same value today -- the rust
+    /// implementation does not remap ids the way python-keystone's
+    /// `generates_uuids() == False` drivers do.
+    async fn record_id_mapping(
+        &self,
+        ctx: &ExecutionContext<'_>,
+        backend_driver: &Arc<dyn IdentityBackend>,
+        entity_id: &str,
+        domain_id: &str,
+        entity_type: IdMappingEntityType,
+    ) -> Result<(), IdentityProviderError> {
+        if Arc::ptr_eq(backend_driver, &self.backend_driver) {
+            return Ok(());
+        }
+        // Reborrow through a fresh, short-lived context: `create_id_mapping`
+        // ties its id/domain arguments to the context's own lifetime, which
+        // freshly created (owned) ids can't satisfy against the caller's
+        // longer-lived `ctx`.
+        let short_ctx = ExecutionContext::internal(ctx.state());
+        short_ctx
+            .state()
+            .provider
+            .get_idmapping_provider()
+            .create_id_mapping(
+                &short_ctx,
+                entity_id,
+                domain_id,
+                entity_type,
+                Some(entity_id),
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Delete the id-mapping row (if any) for an entity just deleted.
+    /// Idempotent, so it's safe to call even when the entity was served by
+    /// the global driver and never had one.
+    async fn forget_id_mapping(
+        &self,
+        ctx: &ExecutionContext<'_>,
+        entity_id: &str,
+    ) -> Result<(), IdentityProviderError> {
+        let short_ctx = ExecutionContext::internal(ctx.state());
+        short_ctx
+            .state()
+            .provider
+            .get_idmapping_provider()
+            .delete_id_mapping(&short_ctx, entity_id)
+            .await?;
+        Ok(())
+    }
+
+    /// Turn a backend-native local id into the public id API consumers see.
+    ///
+    /// A no-op (returns `local_id` unchanged) when `backend` is the global
+    /// driver: default-backend entities are used and exposed under their own
+    /// id directly, mirroring python-keystone's "no mapping needed" case.
+    /// For a non-default backend, gets-or-creates the mapping row --
+    /// [`IdMappingApi::create_id_mapping`] is idempotent for a repeat local
+    /// id (same deterministic sha256 public id, matching python-keystone's
+    /// default `sha256` id generator) -- and returns the public id.
+    async fn shadow_id(
+        &self,
+        ctx: &ExecutionContext<'_>,
+        backend: &Arc<dyn IdentityBackend>,
+        domain_id: &str,
+        local_id: &str,
+        entity_type: IdMappingEntityType,
+    ) -> Result<String, IdentityProviderError> {
+        if Arc::ptr_eq(backend, &self.backend_driver) {
+            return Ok(local_id.to_string());
+        }
+        let short_ctx = ExecutionContext::internal(ctx.state());
+        let mapping = short_ctx
+            .state()
+            .provider
+            .get_idmapping_provider()
+            .create_id_mapping(&short_ctx, local_id, domain_id, entity_type, None)
+            .await?;
+        Ok(mapping.public_id)
     }
 
     /// Resolve the user's and the group's backends and require them to be the
@@ -852,6 +961,15 @@ impl IdentityApi for IdentityService {
             group
         };
 
+        self.record_id_mapping(
+            ctx,
+            &backend_driver,
+            &group.id,
+            &group.domain_id,
+            IdMappingEntityType::Group,
+        )
+        .await?;
+
         Ok(group)
     }
 
@@ -917,6 +1035,15 @@ impl IdentityApi for IdentityService {
             user
         };
 
+        self.record_id_mapping(
+            ctx,
+            &backend_driver,
+            &user.id,
+            &user.domain_id,
+            IdMappingEntityType::User,
+        )
+        .await?;
+
         Ok(user)
     }
 
@@ -930,7 +1057,7 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         group_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        let backend_driver = self.driver_for_group(ctx, group_id).await?;
+        let (backend_driver, local_id) = self.resolve_public_id(ctx, group_id).await?;
         if let Some(vsc) = ctx.ctx() {
             crate::audited_op! {
                 dispatcher: &ctx.state().event_dispatcher,
@@ -940,13 +1067,13 @@ impl IdentityApi for IdentityService {
                     EventPayload::Group { id: group_id.to_string() },
                 ),
                 operation: async {
-                    backend_driver.delete_group(ctx.state(), group_id).await?;
+                    backend_driver.delete_group(ctx.state(), &local_id).await?;
                     Ok::<(), IdentityProviderError>(())
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
-            backend_driver.delete_group(ctx.state(), group_id).await?;
+            backend_driver.delete_group(ctx.state(), &local_id).await?;
             ctx.state()
                 .event_dispatcher
                 .emit(Event::new(
@@ -958,6 +1085,9 @@ impl IdentityApi for IdentityService {
                 .await;
         }
 
+        if !Arc::ptr_eq(&backend_driver, &self.backend_driver) {
+            self.forget_id_mapping(ctx, group_id).await?;
+        }
         cache_remove(GROUP_CACHE_NS, group_id);
         Ok(())
     }
@@ -972,7 +1102,7 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         user_id: &'a str,
     ) -> Result<(), IdentityProviderError> {
-        let backend_driver = self.driver_for_user(ctx, user_id).await?;
+        let (backend_driver, local_id) = self.resolve_public_id(ctx, user_id).await?;
         if let Some(vsc) = ctx.ctx() {
             // Audited delete – fail‐closed on pre‐audit failure.
             crate::audited_op! {
@@ -983,7 +1113,7 @@ impl IdentityApi for IdentityService {
                     EventPayload::User { id: user_id.to_string() },
                 ),
                 operation: async {
-                    backend_driver.delete_user(ctx.state(), user_id).await?;
+                    backend_driver.delete_user(ctx.state(), &local_id).await?;
                     if self.caching {
                         self.user_id_domain_id_cache
                             .write()
@@ -1001,7 +1131,7 @@ impl IdentityApi for IdentityService {
             }?;
         } else {
             // No validated context – perform operation and emit on perimeter.
-            backend_driver.delete_user(ctx.state(), user_id).await?;
+            backend_driver.delete_user(ctx.state(), &local_id).await?;
             if self.caching {
                 self.user_id_domain_id_cache.write().await.remove(user_id);
             }
@@ -1021,6 +1151,9 @@ impl IdentityApi for IdentityService {
                 .await;
         }
 
+        if !Arc::ptr_eq(&backend_driver, &self.backend_driver) {
+            self.forget_id_mapping(ctx, user_id).await?;
+        }
         cache_remove(USER_CACHE_NS, user_id);
         Ok(())
     }
@@ -1042,11 +1175,16 @@ impl IdentityApi for IdentityService {
         if let Some(user) = cache_get::<UserResponse>(USER_CACHE_NS, user_id) {
             return Ok(Some(user));
         }
-        let user = self
-            .driver_for_user(ctx, user_id)
-            .await?
-            .get_user(ctx.state(), user_id)
-            .await?;
+        let (backend, local_id) = self.resolve_public_id(ctx, user_id).await?;
+        let mut user = backend.get_user(ctx.state(), &local_id).await?;
+        if !Arc::ptr_eq(&backend, &self.backend_driver) {
+            if let Some(user) = &mut user {
+                // Non-default backend: the driver knows the entity by
+                // `local_id`, not `user_id` -- restore the public id the
+                // caller looked it up by before it's cached/returned.
+                user.id = user_id.to_string();
+            }
+        }
         if let Some(user) = &user {
             if self.caching {
                 self.user_id_domain_id_cache
@@ -1105,10 +1243,23 @@ impl IdentityApi for IdentityService {
         domain_id: &'a str,
         name: &'a str,
     ) -> Result<Option<String>, IdentityProviderError> {
-        self.driver_for(ctx.state(), Some(domain_id))
-            .await?
+        let backend = self.driver_for(ctx.state(), Some(domain_id)).await?;
+        match backend
             .find_user_by_name_ci(ctx.state(), domain_id, name)
-            .await
+            .await?
+        {
+            Some(local_id) => Ok(Some(
+                self.shadow_id(
+                    ctx,
+                    &backend,
+                    domain_id,
+                    &local_id,
+                    IdMappingEntityType::User,
+                )
+                .await?,
+            )),
+            None => Ok(None),
+        }
     }
 
     /// Find federated user by `idp_id` and `unique_id`.
@@ -1142,10 +1293,26 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         params: &UserListParameters,
     ) -> Result<Vec<UserResponse>, IdentityProviderError> {
-        self.driver_for(ctx.state(), params.domain_id.as_deref())
-            .await?
-            .list_users(ctx.state(), params)
-            .await
+        let backend = self
+            .driver_for(ctx.state(), params.domain_id.as_deref())
+            .await?;
+        let mut users = backend.list_users(ctx.state(), params).await?;
+        if !Arc::ptr_eq(&backend, &self.backend_driver) {
+            for user in &mut users {
+                let local_id = user.id.clone();
+                let domain_id = user.domain_id.clone();
+                user.id = self
+                    .shadow_id(
+                        ctx,
+                        &backend,
+                        &domain_id,
+                        &local_id,
+                        IdMappingEntityType::User,
+                    )
+                    .await?;
+            }
+        }
+        Ok(users)
     }
 
     /// List groups.
@@ -1158,10 +1325,26 @@ impl IdentityApi for IdentityService {
         ctx: &ExecutionContext<'a>,
         params: &GroupListParameters,
     ) -> Result<Vec<Group>, IdentityProviderError> {
-        self.driver_for(ctx.state(), params.domain_id.as_deref())
-            .await?
-            .list_groups(ctx.state(), params)
-            .await
+        let backend = self
+            .driver_for(ctx.state(), params.domain_id.as_deref())
+            .await?;
+        let mut groups = backend.list_groups(ctx.state(), params).await?;
+        if !Arc::ptr_eq(&backend, &self.backend_driver) {
+            for group in &mut groups {
+                let local_id = group.id.clone();
+                let domain_id = group.domain_id.clone();
+                group.id = self
+                    .shadow_id(
+                        ctx,
+                        &backend,
+                        &domain_id,
+                        &local_id,
+                        IdMappingEntityType::Group,
+                    )
+                    .await?;
+            }
+        }
+        Ok(groups)
     }
 
     /// Get single group.
@@ -1181,11 +1364,15 @@ impl IdentityApi for IdentityService {
         if let Some(group) = cache_get::<Group>(GROUP_CACHE_NS, group_id) {
             return Ok(Some(group));
         }
-        let group = self
-            .driver_for_group(ctx, group_id)
-            .await?
-            .get_group(ctx.state(), group_id)
-            .await?;
+        let (backend, local_id) = self.resolve_public_id(ctx, group_id).await?;
+        let mut group = backend.get_group(ctx.state(), &local_id).await?;
+        if !Arc::ptr_eq(&backend, &self.backend_driver) {
+            // See `get_user`: restore the public id the caller looked it up
+            // by, since a non-default backend knows it as `local_id`.
+            if let Some(group) = &mut group {
+                group.id = group_id.to_string();
+            }
+        }
         if let Some(group) = &group {
             cache_set(GROUP_CACHE_NS, group_id, group.clone());
         }
@@ -1237,10 +1424,23 @@ impl IdentityApi for IdentityService {
         domain_id: &'a str,
         name: &'a str,
     ) -> Result<Option<String>, IdentityProviderError> {
-        self.driver_for(ctx.state(), Some(domain_id))
-            .await?
+        let backend = self.driver_for(ctx.state(), Some(domain_id)).await?;
+        match backend
             .find_group_by_name_ci(ctx.state(), domain_id, name)
-            .await
+            .await?
+        {
+            Some(local_id) => Ok(Some(
+                self.shadow_id(
+                    ctx,
+                    &backend,
+                    domain_id,
+                    &local_id,
+                    IdMappingEntityType::Group,
+                )
+                .await?,
+            )),
+            None => Ok(None),
+        }
     }
 
     /// Update group.
@@ -1255,8 +1455,8 @@ impl IdentityApi for IdentityService {
         group_id: &'a str,
         group: GroupUpdate,
     ) -> Result<Group, IdentityProviderError> {
-        let backend_driver = self.driver_for_group(ctx, group_id).await?;
-        let group = if let Some(vsc) = ctx.ctx() {
+        let (backend_driver, local_id) = self.resolve_public_id(ctx, group_id).await?;
+        let mut group = if let Some(vsc) = ctx.ctx() {
             let backend_driver = &backend_driver;
             let state = ctx.state();
             let group_id_clone = group_id.to_string();
@@ -1268,26 +1468,30 @@ impl IdentityApi for IdentityService {
                     EventPayload::Group { id: group_id_clone },
                 ),
                 operation: async {
-                    backend_driver.update_group(state, group_id, group).await
+                    backend_driver.update_group(state, &local_id, group).await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?
         } else {
             let group = backend_driver
-                .update_group(ctx.state(), group_id, group)
+                .update_group(ctx.state(), &local_id, group)
                 .await?;
             ctx.state()
                 .event_dispatcher
                 .emit(Event::new(
                     Operation::Update,
                     EventPayload::Group {
-                        id: group.id.clone(),
+                        id: group_id.to_string(),
                     },
                 ))
                 .await;
             group
         };
 
+        if !Arc::ptr_eq(&backend_driver, &self.backend_driver) {
+            // See `get_user`: restore the public id the caller asked for.
+            group.id = group_id.to_string();
+        }
         cache_set(GROUP_CACHE_NS, group_id, group.clone());
         Ok(group)
     }
@@ -1569,8 +1773,8 @@ impl IdentityApi for IdentityService {
             let cfg = ctx.state().config_manager.config.read().await;
             cfg.security_compliance.validate_password(password)?;
         }
-        let backend_driver = self.driver_for_user(ctx, user_id).await?;
-        let user = if let Some(vsc) = ctx.ctx() {
+        let (backend_driver, local_id) = self.resolve_public_id(ctx, user_id).await?;
+        let mut user = if let Some(vsc) = ctx.ctx() {
             let backend_driver = &backend_driver;
             let state = ctx.state();
             crate::audited_op! {
@@ -1581,13 +1785,13 @@ impl IdentityApi for IdentityService {
                     EventPayload::User { id: user_id.to_string() },
                 ),
                 operation: async {
-                    backend_driver.update_user(state, user_id, user).await
+                    backend_driver.update_user(state, &local_id, user).await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?
         } else {
             let user = backend_driver
-                .update_user(ctx.state(), user_id, user)
+                .update_user(ctx.state(), &local_id, user)
                 .await?;
             ctx.state()
                 .event_dispatcher
@@ -1601,6 +1805,10 @@ impl IdentityApi for IdentityService {
             user
         };
 
+        if !Arc::ptr_eq(&backend_driver, &self.backend_driver) {
+            // See `get_user`: restore the public id the caller asked for.
+            user.id = user_id.to_string();
+        }
         cache_set(USER_CACHE_NS, user_id, user.clone());
         Ok(user)
     }
@@ -1621,11 +1829,11 @@ impl IdentityApi for IdentityService {
     ) -> Result<(), IdentityProviderError> {
         let cfg = ctx.state().config_manager.config.read().await;
         cfg.security_compliance.validate_password(&new_password)?;
-        let backend_driver = self.driver_for_user(ctx, user_id).await?;
+        let (backend_driver, local_id) = self.resolve_public_id(ctx, user_id).await?;
         if let Some(vsc) = ctx.ctx() {
             let backend_driver = &backend_driver;
             let state = ctx.state();
-            let user_id = user_id.to_string();
+            let event_user_id = user_id.to_string();
             let orig_pwd = original_password.clone();
             let new_pwd = new_password.clone();
             crate::audited_op! {
@@ -1633,16 +1841,16 @@ impl IdentityApi for IdentityService {
                 ctx: vsc,
                 event: Event::new(
                     Operation::Update,
-                    EventPayload::User { id: user_id.clone() },
+                    EventPayload::User { id: event_user_id },
                 ),
                 operation: async {
-                    backend_driver.update_user_password(state, &user_id, orig_pwd, new_pwd).await
+                    backend_driver.update_user_password(state, &local_id, orig_pwd, new_pwd).await
                 },
                 on_audit_error: |_: AuditDispatchError| IdentityProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
             backend_driver
-                .update_user_password(ctx.state(), user_id, original_password, new_password)
+                .update_user_password(ctx.state(), &local_id, original_password, new_password)
                 .await?;
             ctx.state()
                 .event_dispatcher

--- a/crates/core/src/identity/service/tests/per_domain_dispatch.rs
+++ b/crates/core/src/identity/service/tests/per_domain_dispatch.rs
@@ -755,3 +755,275 @@ async fn the_non_domain_aware_guard_honours_a_custom_default_domain_id() {
         "unexpected error: {error:?}"
     );
 }
+
+/// Gap 1: creating a user on a domain dispatched to a non-default
+/// backend must record an id-mapping row, so a later
+/// `driver_for_public_id` lookup by the new id dispatches back to the
+/// same backend instead of falling through to the global driver.
+#[tokio::test]
+async fn create_user_on_a_domain_specific_backend_records_an_id_mapping() {
+    let mut idmapping = MockIdMappingProvider::default();
+    idmapping
+        .expect_create_id_mapping()
+        .withf(
+            |_,
+             local_id: &'_ str,
+             domain_id: &'_ str,
+             entity_type: &IdMappingEntityType,
+             public_id: &Option<&str>| {
+                local_id == "u"
+                    && domain_id == "d-ldap"
+                    && *entity_type == IdMappingEntityType::User
+                    && *public_id == Some("u")
+            },
+        )
+        .returning(|_, local_id, domain_id, entity_type, _| {
+            Ok(IdMapping {
+                domain_id: domain_id.to_string(),
+                entity_type,
+                local_id: local_id.to_string(),
+                public_id: local_id.to_string(),
+            })
+        });
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_idmapping(idmapping)),
+    )
+    .await;
+
+    let sql = identity_backend(0);
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(true);
+    ldap_mock.expect_create_user().returning(|_, user| {
+        Ok(UserResponseBuilder::default()
+            .id(user.id.expect("id set by the service"))
+            .domain_id(user.domain_id.expect("domain_id set by the service"))
+            .enabled(true)
+            .name(user.name)
+            .build()
+            .expect("valid user"))
+    });
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(1))));
+
+    let user = provider
+        .create_user(
+            &ExecutionContext::internal(&state),
+            UserCreateBuilder::default()
+                .id("u".to_string())
+                .name("u-name".to_string())
+                .domain_id("d-ldap".to_string())
+                .enabled(true)
+                .build()
+                .expect("valid user create"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(user.id, "u");
+}
+
+/// The mirror of the above: creating on the (same-instance) default
+/// backend must record nothing -- a lookup miss there already falls
+/// back to the global driver, so a mapping row would be dead weight.
+/// The idmapping mock has no expectations set up at all, so an
+/// unwanted call panics the test.
+#[tokio::test]
+async fn create_user_on_the_default_backend_records_no_id_mapping() {
+    let idmapping = MockIdMappingProvider::default();
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_idmapping(idmapping)),
+    )
+    .await;
+
+    let mut backend = MockIdentityBackend::default();
+    backend.expect_is_domain_aware().return_const(true);
+    backend.expect_create_user().returning(|_, user| {
+        Ok(UserResponseBuilder::default()
+            .id(user.id.expect("id set by the service"))
+            .domain_id(user.domain_id.expect("domain_id set by the service"))
+            .enabled(true)
+            .name(user.name)
+            .build()
+            .expect("valid user"))
+    });
+    let provider = IdentityService::from_driver(backend);
+
+    let user = provider
+        .create_user(
+            &ExecutionContext::internal(&state),
+            UserCreateBuilder::default()
+                .id("u".to_string())
+                .name("u-name".to_string())
+                .domain_id("default".to_string())
+                .enabled(true)
+                .build()
+                .expect("valid user create"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(user.id, "u");
+}
+
+/// Gap 1's delete-side counterpart: deleting a user served by a
+/// non-default backend must forget its id-mapping row.
+#[tokio::test]
+async fn delete_user_on_a_domain_specific_backend_forgets_the_id_mapping() {
+    let mut idmapping = MockIdMappingProvider::default();
+    idmapping
+        .expect_get_by_public_id()
+        .withf(|_, public_id: &'_ str| public_id == "u")
+        .returning(|_, _| Ok(Some(user_mapping("d-ldap", "u"))));
+    idmapping
+        .expect_delete_id_mapping()
+        .withf(|_, public_id: &'_ str| public_id == "u")
+        .returning(|_, _| Ok(()));
+    let mut credential_mock = MockCredentialProvider::default();
+    credential_mock
+        .expect_delete_credentials_for_user()
+        .returning(|_, _| Ok(()));
+    let state = get_mocked_state(
+        None,
+        Some(
+            Provider::mocked_builder()
+                .mock_idmapping(idmapping)
+                .mock_credential(credential_mock),
+        ),
+    )
+    .await;
+
+    let sql = identity_backend(0);
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(true);
+    ldap_mock.expect_delete_user().returning(|_, _| Ok(()));
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(1))));
+
+    provider
+        .delete_user(&ExecutionContext::internal(&state), "u")
+        .await
+        .unwrap();
+}
+
+/// python-keystone compat: `get_user` must call the resolved backend with
+/// the mapping's `local_id`, not the caller's public id, and restore the
+/// public id on the returned entity -- a non-default backend (e.g. LDAP)
+/// knows the entity only by its own local id, which need not equal the
+/// public id the mapping minted for it.
+#[tokio::test]
+async fn get_user_dispatches_by_local_id_and_restores_the_public_id() {
+    let state = state_with_idmapping(Some(IdMapping {
+        domain_id: "d-ldap".to_string(),
+        entity_type: IdMappingEntityType::User,
+        local_id: "local-1".to_string(),
+        public_id: "pub-id".to_string(),
+    }))
+    .await;
+
+    let sql = get_user_backend(0);
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(false);
+    ldap_mock
+        .expect_get_user()
+        .withf(|_, user_id: &'_ str| user_id == "local-1")
+        .returning(|_, _| {
+            Ok(Some(
+                UserResponseBuilder::default()
+                    .id("local-1")
+                    .domain_id("d-ldap")
+                    .enabled(true)
+                    .name("u-name")
+                    .build()
+                    .expect("valid user"),
+            ))
+        });
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(1))));
+
+    let user = provider
+        .get_user(&ExecutionContext::internal(&state), "pub-id")
+        .await
+        .unwrap()
+        .expect("user should be there");
+    assert_eq!(user.id, "pub-id");
+}
+
+/// python-keystone compat: entities listed off a non-default backend must
+/// be shadowed through the id mapping (get-or-create, since this is the
+/// first time the entity is seen) so the caller sees a stable public id,
+/// never the backend's raw local id.
+#[tokio::test]
+async fn list_users_shadows_entities_from_a_non_default_backend() {
+    let mut idmapping = MockIdMappingProvider::default();
+    idmapping
+        .expect_create_id_mapping()
+        .withf(
+            |_,
+             local_id: &'_ str,
+             domain_id: &'_ str,
+             entity_type: &IdMappingEntityType,
+             public_id: &Option<&str>| {
+                local_id == "local-1"
+                    && domain_id == "d-ldap"
+                    && *entity_type == IdMappingEntityType::User
+                    && public_id.is_none()
+            },
+        )
+        .returning(|_, local_id, domain_id, entity_type, _| {
+            Ok(IdMapping {
+                domain_id: domain_id.to_string(),
+                entity_type,
+                local_id: local_id.to_string(),
+                public_id: "shadow-pub".to_string(),
+            })
+        });
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_idmapping(idmapping)),
+    )
+    .await;
+
+    let sql = identity_backend(0);
+    let mut ldap_mock = MockIdentityBackend::default();
+    ldap_mock.expect_is_domain_aware().return_const(true);
+    ldap_mock.expect_list_users().returning(|_, _| {
+        Ok(vec![
+            UserResponseBuilder::default()
+                .id("local-1")
+                .domain_id("d-ldap")
+                .enabled(true)
+                .name("u-name")
+                .build()
+                .expect("valid user"),
+        ])
+    });
+    let ldap: Arc<dyn IdentityBackend> = Arc::new(ldap_mock);
+
+    let mut backends = HashMap::new();
+    backends.insert("sql".to_string(), sql.clone());
+    backends.insert("ldap".to_string(), ldap);
+    let provider =
+        IdentityService::from_backends("sql", sql, backends, Some(resolver(ldap_config_source(1))));
+
+    let users = provider
+        .list_users(&ExecutionContext::internal(&state), &list_params("d-ldap"))
+        .await
+        .unwrap();
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].id, "shadow-pub");
+}

--- a/crates/core/src/idmapping/backend.rs
+++ b/crates/core/src/idmapping/backend.rs
@@ -94,4 +94,23 @@ pub trait IdMappingBackend: Send + Sync {
         state: &ServiceState,
         public_id: &'a str,
     ) -> Result<(), IdMappingProviderError>;
+
+    /// Delete every `IdMapping` row belonging to a domain.
+    ///
+    /// Called when the domain itself is deleted, so id mappings for entities
+    /// it used to own on a non-default backend don't outlive it. Idempotent:
+    /// deleting a domain with no mapping rows is not an error.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The domain identifier.
+    ///
+    /// # Returns
+    /// - `Result<(), IdMappingProviderError>` - `Ok` on success (including
+    ///   when nothing was found), or an `Error`.
+    async fn delete_mappings_for_domain<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+    ) -> Result<(), IdMappingProviderError>;
 }

--- a/crates/core/src/idmapping/provider_api.rs
+++ b/crates/core/src/idmapping/provider_api.rs
@@ -95,4 +95,23 @@ pub trait IdMappingApi: Send + Sync {
         ctx: &ExecutionContext<'a>,
         public_id: &'a str,
     ) -> Result<(), IdMappingProviderError>;
+
+    /// Delete every `IdMapping` row belonging to a domain.
+    ///
+    /// Called when the domain itself is deleted, so id mappings for entities
+    /// it used to own on a non-default backend don't outlive it. Idempotent:
+    /// deleting a domain with no mapping rows is not an error.
+    ///
+    /// # Parameters
+    /// - `ctx`: The execution context.
+    /// - `domain_id`: The domain identifier.
+    ///
+    /// # Returns
+    /// - `Result<(), IdMappingProviderError>` - `Ok` on success (including
+    ///   when nothing was found), or an `Error`.
+    async fn delete_mappings_for_domain<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+    ) -> Result<(), IdMappingProviderError>;
 }

--- a/crates/core/src/idmapping/service.rs
+++ b/crates/core/src/idmapping/service.rs
@@ -150,6 +150,25 @@ impl IdMappingApi for IdMappingService {
             .delete_id_mapping(ctx.state(), public_id)
             .await
     }
+
+    /// Delete every `IdMapping` row belonging to a domain.
+    ///
+    /// # Parameters
+    /// - `ctx`: The execution context.
+    /// - `domain_id`: The domain identifier.
+    ///
+    /// # Returns
+    /// - `Result<(), IdMappingProviderError>` - `Ok` on success (including
+    ///   when nothing was found), or an `Error`.
+    async fn delete_mappings_for_domain<'a>(
+        &self,
+        ctx: &ExecutionContext<'a>,
+        domain_id: &'a str,
+    ) -> Result<(), IdMappingProviderError> {
+        self.backend_driver
+            .delete_mappings_for_domain(ctx.state(), domain_id)
+            .await
+    }
 }
 
 #[cfg(test)]
@@ -305,6 +324,22 @@ mod tests {
 
         provider
             .delete_id_mapping(&ExecutionContext::internal(&state), "pid")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_mappings_for_domain() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockIdMappingBackend::default();
+        backend
+            .expect_delete_mappings_for_domain()
+            .withf(|_, did: &'_ str| did == "did")
+            .returning(|_, _| Ok(()));
+        let provider = create_provider(backend);
+
+        provider
+            .delete_mappings_for_domain(&ExecutionContext::internal(&state), "did")
             .await
             .unwrap();
     }

--- a/crates/core/src/mocks.rs
+++ b/crates/core/src/mocks.rs
@@ -1207,6 +1207,12 @@ mod idmapping {
                 ctx: &ExecutionContext<'a>,
                 public_id: &'a str,
             ) -> Result<(), IdMappingProviderError>;
+
+            async fn delete_mappings_for_domain<'a>(
+                &self,
+                ctx: &ExecutionContext<'a>,
+                domain_id: &'a str,
+            ) -> Result<(), IdMappingProviderError>;
         }
     }
 }

--- a/crates/core/src/resource/service.rs
+++ b/crates/core/src/resource/service.rs
@@ -482,12 +482,23 @@ impl ResourceApi for ResourceService {
                 ),
                 operation: async {
                     self.backend_driver.delete_domain(ctx.state(), id).await?;
+                    ctx.state()
+                        .provider
+                        .get_idmapping_provider()
+                        .delete_mappings_for_domain(ctx, id)
+                        .await?;
                     Ok::<(), ResourceProviderError>(())
                 },
                 on_audit_error: |_: AuditDispatchError| ResourceProviderError::Driver("audit dispatch failed".into()),
             }?;
         } else {
             self.backend_driver.delete_domain(ctx.state(), id).await?;
+
+            ctx.state()
+                .provider
+                .get_idmapping_provider()
+                .delete_mappings_for_domain(ctx, id)
+                .await?;
 
             ctx.state()
                 .event_dispatcher
@@ -725,6 +736,7 @@ mod tests {
     use crate::auth::ValidatedSecurityContext;
     use crate::credential::MockCredentialProvider;
     use crate::events::ProviderHooks;
+    use crate::idmapping::MockIdMappingProvider;
     use crate::provider::Provider;
     use crate::resource::backend::MockResourceBackend;
     use crate::tests::get_mocked_state;
@@ -1386,7 +1398,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_domain_invalidates_cache() {
-        let state = get_mocked_state(None, Some(Provider::mocked_builder())).await;
+        let mut idmapping = MockIdMappingProvider::default();
+        idmapping
+            .expect_delete_mappings_for_domain()
+            .withf(|_, id: &'_ str| id == "did")
+            .returning(|_, _| Ok(()));
+        let state = get_mocked_state(
+            None,
+            Some(Provider::mocked_builder().mock_idmapping(idmapping)),
+        )
+        .await;
         let mut backend = MockResourceBackend::default();
         // Populated once by the initial `get_domain`, hit from cache inside
         // `check_domain_mutable`, then re-fetched from the backend after

--- a/crates/idmapping-driver-sql/src/id_mapping/delete.rs
+++ b/crates/idmapping-driver-sql/src/id_mapping/delete.rs
@@ -14,10 +14,12 @@
 
 use sea_orm::DatabaseConnection;
 use sea_orm::entity::*;
+use sea_orm::query::*;
 
 use openstack_keystone_core::error::DbContextExt;
 use openstack_keystone_core::idmapping::IdMappingProviderError;
 
+use crate::entity::id_mapping::Column;
 use crate::entity::prelude::IdMapping as DbIdMapping;
 
 /// Delete the `IdMapping` by the public identifier.
@@ -38,6 +40,28 @@ pub async fn delete<P: AsRef<str>>(
         .exec(db)
         .await
         .context("deleting id mapping")?;
+    Ok(())
+}
+
+/// Delete every `IdMapping` row belonging to a domain.
+///
+/// Silent/idempotent: it is not an error for no mapping to match.
+///
+/// # Parameters
+/// - `db`: The database connection.
+/// - `domain_id`: The domain identifier.
+///
+/// # Returns
+/// A `Result` indicating success, or an `Error`.
+pub async fn delete_by_domain<D: AsRef<str>>(
+    db: &DatabaseConnection,
+    domain_id: D,
+) -> Result<(), IdMappingProviderError> {
+    DbIdMapping::delete_many()
+        .filter(Column::DomainId.eq(domain_id.as_ref()))
+        .exec(db)
+        .await
+        .context("deleting id mappings for domain")?;
     Ok(())
 }
 
@@ -78,5 +102,38 @@ mod tests {
             .into_connection();
 
         delete(&db, "missing").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_domain() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([MockExecResult {
+                rows_affected: 2,
+                last_insert_id: 0,
+            }])
+            .into_connection();
+
+        delete_by_domain(&db, "did").await.unwrap();
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"DELETE FROM "id_mapping" WHERE "id_mapping"."domain_id" = $1"#,
+                ["did".into()]
+            ),]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_domain_is_idempotent_when_nothing_matches() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([MockExecResult {
+                rows_affected: 0,
+                last_insert_id: 0,
+            }])
+            .into_connection();
+
+        delete_by_domain(&db, "missing").await.unwrap();
     }
 }

--- a/crates/idmapping-driver-sql/src/lib.rs
+++ b/crates/idmapping-driver-sql/src/lib.rs
@@ -144,6 +144,22 @@ impl IdMappingBackend for SqlBackend {
     ) -> Result<(), IdMappingProviderError> {
         id_mapping::delete(&state.db.connection(), public_id).await
     }
+
+    /// Delete every `IdMapping` row belonging to a domain.
+    ///
+    /// # Parameters
+    /// - `state`: The service state.
+    /// - `domain_id`: The domain ID.
+    ///
+    /// # Returns
+    /// A `Result` indicating success, or an `Error`.
+    async fn delete_mappings_for_domain<'a>(
+        &self,
+        state: &ServiceState,
+        domain_id: &'a str,
+    ) -> Result<(), IdMappingProviderError> {
+        id_mapping::delete_by_domain(&state.db.connection(), domain_id).await
+    }
 }
 
 #[async_trait]

--- a/tests/integration/src/domain_config.rs
+++ b/tests/integration/src/domain_config.rs
@@ -18,10 +18,9 @@
 //! domain's stored `identity/driver`, and `DomainConfigService` enforces the
 //! single-domain SQL identity-driver registration lock on config writes.
 //!
-//! Both the global and the per-domain driver here are `sql`, so these do not
-//! cover cross-backend routing, the `_select_identity_driver` `DomainNotFound`
-//! guard, or `CrossBackendNotAllowed` -- those need a second, non-domain-aware
-//! backend and are a follow-up (real LDAP harness).
+//! Cross-backend coverage (a second, non-domain-aware backend: LDAP, against
+//! the same fixture harness `identity-driver-ldap`'s own `live_tests` use)
+//! lives in the `cross_backend` submodule below.
 
 use eyre::Result;
 use serde_json::json;
@@ -40,12 +39,32 @@ use crate::common::get_state_with_config;
 fn enable_domain_specific(cfg: &mut Config) {
     cfg.identity.domain_specific_drivers_enabled = true;
     cfg.identity.domain_configurations_from_database = true;
+    // Once `domain_specific_drivers_enabled` is set, the `ldap` backend's
+    // `inventory` registration selects itself regardless of whether any
+    // domain actually uses it (`crates/identity-driver-ldap/src/lib.rs`),
+    // and eagerly health-checks `cfg.ldap.url` while building `Provider`.
+    // Point it at the seeded fixture directory when one is configured for
+    // this test run, rather than leaving it on the default `ldap://localhost`
+    // (which only happens to work here because CI/this box separately
+    // installs an ambient, unseeded `slapd` on the default port for
+    // `identity-driver-ldap`'s own tests -- see `cross_backend::test_url()`).
+    if let Some(url) = cross_backend::test_url() {
+        cfg.ldap = cross_backend::test_ldap_config(&url);
+    }
 }
 
 /// A stored configuration pinning a domain to the `sql` identity driver.
 fn sql_identity_config() -> DomainConfigCreate {
     DomainConfigCreate(
         DomainConfig::from_value(json!({"identity": {"driver": "sql"}}))
+            .expect("valid domain configuration"),
+    )
+}
+
+/// A stored configuration pinning a domain to the `ldap` identity driver.
+fn ldap_identity_config() -> DomainConfigCreate {
+    DomainConfigCreate(
+        DomainConfig::from_value(json!({"identity": {"driver": "ldap"}}))
             .expect("valid domain configuration"),
     )
 }
@@ -151,3 +170,6 @@ async fn deleting_a_domain_config_frees_the_sql_registration() -> Result<()> {
         .await?;
     Ok(())
 }
+
+#[path = "domain_config/cross_backend.rs"]
+mod cross_backend;

--- a/tests/integration/src/domain_config/cross_backend.rs
+++ b/tests/integration/src/domain_config/cross_backend.rs
@@ -1,0 +1,305 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Cross-backend (SQL + LDAP) per-domain identity dispatch
+//!
+//! The parent `domain_config` module only ever has one backend (`sql`)
+//! configured both globally and per domain, so it cannot exercise real
+//! cross-backend routing or the `driver_for` `DomainNotFound` guard for a
+//! non-domain-aware global driver. This module adds a second, non-domain-
+//! aware backend by driving a real LDAP directory -- the same fixture
+//! harness `identity-driver-ldap`'s own `live_tests` module uses
+//! (`tools/start-ldap-test.sh`, seeded from
+//! `crates/identity-driver-ldap/tests/fixtures/base.ldif`).
+//!
+//! Opt-in: every test here skips itself (rather than failing) unless
+//! `KEYSTONE_LDAP_TEST_URL` is set. The `ldap`/`ci-ldap` nextest profiles
+//! set it; run manually with `tools/start-ldap-test.sh && cargo test -p
+//! test_integration domain_config::cross_backend`.
+//!
+//! Also covers `membership_backend`'s `CrossBackendNotAllowed`: that guard
+//! resolves entities via an id-mapping lookup
+//! (`crates/core/src/idmapping/`), which regular `create_user` does not
+//! populate yet (nothing routes through it outside federated/shadow-user
+//! auth) -- so the test seeds the mapping rows directly via `IdMappingApi`
+//! rather than relying on `create_user` to do it.
+
+use eyre::Result;
+use secrecy::SecretString;
+use tracing_test::traced_test;
+
+use openstack_keystone_config::{Config, LdapProvider};
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core_types::identity::*;
+use openstack_keystone_core_types::idmapping::IdMappingEntityType;
+use openstack_keystone_core_types::resource::ResourceProviderError;
+
+use crate::common::get_state_with_config;
+
+use super::{enable_domain_specific, ldap_identity_config, sql_identity_config};
+
+/// Test fixture connection details, or `None` to skip (no live directory
+/// configured for this test run).
+pub(super) fn test_url() -> Option<String> {
+    std::env::var("KEYSTONE_LDAP_TEST_URL").ok()
+}
+
+fn base_dn() -> String {
+    std::env::var("KEYSTONE_LDAP_TEST_BASE_DN").unwrap_or_else(|_| "dc=example,dc=com".into())
+}
+
+fn admin_dn() -> String {
+    std::env::var("KEYSTONE_LDAP_TEST_ADMIN_DN")
+        .unwrap_or_else(|_| format!("cn=admin,{}", base_dn()))
+}
+
+fn admin_pw() -> String {
+    std::env::var("KEYSTONE_LDAP_TEST_ADMIN_PW").unwrap_or_else(|_| "adminpw".into())
+}
+
+/// An `LdapProvider` pointed at the seeded fixture directory.
+pub(super) fn test_ldap_config(url: &str) -> LdapProvider {
+    LdapProvider {
+        url: url.to_string(),
+        user: Some(admin_dn()),
+        password: Some(SecretString::from(admin_pw())),
+        user_tree_dn: format!("ou=Users,{}", base_dn()),
+        group_tree_dn: format!("ou=Groups,{}", base_dn()),
+        suffix: base_dn(),
+        ..Default::default()
+    }
+}
+
+/// Skips (returns from the enclosing test with `Ok(())`) rather than failing
+/// when no live directory is configured for this run.
+macro_rules! skip_unless_configured {
+    () => {
+        if test_url().is_none() {
+            eprintln!(
+                "skipping cross-backend domain_config test: KEYSTONE_LDAP_TEST_URL not set \
+                 (run tools/start-ldap-test.sh first, or use the `ldap` nextest profile)"
+            );
+            return Ok(());
+        }
+    };
+}
+
+/// A domain pinned to `sql` and a domain pinned to `ldap` are served by two
+/// different, live backend instances: each only ever sees its own domain's
+/// data.
+///
+/// The `ldap` side must use domain id `"default"` (`[identity]
+/// default_domain_id`'s value), not a freshly created domain: the LDAP
+/// driver is not domain aware (`is_domain_aware() == false`, a single
+/// directory maps to one domain) and its own list filter short-circuits to
+/// an empty result for any `domain_id` other than the configured default
+/// (`crates/identity-driver-ldap/src/filter.rs::domain_matches`) --
+/// `driver_for`'s dispatch only decides *which* backend serves a domain, it
+/// does not relax that backend's own domain-scoping rules.
+#[tokio::test]
+#[traced_test]
+async fn cross_backend_dispatch_routes_to_correct_backend() -> Result<()> {
+    skip_unless_configured!();
+    let (state, _tmp) = get_state_with_config(enable_domain_specific).await?;
+    let ctx = ExecutionContext::internal(&state);
+
+    let sql_domain = crate::create_domain!(state)?;
+    let ldap_domain_id = "default";
+    let dc = state.provider.get_domain_config_provider();
+    dc.create_domain_config(&state, &sql_domain.id, sql_identity_config())
+        .await?;
+    dc.create_domain_config(&state, ldap_domain_id, ldap_identity_config())
+        .await?;
+
+    let sql_user_name = uuid::Uuid::new_v4().to_string();
+    state
+        .provider
+        .get_identity_provider()
+        .create_user(
+            &ctx,
+            UserCreateBuilder::default()
+                .name(sql_user_name.clone())
+                .domain_id(sql_domain.id.clone())
+                .enabled(true)
+                .build()?,
+        )
+        .await?;
+
+    let sql_users: Vec<UserResponse> = state
+        .provider
+        .get_identity_provider()
+        .list_users(
+            &ctx,
+            &UserListParameters {
+                domain_id: Some(sql_domain.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?
+        .into_iter()
+        .collect();
+    assert_eq!(sql_users.len(), 1, "the sql domain sees only its own user");
+    assert_eq!(sql_users[0].name, sql_user_name);
+
+    let ldap_users: Vec<UserResponse> = state
+        .provider
+        .get_identity_provider()
+        .list_users(
+            &ctx,
+            &UserListParameters {
+                domain_id: Some(ldap_domain_id.to_string()),
+                ..Default::default()
+            },
+        )
+        .await?
+        .into_iter()
+        .collect();
+    // A non-default backend's entities are id-mapped: `list_users` shadows
+    // every returned entity, so `id` is the generated public id, never the
+    // LDAP-native local id. Match on `name` instead, which shadowing leaves
+    // untouched -- the fixture directory maps `name` from each user's `sn`
+    // (`user_name_attribute` default), so `base.ldif`'s `jdoe`/`bsmith` show
+    // up as `Doe`/`Smith`.
+    let ldap_names: Vec<&str> = ldap_users.iter().map(|u| u.name.as_str()).collect();
+    assert!(
+        ldap_names.contains(&"Doe") && ldap_names.contains(&"Smith"),
+        "the ldap domain must see the seeded fixture users, got {ldap_names:?}"
+    );
+    for u in &ldap_users {
+        assert_ne!(
+            u.id, u.name,
+            "an ldap-backed entity's id must be the shadowed public id, not the local cn"
+        );
+    }
+    assert!(
+        !ldap_names.contains(&sql_user_name.as_str()),
+        "the ldap domain must not see the sql domain's user"
+    );
+    Ok(())
+}
+
+/// When the *global* driver is `ldap` (not domain aware) and a domain has no
+/// stored config, dispatch must not silently hand that domain's requests to
+/// the single shared directory -- it 404s `DomainNotFound` instead. Mirrors
+/// python-keystone's `Manager._select_identity_driver`.
+#[tokio::test]
+#[traced_test]
+async fn global_ldap_driver_rejects_unconfigured_domain() -> Result<()> {
+    skip_unless_configured!();
+    let (state, _tmp) = get_state_with_config(|cfg: &mut Config| {
+        enable_domain_specific(cfg);
+        cfg.identity.driver = "ldap".to_string();
+    })
+    .await?;
+    let ctx = ExecutionContext::internal(&state);
+
+    // No domain_config row for this domain: resolution falls back to the
+    // global `ldap` driver, which is not domain aware.
+    let domain = crate::create_domain!(state)?;
+
+    let err = state
+        .provider
+        .get_identity_provider()
+        .list_users(
+            &ctx,
+            &UserListParameters {
+                domain_id: Some(domain.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("a non-domain-aware global driver must reject a non-default domain");
+    assert!(
+        matches!(
+            err,
+            IdentityProviderError::ResourceProvider {
+                source: ResourceProviderError::DomainNotFound(_)
+            }
+        ),
+        "expected DomainNotFound, got {err:?}"
+    );
+    Ok(())
+}
+
+/// A group membership that spans two live backend instances is rejected
+/// `CrossBackendNotAllowed`, once both entities are actually resolvable via
+/// the id mapping (`driver_for_user`/`driver_for_group`,
+/// `crates/core/src/identity/service.rs`).
+///
+/// `create_user` does not itself populate the id mapping today, so this
+/// seeds it directly through `IdMappingApi::create_id_mapping` -- the public
+/// id must be the entity's real id, since that's what
+/// `driver_for_public_id` looks up.
+#[tokio::test]
+#[traced_test]
+async fn cross_backend_group_membership_rejected() -> Result<()> {
+    skip_unless_configured!();
+    let (state, _tmp) = get_state_with_config(enable_domain_specific).await?;
+    let ctx = ExecutionContext::internal(&state);
+
+    let sql_domain = crate::create_domain!(state)?;
+    let ldap_domain_id = "default";
+    let dc = state.provider.get_domain_config_provider();
+    dc.create_domain_config(&state, &sql_domain.id, sql_identity_config())
+        .await?;
+    dc.create_domain_config(&state, ldap_domain_id, ldap_identity_config())
+        .await?;
+
+    let sql_user_name = uuid::Uuid::new_v4().to_string();
+    let sql_user = state
+        .provider
+        .get_identity_provider()
+        .create_user(
+            &ctx,
+            UserCreateBuilder::default()
+                .name(sql_user_name.clone())
+                .domain_id(sql_domain.id.clone())
+                .enabled(true)
+                .build()?,
+        )
+        .await?;
+
+    // A seeded fixture group (`base.ldif`) in the ldap-backed `default`
+    // domain.
+    let ldap_group_id = "admins";
+
+    let idm = state.provider.get_idmapping_provider();
+    idm.create_id_mapping(
+        &ctx,
+        &sql_user.id,
+        &sql_domain.id,
+        IdMappingEntityType::User,
+        Some(sql_user.id.as_str()),
+    )
+    .await?;
+    idm.create_id_mapping(
+        &ctx,
+        ldap_group_id,
+        ldap_domain_id,
+        IdMappingEntityType::Group,
+        Some(ldap_group_id),
+    )
+    .await?;
+
+    let err = state
+        .provider
+        .get_identity_provider()
+        .add_user_to_group(&ctx, &sql_user.id, ldap_group_id)
+        .await
+        .expect_err("a membership spanning two live backends must be rejected");
+    assert!(
+        matches!(err, IdentityProviderError::CrossBackendNotAllowed { .. }),
+        "expected CrossBackendNotAllowed, got {err:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Non-default backends (e.g. LDAP) were dispatched to by the caller's
public id and their entities were never mapped back, only working
because create forced public_id == local_id. Add
IdentityService::resolve_public_id (public id -> backend + local id)
and shadow_id (local id -> public id, get-or-create) and wire them
through get/list/find/update/delete for users and groups, gated on
the backend not being the default driver so default-backend behavior
is unchanged.

Also close the domain-delete id-mapping leak: purge id_mapping rows
for a domain when it's deleted, mirroring python-keystone's
purge_mappings on the domain-deleted event. Adds
IdMappingBackend::delete_mappings_for_domain (sql: DELETE ... WHERE
domain_id = $1) and wires it into ResourceService::delete_domain.

Widen the ldap nextest profile to cover test_integration and extend
enable_domain_specific to point at the fixture LDAP via env vars
instead of the ambient unseeded one, for upcoming cross-backend
integration coverage.

Membership (add/remove/set_user_groups*, list_groups_of_user,
list_users_of_group) and auth-path (authenticate_by_password_inner,
get_user_domain_id) id resolution intentionally left out -- same
latent bug, needs its own security-model.md-reviewed pass.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
