### PR TITLE
feat(adr0034): Build per-instance assignment backends

### DIFF
--- a/crates/assignment-driver-openfga/src/lib.rs
+++ b/crates/assignment-driver-openfga/src/lib.rs
@@ -79,10 +79,12 @@ use reqwest::{Client, RequestBuilder, Response, Url};
 use serde_json::{Value, json};
 use tracing::{debug, error, warn};
 
-use openstack_keystone_config::OpenFGAAssignmentDriver;
+use openstack_keystone_config::{AssignmentBackendConfig, OpenFGAAssignmentDriver};
 use openstack_keystone_core::assignment::{AssignmentProviderError, backend::AssignmentBackend};
 use openstack_keystone_core::keystone::ServiceState;
-use openstack_keystone_core::plugin_manager::BackendRegistration;
+use openstack_keystone_core::plugin_manager::{
+    BackendRegistration, NamedAssignmentBackendRegistration,
+};
 use openstack_keystone_core_types::assignment::*;
 
 mod types;
@@ -116,38 +118,97 @@ inventory::submit! {
     }
 }
 
+inventory::submit! {
+    NamedAssignmentBackendRegistration {
+        driver: "openfga",
+        build: |cfg, name| {
+            let block = cfg.assignment.backend_block(name).cloned();
+            let name = name.to_string();
+            Box::pin(async move {
+                match block {
+                    Some(AssignmentBackendConfig::Openfga(driver_cfg)) => Ok(
+                        Arc::new(OpenFGADriver::with_config(*driver_cfg)?)
+                            as Arc<dyn AssignmentBackend>,
+                    ),
+                    Some(other) => Err(AssignmentProviderError::NamedBackendMisconfigured(
+                        format!(
+                            "[assignment.backends.{name}] has driver `{}`, not `openfga`",
+                            other.driver_name()
+                        ),
+                    )
+                    .into()),
+                    None => Err(AssignmentProviderError::NamedBackendMisconfigured(format!(
+                        "[assignment.backends.{name}] is not defined"
+                    ))
+                    .into()),
+                }
+            })
+        },
+    }
+}
+
 pub struct OpenFGADriver {
     openfga_client: Client,
+    /// An explicit `[openfga]`-shaped configuration this instance is pinned to.
+    /// `Some` for a named `[assignment.backends.<name>]` instance (ADR 0034
+    /// §4); `None` for the global instance, which reads the live `[openfga]`
+    /// section on every call. Held in an `Arc` so [`Self::config`] hands each
+    /// backend call a cheap clone rather than copying the whole struct.
+    config_override: Option<Arc<OpenFGAAssignmentDriver>>,
 }
 
 impl Default for OpenFGADriver {
     fn default() -> Self {
         Self {
             openfga_client: Client::new(),
+            config_override: None,
         }
     }
 }
 
 impl OpenFGADriver {
-    /// Initialize the OpenFGA driver.
-    ///
-    /// `timeout_secs`, when set, is applied as a total per-request timeout on
-    /// the OpenFGA HTTP client.
-    pub fn new(timeout_secs: Option<u16>) -> Result<Self, OpenFGADriverError> {
+    /// Build the OpenFGA HTTP client, applying `timeout_secs` as a total
+    /// per-request timeout when set.
+    fn client(timeout_secs: Option<u16>) -> Result<Client, OpenFGADriverError> {
         let mut builder = Client::builder();
         if let Some(secs) = timeout_secs {
             builder = builder.timeout(Duration::from_secs(secs.into()));
         }
+        Ok(builder.build()?)
+    }
+
+    /// Initialize the global OpenFGA driver: [`Self::config`] reads the live
+    /// `[openfga]` section on every call.
+    ///
+    /// `timeout_secs`, when set, is applied as a total per-request timeout on
+    /// the OpenFGA HTTP client.
+    pub fn new(timeout_secs: Option<u16>) -> Result<Self, OpenFGADriverError> {
         Ok(Self {
-            openfga_client: builder.build()?,
+            openfga_client: Self::client(timeout_secs)?,
+            config_override: None,
         })
     }
 
-    /// Snapshot the `[openfga]` config section.
+    /// Initialize a driver pinned to one explicit configuration, for a named
+    /// `[assignment.backends.<name>]` instance (ADR 0034 §4). [`Self::config`]
+    /// then ignores the global `[openfga]` section entirely. `cfg.timeout` is
+    /// applied to the HTTP client.
+    pub fn with_config(cfg: OpenFGAAssignmentDriver) -> Result<Self, OpenFGADriverError> {
+        Ok(Self {
+            openfga_client: Self::client(cfg.timeout)?,
+            config_override: Some(Arc::new(cfg)),
+        })
+    }
+
+    /// Snapshot this instance's `[openfga]` configuration: the pinned override
+    /// when set, otherwise the live global `[openfga]` section.
     async fn config(
         &self,
         state: &ServiceState,
-    ) -> Result<OpenFGAAssignmentDriver, OpenFGADriverError> {
+    ) -> Result<Arc<OpenFGAAssignmentDriver>, OpenFGADriverError> {
+        if let Some(cfg) = &self.config_override {
+            return Ok(Arc::clone(cfg));
+        }
         state
             .config_manager
             .config
@@ -155,6 +216,7 @@ impl OpenFGADriver {
             .await
             .openfga
             .clone()
+            .map(Arc::new)
             .ok_or(OpenFGADriverError::MissingConfiguration)
     }
 

--- a/crates/assignment-driver-openfga/src/tests.rs
+++ b/crates/assignment-driver-openfga/src/tests.rs
@@ -1311,6 +1311,117 @@ async fn send_retries_transient_server_error() -> Result<()> {
 }
 
 #[tokio::test]
+async fn with_config_pins_each_instance_to_its_own_store() -> Result<()> {
+    // Two `with_config` instances must issue to their own `api_url`/`store_id`,
+    // never the global `[openfga]` (here absent), proving the per-instance
+    // override is consulted (ADR 0034 §4).
+    let srv_a = MockServer::start_async().await;
+    let srv_b = MockServer::start_async().await;
+    let state = get_mocked_state(Some(Config::default()), None).await;
+
+    let mut cfg_a = driver_config(&srv_a.base_url());
+    cfg_a.store_id = "store_a".into();
+    let mut cfg_b = driver_config(&srv_b.base_url());
+    cfg_b.store_id = "store_b".into();
+
+    let hit_a = srv_a
+        .mock_async(|when, then| {
+            when.method("POST").path("/stores/store_a/check");
+            then.status(200).json_body(json!({"allowed": true}));
+        })
+        .await;
+    let hit_b = srv_b
+        .mock_async(|when, then| {
+            when.method("POST").path("/stores/store_b/check");
+            then.status(200).json_body(json!({"allowed": false}));
+        })
+        .await;
+
+    let driver_a = OpenFGADriver::with_config(cfg_a).expect("client builds");
+    let driver_b = OpenFGADriver::with_config(cfg_b).expect("client builds");
+    let grant = user_project_assignment("actor_id", "role_id", "target_id");
+
+    assert!(driver_a.check_grant(&state, &grant).await?);
+    assert!(!driver_b.check_grant(&state, &grant).await?);
+    hit_a.assert_async().await;
+    hit_b.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_named_assignment_backend_builds_the_openfga_block() -> Result<()> {
+    use openstack_keystone_core::plugin_manager::build_named_assignment_backend;
+
+    let srv = MockServer::start_async().await;
+    let mut block = driver_config(&srv.base_url());
+    block.store_id = "named_store".into();
+    let mut config = Config::default();
+    config.assignment.backends.insert(
+        "central_fga".to_string(),
+        AssignmentBackendConfig::Openfga(Box::new(block)),
+    );
+
+    let state = get_mocked_state(Some(Config::default()), None).await;
+    let hit = srv
+        .mock_async(|when, then| {
+            when.method("POST").path("/stores/named_store/check");
+            then.status(200).json_body(json!({"allowed": true}));
+        })
+        .await;
+
+    let backend = build_named_assignment_backend(&config, "openfga", "central_fga")
+        .await
+        .expect("the block builds");
+    assert!(
+        backend
+            .check_grant(&state, &user_project_assignment("a", "role_id", "t"))
+            .await?
+    );
+    hit.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_named_assignment_backend_rejects_a_missing_block() {
+    use openstack_keystone_core::plugin_manager::build_named_assignment_backend;
+
+    match build_named_assignment_backend(&Config::default(), "openfga", "nope").await {
+        Err(AssignmentProviderError::NamedBackendMisconfigured(msg)) => {
+            assert!(
+                msg.contains("[assignment.backends.nope] is not defined"),
+                "{msg}"
+            )
+        }
+        other => panic!(
+            "expected a misconfigured-block error, got {:?}",
+            other.err()
+        ),
+    }
+}
+
+#[tokio::test]
+async fn build_named_assignment_backend_rejects_a_non_openfga_block() {
+    use openstack_keystone_core::plugin_manager::build_named_assignment_backend;
+
+    let mut config = Config::default();
+    config
+        .assignment
+        .backends
+        .insert("central".to_string(), AssignmentBackendConfig::Sql);
+
+    match build_named_assignment_backend(&config, "openfga", "central").await {
+        Err(AssignmentProviderError::NamedBackendMisconfigured(msg)) => assert!(
+            msg.contains("[assignment.backends.central] has driver `sql`, not `openfga`"),
+            "{msg}"
+        ),
+        other => panic!(
+            "expected a misconfigured-block error, got {:?}",
+            other.err()
+        ),
+    }
+}
+
+#[tokio::test]
 async fn send_does_not_retry_client_error() -> Result<()> {
     let srv = MockServer::start_async().await;
     let mut cfg = driver_config(&srv.base_url());

--- a/crates/assignment-driver-sql/src/lib.rs
+++ b/crates/assignment-driver-sql/src/lib.rs
@@ -23,7 +23,9 @@ use openstack_keystone_core::assignment::{AssignmentProviderError, backend::Assi
 use openstack_keystone_core::db::create_table;
 use openstack_keystone_core::error::DatabaseError;
 use openstack_keystone_core::keystone::ServiceState;
-use openstack_keystone_core::plugin_manager::BackendRegistration;
+use openstack_keystone_core::plugin_manager::{
+    BackendRegistration, NamedAssignmentBackendRegistration,
+};
 use openstack_keystone_core::{SqlDriver, SqlDriverRegistration};
 use openstack_keystone_core_types::assignment::*;
 
@@ -51,6 +53,17 @@ inventory::submit! {
         name: "sql",
         selected: |_| true,
         build: |_cfg| Box::pin(async {
+            Ok(Arc::new(SqlBackend::default()) as Arc<dyn AssignmentBackend>)
+        }),
+    }
+}
+
+// A named `sql` instance carries no parameters beyond the global `[database]`,
+// so every block resolves to a plain `SqlBackend` (ADR 0034 §4).
+inventory::submit! {
+    NamedAssignmentBackendRegistration {
+        driver: "sql",
+        build: |_cfg, _name| Box::pin(async {
             Ok(Arc::new(SqlBackend::default()) as Arc<dyn AssignmentBackend>)
         }),
     }

--- a/crates/core-types/src/assignment/error.rs
+++ b/crates/core-types/src/assignment/error.rs
@@ -45,6 +45,15 @@ pub enum AssignmentProviderError {
     #[error("{0}")]
     InvalidAssignmentType(String),
 
+    /// A named `[assignment.backends.<name>]` block referenced by
+    /// `[assignment.domains]` is absent or names a different driver
+    /// (ADR 0034 §4). A server-config mistake surfaced when a backend
+    /// instance is built, kept distinct from [`Self::Driver`] (a runtime
+    /// backend fault) so a config reload / write-time validation can tell
+    /// the two apart.
+    #[error("{0}")]
+    NamedBackendMisconfigured(String),
+
     /// The request shape is not supported by the configured backend driver
     /// (e.g. a query the OpenFGA driver cannot answer without a target
     /// scope). A permanent, driver-specific limitation - not a transient

--- a/crates/core/src/plugin_manager.rs
+++ b/crates/core/src/plugin_manager.rs
@@ -163,6 +163,99 @@ where
     Ok(())
 }
 
+/// A driver's self-registration for building a *named* assignment backend
+/// instance from an `[assignment.backends.<name>]` block (ADR 0034 §4).
+///
+/// Distinct from [`BackendRegistration`]: the global assignment driver is
+/// selected by `[assignment] driver` and configured from its own global
+/// section, whereas a named instance is built from one config block passed by
+/// name. A driver crate submits one of these next to its
+/// [`BackendRegistration`] with `inventory::submit!`.
+pub struct NamedAssignmentBackendRegistration {
+    /// The driver discriminator this builder handles, matching an
+    /// `[assignment.backends.<name>]` block's `driver =` (e.g. `"openfga"`).
+    pub driver: &'static str,
+    /// Builds one instance from the named block. Reads `config.assignment
+    /// .backend_block(block_name)` for its parameters; fails when the block is
+    /// absent or names a different driver.
+    pub build: fn(config: &Config, block_name: &str) -> BuildFuture<dyn AssignmentBackend>,
+}
+
+inventory::collect!(NamedAssignmentBackendRegistration);
+
+/// Build the global assignment backend for `driver` without a
+/// [`PluginManager`] — the entry point a config reload uses to rebuild the
+/// global instance in place (ADR 0034 §9).
+///
+/// # Errors
+/// - [`AssignmentProviderError::UnsupportedDriver`] when no driver registered
+///   under `driver`.
+/// - [`AssignmentProviderError::Driver`] when more than one driver registered
+///   under `driver`, or wrapping any error from the driver's constructor.
+pub async fn build_global_assignment_backend(
+    config: &Config,
+    driver: &str,
+) -> Result<Arc<dyn AssignmentBackend>, AssignmentProviderError> {
+    let reg = single_registration(
+        inventory::iter::<BackendRegistration<dyn AssignmentBackend>>
+            .into_iter()
+            .filter(|reg| reg.name == driver),
+        driver,
+    )?;
+    (reg.build)(config)
+        .await
+        .map_err(|err| AssignmentProviderError::Driver(err.to_string()))
+}
+
+/// Pick the sole registration from `matches`, mirroring the duplicate-name
+/// rejection [`register_backends`] does at plugin-manager build time.
+///
+/// # Errors
+/// - [`AssignmentProviderError::UnsupportedDriver`] when `matches` is empty.
+/// - [`AssignmentProviderError::Driver`] when it yields more than one.
+fn single_registration<T>(
+    mut matches: impl Iterator<Item = T>,
+    driver: &str,
+) -> Result<T, AssignmentProviderError> {
+    let reg = matches
+        .next()
+        .ok_or_else(|| AssignmentProviderError::UnsupportedDriver(driver.to_string()))?;
+    if matches.next().is_some() {
+        return Err(AssignmentProviderError::Driver(format!(
+            "multiple assignment drivers registered under `{driver}`"
+        )));
+    }
+    Ok(reg)
+}
+
+/// Build one named assignment backend instance from the
+/// `[assignment.backends.<block_name>]` block, dispatching on `driver`
+/// (ADR 0034 §4).
+///
+/// # Errors
+/// - [`AssignmentProviderError::UnsupportedDriver`] when no driver registered
+///   a [`NamedAssignmentBackendRegistration`] for `driver`.
+/// - [`AssignmentProviderError::NamedBackendMisconfigured`] when the block is
+///   absent or names a different driver.
+/// - [`AssignmentProviderError::Driver`] when more than one driver registered
+///   under `driver`, or wrapping any other construction failure.
+pub async fn build_named_assignment_backend(
+    config: &Config,
+    driver: &str,
+    block_name: &str,
+) -> Result<Arc<dyn AssignmentBackend>, AssignmentProviderError> {
+    let reg = single_registration(
+        inventory::iter::<NamedAssignmentBackendRegistration>
+            .into_iter()
+            .filter(|reg| reg.driver == driver),
+        driver,
+    )?;
+    (reg.build)(config, block_name).await.map_err(|err| {
+        err.downcast::<AssignmentProviderError>()
+            .unwrap_or_else(|err| AssignmentProviderError::Driver(err.to_string()))
+    })
+}
+
 /// Plugin manager trait.
 pub trait PluginManagerApi {
     /// Get registered API Key backend.
@@ -203,6 +296,16 @@ pub trait PluginManagerApi {
         &self,
         name: S,
     ) -> Result<&Arc<dyn AssignmentBackend>, AssignmentProviderError>;
+
+    /// Every registered assignment backend, keyed by driver name.
+    ///
+    /// The assignment provider clones this to seed its per-domain dispatch
+    /// bundle (ADR 0034 §4); with the `openfga` driver crate linked it holds
+    /// both `"sql"` and `"openfga"`.
+    ///
+    /// # Returns
+    /// - `&HashMap<String, Arc<dyn AssignmentBackend>>` - The registry.
+    fn assignment_backends(&self) -> &HashMap<String, Arc<dyn AssignmentBackend>>;
 
     /// Get registered catalog backend.
     ///
@@ -716,4 +819,29 @@ pub trait PluginManagerApi {
         name: S,
         plugin: Arc<dyn PolicyStoreBackend>,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use openstack_keystone_config::Config;
+
+    use super::*;
+
+    /// No assignment driver crate is linked into `core`'s own test binary, so
+    /// every name is unknown — the lookup must report it rather than panic.
+    #[tokio::test]
+    async fn build_global_assignment_backend_rejects_an_unknown_driver() {
+        match build_global_assignment_backend(&Config::default(), "nope").await {
+            Err(AssignmentProviderError::UnsupportedDriver(name)) => assert_eq!(name, "nope"),
+            other => panic!("expected UnsupportedDriver, got {:?}", other.err()),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_named_assignment_backend_rejects_an_unknown_driver() {
+        match build_named_assignment_backend(&Config::default(), "nope", "block").await {
+            Err(AssignmentProviderError::UnsupportedDriver(name)) => assert_eq!(name, "nope"),
+            other => panic!("expected UnsupportedDriver, got {:?}", other.err()),
+        }
+    }
 }

--- a/crates/keystone/src/plugin_manager.rs
+++ b/crates/keystone/src/plugin_manager.rs
@@ -186,6 +186,10 @@ impl PluginManagerApi for PluginManager {
         )
     }
 
+    fn assignment_backends(&self) -> &HashMap<String, Arc<dyn AssignmentBackend>> {
+        &self.assignment_backends
+    }
+
     /// Get registered catalog backend.
     ///
     /// # Parameters


### PR DESCRIPTION
The OpenFGA driver read the global [openfga] section on every backend
call, so two instances always hit the same store. Give it a
config_override for a pinned [assignment.backends.<name>] block; the
global instance keeps reading the live section.

Add NamedAssignmentBackendRegistration plus
build_global_assignment_backend and build_named_assignment_backend so a
reload can rebuild instances without a PluginManager (inventory::iter
lives in core). Expose PluginManagerApi::assignment_backends() to seed
the dispatch bundle.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
