### PR TITLE
feat(adr0034): Add per-domain driver config surface

### DIFF
--- a/crates/config/src/assignment.rs
+++ b/crates/config/src/assignment.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::Deserialize;
 use url::Url;
@@ -22,13 +22,34 @@ use crate::pagination::ListLimitConfig;
 /// Assignment Provider.
 #[derive(Debug, Deserialize, Clone)]
 pub struct AssignmentProvider {
-    /// Assignment provider driver.
+    /// Assignment provider driver. The global default: serves `system`
+    /// targets, every unconfigured domain and every resolution fallback
+    /// (ADR 0034 §4).
     #[serde(default = "default_sql_driver")]
     pub driver: String,
 
     /// `GET /v3/role_assignments` pagination limits.
     #[serde(default)]
     pub list_limit: ListLimitConfig,
+
+    /// Whether the assignment provider dispatches per domain (ADR 0034 §2).
+    /// Off by default and independent of `[identity]
+    /// domain_specific_drivers_enabled`: an operator running per-domain LDAP
+    /// identity must not silently acquire per-domain assignment routing. When
+    /// off, every operation goes to `driver`.
+    #[serde(default)]
+    pub domain_specific_drivers_enabled: bool,
+
+    /// Named driver-configuration blocks, `[assignment.backends.<name>]`
+    /// (ADR 0034 §4). Any number of domains may point at one block through
+    /// `domains`; they then share a single backend instance.
+    #[serde(default)]
+    pub backends: HashMap<String, AssignmentBackendConfig>,
+
+    /// `[assignment.domains]`: domain id -> backend block name (ADR 0034 §4).
+    /// No per-domain parameters; the parameters live in the named block.
+    #[serde(default)]
+    pub domains: HashMap<String, String>,
 }
 
 impl Default for AssignmentProvider {
@@ -36,6 +57,53 @@ impl Default for AssignmentProvider {
         Self {
             driver: default_sql_driver(),
             list_limit: ListLimitConfig::default(),
+            domain_specific_drivers_enabled: false,
+            backends: HashMap::new(),
+            domains: HashMap::new(),
+        }
+    }
+}
+
+impl AssignmentProvider {
+    /// The set of driver names a domain's API-stored `assignment/driver`
+    /// binding may name (ADR 0034 §3): `sql`, the global `driver`, and the
+    /// `driver` of every `[assignment.backends.*]` block.
+    pub fn bindable_driver_names(&self) -> HashSet<String> {
+        let mut names = HashSet::from(["sql".to_string(), self.driver.clone()]);
+        names.extend(self.backends.values().map(|b| b.driver_name().to_string()));
+        names
+    }
+
+    /// The `[assignment.backends.<name>]` block, if defined.
+    pub fn backend_block(&self, name: &str) -> Option<&AssignmentBackendConfig> {
+        self.backends.get(name)
+    }
+}
+
+/// One `[assignment.backends.<name>]` block: a `driver` discriminator plus that
+/// driver's full configuration. Kept in server config, never in the API
+/// (ADR 0034 §3): an API-writable driver configuration is a role-minting
+/// escalation.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(tag = "driver", rename_all = "lowercase")]
+pub enum AssignmentBackendConfig {
+    /// A `sql` backend. Carries no parameters beyond the global `[database]`;
+    /// rarely needed as an explicit block (an SQL-backed domain with no
+    /// mapping already shares the global instance).
+    Sql,
+    /// An `openfga` backend with its own store id, model id, API URL and
+    /// bearer token. The full `[openfga]` option set is flattened at the same
+    /// level as `driver = openfga`. Boxed to keep the enum small (the `Sql`
+    /// variant is a unit).
+    Openfga(Box<OpenFGAAssignmentDriver>),
+}
+
+impl AssignmentBackendConfig {
+    /// The wire name of the block's driver (`"sql"` / `"openfga"`).
+    pub fn driver_name(&self) -> &'static str {
+        match self {
+            Self::Sql => "sql",
+            Self::Openfga(_) => "openfga",
         }
     }
 }
@@ -149,4 +217,94 @@ pub struct OpenFGAAssignmentDriver {
     /// Id format transform applied between Keystone and OpenFGA.
     #[serde(default)]
     pub id_transform: OpenFGAIdTransform,
+}
+
+#[cfg(test)]
+mod tests {
+    use config::{Config, File, FileFormat};
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Default, Deserialize)]
+    struct Wrapper {
+        #[serde(default)]
+        assignment: AssignmentProvider,
+    }
+
+    fn parse(ini: &str) -> AssignmentProvider {
+        Config::builder()
+            .add_source(File::from_str(ini, FileFormat::Ini))
+            .build()
+            .unwrap()
+            .try_deserialize::<Wrapper>()
+            .unwrap()
+            .assignment
+    }
+
+    #[test]
+    fn defaults_when_section_absent() {
+        let a = parse("[DEFAULT]\n");
+        assert_eq!(a.driver, "sql");
+        assert!(!a.domain_specific_drivers_enabled);
+        assert!(a.backends.is_empty());
+        assert!(a.domains.is_empty());
+    }
+
+    #[test]
+    fn switch_parses() {
+        let a = parse("[assignment]\ndomain_specific_drivers_enabled = true\n");
+        assert!(a.domain_specific_drivers_enabled);
+    }
+
+    /// Blocking check (ADR 0034 §4): the `config` INI parser must merge a leaf
+    /// `[assignment]` section with the nested `[assignment.backends.<name>]`
+    /// and `[assignment.domains]` sections under the same top-level name.
+    #[test]
+    fn leaf_and_nested_sections_merge() {
+        let a = parse(
+            r#"
+[assignment]
+driver = sql
+domain_specific_drivers_enabled = true
+
+[assignment.backends.central_fga]
+driver = openfga
+api_url = https://openfga.internal:8080/
+store_id = 01ABC
+
+[assignment.domains]
+1111 = central_fga
+2222 = central_fga
+"#,
+        );
+        assert_eq!(a.driver, "sql");
+        assert!(a.domain_specific_drivers_enabled);
+
+        let block = a.backend_block("central_fga").expect("block present");
+        match block {
+            AssignmentBackendConfig::Openfga(cfg) => {
+                assert_eq!(cfg.store_id, "01ABC");
+                assert_eq!(cfg.api_url.as_str(), "https://openfga.internal:8080/");
+            }
+            other => panic!("expected openfga block, got {other:?}"),
+        }
+
+        assert_eq!(a.domains.get("1111"), Some(&"central_fga".to_string()));
+        assert_eq!(a.domains.get("2222"), Some(&"central_fga".to_string()));
+
+        assert_eq!(
+            a.bindable_driver_names(),
+            HashSet::from(["sql".to_string(), "openfga".to_string()])
+        );
+    }
+
+    #[test]
+    fn sql_backend_block_parses() {
+        let a = parse("[assignment.backends.local]\ndriver = sql\n");
+        assert!(matches!(
+            a.backend_block("local"),
+            Some(AssignmentBackendConfig::Sql)
+        ));
+    }
 }

--- a/crates/config/src/domain_config.rs
+++ b/crates/config/src/domain_config.rs
@@ -1,0 +1,86 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use serde::Deserialize;
+
+/// `[domain_config]` section: which sources the per-domain configuration
+/// resolver consults (ADR 0034 §2).
+///
+/// Both fields are `Option<bool>` on purpose. Unset means "inherit the
+/// deprecated `[identity]` switch", so an existing deployment that only sets
+/// the `[identity]` keys keeps its behaviour, defaults included:
+///
+/// - `from_files` unset  -> `[identity] domain_specific_drivers_enabled`
+/// - `from_database` unset -> `[identity] domain_configurations_from_database`
+///
+/// When a `[domain_config]` key is set explicitly it wins; a conflicting
+/// `[identity]` key set to a different value logs one `WARN` at construction
+/// (see `openstack_keystone_core::domain_config::resolver`).
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct DomainConfigSection {
+    /// Whether to consult the `fs` source (per-domain files under `[identity]
+    /// domain_config_dir`). Unset inherits `[identity]
+    /// domain_specific_drivers_enabled`.
+    #[serde(default)]
+    pub from_files: Option<bool>,
+
+    /// Whether to consult the `sql` source (the `domain_config` table). Unset
+    /// inherits `[identity] domain_configurations_from_database`.
+    #[serde(default)]
+    pub from_database: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use config::{Config, File, FileFormat};
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Default, Deserialize)]
+    struct Wrapper {
+        #[serde(default)]
+        domain_config: DomainConfigSection,
+    }
+
+    fn parse(ini: &str) -> DomainConfigSection {
+        Config::builder()
+            .add_source(File::from_str(ini, FileFormat::Ini))
+            .build()
+            .unwrap()
+            .try_deserialize::<Wrapper>()
+            .unwrap()
+            .domain_config
+    }
+
+    #[test]
+    fn unset_keys_are_none() {
+        let section = parse("[DEFAULT]\n");
+        assert_eq!(section.from_files, None);
+        assert_eq!(section.from_database, None);
+    }
+
+    #[test]
+    fn explicit_false_round_trips_as_some_false() {
+        let section = parse("[domain_config]\nfrom_files = false\nfrom_database = false\n");
+        assert_eq!(section.from_files, Some(false));
+        assert_eq!(section.from_database, Some(false));
+    }
+
+    #[test]
+    fn explicit_true_round_trips_as_some_true() {
+        let section = parse("[domain_config]\nfrom_files = true\nfrom_database = true\n");
+        assert_eq!(section.from_files, Some(true));
+        assert_eq!(section.from_database, Some(true));
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -76,6 +76,7 @@ mod credential;
 mod database;
 mod default;
 mod distributed_storage;
+mod domain_config;
 mod ec2;
 mod federation;
 mod fernet_token;
@@ -120,6 +121,7 @@ pub use credential::*;
 pub use database::*;
 pub use default::*;
 pub use distributed_storage::*;
+pub use domain_config::*;
 pub use ec2::*;
 pub use federation::*;
 pub use fernet_token::*;
@@ -202,6 +204,11 @@ pub struct Config {
     #[serde(default)]
     #[validate(nested)]
     pub distributed_storage: Option<DistributedStorageConfiguration>,
+
+    /// `[domain_config]` section: per-domain configuration resolver sources
+    /// (ADR 0034 §2). Unset keys inherit the deprecated `[identity]` switches.
+    #[serde(default)]
+    pub domain_config: DomainConfigSection,
 
     /// Dynamic (WebAssembly) auth plugins configuration - ADR 0025.
     #[serde(default)]

--- a/crates/core-types/src/domain_config/config.rs
+++ b/crates/core-types/src/domain_config/config.rs
@@ -249,6 +249,9 @@ impl DomainConfigGroup {
             DomainConfigGroupName::Ldap => {
                 decode_group::<LdapProvider>(self)?;
             }
+            DomainConfigGroupName::Assignment => {
+                decode_group::<AssignmentGroupValues>(self)?;
+            }
         }
         Ok(())
     }
@@ -589,6 +592,23 @@ impl DomainConfig {
             identity.list_limit.max_list_limit = config.identity.list_limit.max_list_limit;
         }
         Ok(identity)
+    }
+
+    /// The driver name the domain's `assignment` group binds, if any
+    /// (ADR 0034 §3).
+    ///
+    /// Unlike `resolve_identity` / `resolve_ldap` there is nothing to inherit
+    /// from a global section: the API only ever carries the bare driver name,
+    /// and the driver *configuration* lives in server config. Returns `None`
+    /// when the domain stores no `assignment/driver`.
+    ///
+    /// # Returns
+    /// - `Option<String>` - The bound driver name.
+    pub fn resolve_assignment_driver_name(&self) -> Option<String> {
+        self.group(DomainConfigGroupName::Assignment)
+            .and_then(|group| group.get("driver"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
     }
 
     /// The domain's `[ldap]` section: the global one with the domain's
@@ -1122,6 +1142,16 @@ fn whitelisted_only(
         .into_iter()
         .filter(|(option, _)| super::is_whitelisted(group, option))
         .collect())
+}
+
+/// The decodable shape of the `assignment` domain-config group (ADR 0034 §3):
+/// a single required `driver` string. Kept local so `AssignmentProvider` need
+/// not gain a round-trip it is not otherwise used for — the group only ever
+/// carries `driver`.
+#[derive(Deserialize)]
+struct AssignmentGroupValues {
+    #[allow(dead_code)]
+    driver: String,
 }
 
 /// Decode a group into the config section it overrides.

--- a/crates/core-types/src/domain_config/config/tests.rs
+++ b/crates/core-types/src/domain_config/config/tests.rs
@@ -210,11 +210,11 @@ fn config_skips_unsupported_options_on_read() {
 
 #[test]
 fn config_rejects_unknown_groups() {
-    let err = DomainConfig::from_value(json!({"assignment": {"driver": "sql"}}))
+    let err = DomainConfig::from_value(json!({"quota": {"driver": "sql"}}))
         .expect_err("an unsupported group is refused");
     assert_eq!(
         err.to_string(),
-        "group assignment is not supported for domain specific configurations"
+        "group quota is not supported for domain specific configurations"
     );
 }
 
@@ -984,5 +984,44 @@ mod overlay {
             option(&base, DomainConfigGroupName::Ldap, "url"),
             Some(&json!("ldap://file"))
         );
+    }
+}
+
+mod assignment_group {
+    use super::*;
+
+    #[test]
+    fn resolve_assignment_driver_name_extracts_the_binding() {
+        let config = config_from(json!({"assignment": {"driver": "openfga"}}));
+        assert_eq!(
+            config.resolve_assignment_driver_name(),
+            Some("openfga".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_assignment_driver_name_is_none_when_unset() {
+        let config = config_from(json!({"identity": {"driver": "ldap"}}));
+        assert_eq!(config.resolve_assignment_driver_name(), None);
+    }
+
+    #[test]
+    fn validate_values_accepts_a_string_driver() {
+        let config = config_from(json!({"assignment": {"driver": "sql"}}));
+        config
+            .group(DomainConfigGroupName::Assignment)
+            .expect("group")
+            .validate_values()
+            .expect("a string driver is valid");
+    }
+
+    #[test]
+    fn validate_values_rejects_a_non_scalar_driver() {
+        let config = config_from(json!({"assignment": {"driver": ["sql", "openfga"]}}));
+        config
+            .group(DomainConfigGroupName::Assignment)
+            .expect("group")
+            .validate_values()
+            .expect_err("an array driver is rejected");
     }
 }

--- a/crates/core-types/src/domain_config/option.rs
+++ b/crates/core-types/src/domain_config/option.rs
@@ -34,11 +34,14 @@ pub enum DomainConfigGroupName {
     Identity,
     /// The `[ldap]` group: how that domain's LDAP directory is reached.
     Ldap,
+    /// The `[assignment]` group: which assignment driver the domain uses
+    /// (ADR 0034 §3). One option, `driver`. Cloud-admin only (§6).
+    Assignment,
 }
 
 impl DomainConfigGroupName {
     /// Every configurable group, in a stable order.
-    pub const ALL: &'static [Self] = &[Self::Identity, Self::Ldap];
+    pub const ALL: &'static [Self] = &[Self::Identity, Self::Ldap, Self::Assignment];
 
     /// Wire name of the group.
     ///
@@ -49,6 +52,7 @@ impl DomainConfigGroupName {
         match self {
             Self::Identity => "identity",
             Self::Ldap => "ldap",
+            Self::Assignment => "assignment",
         }
     }
 }
@@ -74,6 +78,7 @@ impl FromStr for DomainConfigGroupName {
         match s {
             "identity" => Ok(Self::Identity),
             "ldap" => Ok(Self::Ldap),
+            "assignment" => Ok(Self::Assignment),
             other => Err(DomainConfigProviderError::UnsupportedGroup(
                 other.to_string(),
             )),
@@ -152,6 +157,17 @@ pub const LDAP_WHITELISTED_OPTIONS: &[&str] = &[
 /// it, and are expected to live in separate storage from the whitelisted ones.
 pub const LDAP_SENSITIVE_OPTIONS: &[&str] = &["password"];
 
+/// Whitelisted (readable) options of the `assignment` group (ADR 0034 §3).
+///
+/// Deliberately just `driver`: `list_limit` is a per-provider tuning knob, and
+/// the driver *configuration* (OpenFGA store id, URL, bearer token) is kept in
+/// server config, never the API (§3/§6).
+pub const ASSIGNMENT_WHITELISTED_OPTIONS: &[&str] = &["driver"];
+
+/// Sensitive (write-only) options of the `assignment` group. None: the API
+/// never carries a driver configuration, so it never carries a secret.
+pub const ASSIGNMENT_SENSITIVE_OPTIONS: &[&str] = &[];
+
 /// Whitelisted (readable) options of a group.
 ///
 /// # Parameters
@@ -163,6 +179,7 @@ pub const fn whitelisted_options(group: DomainConfigGroupName) -> &'static [&'st
     match group {
         DomainConfigGroupName::Identity => IDENTITY_WHITELISTED_OPTIONS,
         DomainConfigGroupName::Ldap => LDAP_WHITELISTED_OPTIONS,
+        DomainConfigGroupName::Assignment => ASSIGNMENT_WHITELISTED_OPTIONS,
     }
 }
 
@@ -177,6 +194,7 @@ pub const fn sensitive_options(group: DomainConfigGroupName) -> &'static [&'stat
     match group {
         DomainConfigGroupName::Identity => IDENTITY_SENSITIVE_OPTIONS,
         DomainConfigGroupName::Ldap => LDAP_SENSITIVE_OPTIONS,
+        DomainConfigGroupName::Assignment => ASSIGNMENT_SENSITIVE_OPTIONS,
     }
 }
 
@@ -431,10 +449,10 @@ mod tests {
 
     #[test]
     fn unknown_group_is_rejected() {
-        let err = DomainConfigGroupName::from_str("assignment").unwrap_err();
+        let err = DomainConfigGroupName::from_str("quota").unwrap_err();
         assert_eq!(
             err.to_string(),
-            "group assignment is not supported for domain specific configurations"
+            "group quota is not supported for domain specific configurations"
         );
     }
 
@@ -444,7 +462,9 @@ mod tests {
         // visible in the diff of a failing test, not just in the constant.
         assert_eq!(IDENTITY_WHITELISTED_OPTIONS.len(), 2);
         assert_eq!(LDAP_WHITELISTED_OPTIONS.len(), 49);
+        assert_eq!(ASSIGNMENT_WHITELISTED_OPTIONS, &["driver"]);
         assert!(IDENTITY_SENSITIVE_OPTIONS.is_empty());
+        assert!(ASSIGNMENT_SENSITIVE_OPTIONS.is_empty());
         assert_eq!(LDAP_SENSITIVE_OPTIONS, &["password"]);
 
         // `password` is sensitive, therefore deliberately absent from the

--- a/crates/domain-config-driver-fs/src/store/tests.rs
+++ b/crates/domain-config-driver-fs/src/store/tests.rs
@@ -72,7 +72,7 @@ fn ignores_an_unknown_section_with_a_warning() {
     write(
         dir.path(),
         "keystone.Acme.conf",
-        "[identity]\ndriver = ldap\n\n[assignment]\ndriver = sql\n\n[ldap]\nurl = ldap://host\n",
+        "[identity]\ndriver = ldap\n\n[quota]\ndriver = sql\n\n[ldap]\nurl = ldap://host\n",
     );
 
     let store = DomainConfigStore::load(dir.path()).unwrap();
@@ -180,7 +180,7 @@ fn files_that_configure_nothing_are_skipped_with_a_warning() {
     write(
         dir.path(),
         "keystone.Unknown.conf",
-        "[assignment]\ndriver = sql\n",
+        "[quota]\ndriver = sql\n",
     );
     write(dir.path(), "keystone.Blank.conf", "[ldap]\n");
 

--- a/crates/domain-config-driver-sql/src/option.rs
+++ b/crates/domain-config-driver-sql/src/option.rs
@@ -258,7 +258,7 @@ mod tests {
     #[test]
     fn decoding_skips_a_group_that_is_not_configurable() {
         assert!(
-            decode("assignment", "driver".to_string(), r#""sql""#)
+            decode("quota", "driver".to_string(), r#""sql""#)
                 .unwrap()
                 .is_none()
         );


### PR DESCRIPTION
First of the stacked ADR 0034 PRs: parse-only, no dispatch wired yet.

- `[domain_config]` section with `Option<bool>` from_files/from_database
  so an unset key inherits the deprecated `[identity]` switch
- `[assignment]` gains domain_specific_drivers_enabled, plus
  `[assignment.backends.<name>]` driver blocks and an
  `[assignment.domains]` id->block map; INI merge of the leaf and
  nested sections is covered by test
- `assignment` domain-config group (whitelist: `driver` only, no
  sensitive options) with resolve_assignment_driver_name and a
  validate_values arm rejecting a non-scalar driver
- fs and sql domain-config driver tests move their "unknown group"
  fixture off `assignment` (now supported) onto `quota`

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
