### PR TITLE
feat(adr0034): Restrict the assignment DC group to admins

### DIFF
--- a/crates/keystone/src/api/v3/domain_config/group.rs
+++ b/crates/keystone/src/api/v3/domain_config/group.rs
@@ -340,4 +340,244 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
+
+    /// ADR 0034 §6, driven through the real `identity/domain_config/update`
+    /// and `.../delete` Rego (via `get_state_with_real_policy`'s `opa run`
+    /// subprocess + the production `HttpPolicyEnforcer`): a domain-scoped
+    /// `manager` may write every group of their own domain *except*
+    /// `assignment`, which is reserved for cloud admins. Requires `opa` on
+    /// `PATH`.
+    mod real_policy_decision {
+        use openstack_keystone_core::auth::ValidatedSecurityContext;
+        use openstack_keystone_core_types::auth::{
+            AuthenticationContext, AuthzInfoBuilder, IdentityInfo, PrincipalInfo, ScopeInfo,
+            SecurityContext, UserIdentityInfoBuilder,
+        };
+        use openstack_keystone_core_types::identity::UserResponseBuilder;
+        use openstack_keystone_core_types::resource::Domain;
+        use openstack_keystone_core_types::role::RoleRef;
+
+        use super::*;
+        use crate::api::tests::get_state_with_real_policy;
+
+        fn domain_scoped_vsc(caller_domain_id: &str, roles: &[&str]) -> ValidatedSecurityContext {
+            let authz = AuthzInfoBuilder::default()
+                .scope(ScopeInfo::Domain(Domain {
+                    id: caller_domain_id.to_string(),
+                    name: caller_domain_id.to_string(),
+                    enabled: true,
+                    ..Default::default()
+                }))
+                .roles(
+                    roles
+                        .iter()
+                        .enumerate()
+                        .map(|(i, name)| RoleRef {
+                            domain_id: None,
+                            id: format!("role-{i}"),
+                            name: Some((*name).to_string()),
+                        })
+                        .collect::<Vec<_>>(),
+                )
+                .build()
+                .unwrap();
+
+            let sc = SecurityContext::test_build()
+                .authentication_context(AuthenticationContext::Password)
+                .principal(PrincipalInfo {
+                    identity: IdentityInfo::User(
+                        UserIdentityInfoBuilder::default()
+                            .user_id("caller")
+                            .user(
+                                UserResponseBuilder::default()
+                                    .id("caller")
+                                    .domain_id(caller_domain_id)
+                                    .enabled(true)
+                                    .name("caller")
+                                    .build()
+                                    .unwrap(),
+                            )
+                            .user_domain(Domain {
+                                id: caller_domain_id.to_string(),
+                                name: caller_domain_id.to_string(),
+                                enabled: true,
+                                ..Default::default()
+                            })
+                            .build()
+                            .unwrap(),
+                    ),
+                })
+                .authorization(authz)
+                .build();
+            ValidatedSecurityContext::test_new(sc)
+        }
+
+        /// `PATCH /did/config/<group>` with `{"config": body}` under `vsc`,
+        /// against the real policy. The provider mock echoes the write back,
+        /// so a policy `allow` yields 200 and a deny yields 403.
+        async fn patch_group(
+            vsc: ValidatedSecurityContext,
+            group_name: &str,
+            body: serde_json::Value,
+        ) -> StatusCode {
+            let mut mock = MockDomainConfigProvider::default();
+            mock.expect_update_domain_config_group()
+                .returning(|_, _, group, config| Ok(config.0.into_group(group).unwrap()));
+
+            let (state, _opa_guard) =
+                get_state_with_real_policy(Provider::mocked_builder().mock_domain_config(mock))
+                    .await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .method("PATCH")
+                        .uri(format!("/did/config/{group_name}"))
+                        .extension(vsc)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(json!({"config": body}).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        /// `PATCH /did/config/<group>/<option>` with `{"config": body}` under
+        /// `vsc`, against the real policy. This is a distinct handler from
+        /// `patch_group` (`option.rs`, input shape `{domain_id, group,
+        /// option}` — no `config`), so the `assignment` guard needs its own
+        /// end-to-end coverage on the option path.
+        async fn patch_option(
+            vsc: ValidatedSecurityContext,
+            group_name: &str,
+            option: &str,
+            body: serde_json::Value,
+        ) -> StatusCode {
+            let mut mock = MockDomainConfigProvider::default();
+            mock.expect_update_domain_config_option()
+                .returning(|_, _, option| Ok(option));
+
+            let (state, _opa_guard) =
+                get_state_with_real_policy(Provider::mocked_builder().mock_domain_config(mock))
+                    .await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            api.as_service()
+                .oneshot(
+                    Request::builder()
+                        .method("PATCH")
+                        .uri(format!("/did/config/{group_name}/{option}"))
+                        .extension(vsc)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(json!({"config": body}).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .status()
+        }
+
+        #[tokio::test]
+        async fn manager_may_write_a_non_assignment_group_of_their_domain() {
+            let status = patch_group(
+                domain_scoped_vsc("did", &["manager"]),
+                "ldap",
+                json!({"ldap": {"url": "ldap://in"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn manager_is_denied_the_assignment_group() {
+            let status = patch_group(
+                domain_scoped_vsc("did", &["manager"]),
+                "assignment",
+                json!({"assignment": {"driver": "sql"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn admin_role_may_write_the_assignment_group() {
+            let status = patch_group(
+                domain_scoped_vsc("did", &["admin"]),
+                "assignment",
+                json!({"assignment": {"driver": "sql"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn manager_is_denied_the_assignment_group_on_the_option_path() {
+            let status = patch_option(
+                domain_scoped_vsc("did", &["manager"]),
+                "assignment",
+                "driver",
+                json!({"assignment": {"driver": "sql"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn admin_role_may_write_the_assignment_group_on_the_option_path() {
+            let status = patch_option(
+                domain_scoped_vsc("did", &["admin"]),
+                "assignment",
+                "driver",
+                json!({"assignment": {"driver": "sql"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn manager_may_write_a_non_assignment_option_of_their_domain() {
+            let status = patch_option(
+                domain_scoped_vsc("did", &["manager"]),
+                "ldap",
+                "url",
+                json!({"ldap": {"url": "ldap://in"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn manager_is_denied_deleting_the_assignment_group() {
+            let mut mock = MockDomainConfigProvider::default();
+            mock.expect_delete_domain_config_group().never();
+
+            let (state, _opa_guard) =
+                get_state_with_real_policy(Provider::mocked_builder().mock_domain_config(mock))
+                    .await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            let response = api
+                .as_service()
+                .oneshot(
+                    Request::builder()
+                        .method("DELETE")
+                        .uri("/did/config/assignment")
+                        .extension(domain_scoped_vsc("did", &["manager"]))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        }
+    }
 }

--- a/policy/domain_config/create.rego
+++ b/policy/domain_config/create.rego
@@ -21,10 +21,23 @@ allow if {
 	input.credentials.is_admin
 }
 
-# A domain manager may configure the domain their token is scoped to.
+# A domain manager may configure the domain their token is scoped to, except
+# the `assignment` group: binding a domain to an assignment backend is a
+# role-minting surface reserved for cloud admins (ADR 0034 §6).
 allow if {
 	"manager" in input.credentials.roles
 	input.credentials.domain_id == input.target.domain_id
+	not touches_assignment_group
+}
+
+# The write addresses the `assignment` group directly (group or option path).
+touches_assignment_group if {
+	input.target.group == "assignment"
+}
+
+# ...or carries an `assignment` block in a whole-config PATCH/PUT body.
+touches_assignment_group if {
+	input.target.config.assignment
 }
 
 violation contains {"field": "", "msg": "writing a domain configuration requires system admin or the `manager` role on the domain."} if {

--- a/policy/domain_config/create_test.rego
+++ b/policy/domain_config/create_test.rego
@@ -12,6 +12,29 @@ test_domain_manager_allowed if {
 		"credentials": {"roles": ["manager"], "domain_id": "d1"},
 		"target": {"domain_id": "d1"},
 	}
+	create.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "identity"},
+	}
+}
+
+# ADR 0034 §6: the `assignment` group is cloud-admin only.
+test_domain_manager_denied_the_assignment_group if {
+	not create.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
+	not create.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
+	}
+}
+
+test_admin_allowed_the_assignment_group if {
+	create.allow with input as {
+		"credentials": {"roles": ["admin"], "is_admin": true},
+		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
+	}
 }
 
 test_forbidden if {

--- a/policy/domain_config/delete.rego
+++ b/policy/domain_config/delete.rego
@@ -20,10 +20,21 @@ allow if {
 	input.credentials.is_admin
 }
 
-# A domain manager may configure the domain their token is scoped to.
+# A domain manager may configure the domain their token is scoped to, except
+# the `assignment` group: binding a domain to an assignment backend is a
+# role-minting surface reserved for cloud admins (ADR 0034 §6). A whole-config
+# DELETE carries no group, so a manager can still drop their domain's whole
+# configuration — that only reverts the domain to the global driver, which
+# mints nothing.
 allow if {
 	"manager" in input.credentials.roles
 	input.credentials.domain_id == input.target.domain_id
+	not touches_assignment_group
+}
+
+# The delete addresses the `assignment` group directly (group or option path).
+touches_assignment_group if {
+	input.target.group == "assignment"
 }
 
 violation contains {"field": "", "msg": "deleting a domain configuration requires system admin or the `manager` role on the domain."} if {

--- a/policy/domain_config/delete_test.rego
+++ b/policy/domain_config/delete_test.rego
@@ -12,6 +12,29 @@ test_domain_manager_allowed if {
 		"credentials": {"roles": ["manager"], "domain_id": "d1"},
 		"target": {"domain_id": "d1"},
 	}
+	delete.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "identity"},
+	}
+}
+
+# ADR 0034 §6: the `assignment` group is cloud-admin only.
+test_domain_manager_denied_the_assignment_group if {
+	not delete.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
+	not delete.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment", "option": "driver"},
+	}
+}
+
+test_admin_allowed_the_assignment_group if {
+	delete.allow with input as {
+		"credentials": {"roles": ["admin"], "is_admin": true},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
 }
 
 test_forbidden if {

--- a/policy/domain_config/update.rego
+++ b/policy/domain_config/update.rego
@@ -22,10 +22,23 @@ allow if {
 	input.credentials.is_admin
 }
 
-# A domain manager may configure the domain their token is scoped to.
+# A domain manager may configure the domain their token is scoped to, except
+# the `assignment` group: binding a domain to an assignment backend is a
+# role-minting surface reserved for cloud admins (ADR 0034 §6).
 allow if {
 	"manager" in input.credentials.roles
 	input.credentials.domain_id == input.target.domain_id
+	not touches_assignment_group
+}
+
+# The write addresses the `assignment` group directly (group or option path).
+touches_assignment_group if {
+	input.target.group == "assignment"
+}
+
+# ...or carries an `assignment` block in a whole-config PATCH/PUT body.
+touches_assignment_group if {
+	input.target.config.assignment
 }
 
 violation contains {"field": "", "msg": "writing a domain configuration requires system admin or the `manager` role on the domain."} if {

--- a/policy/domain_config/update_test.rego
+++ b/policy/domain_config/update_test.rego
@@ -12,6 +12,37 @@ test_domain_manager_allowed if {
 		"credentials": {"roles": ["manager"], "domain_id": "d1"},
 		"target": {"domain_id": "d1"},
 	}
+	update.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "identity"},
+	}
+}
+
+# ADR 0034 §6: the `assignment` group is cloud-admin only.
+test_domain_manager_denied_the_assignment_group if {
+	not update.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
+	not update.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment", "option": "driver"},
+	}
+	not update.allow with input as {
+		"credentials": {"roles": ["manager"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
+	}
+}
+
+test_admin_allowed_the_assignment_group if {
+	update.allow with input as {
+		"credentials": {"roles": ["admin"], "is_admin": true},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
+	update.allow with input as {
+		"credentials": {"roles": [], "is_admin": true},
+		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
+	}
 }
 
 test_forbidden if {


### PR DESCRIPTION
The `assignment` group binds a domain to an assignment backend, which is
a role-minting surface: a domain manager who could set it would pick
which driver mints roles for their own domain (ADR 0034 §6).

- Add a `touches_assignment_group` guard to the domain-manager `allow`
  clause of domain_config create/update/delete. It fires on the group or
  option path (`input.target.group == "assignment"`) and on an
  `assignment` block in a whole-config PATCH/PUT body
  (`input.target.config.assignment`).
- The `admin` / `is_admin` clauses stay unconditional; they key on the
  authentication chain and are never satisfiable by a domain-scoped
  token.
- A whole-config DELETE carries no group, so a manager can still drop
  their domain's entire configuration; that only reverts the domain to
  the global driver, which mints nothing.
- Cover the decision with `opa test` cases and, in the group handler,
  with tests driven through the real `opa run` policy and the production
  HttpPolicyEnforcer.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
