### PR TITLE
test(adr0034): Add per-domain assignment driver tests

### DIFF
--- a/crates/core/src/assignment/service.rs
+++ b/crates/core/src/assignment/service.rs
@@ -213,6 +213,43 @@ impl AssignmentService {
         }
     }
 
+    /// Build a service with an explicit routing bundle and resolver, bypassing
+    /// [`Self::new`]'s plugin-manager backend build. Test-only: lets a
+    /// dispatch test wire mock backends straight into the bundle. Per-domain
+    /// dispatch is on whenever `resolver` is `Some`. The fan-out set is
+    /// derived (global plus every distinct named instance), matching
+    /// [`Self::rebuild`].
+    #[cfg(test)]
+    pub(crate) fn from_parts(
+        global_driver_name: impl Into<String>,
+        global: Arc<dyn AssignmentBackend>,
+        domains: HashMap<String, String>,
+        backend_blocks: HashMap<String, AssignmentBackendConfig>,
+        instances: HashMap<String, Arc<dyn AssignmentBackend>>,
+        resolver: Option<Arc<DomainConfigResolver>>,
+    ) -> Self {
+        let mut fanout = vec![global.clone()];
+        for instance in instances.values() {
+            if !fanout.iter().any(|b| Arc::ptr_eq(b, instance)) {
+                fanout.push(instance.clone());
+            }
+        }
+        let bundle = AssignmentBundle {
+            global,
+            global_driver_name: global_driver_name.into(),
+            dispatch_enabled: resolver.is_some(),
+            domains,
+            backend_blocks,
+            instances,
+            fanout,
+        };
+        Self {
+            resolver,
+            bundle: ArcSwap::from_pointee(bundle),
+            binding_cache: RwLock::new(HashMap::new()),
+        }
+    }
+
     /// The backend that serves an assignment on `(kind, target_id)`.
     ///
     /// `system` targets and every operation while dispatch is off use the
@@ -255,8 +292,12 @@ impl AssignmentService {
             }
         };
 
-        let (name, newly_resolved) = match self.binding_cache.read().await.get(&domain_id).cloned()
-        {
+        // Read into an owned value in its own statement: a guard held as a
+        // `match` scrutinee temporary would still be live in the `None` arm and
+        // deadlock the `write().await` below (edition 2024 rescopes `if let`
+        // temporaries but not `match` ones).
+        let cached = self.binding_cache.read().await.get(&domain_id).cloned();
+        let (name, newly_resolved) = match cached {
             Some(name) => (name, false),
             None => {
                 let name = match resolver.effective_config(ctx.state(), &domain_id).await {
@@ -728,192 +769,5 @@ impl AssignmentApi for AssignmentService {
 }
 
 #[cfg(test)]
-mod tests {
-    use openstack_keystone_core_types::revoke::*;
-    use openstack_keystone_core_types::role::*;
-
-    use super::*;
-    use crate::assignment::backend::MockAssignmentBackend;
-    use crate::provider::Provider;
-    use crate::revoke::MockRevokeProvider;
-    use crate::role::MockRoleProvider;
-    use crate::tests::get_mocked_state;
-
-    #[test]
-    fn target_kind_partitions_every_assignment_type() {
-        assert!(matches!(
-            target_kind(&AssignmentType::UserDomain),
-            TargetKind::Domain
-        ));
-        assert!(matches!(
-            target_kind(&AssignmentType::GroupDomain),
-            TargetKind::Domain
-        ));
-        assert!(matches!(
-            target_kind(&AssignmentType::UserProject),
-            TargetKind::Project
-        ));
-        assert!(matches!(
-            target_kind(&AssignmentType::GroupProject),
-            TargetKind::Project
-        ));
-        assert!(matches!(
-            target_kind(&AssignmentType::UserSystem),
-            TargetKind::System
-        ));
-        assert!(matches!(
-            target_kind(&AssignmentType::GroupSystem),
-            TargetKind::System
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_crate_grant() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockAssignmentBackend::default();
-        backend.expect_create_grant().returning(|_, _| {
-            Ok(AssignmentBuilder::default()
-                .actor_id("actor")
-                .role_id("rid1")
-                .target_id("target_id")
-                .r#type(AssignmentType::UserProject)
-                .build()
-                .unwrap())
-        });
-
-        let provider = AssignmentService::from_backend(Arc::new(backend));
-
-        assert!(
-            provider
-                .create_grant(
-                    &ExecutionContext::internal(&state),
-                    AssignmentCreate::user_project("actor_id", "target_id", "role_id", false)
-                )
-                .await
-                .is_ok()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_list_assignments() {
-        let state = get_mocked_state(None, None).await;
-        let mut backend = MockAssignmentBackend::default();
-        backend
-            .expect_list_assignments()
-            .returning(|_, _| Ok(vec![]));
-
-        let provider = AssignmentService::from_backend(Arc::new(backend));
-
-        assert!(
-            provider
-                .list_role_assignments(
-                    &ExecutionContext::internal(&state),
-                    &RoleAssignmentListParameters {
-                        role_id: Some("rid".into()),
-                        resolve_implied_roles: false,
-                        ..Default::default()
-                    },
-                )
-                .await
-                .is_ok()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_list_assignments_include_names() {
-        let mut role_mock = MockRoleProvider::default();
-        role_mock.expect_list_roles().returning(|_, _| {
-            Ok(vec![
-                RoleBuilder::default()
-                    .id("rid1")
-                    .name("rid1_name")
-                    .build()
-                    .unwrap(),
-                RoleBuilder::default()
-                    .id("rid2")
-                    .name("rid2_name")
-                    .build()
-                    .unwrap(),
-            ])
-        });
-        let state =
-            get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
-        let mut backend = MockAssignmentBackend::default();
-        backend
-            .expect_list_assignments()
-            .withf(|_, params: &RoleAssignmentListParameters| {
-                params.role_id == Some("rid".into()) && params.include_names.is_some_and(|x| x)
-            })
-            .returning(|_, _| {
-                Ok(vec![
-                    AssignmentBuilder::default()
-                        .actor_id("actor")
-                        .role_id("rid1")
-                        .target_id("target_id")
-                        .r#type(AssignmentType::UserProject)
-                        .build()
-                        .unwrap(),
-                ])
-            });
-
-        let provider = AssignmentService::from_backend(Arc::new(backend));
-
-        let res = provider
-            .list_role_assignments(
-                &ExecutionContext::internal(&state),
-                &RoleAssignmentListParameters {
-                    role_id: Some("rid".into()),
-                    include_names: Some(true),
-                    resolve_implied_roles: false,
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap();
-        assert!(
-            res.iter()
-                .find(|x| x.role_id == "rid1" && x.role_name == Some("rid1_name".into()))
-                .is_some()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_revoke_grant() {
-        let mut revoke_mock = MockRevokeProvider::default();
-        revoke_mock
-            .expect_create_revocation_event()
-            .withf(|_, params: &RevocationEventCreate| {
-                params.project_id == Some("target_id".into())
-                    && params.user_id == Some("actor".into())
-                    && params.role_id == Some("rid1".into())
-            })
-            .returning(|_, _| Ok(RevocationEvent::default()));
-        let state = get_mocked_state(
-            None,
-            Some(Provider::mocked_builder().mock_revoke(revoke_mock)),
-        )
-        .await;
-        let mut backend = MockAssignmentBackend::default();
-        let assignment = AssignmentBuilder::default()
-            .actor_id("actor")
-            .role_id("rid1")
-            .target_id("target_id")
-            .r#type(AssignmentType::UserProject)
-            .build()
-            .unwrap();
-        let assignment_clone = assignment.clone();
-        backend
-            .expect_revoke_grant()
-            .withf(move |_, params: &Assignment| *params == assignment_clone)
-            .returning(|_, _| Ok(()));
-
-        let provider = AssignmentService::from_backend(Arc::new(backend));
-
-        assert!(
-            provider
-                .revoke_grant(&ExecutionContext::internal(&state), assignment)
-                .await
-                .is_ok()
-        );
-    }
-}
+#[path = "service/tests.rs"]
+mod tests;

--- a/crates/core/src/assignment/service/tests.rs
+++ b/crates/core/src/assignment/service/tests.rs
@@ -1,0 +1,211 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for [`super::AssignmentService`].
+//!
+//! Split out of `service.rs` to keep the implementation file short. Per-domain
+//! target-keyed dispatch, the untargeted fan-out and the reload reactor live in
+//! the [`per_domain_dispatch`] and [`reload`] submodules (ADR 0034 "Testing").
+
+use openstack_keystone_core_types::revoke::*;
+use openstack_keystone_core_types::role::*;
+
+use super::*;
+use crate::assignment::backend::MockAssignmentBackend;
+use crate::provider::Provider;
+use crate::revoke::MockRevokeProvider;
+use crate::role::MockRoleProvider;
+use crate::tests::get_mocked_state;
+
+#[path = "tests/per_domain_dispatch.rs"]
+mod per_domain_dispatch;
+#[path = "tests/reload.rs"]
+mod reload;
+
+#[test]
+fn target_kind_partitions_every_assignment_type() {
+    assert!(matches!(
+        target_kind(&AssignmentType::UserDomain),
+        TargetKind::Domain
+    ));
+    assert!(matches!(
+        target_kind(&AssignmentType::GroupDomain),
+        TargetKind::Domain
+    ));
+    assert!(matches!(
+        target_kind(&AssignmentType::UserProject),
+        TargetKind::Project
+    ));
+    assert!(matches!(
+        target_kind(&AssignmentType::GroupProject),
+        TargetKind::Project
+    ));
+    assert!(matches!(
+        target_kind(&AssignmentType::UserSystem),
+        TargetKind::System
+    ));
+    assert!(matches!(
+        target_kind(&AssignmentType::GroupSystem),
+        TargetKind::System
+    ));
+}
+
+#[tokio::test]
+async fn test_crate_grant() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockAssignmentBackend::default();
+    backend.expect_create_grant().returning(|_, _| {
+        Ok(AssignmentBuilder::default()
+            .actor_id("actor")
+            .role_id("rid1")
+            .target_id("target_id")
+            .r#type(AssignmentType::UserProject)
+            .build()
+            .unwrap())
+    });
+
+    let provider = AssignmentService::from_backend(Arc::new(backend));
+
+    assert!(
+        provider
+            .create_grant(
+                &ExecutionContext::internal(&state),
+                AssignmentCreate::user_project("actor_id", "target_id", "role_id", false)
+            )
+            .await
+            .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn test_list_assignments() {
+    let state = get_mocked_state(None, None).await;
+    let mut backend = MockAssignmentBackend::default();
+    backend
+        .expect_list_assignments()
+        .returning(|_, _| Ok(vec![]));
+
+    let provider = AssignmentService::from_backend(Arc::new(backend));
+
+    assert!(
+        provider
+            .list_role_assignments(
+                &ExecutionContext::internal(&state),
+                &RoleAssignmentListParameters {
+                    role_id: Some("rid".into()),
+                    resolve_implied_roles: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn test_list_assignments_include_names() {
+    let mut role_mock = MockRoleProvider::default();
+    role_mock.expect_list_roles().returning(|_, _| {
+        Ok(vec![
+            RoleBuilder::default()
+                .id("rid1")
+                .name("rid1_name")
+                .build()
+                .unwrap(),
+            RoleBuilder::default()
+                .id("rid2")
+                .name("rid2_name")
+                .build()
+                .unwrap(),
+        ])
+    });
+    let state = get_mocked_state(None, Some(Provider::mocked_builder().mock_role(role_mock))).await;
+    let mut backend = MockAssignmentBackend::default();
+    backend
+        .expect_list_assignments()
+        .withf(|_, params: &RoleAssignmentListParameters| {
+            params.role_id == Some("rid".into()) && params.include_names.is_some_and(|x| x)
+        })
+        .returning(|_, _| {
+            Ok(vec![
+                AssignmentBuilder::default()
+                    .actor_id("actor")
+                    .role_id("rid1")
+                    .target_id("target_id")
+                    .r#type(AssignmentType::UserProject)
+                    .build()
+                    .unwrap(),
+            ])
+        });
+
+    let provider = AssignmentService::from_backend(Arc::new(backend));
+
+    let res = provider
+        .list_role_assignments(
+            &ExecutionContext::internal(&state),
+            &RoleAssignmentListParameters {
+                role_id: Some("rid".into()),
+                include_names: Some(true),
+                resolve_implied_roles: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(
+        res.iter()
+            .find(|x| x.role_id == "rid1" && x.role_name == Some("rid1_name".into()))
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn test_revoke_grant() {
+    let mut revoke_mock = MockRevokeProvider::default();
+    revoke_mock
+        .expect_create_revocation_event()
+        .withf(|_, params: &RevocationEventCreate| {
+            params.project_id == Some("target_id".into())
+                && params.user_id == Some("actor".into())
+                && params.role_id == Some("rid1".into())
+        })
+        .returning(|_, _| Ok(RevocationEvent::default()));
+    let state = get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_revoke(revoke_mock)),
+    )
+    .await;
+    let mut backend = MockAssignmentBackend::default();
+    let assignment = AssignmentBuilder::default()
+        .actor_id("actor")
+        .role_id("rid1")
+        .target_id("target_id")
+        .r#type(AssignmentType::UserProject)
+        .build()
+        .unwrap();
+    let assignment_clone = assignment.clone();
+    backend
+        .expect_revoke_grant()
+        .withf(move |_, params: &Assignment| *params == assignment_clone)
+        .returning(|_, _| Ok(()));
+
+    let provider = AssignmentService::from_backend(Arc::new(backend));
+
+    assert!(
+        provider
+            .revoke_grant(&ExecutionContext::internal(&state), assignment)
+            .await
+            .is_ok()
+    );
+}

--- a/crates/core/src/assignment/service/tests/per_domain_dispatch.rs
+++ b/crates/core/src/assignment/service/tests/per_domain_dispatch.rs
@@ -1,0 +1,573 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-domain assignment driver dispatch unit tests (ADR 0034 "Testing").
+//!
+//! Split out of `service.rs::tests`. Covers target-keyed routing
+//! ([`AssignmentService::driver_for_target`]), the per-domain resolution cache,
+//! the `system` carve-out (§1), stale-binding fallback (§4), the shared-backend
+//! fast path (§4), the cross-domain grant invariant (§1) and the untargeted
+//! fan-out with de-dup / pagination / fail-fast (§5).
+
+use serde_json::json;
+
+use openstack_keystone_core_types::domain_config::DomainConfig;
+use openstack_keystone_core_types::resource::Project;
+
+use super::*;
+use crate::domain_config::backend::{DomainConfigBackend, MockDomainConfigBackend};
+use crate::domain_config::error::DomainConfigProviderError;
+use crate::resource::MockResourceProvider;
+
+/// A domain-config `database` source whose `get_domain_config` answers `answer`
+/// (cloned) every call, expected exactly `calls` times.
+fn config_source(
+    answer: Result<Option<DomainConfig>, DomainConfigProviderError>,
+    calls: usize,
+) -> Arc<dyn DomainConfigBackend> {
+    let mut mock = MockDomainConfigBackend::new();
+    mock.expect_get_domain_config()
+        .times(calls)
+        .returning(move |_, _| match &answer {
+            Ok(maybe) => Ok(maybe.clone()),
+            Err(err) => Err(DomainConfigProviderError::Driver(err.to_string())),
+        });
+    Arc::new(mock)
+}
+
+/// A resolver whose only active source is the database `source`.
+fn resolver(source: Arc<dyn DomainConfigBackend>) -> Arc<DomainConfigResolver> {
+    Arc::new(DomainConfigResolver::from_sources(None, Some(source)))
+}
+
+/// A stored overlay binding `assignment/driver = <driver>`.
+fn binding(driver: &str) -> DomainConfig {
+    DomainConfig::from_value(json!({ "assignment": { "driver": driver } })).expect("valid config")
+}
+
+/// An assignment backend whose `create_grant` is expected exactly `calls`
+/// times and echoes a fixed assignment.
+fn create_backend(calls: usize) -> Arc<dyn AssignmentBackend> {
+    let mut mock = MockAssignmentBackend::default();
+    mock.expect_create_grant()
+        .times(calls)
+        .returning(|_, grant| {
+            Ok(AssignmentBuilder::default()
+                .actor_id(grant.actor_id)
+                .role_id(grant.role_id)
+                .target_id(grant.target_id)
+                .r#type(grant.r#type)
+                .build()
+                .unwrap())
+        });
+    Arc::new(mock)
+}
+
+/// An assignment backend whose `list_assignments` is expected exactly `calls`
+/// times and returns `rows`.
+fn list_backend(calls: usize, rows: Vec<Assignment>) -> Arc<dyn AssignmentBackend> {
+    let mut mock = MockAssignmentBackend::default();
+    mock.expect_list_assignments()
+        .times(calls)
+        .returning(move |_, _| Ok(rows.clone()));
+    Arc::new(mock)
+}
+
+fn assignment(actor: &str, target: &str, role: &str, kind: AssignmentType) -> Assignment {
+    AssignmentBuilder::default()
+        .actor_id(actor)
+        .role_id(role)
+        .target_id(target)
+        .r#type(kind)
+        .build()
+        .unwrap()
+}
+
+/// State whose resource provider resolves every project id to `Project` in
+/// `domain_id`.
+async fn state_with_project_domain(domain_id: &'static str) -> ServiceState {
+    let mut resource = MockResourceProvider::default();
+    resource
+        .expect_get_project()
+        .returning(move |_, project_id| {
+            Ok(Some(Project {
+                id: project_id.to_string(),
+                name: project_id.to_string(),
+                domain_id: domain_id.to_string(),
+                enabled: true,
+                ..Default::default()
+            }))
+        });
+    get_mocked_state(
+        None,
+        Some(Provider::mocked_builder().mock_resource(resource)),
+    )
+    .await
+}
+
+/// One named `sql` block `b_sql` bound to `domains`, its instance, plus a
+/// distinct global backend named `openfga` — so a `sql` binding is never the
+/// global name.
+fn service(
+    global: Arc<dyn AssignmentBackend>,
+    named: Arc<dyn AssignmentBackend>,
+    domains: &[(&str, &str)],
+    source: Arc<dyn DomainConfigBackend>,
+) -> AssignmentService {
+    let mut blocks = HashMap::new();
+    blocks.insert("b_sql".to_string(), AssignmentBackendConfig::Sql);
+    let mut instances = HashMap::new();
+    instances.insert("b_sql".to_string(), named);
+    AssignmentService::from_parts(
+        "openfga",
+        global,
+        domains
+            .iter()
+            .map(|(d, b)| (d.to_string(), b.to_string()))
+            .collect(),
+        blocks,
+        instances,
+        Some(resolver(source)),
+    )
+}
+
+#[tokio::test]
+async fn a_stored_binding_routes_a_domain_grant_to_the_named_instance() {
+    let state = get_mocked_state(None, None).await;
+    let global = create_backend(0);
+    let named = create_backend(1);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 1),
+    );
+
+    provider
+        .create_grant(
+            &ExecutionContext::internal(&state),
+            AssignmentCreate::user_domain("u", "d1", "r", false),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_domain_without_a_binding_uses_the_global_backend() {
+    let state = get_mocked_state(None, None).await;
+    let global = create_backend(1);
+    let named = create_backend(0);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(None), 1),
+    );
+
+    provider
+        .create_grant(
+            &ExecutionContext::internal(&state),
+            AssignmentCreate::user_domain("u", "d1", "r", false),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn the_resolution_is_cached_per_domain() {
+    let state = get_mocked_state(None, None).await;
+    let global = create_backend(0);
+    let named = create_backend(2);
+    // The source is consulted exactly once for two grants on the same domain.
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 1),
+    );
+
+    let ctx = ExecutionContext::internal(&state);
+    provider
+        .create_grant(&ctx, AssignmentCreate::user_domain("u", "d1", "r", false))
+        .await
+        .unwrap();
+    provider
+        .create_grant(&ctx, AssignmentCreate::group_domain("g", "d1", "r", false))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_resolver_error_falls_back_to_the_global_backend() {
+    let state = get_mocked_state(None, None).await;
+    let global = create_backend(1);
+    let named = create_backend(0);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Err(DomainConfigProviderError::Driver("boom".into())), 1),
+    );
+
+    provider
+        .create_grant(
+            &ExecutionContext::internal(&state),
+            AssignmentCreate::user_domain("u", "d1", "r", false),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_system_target_never_consults_the_resolver() {
+    // ADR 0034 §1: `system` targets always use the global backend and never
+    // touch the domain-config source (which also bounds the §6 blast radius).
+    let state = get_mocked_state(None, None).await;
+    let global = create_backend(1);
+    let named = create_backend(0);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 0),
+    );
+
+    provider
+        .create_grant(
+            &ExecutionContext::internal(&state),
+            AssignmentCreate::user_system("u", "all", "r", false),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_project_target_routes_on_its_owning_domain() {
+    // The dispatch domain of a project grant is the project's `domain_id`,
+    // fetched from the resource provider — not the actor's domain.
+    let state = state_with_project_domain("d1").await;
+    let global = create_backend(0);
+    let named = create_backend(1);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 1),
+    );
+
+    provider
+        .create_grant(
+            &ExecutionContext::internal(&state),
+            AssignmentCreate::user_project("actor-in-another-domain", "p1", "r", false),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_stale_binding_falls_back_to_the_global_backend() {
+    // A domain that resolves a non-global driver name but has no matching
+    // live `[assignment.domains]` → `[assignment.backends.*]` block routes to
+    // the global backend (ADR 0034 §4 step 3).
+    let state = get_mocked_state(None, None).await;
+    let global = create_backend(1);
+    let named = create_backend(0);
+    let provider = service(
+        global,
+        named,
+        &[], // d1 is bound in the store but mapped nowhere.
+        config_source(Ok(Some(binding("sql"))), 1),
+    );
+
+    provider
+        .create_grant(
+            &ExecutionContext::internal(&state),
+            AssignmentCreate::user_domain("u", "d1", "r", false),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn two_domains_on_one_block_share_the_backend_instance() {
+    // ADR 0034 §4: two domains mapped to the same block resolve to the very
+    // same `Arc`, and the fan-out set counts it once.
+    let state = get_mocked_state(None, None).await;
+    let global = create_backend(0);
+    let named = create_backend(2);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql"), ("d2", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 2),
+    );
+
+    let ctx = ExecutionContext::internal(&state);
+    provider
+        .create_grant(&ctx, AssignmentCreate::user_domain("u", "d1", "r", false))
+        .await
+        .unwrap();
+    provider
+        .create_grant(&ctx, AssignmentCreate::user_domain("u", "d2", "r", false))
+        .await
+        .unwrap();
+
+    let bundle = provider.bundle.load_full();
+    assert_eq!(bundle.fanout.len(), 2, "global + one shared named instance");
+}
+
+#[tokio::test]
+async fn a_cross_domain_project_grant_is_written_to_and_read_from_the_target_domain() {
+    // ADR 0034 §1: an actor in domain A granted a role on a project in domain
+    // B is written to B's driver and shows up in B's target-scoped listing;
+    // A's driver is never touched.
+    let state = state_with_project_domain("d-b").await;
+
+    let mut global_mock = MockAssignmentBackend::default();
+    global_mock.expect_create_grant().times(0);
+    global_mock.expect_list_assignments().times(0);
+    let global: Arc<dyn AssignmentBackend> = Arc::new(global_mock);
+
+    let row = assignment("actor-in-a", "p-in-b", "r", AssignmentType::UserProject);
+    let mut named_mock = MockAssignmentBackend::default();
+    named_mock
+        .expect_create_grant()
+        .once()
+        .returning(|_, grant| {
+            Ok(AssignmentBuilder::default()
+                .actor_id(grant.actor_id)
+                .role_id(grant.role_id)
+                .target_id(grant.target_id)
+                .r#type(grant.r#type)
+                .build()
+                .unwrap())
+        });
+    let row_clone = row.clone();
+    named_mock
+        .expect_list_assignments()
+        .once()
+        .returning(move |_, _| Ok(vec![row_clone.clone()]));
+    let named: Arc<dyn AssignmentBackend> = Arc::new(named_mock);
+
+    let provider = service(
+        global,
+        named,
+        &[("d-b", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 1),
+    );
+
+    let ctx = ExecutionContext::internal(&state);
+    provider
+        .create_grant(
+            &ctx,
+            AssignmentCreate::user_project("actor-in-a", "p-in-b", "r", false),
+        )
+        .await
+        .unwrap();
+
+    let listed = provider
+        .list_role_assignments(
+            &ctx,
+            &RoleAssignmentListParameters {
+                domain_id: Some("d-b".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(listed, vec![row]);
+}
+
+#[tokio::test]
+async fn an_untargeted_listing_fans_out_and_unions_the_results() {
+    let state = get_mocked_state(None, None).await;
+    let g_row = assignment("u", "d-global", "r", AssignmentType::UserDomain);
+    let n_row = assignment("u", "d1", "r", AssignmentType::UserDomain);
+    let global = list_backend(1, vec![g_row.clone()]);
+    let named = list_backend(1, vec![n_row.clone()]);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 0),
+    );
+
+    let mut listed = provider
+        .list_role_assignments(
+            &ExecutionContext::internal(&state),
+            &RoleAssignmentListParameters::default(),
+        )
+        .await
+        .unwrap();
+    listed.sort_by_key(Assignment::pagination_marker);
+    let mut want = vec![g_row, n_row];
+    want.sort_by_key(Assignment::pagination_marker);
+    assert_eq!(listed, want);
+}
+
+#[tokio::test]
+async fn an_untargeted_listing_deduplicates_across_backends() {
+    let state = get_mocked_state(None, None).await;
+    let row = assignment("u", "d1", "r", AssignmentType::UserDomain);
+    let global = list_backend(1, vec![row.clone()]);
+    let named = list_backend(1, vec![row.clone()]);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 0),
+    );
+
+    let listed = provider
+        .list_role_assignments(
+            &ExecutionContext::internal(&state),
+            &RoleAssignmentListParameters::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(listed, vec![row]);
+}
+
+#[tokio::test]
+async fn an_untargeted_listing_paginates_the_union_once() {
+    let state = get_mocked_state(None, None).await;
+    let global = list_backend(
+        1,
+        vec![
+            assignment("u", "a", "r", AssignmentType::UserDomain),
+            assignment("u", "c", "r", AssignmentType::UserDomain),
+        ],
+    );
+    let named = list_backend(
+        1,
+        vec![assignment("u", "b", "r", AssignmentType::UserDomain)],
+    );
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 0),
+    );
+
+    let listed = provider
+        .list_role_assignments(
+            &ExecutionContext::internal(&state),
+            &RoleAssignmentListParameters {
+                pagination: openstack_keystone_core_types::ListPagination {
+                    limit: Some(1),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    // `limit + 1` rows off the sorted, deduplicated union of both backends.
+    assert_eq!(listed.len(), 2);
+    assert_eq!(listed[0].target_id, "a");
+    assert_eq!(listed[1].target_id, "b");
+}
+
+#[tokio::test]
+async fn an_untargeted_listing_fails_the_whole_call_on_one_backend_error() {
+    let state = get_mocked_state(None, None).await;
+    let global = list_backend(
+        1,
+        vec![assignment("u", "d", "r", AssignmentType::UserDomain)],
+    );
+    let mut named_mock = MockAssignmentBackend::default();
+    named_mock
+        .expect_list_assignments()
+        .returning(|_, _| Err(AssignmentProviderError::Driver("openfga 501".into())));
+    let named: Arc<dyn AssignmentBackend> = Arc::new(named_mock);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 0),
+    );
+
+    let error = provider
+        .list_role_assignments(
+            &ExecutionContext::internal(&state),
+            &RoleAssignmentListParameters::default(),
+        )
+        .await
+        .expect_err("one backend error must fail the whole fan-out");
+    assert!(matches!(error, AssignmentProviderError::Driver(_)));
+}
+
+#[tokio::test]
+async fn a_system_filtered_listing_uses_only_the_global_backend() {
+    let state = get_mocked_state(None, None).await;
+    let global = list_backend(1, vec![]);
+    let named = list_backend(0, vec![]);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 0),
+    );
+
+    provider
+        .list_role_assignments(
+            &ExecutionContext::internal(&state),
+            &RoleAssignmentListParameters {
+                system_id: Some("all".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_domain_filtered_listing_routes_to_that_domains_driver() {
+    let state = get_mocked_state(None, None).await;
+    let global = list_backend(0, vec![]);
+    let named = list_backend(1, vec![]);
+    let provider = service(
+        global,
+        named,
+        &[("d1", "b_sql")],
+        config_source(Ok(Some(binding("sql"))), 1),
+    );
+
+    provider
+        .list_role_assignments(
+            &ExecutionContext::internal(&state),
+            &RoleAssignmentListParameters {
+                domain_id: Some("d1".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn dispatch_off_routes_every_target_to_the_single_backend() {
+    // `from_backend` builds a `dispatch_enabled: false` bundle with no
+    // resolver: even a domain grant goes straight to the one backend.
+    let state = get_mocked_state(None, None).await;
+    let provider = AssignmentService::from_backend(create_backend(1));
+
+    provider
+        .create_grant(
+            &ExecutionContext::internal(&state),
+            AssignmentCreate::user_domain("u", "d1", "r", false),
+        )
+        .await
+        .unwrap();
+}

--- a/crates/core/src/assignment/service/tests/reload.rs
+++ b/crates/core/src/assignment/service/tests/reload.rs
@@ -1,0 +1,202 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! [`AssignmentService::reload`] / `refresh_bindings` unit tests (ADR 0034 §9).
+//!
+//! These cover the bundle-rebuild paths that do **not** need a plugin-manager
+//! backend build: an unchanged block is reused by `Arc::ptr_eq`, a block a
+//! bound domain no longer maps to is dropped, the dispatch switch going off
+//! drops every named instance, the binding cache is cleared, and an
+//! unresolvable new configuration keeps the last-known-good bundle (`Ok(false)`).
+//! Cases that add or mutate an `[assignment.backends.*]` block (which builds a
+//! fresh instance through `inventory`) live in `tests/integration`, where the
+//! driver crates are linked.
+
+use std::collections::HashMap;
+
+use openstack_keystone_config::{AssignmentBackendConfig, AssignmentProvider, Config};
+
+use super::*;
+use crate::domain_config::backend::{DomainConfigBackend, MockDomainConfigBackend};
+use crate::domain_config::error::DomainConfigProviderError;
+
+/// A resolver whose database source reports `bound` as the set of domains
+/// carrying an `assignment/driver` binding, `Err` when `bound` is `Err`.
+fn resolver_over(bound: Result<Vec<&'static str>, ()>) -> Arc<DomainConfigResolver> {
+    let mut mock = MockDomainConfigBackend::new();
+    mock.expect_list_domains_with_option()
+        .returning(move |_, _, _| match &bound {
+            Ok(domains) => Ok(domains.iter().map(|d| d.to_string()).collect()),
+            Err(()) => Err(DomainConfigProviderError::Driver("boom".into())),
+        });
+    let source: Arc<dyn DomainConfigBackend> = Arc::new(mock);
+    Arc::new(DomainConfigResolver::from_sources(None, Some(source)))
+}
+
+/// `[assignment]` with the dispatch switch `on`, one `sql` block `b_sql` and
+/// `domains` mapping `d1 → b_sql`.
+fn assignment_section(dispatch_on: bool, map_d1: bool) -> AssignmentProvider {
+    let mut backends = HashMap::new();
+    backends.insert("b_sql".to_string(), AssignmentBackendConfig::Sql);
+    let mut domains = HashMap::new();
+    if map_d1 {
+        domains.insert("d1".to_string(), "b_sql".to_string());
+    }
+    AssignmentProvider {
+        driver: "openfga".to_string(),
+        domain_specific_drivers_enabled: dispatch_on,
+        backends,
+        domains,
+        ..Default::default()
+    }
+}
+
+fn config(section: AssignmentProvider) -> Config {
+    Config {
+        assignment: section,
+        ..Default::default()
+    }
+}
+
+/// A service whose live bundle already carries `named` as the `b_sql` instance
+/// (as a first reload would have built it), wired to `resolver`.
+async fn service_with_named(
+    named: Arc<dyn AssignmentBackend>,
+    map_d1: bool,
+    resolver: Arc<DomainConfigResolver>,
+) -> (AssignmentService, ServiceState) {
+    let state = get_mocked_state(Some(config(assignment_section(true, map_d1))), None).await;
+    let mut blocks = HashMap::new();
+    blocks.insert("b_sql".to_string(), AssignmentBackendConfig::Sql);
+    let mut instances = HashMap::new();
+    instances.insert("b_sql".to_string(), named);
+    let provider = AssignmentService::from_parts(
+        "openfga",
+        Arc::new(MockAssignmentBackend::default()),
+        map_d1
+            .then(|| ("d1".to_string(), "b_sql".to_string()))
+            .into_iter()
+            .collect(),
+        blocks,
+        instances,
+        Some(resolver),
+    );
+    (provider, state)
+}
+
+#[tokio::test]
+async fn an_unchanged_block_is_reused_by_pointer() {
+    let named: Arc<dyn AssignmentBackend> = Arc::new(MockAssignmentBackend::default());
+    let (provider, state) =
+        service_with_named(named.clone(), true, resolver_over(Ok(vec!["d1"]))).await;
+
+    let changed = provider.reload(&state).await.unwrap();
+
+    assert!(!changed, "identical config must report no change");
+    let bundle = provider.bundle.load_full();
+    assert!(
+        Arc::ptr_eq(&bundle.instances["b_sql"], &named),
+        "the live instance must be the very same Arc"
+    );
+    assert_eq!(bundle.fanout.len(), 2);
+}
+
+#[tokio::test]
+async fn a_block_no_bound_domain_maps_to_is_dropped() {
+    let named: Arc<dyn AssignmentBackend> = Arc::new(MockAssignmentBackend::default());
+    // Live bundle maps d1 → b_sql; the reloaded config drops the mapping.
+    let (provider, state) = service_with_named(named, true, resolver_over(Ok(vec!["d1"]))).await;
+    *state.config_manager.config.write().await = config(assignment_section(true, false));
+
+    let changed = provider.reload(&state).await.unwrap();
+
+    assert!(changed);
+    let bundle = provider.bundle.load_full();
+    assert!(bundle.instances.is_empty());
+    assert_eq!(
+        bundle.fanout.len(),
+        1,
+        "fan-out is the global backend alone"
+    );
+}
+
+#[tokio::test]
+async fn turning_the_dispatch_switch_off_drops_every_named_instance() {
+    let named: Arc<dyn AssignmentBackend> = Arc::new(MockAssignmentBackend::default());
+    let (provider, state) = service_with_named(named, true, resolver_over(Ok(vec!["d1"]))).await;
+    *state.config_manager.config.write().await = config(assignment_section(false, true));
+
+    let changed = provider.reload(&state).await.unwrap();
+
+    assert!(changed);
+    let bundle = provider.bundle.load_full();
+    assert!(!bundle.dispatch_enabled);
+    assert!(bundle.instances.is_empty());
+}
+
+#[tokio::test]
+async fn reload_clears_the_binding_cache() {
+    let mut named_mock = MockAssignmentBackend::default();
+    named_mock.expect_create_grant().returning(|_, grant| {
+        Ok(AssignmentBuilder::default()
+            .actor_id(grant.actor_id)
+            .role_id(grant.role_id)
+            .target_id(grant.target_id)
+            .r#type(grant.r#type)
+            .build()
+            .unwrap())
+    });
+    let named: Arc<dyn AssignmentBackend> = Arc::new(named_mock);
+    let (provider, state) = service_with_named(named, true, resolver_over(Ok(vec!["d1"]))).await;
+
+    // Populate the per-domain resolution cache — but the resolver mock here
+    // only answers `list_domains_with_option`, so a grant that had to consult
+    // `effective_config` would panic. Instead assert the cache directly.
+    provider
+        .binding_cache
+        .write()
+        .await
+        .insert("d1".to_string(), "sql".to_string());
+
+    provider.reload(&state).await.unwrap();
+
+    assert!(
+        provider.binding_cache.read().await.is_empty(),
+        "the binding cache must be cleared on reload"
+    );
+}
+
+#[tokio::test]
+async fn an_unresolvable_new_config_keeps_the_previous_bundle() {
+    let named: Arc<dyn AssignmentBackend> = Arc::new(MockAssignmentBackend::default());
+    let (provider, state) = service_with_named(named.clone(), true, resolver_over(Err(()))).await;
+
+    let changed = provider.reload(&state).await.unwrap();
+
+    assert!(!changed, "a failed rebuild reports Ok(false)");
+    let bundle = provider.bundle.load_full();
+    assert!(
+        Arc::ptr_eq(&bundle.instances["b_sql"], &named),
+        "the last-known-good bundle stays in service"
+    );
+}
+
+#[tokio::test]
+async fn refresh_bindings_swallows_a_rebuild_error() {
+    let named: Arc<dyn AssignmentBackend> = Arc::new(MockAssignmentBackend::default());
+    let (provider, state) = service_with_named(named, true, resolver_over(Err(()))).await;
+
+    // Best-effort: never surfaces the error to the domain-config write path.
+    provider.refresh_bindings(&state).await.unwrap();
+}

--- a/tests/api/src/domain_config.rs
+++ b/tests/api/src/domain_config.rs
@@ -1,0 +1,154 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! SDK bindings for the `/v3/domains/{domain_id}/config` domain-configuration
+//! API.
+//!
+//! Every payload nests under a single `config` key
+//! (`{"config": {"<group>": {"<option>": <value>}}}`); group- and
+//! option-scoped requests use the same envelope with only the addressed group
+//! present. Used by the ADR 0034 §6 authorization tests, which check that the
+//! `assignment` group is writable only by a cloud admin.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use eyre::Result;
+use serde_json::{Value, json};
+
+use openstack_keystone_api_types::v3::domain_config::DomainConfigResponse;
+use openstack_sdk::AsyncOpenStack;
+use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::rest_endpoint_prelude::*;
+
+/// One `config` write or read, parameterised by method and path so the
+/// whole-config, group and option shapes share a single impl.
+struct DomainConfigRequest {
+    method: http::Method,
+    endpoint: String,
+    body: Option<Value>,
+}
+
+impl RestEndpoint for DomainConfigRequest {
+    fn method(&self) -> http::Method {
+        self.method.clone()
+    }
+
+    fn endpoint(&self) -> Cow<'static, str> {
+        self.endpoint.clone().into()
+    }
+
+    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
+        match &self.body {
+            Some(config) => {
+                let mut params = JsonBodyParams::default();
+                params.push("config", config.clone());
+                params.into_body()
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn service_type(&self) -> ServiceType {
+        ServiceType::Identity
+    }
+
+    fn api_version(&self) -> Option<ApiVersion> {
+        Some(ApiVersion::new(3, 0))
+    }
+}
+
+async fn send(client: &Arc<AsyncOpenStack>, request: DomainConfigRequest) -> Result<Value> {
+    let response: DomainConfigResponse = request.query_async(client.as_ref()).await?;
+    Ok(response.config)
+}
+
+/// `PUT /v3/domains/{domain_id}/config` — create (replace) the whole
+/// configuration. `body` is the group map, e.g.
+/// `json!({"assignment": {"driver": "sql"}})`.
+pub async fn replace_domain_config(
+    client: &Arc<AsyncOpenStack>,
+    domain_id: &str,
+    body: Value,
+) -> Result<Value> {
+    send(
+        client,
+        DomainConfigRequest {
+            method: http::Method::PUT,
+            endpoint: format!("domains/{domain_id}/config"),
+            body: Some(body),
+        },
+    )
+    .await
+}
+
+/// `PATCH /v3/domains/{domain_id}/config/{group}` — merge changes into one
+/// group.
+pub async fn patch_domain_config_group(
+    client: &Arc<AsyncOpenStack>,
+    domain_id: &str,
+    group: &str,
+    body: Value,
+) -> Result<Value> {
+    send(
+        client,
+        DomainConfigRequest {
+            method: http::Method::PATCH,
+            endpoint: format!("domains/{domain_id}/config/{group}"),
+            body: Some(body),
+        },
+    )
+    .await
+}
+
+/// `PATCH /v3/domains/{domain_id}/config/{group}/{option}` — merge one option.
+pub async fn patch_domain_config_option(
+    client: &Arc<AsyncOpenStack>,
+    domain_id: &str,
+    group: &str,
+    option: &str,
+    body: Value,
+) -> Result<Value> {
+    send(
+        client,
+        DomainConfigRequest {
+            method: http::Method::PATCH,
+            endpoint: format!("domains/{domain_id}/config/{group}/{option}"),
+            body: Some(body),
+        },
+    )
+    .await
+}
+
+/// `GET /v3/domains/{domain_id}/config/{group}` — read one stored group.
+pub async fn get_domain_config_group(
+    client: &Arc<AsyncOpenStack>,
+    domain_id: &str,
+    group: &str,
+) -> Result<Value> {
+    send(
+        client,
+        DomainConfigRequest {
+            method: http::Method::GET,
+            endpoint: format!("domains/{domain_id}/config/{group}"),
+            body: None,
+        },
+    )
+    .await
+}
+
+/// `{"<group>": {"driver": "<driver>"}}` — the single-option write body the
+/// binding tests pass to every write shape.
+pub fn driver_body(group: &str, driver: &str) -> Value {
+    json!({ group: { "driver": driver } })
+}

--- a/tests/api/src/lib.rs
+++ b/tests/api/src/lib.rs
@@ -17,6 +17,7 @@ pub mod assignment;
 pub mod auth;
 pub mod common;
 pub mod credential;
+pub mod domain_config;
 pub mod endpoint;
 pub mod federation;
 pub mod fixtures;

--- a/tests/api/tests/api_v3.rs
+++ b/tests/api/tests/api_v3.rs
@@ -20,6 +20,7 @@ mod api_v3 {
     mod assignment;
     mod auth;
     mod credential;
+    mod domain_config;
     mod endpoint;
     mod identity;
     mod policy;

--- a/tests/api/tests/api_v3/domain_config.rs
+++ b/tests/api/tests/api_v3/domain_config.rs
@@ -1,0 +1,141 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Live end-to-end coverage of ADR 0034 §6: binding a domain to an
+//! assignment backend (`assignment/driver` in the domain-config API) is a
+//! role-minting surface reserved for cloud admins.
+//!
+//! A cloud (system) admin can write it on every shape; a non-system caller
+//! is refused it by the real OPA policy over real HTTP.
+//!
+//! Two ADR aspects are covered elsewhere, not here:
+//!
+//! - **The domain-`manager` carve-out** — a domain manager may write every
+//!   other group of their own domain but not `assignment` — needs a
+//!   domain-scoped non-admin token, which the v3 API cannot mint (there is
+//!   no domain role-grant route; only project and system). It is verified in
+//!   `policy/domain_config/{create,update}_test.rego` and the
+//!   `crates/keystone/src/api/v3/domain_config/group.rs` handler tests.
+//! - **Provisioning a named OpenFGA backend and routing a domain onto it** —
+//!   the live server runs a fixed sql-only `[assignment]` config. That path
+//!   is covered by `tests/integration/src/assignment_per_domain.rs`.
+
+use eyre::Result;
+use serde_json::Value;
+
+use test_api::asserts::assert_forbidden;
+use test_api::common::get_system_scope_session;
+use test_api::domain_config::{
+    driver_body, get_domain_config_group, patch_domain_config_group, patch_domain_config_option,
+    replace_domain_config,
+};
+use test_api::fixtures::{ProjectScopedUser, warn_on_cleanup_failure};
+use test_api::guard::ResourceGuard;
+use test_api::resource::domain::create_test_domain;
+
+fn stored_driver(config: &Value) -> Option<&str> {
+    config.pointer("/assignment/driver").and_then(Value::as_str)
+}
+
+/// A cloud admin writes `assignment/driver` for a fresh domain and reads it
+/// back — the positive half of the §6 contract.
+#[tokio::test]
+async fn test_cloud_admin_binds_the_assignment_driver() -> Result<()> {
+    let admin = get_system_scope_session().await?;
+    let domain = create_test_domain(&admin).await?;
+
+    let result: Result<Value> = async {
+        replace_domain_config(&admin, &domain.id, driver_body("assignment", "sql")).await?;
+        get_domain_config_group(&admin, &domain.id, "assignment").await
+    }
+    .await;
+
+    let cleanup = domain.delete().await;
+    let stored = result?;
+    cleanup?;
+
+    assert_eq!(
+        stored_driver(&stored),
+        Some("sql"),
+        "the cloud admin's assignment binding must round-trip through the config API"
+    );
+    Ok(())
+}
+
+/// A non-system caller (here a project-scoped `manager` of the domain) is
+/// refused the `assignment` binding on every write shape — whole-config
+/// `PUT`, group `PATCH`, and option `PATCH`.
+#[tokio::test]
+async fn test_a_non_system_caller_is_refused_the_assignment_binding() -> Result<()> {
+    let admin = get_system_scope_session().await?;
+    let domain = create_test_domain(&admin).await?;
+
+    // A driver is already bound, so the writes under test are updates, not
+    // first writes — the policy denial, not a validation error, is the
+    // failure being asserted.
+    if let Err(error) =
+        replace_domain_config(&admin, &domain.id, driver_body("assignment", "sql")).await
+    {
+        warn_on_cleanup_failure("adr34 domain", domain.delete().await);
+        return Err(error);
+    }
+
+    let manager = match ProjectScopedUser::provision(&admin, &domain.id, "manager").await {
+        Ok(manager) => manager,
+        Err(error) => {
+            warn_on_cleanup_failure("adr34 domain", domain.delete().await);
+            return Err(error);
+        }
+    };
+
+    let whole = replace_domain_config(
+        &manager.session,
+        &domain.id,
+        driver_body("assignment", "openfga"),
+    )
+    .await;
+    let group = patch_domain_config_group(
+        &manager.session,
+        &domain.id,
+        "assignment",
+        driver_body("assignment", "openfga"),
+    )
+    .await;
+    let option = patch_domain_config_option(
+        &manager.session,
+        &domain.id,
+        "assignment",
+        "driver",
+        driver_body("assignment", "openfga"),
+    )
+    .await;
+
+    let manager_cleanup = manager.cleanup().await;
+    let domain_cleanup = domain.delete().await;
+
+    assert_forbidden(
+        whole,
+        "a non-system caller must not replace a config carrying an assignment block",
+    );
+    assert_forbidden(
+        group,
+        "a non-system caller must not write the assignment group",
+    );
+    assert_forbidden(
+        option,
+        "a non-system caller must not write assignment/driver",
+    );
+    manager_cleanup?;
+    domain_cleanup?;
+    Ok(())
+}

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -11,7 +11,7 @@ dist = false
 
 [dependencies]
 async-trait.workspace = true
-axum = { workspace = true, features = ["http1", "tokio"] }
+axum = { workspace = true, features = ["http1", "json", "tokio"] }
 chrono.workspace = true
 eyre.workspace = true
 http-body-util.workspace = true
@@ -30,7 +30,9 @@ openstack-keystone-token-driver-fernet.workspace = true
 openstack-keystone-trust-driver-sql = { version = "0.1", path = "../../crates/trust-driver-sql/" }
 openstack-keystone-distributed-storage.workspace = true
 openstack-keystone-storage-api.workspace = true
-openstack-keystone = { version = "0.1", path = "../../crates/keystone/" }
+openstack-keystone = { version = "0.1", path = "../../crates/keystone/", features = [
+    "openfga",
+] }
 rcgen.workspace = true
 sea-orm = { workspace = true, features = ["sqlx-mysql", "sqlx-postgres", "sqlx-sqlite", "runtime-tokio", "runtime-tokio-native-tls"] }
 secrecy = { workspace = true, features = ["serde"] }
@@ -42,7 +44,7 @@ time = { version = "0.3", default-features = true }
 tempfile.workspace = true
 tower.workspace = true
 tracing.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["net"] }
 tokio-util.workspace = true
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/tests/integration/src/assignment_per_domain.rs
+++ b/tests/integration/src/assignment_per_domain.rs
@@ -1,0 +1,805 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! # Per-domain assignment driver dispatch (ADR 0034)
+//!
+//! Exercises `[assignment] domain_specific_drivers_enabled` end to end through
+//! the full `Provider` stack: `AssignmentService` builds a real
+//! `DomainConfigResolver`, `reload` / `refresh_bindings` enumerate the bound
+//! domains with the SQL domain-config driver's `list_domains_with_option` and
+//! rebuild the routing bundle through the real backend factories
+//! (`build_global_assignment_backend` / `build_named_assignment_backend`), and
+//! `DomainConfigService` enforces the write-time binding validation (§3).
+//!
+//! A stub OpenFGA HTTP server ([`openfga_stub`]) stands in for a real store, so
+//! a domain bound to a named `[assignment.backends.*]` OpenFGA block exercises
+//! the driver crate end to end: `create_grant` writes a tuple over real HTTP,
+//! the target-scoped listing reads it back, and the grant stays disjoint from
+//! the global SQL backend. The reload reactor building that named instance
+//! through `inventory` (the driver crates are not linked into the
+//! `openstack-keystone-core` test binary), the fan-out union / de-dup over
+//! several live backends, and the config-API rejection path are covered here
+//! too.
+
+use eyre::Result;
+use serde_json::{Value, json};
+use tracing_test::traced_test;
+
+use openstack_keystone_config::{AssignmentBackendConfig, Config, OpenFGAAssignmentDriver};
+use openstack_keystone_core::auth::ExecutionContext;
+use openstack_keystone_core::domain_config::DomainConfigProviderError;
+use openstack_keystone_core_types::assignment::*;
+use openstack_keystone_core_types::domain_config::{DomainConfig, DomainConfigCreate};
+
+use crate::common::get_state_with_config;
+use crate::{create_domain, create_role, create_user};
+
+/// Turn per-domain assignment dispatch on with the database as the config
+/// source. The resolver is fixed at construction, so this must run before the
+/// `Provider` is built (hence the `get_state_with_config` mutator).
+fn enable_assignment_dispatch(cfg: &mut Config) {
+    cfg.assignment.domain_specific_drivers_enabled = true;
+    cfg.domain_config.from_database = Some(true);
+}
+
+/// [`enable_assignment_dispatch`] plus a named `[assignment.backends.<name>]`
+/// block, so that block's driver name becomes bindable (§3) and a bound domain
+/// mapped to it drives the named backend factory on reload.
+fn enable_with_block(name: &str, block: AssignmentBackendConfig) -> impl FnOnce(&mut Config) + '_ {
+    move |cfg| {
+        enable_assignment_dispatch(cfg);
+        cfg.assignment.backends.insert(name.to_string(), block);
+    }
+}
+
+/// A named OpenFGA block pointing at `api_url` / `store_id`, with the given
+/// Keystone-role-id -> OpenFGA-relation map (`Value::Null` for none).
+fn openfga_block_at(
+    api_url: &str,
+    store_id: &str,
+    role_to_relation: Value,
+) -> AssignmentBackendConfig {
+    let driver: OpenFGAAssignmentDriver = serde_json::from_value(json!({
+        "api_url": api_url,
+        "store_id": store_id,
+        "model_id": null,
+        "timeout": null,
+        "role_to_relation": role_to_relation,
+    }))
+    .expect("valid openfga assignment block");
+    AssignmentBackendConfig::Openfga(Box::new(driver))
+}
+
+/// A named OpenFGA block at a dead address. Used where the block is only there
+/// to make `openfga` a bindable name and no operation routes to it: `with_config`
+/// only builds a `reqwest::Client`, so constructing it does no I/O.
+fn openfga_block() -> AssignmentBackendConfig {
+    openfga_block_at(
+        "http://127.0.0.1:59191/",
+        "01JTESTSTORE000000000000",
+        Value::Null,
+    )
+}
+
+/// The `[assignment.backends.<name>]` OpenFGA block wired to a live stub, with
+/// `role_id` mapped to the `member` relation.
+fn openfga_block_for(stub: &openfga_stub::StubHandle, role_id: &str) -> AssignmentBackendConfig {
+    let mut role_to_relation = serde_json::Map::new();
+    role_to_relation.insert(role_id.to_string(), json!("member"));
+    openfga_block_at(
+        &stub.api_url(),
+        "01JSTUBSTORE0000000000000",
+        Value::Object(role_to_relation),
+    )
+}
+
+/// A stored overlay pinning a domain to `assignment/driver = <driver>`.
+fn assignment_binding(driver: &str) -> DomainConfigCreate {
+    DomainConfigCreate(
+        DomainConfig::from_value(json!({ "assignment": { "driver": driver } }))
+            .expect("valid domain configuration"),
+    )
+}
+
+/// Grant `role` to `user` on `domain` and report whether the domain-scoped
+/// listing (which target-routes on `domain`) sees it.
+async fn grant_and_see_on_domain(
+    state: &std::sync::Arc<openstack_keystone::keystone::Service>,
+    user: &str,
+    domain: &str,
+    role: &str,
+) -> Result<bool> {
+    let ctx = ExecutionContext::internal(state);
+    state
+        .provider
+        .get_assignment_provider()
+        .create_grant(
+            &ctx,
+            AssignmentCreate::user_domain(user, domain, role, false),
+        )
+        .await?;
+    let seen = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(
+            &ctx,
+            &RoleAssignmentListParameters {
+                domain_id: Some(domain.to_string()),
+                user_id: Some(user.to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    Ok(seen.iter().any(|a| a.role_id == role))
+}
+
+/// With dispatch on and no named block, a domain that stores
+/// `assignment/driver = sql` still serves grants through the (shared) global
+/// SQL backend, and a domain with no binding does too. The `refresh_bindings`
+/// fired by the config write runs `rebuild` through the real `Provider` and
+/// must not error.
+#[tokio::test]
+#[traced_test]
+async fn dispatch_on_serves_the_global_sql_grant_path() -> Result<()> {
+    let (state, _tmp) = get_state_with_config(enable_assignment_dispatch).await?;
+    let pinned = create_domain!(state)?;
+    let plain = create_domain!(state)?;
+    let role = create_role!(state)?;
+    let u_pinned = create_user!(state, pinned.id.clone())?;
+    let u_plain = create_user!(state, plain.id.clone())?;
+
+    state
+        .provider
+        .get_domain_config_provider()
+        .create_domain_config(&state, &pinned.id, assignment_binding("sql"))
+        .await?;
+
+    assert!(
+        grant_and_see_on_domain(&state, &u_pinned.id, &pinned.id, &role.id).await?,
+        "the sql-pinned domain must serve the grant"
+    );
+    assert!(
+        grant_and_see_on_domain(&state, &u_plain.id, &plain.id, &role.id).await?,
+        "the unbound domain must serve the grant via the global backend"
+    );
+    Ok(())
+}
+
+/// A bound domain mapped to a named `[assignment.backends.*]` block makes
+/// `reload` build that instance through the real backend factory (`inventory`)
+/// and report a change; a second reload with nothing changed reports none. A
+/// grant on an unrelated domain keeps working throughout.
+#[tokio::test]
+#[traced_test]
+async fn a_named_block_is_built_by_the_reload_reactor() -> Result<()> {
+    let (state, _tmp) =
+        get_state_with_config(enable_with_block("central_fga", openfga_block())).await?;
+    let fga_domain = create_domain!(state)?;
+    let sql_domain = create_domain!(state)?;
+    let role = create_role!(state)?;
+    let u_fga = create_user!(state, fga_domain.id.clone())?;
+    let u_sql = create_user!(state, sql_domain.id.clone())?;
+
+    // Map the domain id (only known now) to the block, then bind it.
+    state
+        .config_manager
+        .config
+        .write()
+        .await
+        .assignment
+        .domains
+        .insert(fga_domain.id.clone(), "central_fga".to_string());
+
+    // The config-API write fires `refresh_bindings`, which rebuilds the bundle:
+    // `central_fga` is now a block a bound domain maps to, so the OpenFGA
+    // backend factory runs. `with_config` does no I/O, so this succeeds.
+    state
+        .provider
+        .get_domain_config_provider()
+        .create_domain_config(&state, &fga_domain.id, assignment_binding("openfga"))
+        .await?;
+
+    // Positive proof the named instance landed in the routing bundle: a grant
+    // on the mapped domain routes to `central_fga`, whose block carries no role
+    // mapping and a dead `api_url`, so the OpenFGA driver rejects it. Had the
+    // block not been built, the grant would have fallen back to the global SQL
+    // backend and succeeded.
+    let ctx = ExecutionContext::internal(&state);
+    let routed = state
+        .provider
+        .get_assignment_provider()
+        .create_grant(
+            &ctx,
+            AssignmentCreate::user_domain(&u_fga.id, &fga_domain.id, &role.id, false),
+        )
+        .await;
+    assert!(
+        matches!(routed, Err(AssignmentProviderError::Driver(_))),
+        "the mapped domain must route to the named OpenFGA instance, got {routed:?}"
+    );
+
+    // An explicit reload with the config unchanged is a no-op.
+    let changed = state
+        .provider
+        .get_assignment_provider()
+        .reload(&state)
+        .await?;
+    assert!(!changed, "an unchanged configuration reloads to no change");
+
+    // The unrelated SQL domain is untouched by the OpenFGA block.
+    assert!(
+        grant_and_see_on_domain(&state, &u_sql.id, &sql_domain.id, &role.id).await?,
+        "a domain outside the named block still routes to the global backend"
+    );
+    Ok(())
+}
+
+/// A domain that resolves a non-global driver name it has no
+/// `[assignment.domains]` mapping for falls back to the global backend and logs
+/// the stale binding once (ADR 0034 §4 step 3). The grant still succeeds.
+#[tokio::test]
+#[traced_test]
+async fn an_unmapped_binding_falls_back_to_global_and_warns() -> Result<()> {
+    let (state, _tmp) =
+        get_state_with_config(enable_with_block("central_fga", openfga_block())).await?;
+    let domain = create_domain!(state)?;
+    let role = create_role!(state)?;
+    let user = create_user!(state, domain.id.clone())?;
+
+    // `openfga` is bindable (a block names it) but the domain is mapped
+    // nowhere, so resolution is stale -> global.
+    state
+        .provider
+        .get_domain_config_provider()
+        .create_domain_config(&state, &domain.id, assignment_binding("openfga"))
+        .await?;
+
+    assert!(
+        grant_and_see_on_domain(&state, &user.id, &domain.id, &role.id).await?,
+        "a stale binding must not break the grant path"
+    );
+    assert!(
+        logs_contain("stale assignment binding"),
+        "the stale binding must be logged once"
+    );
+    Ok(())
+}
+
+/// `DomainConfigService` rejects an `assignment/driver` binding that names no
+/// configured backend (ADR 0034 §3), and the rejected write does not land.
+/// `sql` is always accepted.
+#[tokio::test]
+#[traced_test]
+async fn the_config_api_rejects_an_unbindable_driver() -> Result<()> {
+    let (state, _tmp) = get_state_with_config(enable_assignment_dispatch).await?;
+    let domain = create_domain!(state)?;
+    let dc = state.provider.get_domain_config_provider();
+
+    let err = dc
+        .create_domain_config(&state, &domain.id, assignment_binding("openfga"))
+        .await
+        .expect_err("no block names `openfga`, so the binding must be rejected");
+    assert!(
+        matches!(err, DomainConfigProviderError::InvalidOptionValue { .. }),
+        "expected InvalidOptionValue, got {err:?}"
+    );
+    assert!(
+        dc.get_domain_config(&state, &domain.id).await?.is_none(),
+        "the rejected binding must not have been stored"
+    );
+
+    dc.create_domain_config(&state, &domain.id, assignment_binding("sql"))
+        .await?;
+    Ok(())
+}
+
+/// An untargeted `GET /v3/role_assignments` fans out over every backend in the
+/// bundle (global plus each distinct named instance) and unions the results,
+/// de-duplicating (ADR 0034 §5). Two live SQL backends over the same database
+/// each return every row, so without de-dup the union would double every
+/// assignment.
+#[tokio::test]
+#[traced_test]
+async fn an_untargeted_listing_unions_and_deduplicates_the_fanout() -> Result<()> {
+    let (state, _tmp) =
+        get_state_with_config(enable_with_block("b_sql", AssignmentBackendConfig::Sql)).await?;
+    let ctx = ExecutionContext::internal(&state);
+    let mapped = create_domain!(state)?;
+    let other = create_domain!(state)?;
+    let role = create_role!(state)?;
+    let u_mapped = create_user!(state, mapped.id.clone())?;
+    let u_other = create_user!(state, other.id.clone())?;
+
+    // Make `b_sql` an active named instance: map a bound domain to it. The
+    // instance is a fresh `SqlBackend` Arc, so the fan-out set is
+    // [global, b_sql] — two live backends over the one database.
+    state
+        .config_manager
+        .config
+        .write()
+        .await
+        .assignment
+        .domains
+        .insert(mapped.id.clone(), "b_sql".to_string());
+    state
+        .provider
+        .get_domain_config_provider()
+        .create_domain_config(&state, &mapped.id, assignment_binding("sql"))
+        .await?;
+
+    for (user, domain) in [(&u_mapped.id, &mapped.id), (&u_other.id, &other.id)] {
+        state
+            .provider
+            .get_assignment_provider()
+            .create_grant(
+                &ctx,
+                AssignmentCreate::user_domain(user, domain, &role.id, false),
+            )
+            .await?;
+    }
+
+    let listed = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(&ctx, &RoleAssignmentListParameters::default())
+        .await?;
+
+    let distinct: std::collections::HashSet<_> = listed
+        .iter()
+        .map(|a| (a.actor_id.clone(), a.target_id.clone(), a.role_id.clone()))
+        .collect();
+    assert_eq!(
+        distinct.len(),
+        2,
+        "two grants were created; the fan-out must union to exactly those"
+    );
+    assert_eq!(
+        listed.len(),
+        distinct.len(),
+        "the fan-out over two identical SQL backends must de-duplicate"
+    );
+    Ok(())
+}
+
+/// The bundle's per-domain resolution is cached: repeated grants on one bound
+/// domain do not re-read the stored config on every call. Observable only as
+/// "no error / correct result" here; the call-count assertion is in the unit
+/// suite.
+#[tokio::test]
+#[traced_test]
+async fn repeated_grants_on_a_bound_domain_reuse_the_cached_resolution() -> Result<()> {
+    let (state, _tmp) = get_state_with_config(enable_assignment_dispatch).await?;
+    let domain = create_domain!(state)?;
+    let user = create_user!(state, domain.id.clone())?;
+    let role_a = create_role!(state)?;
+    let role_b = create_role!(state)?;
+
+    state
+        .provider
+        .get_domain_config_provider()
+        .create_domain_config(&state, &domain.id, assignment_binding("sql"))
+        .await?;
+
+    let ctx = ExecutionContext::internal(&state);
+    for role in [&role_a.id, &role_b.id] {
+        state
+            .provider
+            .get_assignment_provider()
+            .create_grant(
+                &ctx,
+                AssignmentCreate::user_domain(&user.id, &domain.id, role, false),
+            )
+            .await?;
+    }
+
+    let listed = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(
+            &ctx,
+            &RoleAssignmentListParameters {
+                domain_id: Some(domain.id.clone()),
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    let roles: std::collections::HashSet<_> = listed.iter().map(|a| a.role_id.clone()).collect();
+    assert!(roles.contains(&role_a.id) && roles.contains(&role_b.id));
+    Ok(())
+}
+
+/// Wire a domain to a named OpenFGA block backed by a live stub server: adding
+/// the block plus the `[assignment.domains]` mapping, then storing the
+/// `assignment/driver = openfga` binding whose write fires `refresh_bindings`,
+/// which builds the named instance through the real `inventory` factory. Every
+/// caller shares one `stub`; the returned tuple keeps the domains/user/role in
+/// scope.
+async fn bind_domain_to_openfga_stub(
+    state: &std::sync::Arc<openstack_keystone::keystone::Service>,
+    stub: &openfga_stub::StubHandle,
+    fga_domain: &str,
+    role_id: &str,
+) -> Result<()> {
+    {
+        let mut cfg = state.config_manager.config.write().await;
+        cfg.assignment
+            .backends
+            .insert("central_fga".to_string(), openfga_block_for(stub, role_id));
+        cfg.assignment
+            .domains
+            .insert(fga_domain.to_string(), "central_fga".to_string());
+    }
+    state
+        .provider
+        .get_domain_config_provider()
+        .create_domain_config(state, fga_domain, assignment_binding("openfga"))
+        .await?;
+    Ok(())
+}
+
+/// A domain bound to a named OpenFGA block routes its grants to that store over
+/// real HTTP (the stub OpenFGA server), and the grant stays disjoint from the
+/// global SQL backend — neither store sees the other's rows (ADR 0034 §1, §4).
+#[tokio::test]
+#[traced_test]
+async fn openfga_bound_domain_routes_grants_to_that_store_disjoint_from_sql() -> Result<()> {
+    let stub = openfga_stub::start().await;
+
+    let (state, _tmp) = get_state_with_config(enable_assignment_dispatch).await?;
+    let fga_domain = create_domain!(state)?;
+    let sql_domain = create_domain!(state)?;
+    let role = create_role!(state)?;
+    let u_fga = create_user!(state, fga_domain.id.clone())?;
+    let u_sql = create_user!(state, sql_domain.id.clone())?;
+
+    bind_domain_to_openfga_stub(&state, &stub, &fga_domain.id, &role.id).await?;
+    assert!(
+        !logs_contain("assignment driver reload failed"),
+        "building the named OpenFGA instance must not error"
+    );
+
+    let ctx = ExecutionContext::internal(&state);
+    for (user, domain) in [(&u_fga.id, &fga_domain.id), (&u_sql.id, &sql_domain.id)] {
+        state
+            .provider
+            .get_assignment_provider()
+            .create_grant(
+                &ctx,
+                AssignmentCreate::user_domain(user, domain, &role.id, false),
+            )
+            .await?;
+    }
+
+    // Only the OpenFGA-bound domain's grant reached the OpenFGA store, in the
+    // driver's canonical `type:id` tuple shape.
+    assert_eq!(
+        stub.tuples(),
+        vec![(
+            format!("user:{}", u_fga.id),
+            "member".to_string(),
+            format!("domain:{}", fga_domain.id),
+        )],
+        "only the openfga-bound domain's grant may reach the openfga store"
+    );
+    assert_eq!(
+        stub.writes(),
+        1,
+        "exactly one write reached the openfga store"
+    );
+
+    // The target-scoped listing on the fga domain routes to OpenFGA and reads
+    // the tuple back through the driver.
+    let via_fga = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(
+            &ctx,
+            &RoleAssignmentListParameters {
+                domain_id: Some(fga_domain.id.clone()),
+                user_id: Some(u_fga.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(
+        via_fga.iter().any(|a| a.role_id == role.id),
+        "the openfga-routed listing must see the grant it wrote"
+    );
+    assert!(
+        stub.reads() >= 1,
+        "the target-scoped listing must have read the openfga store"
+    );
+
+    // The SQL backend holds its own domain's grant and nothing from OpenFGA.
+    let via_sql = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(
+            &ctx,
+            &RoleAssignmentListParameters {
+                domain_id: Some(sql_domain.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(
+        via_sql.iter().any(|a| a.actor_id == u_sql.id),
+        "the sql domain's own grant is served by sql"
+    );
+    assert!(
+        !via_sql.iter().any(|a| a.actor_id == u_fga.id),
+        "the openfga grant must not appear in the sql backend"
+    );
+    Ok(())
+}
+
+/// With an OpenFGA instance in the fan-out set, an untargeted
+/// `list_role_assignments` fails the whole call: the OpenFGA driver cannot
+/// enumerate every assignment, and ADR 0034 §5 fails the union on any backend
+/// error rather than silently dropping a backend.
+#[tokio::test]
+#[traced_test]
+async fn untargeted_fanout_fails_when_openfga_cannot_serve_it() -> Result<()> {
+    let stub = openfga_stub::start().await;
+
+    let (state, _tmp) = get_state_with_config(enable_assignment_dispatch).await?;
+    let fga_domain = create_domain!(state)?;
+    let role = create_role!(state)?;
+    let user = create_user!(state, fga_domain.id.clone())?;
+
+    bind_domain_to_openfga_stub(&state, &stub, &fga_domain.id, &role.id).await?;
+
+    let ctx = ExecutionContext::internal(&state);
+    state
+        .provider
+        .get_assignment_provider()
+        .create_grant(
+            &ctx,
+            AssignmentCreate::user_domain(&user.id, &fga_domain.id, &role.id, false),
+        )
+        .await?;
+
+    let listed = state
+        .provider
+        .get_assignment_provider()
+        .list_role_assignments(&ctx, &RoleAssignmentListParameters::default())
+        .await;
+    assert!(
+        matches!(listed, Err(AssignmentProviderError::NotImplemented(_))),
+        "an untargeted fan-out including an openfga instance must fail the whole \
+         call, not drop the backend, got {listed:?}"
+    );
+    Ok(())
+}
+
+/// A minimal stateful OpenFGA HTTP server for the integration suite.
+///
+/// Speaks just enough of the OpenFGA REST surface for the assignment driver
+/// (`crates/assignment-driver-openfga`): `write` (tuple add / delete), `read`
+/// (filtered tuple listing), `check` / `batch-check` (exact-tuple match) and
+/// `streamed-list-objects`. Tuples live in memory; requests are counted so a
+/// test can assert a grant reached this store and not the SQL one.
+mod openfga_stub {
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    use axum::{
+        Json, Router,
+        extract::{Path, State},
+        routing::post,
+    };
+    use serde_json::{Value, json};
+    use tokio::net::TcpListener;
+
+    /// `(user, relation, object)`, each an OpenFGA `type:id` string except the
+    /// relation.
+    type Tuple = (String, String, String);
+
+    #[derive(Default)]
+    pub struct Store {
+        pub tuples: Vec<Tuple>,
+        pub writes: usize,
+        pub reads: usize,
+    }
+
+    /// Aborts the background `axum::serve` task once the last [`StubHandle`]
+    /// clone is dropped, so a stub does not outlive its test.
+    struct ServerTask(tokio::task::JoinHandle<()>);
+
+    impl Drop for ServerTask {
+        fn drop(&mut self) {
+            self.0.abort();
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct StubHandle {
+        store: Arc<Mutex<Store>>,
+        addr: SocketAddr,
+        _task: Arc<ServerTask>,
+    }
+
+    impl StubHandle {
+        /// `api_url` for an `[assignment.backends.*]` OpenFGA block: a trailing
+        /// slash so the driver's relative `stores/{id}/...` paths resolve
+        /// without dropping the host.
+        pub fn api_url(&self) -> String {
+            format!("http://{}/", self.addr)
+        }
+
+        pub fn tuples(&self) -> Vec<Tuple> {
+            self.lock().tuples.clone()
+        }
+
+        pub fn writes(&self) -> usize {
+            self.lock().writes
+        }
+
+        pub fn reads(&self) -> usize {
+            self.lock().reads
+        }
+
+        fn lock(&self) -> std::sync::MutexGuard<'_, Store> {
+            self.store.lock().expect("stub store lock")
+        }
+    }
+
+    /// Bind a stub OpenFGA server on an ephemeral loopback port and serve it on
+    /// a background task for the rest of the test process.
+    pub async fn start() -> StubHandle {
+        let store = Arc::new(Mutex::new(Store::default()));
+        let app = Router::new()
+            .route("/stores/{store_id}/write", post(write))
+            .route("/stores/{store_id}/read", post(read))
+            .route("/stores/{store_id}/check", post(check))
+            .route("/stores/{store_id}/batch-check", post(batch_check))
+            .route(
+                "/stores/{store_id}/streamed-list-objects",
+                post(list_objects),
+            )
+            .with_state(store.clone());
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind openfga stub");
+        let addr = listener.local_addr().expect("stub local addr");
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app.into_make_service()).await;
+        });
+        StubHandle {
+            store,
+            addr,
+            _task: Arc::new(ServerTask(task)),
+        }
+    }
+
+    fn field<'a>(key: &'a Value, name: &str) -> Option<&'a str> {
+        key.get(name).and_then(Value::as_str)
+    }
+
+    /// Whether every field present in `key` (`user` / `relation` / `object`)
+    /// matches a stored tuple.
+    fn matches(t: &Tuple, key: &Value) -> bool {
+        let (u, r, o) = t;
+        field(key, "user").is_none_or(|w| w == u)
+            && field(key, "relation").is_none_or(|w| w == r)
+            && field(key, "object").is_none_or(|w| w == o)
+    }
+
+    fn exact(tuples: &[Tuple], key: &Value) -> bool {
+        matches!(
+            (
+                field(key, "user"),
+                field(key, "relation"),
+                field(key, "object")
+            ),
+            (Some(_), Some(_), Some(_))
+        ) && tuples.iter().any(|t| matches(t, key))
+    }
+
+    async fn write(
+        Path(_store_id): Path<String>,
+        State(store): State<Arc<Mutex<Store>>>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let mut guard = store.lock().expect("stub store lock");
+        guard.writes += 1;
+        if let Some(keys) = body.pointer("/writes/tuple_keys").and_then(Value::as_array) {
+            for k in keys.clone() {
+                if let (Some(u), Some(r), Some(o)) = (
+                    field(&k, "user"),
+                    field(&k, "relation"),
+                    field(&k, "object"),
+                ) {
+                    let t = (u.to_string(), r.to_string(), o.to_string());
+                    if !guard.tuples.contains(&t) {
+                        guard.tuples.push(t);
+                    }
+                }
+            }
+        }
+        if let Some(keys) = body
+            .pointer("/deletes/tuple_keys")
+            .and_then(Value::as_array)
+        {
+            for k in keys.clone() {
+                guard.tuples.retain(|t| !matches(t, &k));
+            }
+        }
+        Json(json!({}))
+    }
+
+    async fn read(
+        Path(_store_id): Path<String>,
+        State(store): State<Arc<Mutex<Store>>>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let mut guard = store.lock().expect("stub store lock");
+        guard.reads += 1;
+        let key = body.get("tuple_key").cloned().unwrap_or(Value::Null);
+        let tuples: Vec<Value> = guard
+            .tuples
+            .iter()
+            .filter(|t| matches(t, &key))
+            .map(|(u, r, o)| json!({ "key": { "user": u, "relation": r, "object": o } }))
+            .collect();
+        Json(json!({ "tuples": tuples, "continuation_token": null }))
+    }
+
+    async fn check(
+        Path(_store_id): Path<String>,
+        State(store): State<Arc<Mutex<Store>>>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let guard = store.lock().expect("stub store lock");
+        let allowed = exact(&guard.tuples, body.get("tuple_key").unwrap_or(&Value::Null));
+        Json(json!({ "allowed": allowed }))
+    }
+
+    async fn batch_check(
+        Path(_store_id): Path<String>,
+        State(store): State<Arc<Mutex<Store>>>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let guard = store.lock().expect("stub store lock");
+        let mut result = serde_json::Map::new();
+        if let Some(checks) = body.get("checks").and_then(Value::as_array) {
+            for c in checks {
+                let cid = field(c, "correlation_id").unwrap_or("");
+                let allowed = exact(&guard.tuples, c.get("tuple_key").unwrap_or(&Value::Null));
+                result.insert(cid.to_string(), json!({ "allowed": allowed }));
+            }
+        }
+        Json(json!({ "result": result }))
+    }
+
+    async fn list_objects(
+        Path(_store_id): Path<String>,
+        State(store): State<Arc<Mutex<Store>>>,
+        Json(body): Json<Value>,
+    ) -> String {
+        let guard = store.lock().expect("stub store lock");
+        let want_user = body.get("user").and_then(Value::as_str);
+        let want_relation = body.get("relation").and_then(Value::as_str);
+        let want_type = body.get("type").and_then(Value::as_str);
+        let mut out = String::new();
+        for (u, r, o) in &guard.tuples {
+            let type_ok = want_type.is_none_or(|t| o.starts_with(&format!("{t}:")));
+            if want_user.is_none_or(|w| w == u) && want_relation.is_none_or(|w| w == r) && type_ok {
+                out.push_str(&json!({ "result": { "object": o } }).to_string());
+                out.push('\n');
+            }
+        }
+        out
+    }
+}

--- a/tests/integration/src/integration.rs
+++ b/tests/integration/src/integration.rs
@@ -18,6 +18,7 @@
 mod api_key;
 mod application_credential;
 mod assignment;
+mod assignment_per_domain;
 mod audit;
 mod catalog;
 mod common;


### PR DESCRIPTION
Unit suites under crates/core/src/assignment/service/tests/:
target-keyed dispatch, the per-domain resolution cache, the system
carve-out, stale binding fallback, the shared-backend fast path, the
cross-domain grant invariant, and the untargeted fan-out with de-dup /
pagination / fail-fast. Reload suite: block reuse by pointer, drop of an
unmapped block, dispatch switch-off, cache clear, and last-known-good on
an unresolvable config.

Integration suite tests/integration/src/assignment_per_domain.rs, over
the real Provider stack: dispatch-on still serves the global SQL path, a
named [assignment.backends.*] block is built by the reload reactor
through inventory, an unmapped binding falls back to global, the config
API rejects an unbindable driver, an untargeted listing unions and
de-duplicates two live SQL backends, and per-domain resolution is
cached. A stub OpenFGA HTTP server (mod openfga_stub, a stateful axum
tuple store) then drives the OpenFGA driver crate end to end: a domain
bound to a named OpenFGA block routes create_grant to it over real HTTP,
the target-scoped listing reads the tuple back through the driver, and
the grant stays disjoint from the global SQL backend; an untargeted
fan-out with an OpenFGA instance present fails the whole call.
tests/integration/Cargo.toml gains the axum json and tokio net features
and turns on openstack-keystone's openfga feature, which links the
OpenFGA assignment driver and its NamedAssignmentBackendRegistration
into the integration binary.

Live test_api suite tests/api/tests/api_v3/domain_config.rs, over the
real server and OPA: a cloud admin binds assignment/driver and reads it
back; a non-system caller is refused it on the whole-config, group and
option write shapes (ADR 0034 section 6).

driver_for_target held the binding_cache read guard as a match scrutinee
temporary while the None arm awaited a write on the same lock, a
self-deadlock on every resolver-routed grant or listing. Edition 2024
rescopes if-let scrutinee temporaries but not match ones; read into an
owned value first.

Split the in-file unit module into service/tests.rs and add a from_parts
test constructor that wires mock backends straight into the routing
bundle.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
