### PR TITLE
feat(adr0034): Reload assignment bundle on config change

### DIFF
--- a/crates/core/src/domain_config/service.rs
+++ b/crates/core/src/domain_config/service.rs
@@ -170,6 +170,72 @@ impl DomainConfigService {
         }
         Ok(())
     }
+
+    /// The `assignment/driver` a domain configuration sets, if any
+    /// (ADR 0034 §3). `driver` is the group's only whitelisted option, so a
+    /// `Some` here also means "this write touches the `assignment` group".
+    fn assignment_driver(config: &DomainConfig) -> Option<String> {
+        config.resolve_assignment_driver_name()
+    }
+
+    /// Reject a write that would bind a domain to an `assignment/driver` no
+    /// running backend can serve (ADR 0034 §3): the name must be `sql`, the
+    /// global `[assignment] driver`, or the `driver` of some
+    /// `[assignment.backends.*]` block. An unrecognised name would otherwise
+    /// be stored happily and then silently fall back to the global driver at
+    /// resolve time — catch it at the write instead. `None` (the write does
+    /// not set `assignment/driver`) passes.
+    async fn validate_assignment_binding(
+        &self,
+        state: &ServiceState,
+        driver: Option<&str>,
+    ) -> Result<(), DomainConfigProviderError> {
+        let Some(driver) = driver else {
+            return Ok(());
+        };
+        let bindable = state
+            .config_manager
+            .config
+            .read()
+            .await
+            .assignment
+            .bindable_driver_names();
+        if !bindable.contains(driver) {
+            let mut names: Vec<_> = bindable.into_iter().collect();
+            names.sort();
+            return Err(DomainConfigProviderError::InvalidOptionValue {
+                group: "assignment".to_owned(),
+                option: "driver".to_owned(),
+                source: serde::de::Error::custom(format!(
+                    "{driver:?} names no configured assignment backend; valid names: {names:?}"
+                )),
+            });
+        }
+        Ok(())
+    }
+
+    /// Recompute the assignment provider's domain→driver bindings and
+    /// untargeted fan-out set after a write that touched the `assignment`
+    /// group (ADR 0034 §9). Best-effort: the write has already committed, so
+    /// a failure here is logged and swallowed — the fan-out set self-heals on
+    /// the next full config reload.
+    async fn refresh_assignment_bindings(&self, state: &ServiceState, touched: bool) {
+        if !touched {
+            return;
+        }
+        if let Err(error) = state
+            .provider
+            .get_assignment_provider()
+            .refresh_bindings(state)
+            .await
+        {
+            tracing::warn!(
+                %error,
+                "assignment binding refresh after a domain-config write failed; \
+                 the fan-out set self-heals on the next reload"
+            );
+        }
+    }
 }
 
 #[async_trait]
@@ -181,6 +247,11 @@ impl DomainConfigApi for DomainConfigService {
         config: DomainConfigCreate,
     ) -> Result<DomainConfig, DomainConfigProviderError> {
         let driver = Self::identity_driver(&config.0);
+        let assignment_driver = Self::assignment_driver(&config.0);
+        // Validate before `reconcile_registration_before`: a rejected write
+        // must not leave the SQL identity-driver registration claimed.
+        self.validate_assignment_binding(state, assignment_driver.as_deref())
+            .await?;
         self.reconcile_registration_before(state, domain_id, driver.as_deref())
             .await?;
         let stored = self
@@ -189,6 +260,8 @@ impl DomainConfigApi for DomainConfigService {
             .await?;
         self.reconcile_registration_after(state, domain_id, driver.as_deref())
             .await?;
+        self.refresh_assignment_bindings(state, assignment_driver.is_some())
+            .await;
         Ok(stored)
     }
 
@@ -232,6 +305,9 @@ impl DomainConfigApi for DomainConfigService {
         config: DomainConfigUpdate,
     ) -> Result<DomainConfig, DomainConfigProviderError> {
         let driver = Self::identity_driver(&config.0);
+        let assignment_driver = Self::assignment_driver(&config.0);
+        self.validate_assignment_binding(state, assignment_driver.as_deref())
+            .await?;
         self.reconcile_registration_before(state, domain_id, driver.as_deref())
             .await?;
         let stored = self
@@ -240,6 +316,8 @@ impl DomainConfigApi for DomainConfigService {
             .await?;
         self.reconcile_registration_after(state, domain_id, driver.as_deref())
             .await?;
+        self.refresh_assignment_bindings(state, assignment_driver.is_some())
+            .await;
         Ok(stored)
     }
 
@@ -253,6 +331,11 @@ impl DomainConfigApi for DomainConfigService {
         let driver = (group == DomainConfigGroupName::Identity)
             .then(|| Self::identity_driver(&config.0))
             .flatten();
+        let assignment_driver = (group == DomainConfigGroupName::Assignment)
+            .then(|| Self::assignment_driver(&config.0))
+            .flatten();
+        self.validate_assignment_binding(state, assignment_driver.as_deref())
+            .await?;
         self.reconcile_registration_before(state, domain_id, driver.as_deref())
             .await?;
         let stored = self
@@ -261,6 +344,8 @@ impl DomainConfigApi for DomainConfigService {
             .await?;
         self.reconcile_registration_after(state, domain_id, driver.as_deref())
             .await?;
+        self.refresh_assignment_bindings(state, assignment_driver.is_some())
+            .await;
         Ok(stored)
     }
 
@@ -273,6 +358,12 @@ impl DomainConfigApi for DomainConfigService {
         let driver = (option.group == DomainConfigGroupName::Identity && option.option == "driver")
             .then(|| option.value.as_value().as_str().map(str::to_owned))
             .flatten();
+        let assignment_driver = (option.group == DomainConfigGroupName::Assignment
+            && option.option == "driver")
+            .then(|| option.value.as_value().as_str().map(str::to_owned))
+            .flatten();
+        self.validate_assignment_binding(state, assignment_driver.as_deref())
+            .await?;
         self.reconcile_registration_before(state, domain_id, driver.as_deref())
             .await?;
         let stored = self
@@ -281,6 +372,8 @@ impl DomainConfigApi for DomainConfigService {
             .await?;
         self.reconcile_registration_after(state, domain_id, driver.as_deref())
             .await?;
+        self.refresh_assignment_bindings(state, assignment_driver.is_some())
+            .await;
         Ok(stored)
     }
 
@@ -292,6 +385,9 @@ impl DomainConfigApi for DomainConfigService {
         self.backend_driver
             .delete_domain_config(state, domain_id)
             .await?;
+        // A whole-config delete may have dropped an `assignment/driver`
+        // binding; refresh unconditionally (ADR 0034 §9).
+        self.refresh_assignment_bindings(state, true).await;
         self.release_sql_registration(state, domain_id).await
     }
 
@@ -307,6 +403,8 @@ impl DomainConfigApi for DomainConfigService {
         if group == DomainConfigGroupName::Identity {
             self.release_sql_registration(state, domain_id).await?;
         }
+        self.refresh_assignment_bindings(state, group == DomainConfigGroupName::Assignment)
+            .await;
         Ok(())
     }
 
@@ -323,6 +421,11 @@ impl DomainConfigApi for DomainConfigService {
         if group == DomainConfigGroupName::Identity && option == "driver" {
             self.release_sql_registration(state, domain_id).await?;
         }
+        self.refresh_assignment_bindings(
+            state,
+            group == DomainConfigGroupName::Assignment && option == "driver",
+        )
+        .await;
         Ok(())
     }
 
@@ -521,5 +624,104 @@ mod tests {
             .delete_domain_config(&state, "d1")
             .await
             .unwrap();
+    }
+
+    /// A `Config` with one `[assignment.backends.central_fga]` block whose
+    /// driver is `openfga`.
+    fn config_with_openfga_backend() -> Config {
+        let mut config = Config::default();
+        config.assignment.backends.insert(
+            "central_fga".to_string(),
+            serde_json::from_value(json!({
+                "driver": "openfga",
+                "api_url": "http://fga.example/",
+                "store_id": "s1",
+            }))
+            .expect("a valid openfga backend block"),
+        );
+        config
+    }
+
+    #[tokio::test]
+    async fn an_unbacked_assignment_driver_is_rejected_before_the_registration_claim() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        // The reorder guarantee (ADR 0034 §3): validation fails before the SQL
+        // identity-driver registration is claimed, so a rejected write leaves
+        // no dangling claim behind.
+        backend.expect_obtain_registration().never();
+        backend.expect_create_domain_config().never();
+
+        let error = service(backend, true)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({
+                    "identity": {"driver": "sql"},
+                    "assignment": {"driver": "openfga"},
+                }))),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            DomainConfigProviderError::InvalidOptionValue { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_assignment_driver_named_by_a_backend_block_is_accepted() {
+        let state = get_mocked_state(Some(config_with_openfga_backend()), None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_create_domain_config()
+            .returning(|_, _, _| Ok(config(json!({"assignment": {"driver": "openfga"}}))));
+
+        service(backend, false)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({"assignment": {"driver": "openfga"}}))),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn the_sql_assignment_driver_is_always_accepted() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_create_domain_config()
+            .returning(|_, _, _| Ok(config(json!({"assignment": {"driver": "sql"}}))));
+
+        service(backend, false)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({"assignment": {"driver": "sql"}}))),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn an_unbacked_assignment_driver_is_rejected_on_the_option_path() {
+        let state = get_mocked_state(None, None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend.expect_update_domain_config_option().never();
+
+        let error = service(backend, true)
+            .update_domain_config_option(
+                &state,
+                "d1",
+                DomainConfigOption::new(DomainConfigGroupName::Assignment, "driver", "openfga"),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            DomainConfigProviderError::InvalidOptionValue { .. }
+        ));
     }
 }

--- a/crates/keystone/src/api/v3/auth/project/list.rs
+++ b/crates/keystone/src/api/v3/auth/project/list.rs
@@ -52,6 +52,10 @@ pub(super) async fn list(
         .await?;
 
     let exec = ExecutionContext::from_auth(&state, &user_auth);
+    // Untargeted (`user_id`-only) listing: ADR 0034 §5 routes this through the
+    // assignment provider's fan-out over every active per-domain backend, and
+    // the deduped union is returned here unchanged. Effective mode keeps it
+    // answerable on an OpenFGA-backed domain.
     let project_ids: HashSet<String> = state
         .provider
         .get_assignment_provider()

--- a/crates/keystone/src/api/v3/role_assignment/list.rs
+++ b/crates/keystone/src/api/v3/role_assignment/list.rs
@@ -76,6 +76,10 @@ pub(super) async fn list(
         page_reverse: false,
     };
 
+    // ADR 0034 §5: a targeted query (`scope.project`/`scope.domain`/
+    // `scope.system` filter) routes to that target's driver; an untargeted or
+    // actor-/role-only query fans out over every active backend and the
+    // provider returns the deduped, re-paginated union.
     let raw_assignments = state
         .provider
         .get_assignment_provider()

--- a/crates/keystone/src/api/v4/auth_plugin/identity_link/mod.rs
+++ b/crates/keystone/src/api/v4/auth_plugin/identity_link/mod.rs
@@ -19,7 +19,7 @@
 
 use openstack_keystone_config::{DynamicPluginConfig, PluginMode};
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core_types::assignment::{AssignmentType, RoleAssignmentListParameters};
+use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
 
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
@@ -72,8 +72,12 @@ async fn target_holds_system_role(
     exec: &ExecutionContext<'_>,
     user_id: &str,
 ) -> Result<bool, KeystoneApiError> {
+    // Filter on the system target directly: ADR 0034 §5 routes a `system_id`
+    // listing to the global assignment driver alone, where a bare `user_id`
+    // listing would fan out across every per-domain backend and union.
     let params = RoleAssignmentListParameters {
         user_id: Some(user_id.to_string()),
+        system_id: Some("system".to_string()),
         effective: Some(true),
         ..Default::default()
     };
@@ -82,12 +86,7 @@ async fn target_holds_system_role(
         .get_assignment_provider()
         .list_role_assignments(exec, &params)
         .await?;
-    Ok(assignments.iter().any(|a| {
-        matches!(
-            a.r#type,
-            AssignmentType::UserSystem | AssignmentType::GroupSystem
-        )
-    }))
+    Ok(!assignments.is_empty())
 }
 
 #[cfg(test)]

--- a/crates/keystone/src/scim/group/delete.rs
+++ b/crates/keystone/src/scim/group/delete.rs
@@ -52,8 +52,15 @@ pub(super) async fn delete(
     // §6.B step 1: clear the group's role assignments — this is the
     // security-relevant action, since a "deleted-looking" group that still
     // grants roles would be a silent escalation path.
+    // `effective(true)` on an actor-only listing: ADR 0034 §5 — the OpenFGA
+    // driver cannot answer a non-effective actor-only query (no target scope
+    // to `read` by) and returns 501, which would fail this whole listing once
+    // any domain runs on OpenFGA. Effective mode is answerable there, and for
+    // the SQL driver a `group_id`-only listing is unaffected by the flag (it
+    // only expands a `user_id`).
     let params = RoleAssignmentListParametersBuilder::default()
         .group_id(id.clone())
+        .effective(true)
         .build()?;
     let assignments = state
         .provider

--- a/crates/keystone/src/server/startup/background.rs
+++ b/crates/keystone/src/server/startup/background.rs
@@ -82,6 +82,28 @@ pub async fn spawn_all(startup: &Startup, phase_start: Instant) {
         state.clone(),
     ));
     spawn(reconnect_db_on_config_change(token.clone(), state.clone()));
+    spawn(reload_assignment_drivers_on_config_change(
+        token.clone(),
+        state.clone(),
+    ));
+
+    // ADR 0034 §9: `AssignmentService::new` runs before `ServiceState`
+    // exists, so it starts on a global-only bootstrap bundle. Prime the real
+    // bundle now — the named `[assignment.backends.*]` instances and the
+    // untargeted fan-out set — since the resolver can finally enumerate the
+    // domains bound to a per-domain driver. `reload` logs and retains the
+    // bootstrap bundle on a build failure (it never returns `Err`), and a
+    // global-only deployment just rebuilds the same bundle, so there is
+    // nothing to handle here beyond a trace when the bundle actually changed.
+    if state
+        .provider
+        .get_assignment_provider()
+        .reload(state)
+        .await
+        .unwrap_or(false)
+    {
+        debug!("Assignment dispatch bundle primed at startup");
+    }
 
     subscribe_event_hooks(state).await;
     debug_elapsed(phase_start, "subscribe_event_hooks");
@@ -258,6 +280,45 @@ async fn reload_rate_limits_on_config_change(cancel: CancellationToken, state: S
             }
             () = cancel.cancelled() => {
                 info!("Cancellation requested. Stopping rate-limit reload task.");
+                break;
+            }
+        }
+    }
+}
+
+/// Rebuild the per-domain assignment dispatch bundle when `[assignment]` or a
+/// domain's stored `assignment/driver` binding changes across a configuration
+/// reload (ADR 0034 §9): the global backend, the named
+/// `[assignment.backends.*]` instances and the untargeted fan-out set.
+///
+/// Triggered only by `ConfigManager::notify_tx`; no periodic fallback. An
+/// unresolvable new configuration is logged and the last-known-good bundle is
+/// left in service — `AssignmentApi::reload` already collapses that into
+/// `Ok(false)`, so the `Err` arm here is a belt-and-braces log only.
+async fn reload_assignment_drivers_on_config_change(
+    cancel: CancellationToken,
+    state: ServiceState,
+) {
+    let mut reload_rx = state.config_manager.notify_tx.subscribe();
+    loop {
+        tokio::select! {
+            recv = reload_rx.recv() => {
+                match recv {
+                    Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                        match state.provider.get_assignment_provider().reload(&state).await {
+                            Ok(true) => info!("Assignment dispatch bundle reloaded"),
+                            Ok(false) => {}
+                            Err(error) => error!(
+                                %error,
+                                "Assignment driver reload failed; retaining last-known-good bundle"
+                            ),
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            () = cancel.cancelled() => {
+                info!("Cancellation requested. Stopping assignment driver reload task.");
                 break;
             }
         }


### PR DESCRIPTION
Wire the per-domain assignment dispatch bundle to configuration and
domain-config changes, and fix the fan-out call sites (ADR 0034 §5,
§9).

- Add reload_assignment_drivers_on_config_change: a notify_tx reactor
  that rebuilds the bundle on every config reload. Prime it once at
  startup, since AssignmentService::new runs before ServiceState
  exists and starts on a global-only bootstrap bundle.
- DomainConfigService refreshes the provider's bindings after a write
  that touches the assignment group, best-effort. The fan-out set
  self-heals on the next full reload if the refresh fails.
- Reject a domain-config write binding assignment/driver to a name no
  running backend serves (not sql, the global [assignment] driver, or
  an [assignment.backends.*] block driver). Validate before the SQL
  identity-driver registration is claimed, so a rejected write leaves
  no dangling claim.
- target_holds_system_role filters on system_id, routing to the
  global driver instead of fanning out over every backend for a bare
  user_id.
- The SCIM group-delete assignment sweep asks for effective mode: the
  OpenFGA driver returns 501 for a non-effective actor-only listing,
  which would fail the whole sweep once any domain runs on OpenFGA.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
