### PR TITLE
fix(adr0034): Post implementation fixes

### DIFF
--- a/crates/assignment-driver-openfga/src/lib.rs
+++ b/crates/assignment-driver-openfga/src/lib.rs
@@ -49,9 +49,10 @@
 //!   (`inherited: false`, `implied_via: None`) assignment. `resolve_implied_roles`
 //!   only takes effect in this mode (again, via the model).
 //! - **otherwise** - use a raw `read` of the stored tuples (direct grants
-//!   only). An actor-only query is rejected in this mode
-//!   (`ListingActorWithoutScopeRequiresEffective`): OpenFGA's `read` cannot
-//!   enumerate tuples by user alone.
+//!   only). An actor-only query issues a type-scoped `read` (`object:
+//!   "type:"`) with a `user` filter per target type, returning only the
+//!   actor's stored tuples -- the actor-keyed counterpart of a target-scoped
+//!   listing, used by SCIM deprovisioning.
 //!
 //! A **target-scoped** listing always uses `read` (direct only) even in
 //! effective mode - this driver does not call `list-users`, so group-derived
@@ -789,21 +790,30 @@ impl AssignmentBackend for OpenFGADriver {
                 }
             }
             // actor without a target scope: enumerate the objects the actor
-            // holds each role relation on, per target kind. Only answerable in
-            // effective mode - OpenFGA's `read` cannot enumerate by user alone.
+            // holds each role relation on, per target kind.
+            //
+            // - effective mode: `list-objects` per (relation, target type),
+            //   which resolves the model (group- and hierarchy-derived grants).
+            // - otherwise: a direct `read` per (target type[, relation]) with a
+            //   `user` filter and a type-scoped `object` (`type:`), which
+            //   returns only stored tuples for the actor. This is the same
+            //   "direct tuples only" contract the target-scoped branch gives,
+            //   just keyed on the actor -- SCIM deprovisioning needs to sweep a
+            //   principal's grants without knowing every target up front.
             (Some((actor_kind, actor_id)), None) => {
-                if !effective {
-                    Err(OpenFGADriverError::ListingActorWithoutScopeRequiresEffective)?;
-                }
-                let pairs: Vec<(String, String)> = match &role_relation {
-                    Some(pair) => vec![pair.clone()],
-                    None => role_relations(cfg),
-                };
                 let users = mapper.objects_for(actor_kind, actor_id);
-                let mut tasks = Vec::new();
-                for user in &users {
-                    for tkind in [Kind::Project, Kind::Domain, Kind::System] {
-                        for object_type in mapper.types_for(tkind) {
+                let target_types = [Kind::Project, Kind::Domain, Kind::System]
+                    .into_iter()
+                    .flat_map(|tkind| mapper.types_for(tkind));
+
+                if effective {
+                    let pairs: Vec<(String, String)> = match &role_relation {
+                        Some(pair) => vec![pair.clone()],
+                        None => role_relations(cfg),
+                    };
+                    let mut tasks = Vec::new();
+                    for user in &users {
+                        for object_type in target_types.clone() {
                             for (role_id, relation) in &pairs {
                                 tasks.push(async move {
                                     let mut out: Vec<Assignment> = Vec::new();
@@ -835,8 +845,38 @@ impl AssignmentBackend for OpenFGADriver {
                             }
                         }
                     }
+                    results.extend(fan_out(max_concurrency, tasks).await?);
+                } else {
+                    let role_relation_ref = &role_relation;
+                    let mut tasks = Vec::new();
+                    for user in &users {
+                        for object_type in target_types.clone() {
+                            tasks.push(async move {
+                                let tuple_key = match role_relation_ref {
+                                    Some((_, relation)) => json!({
+                                        "user": user,
+                                        "relation": relation,
+                                        "object": format!("{object_type}:"),
+                                    }),
+                                    None => json!({
+                                        "user": user,
+                                        "object": format!("{object_type}:"),
+                                    }),
+                                };
+                                let mut out: Vec<Assignment> = Vec::new();
+                                for tuple in self.openfga_read(cfg, tuple_key).await? {
+                                    if let Some(assignment) =
+                                        tuple_to_assignment(cfg, mapper, &tuple)
+                                    {
+                                        out.push(assignment);
+                                    }
+                                }
+                                Ok::<_, OpenFGADriverError>(out)
+                            });
+                        }
+                    }
+                    results.extend(fan_out(max_concurrency, tasks).await?);
                 }
-                results.extend(fan_out(max_concurrency, tasks).await?);
             }
             // target scope, maybe a role filter: read stored tuples per rep.
             // Always direct - OpenFGA's `read` does not resolve group-derived

--- a/crates/assignment-driver-openfga/src/lib.rs
+++ b/crates/assignment-driver-openfga/src/lib.rs
@@ -157,24 +157,28 @@ pub struct OpenFGADriver {
     config_override: Option<Arc<OpenFGAAssignmentDriver>>,
 }
 
+/// Total per-request timeout applied to the OpenFGA HTTP client when the
+/// configuration leaves `timeout` unset. Without a cap a stalled OpenFGA store
+/// wedges an assignment call (and its caller's token issuance) indefinitely.
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+
 impl Default for OpenFGADriver {
     fn default() -> Self {
         Self {
-            openfga_client: Client::new(),
+            openfga_client: Self::client(None).unwrap_or_else(|_| Client::new()),
             config_override: None,
         }
     }
 }
 
 impl OpenFGADriver {
-    /// Build the OpenFGA HTTP client, applying `timeout_secs` as a total
-    /// per-request timeout when set.
+    /// Build the OpenFGA HTTP client with a total per-request timeout:
+    /// `timeout_secs` when set, otherwise [`DEFAULT_REQUEST_TIMEOUT_SECS`].
     fn client(timeout_secs: Option<u16>) -> Result<Client, OpenFGADriverError> {
-        let mut builder = Client::builder();
-        if let Some(secs) = timeout_secs {
-            builder = builder.timeout(Duration::from_secs(secs.into()));
-        }
-        Ok(builder.build()?)
+        let timeout = timeout_secs
+            .map(|secs| Duration::from_secs(secs.into()))
+            .unwrap_or_else(|| Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS));
+        Ok(Client::builder().timeout(timeout).build()?)
     }
 
     /// Initialize the global OpenFGA driver: [`Self::config`] reads the live

--- a/crates/assignment-driver-openfga/src/tests.rs
+++ b/crates/assignment-driver-openfga/src/tests.rs
@@ -1261,11 +1261,53 @@ async fn list_assignments_actor_and_target_role_direct_mode_reads_tuple() -> Res
 }
 
 #[tokio::test]
-async fn list_assignments_actor_without_scope_direct_mode_errors() -> Result<()> {
+async fn list_assignments_actor_without_scope_direct_mode_reads_stored_tuples() -> Result<()> {
     let srv = MockServer::start_async().await;
-    let state = state_with(driver_config(&srv.base_url())).await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.role_to_relation = Some(HashMap::from([("rid1".into(), "relation1".into())]));
+    let state = state_with(cfg).await;
 
-    match driver()
+    // A non-effective actor-only listing must never touch the model-resolving
+    // endpoints.
+    let list_objects = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/streamed-list-objects");
+            then.status(200).body("");
+        })
+        .await;
+
+    // One type-scoped `read` per target type, filtered by the actor.
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body(json!({
+                "authorization_model_id": "model_id",
+                "tuple_key": { "user": "user:user_id", "object": "project:" }
+            }));
+        then.status(200).json_body(json!({
+            "tuples": [
+                { "key": { "user": "user:user_id", "object": "project:p1", "relation": "relation1" } }
+            ]
+        }));
+    })
+    .await;
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body_includes(r#"{"tuple_key":{"object":"domain:"}}"#);
+        then.status(200).json_body(json!({ "tuples": [] }));
+    })
+    .await;
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body_includes(r#"{"tuple_key":{"object":"system:"}}"#);
+        then.status(200).json_body(json!({ "tuples": [] }));
+    })
+    .await;
+
+    let res = driver()
         .list_assignments(
             &state,
             &RoleAssignmentListParameters {
@@ -1273,13 +1315,56 @@ async fn list_assignments_actor_without_scope_direct_mode_errors() -> Result<()>
                 ..Default::default()
             },
         )
-        .await
-    {
-        Err(AssignmentProviderError::NotImplemented(msg)) => {
-            assert!(msg.contains("requires effective mode"), "got {msg:?}")
-        }
-        other => panic!("expected a not-implemented error, got {other:?}"),
-    }
+        .await?;
+
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0].actor_id, "user_id");
+    assert_eq!(res[0].role_id, "rid1");
+    assert_eq!(res[0].target_id, "p1");
+    assert_eq!(res[0].r#type, AssignmentType::UserProject);
+    assert_eq!(list_objects.calls_async().await, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_assignments_actor_without_scope_direct_mode_honours_role_filter() -> Result<()> {
+    let srv = MockServer::start_async().await;
+    let mut cfg = driver_config(&srv.base_url());
+    cfg.role_to_relation = Some(HashMap::from([
+        ("rid1".into(), "relation1".into()),
+        ("rid2".into(), "relation2".into()),
+    ]));
+    let state = state_with(cfg).await;
+
+    // Every read carries the filtered relation; `relation2` is never asked for.
+    srv.mock_async(|when, then| {
+        when.method("POST")
+            .path("/stores/store_id/read")
+            .json_body_includes(r#"{"tuple_key":{"relation":"relation1"}}"#);
+        then.status(200).json_body(json!({ "tuples": [] }));
+    })
+    .await;
+    let unfiltered = srv
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path("/stores/store_id/read")
+                .json_body_includes(r#"{"tuple_key":{"relation":"relation2"}}"#);
+            then.status(200).json_body(json!({ "tuples": [] }));
+        })
+        .await;
+
+    driver()
+        .list_assignments(
+            &state,
+            &RoleAssignmentListParameters {
+                user_id: Some("user_id".into()),
+                role_id: Some("rid1".into()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_eq!(unfiltered.calls_async().await, 0);
     Ok(())
 }
 

--- a/crates/config/src/assignment.rs
+++ b/crates/config/src/assignment.rs
@@ -153,7 +153,7 @@ pub enum OpenFGAIdTransform {
 /// (`user`, `group`, `project`, `domain`, `system`) has a list of OpenFGA
 /// type names; the first is canonical (used for writes) and every entry is
 /// consulted on reads, checks and deletes.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Deserialize, Clone, PartialEq)]
 pub struct OpenFGAAssignmentDriver {
     /// Base OpenFGA API url. Must end with `/` for the relative
     /// `stores/{id}/...` paths to resolve without dropping a path prefix.
@@ -217,6 +217,30 @@ pub struct OpenFGAAssignmentDriver {
     /// Id format transform applied between Keystone and OpenFGA.
     #[serde(default)]
     pub id_transform: OpenFGAIdTransform,
+}
+
+impl std::fmt::Debug for OpenFGAAssignmentDriver {
+    /// Hand-written so `api_key` (a bearer token) never reaches a log line or a
+    /// panic message. Its presence is still shown; its value is not.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenFGAAssignmentDriver")
+            .field("api_url", &self.api_url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("model_id", &self.model_id)
+            .field("store_id", &self.store_id)
+            .field("timeout", &self.timeout)
+            .field("max_retries", &self.max_retries)
+            .field("retry_backoff_ms", &self.retry_backoff_ms)
+            .field("max_concurrency", &self.max_concurrency)
+            .field("role_to_relation", &self.role_to_relation)
+            .field("user_actor_types", &self.user_actor_types)
+            .field("group_actor_types", &self.group_actor_types)
+            .field("project_target_types", &self.project_target_types)
+            .field("domain_target_types", &self.domain_target_types)
+            .field("system_target_types", &self.system_target_types)
+            .field("id_transform", &self.id_transform)
+            .finish()
+    }
 }
 
 #[cfg(test)]
@@ -306,5 +330,24 @@ store_id = 01ABC
             a.backend_block("local"),
             Some(AssignmentBackendConfig::Sql)
         ));
+    }
+
+    #[test]
+    fn debug_redacts_the_api_key() {
+        let a = parse(
+            r#"
+[assignment.backends.central_fga]
+driver = openfga
+api_url = https://openfga.internal:8080/
+store_id = 01ABC
+api_key = super-secret-token
+"#,
+        );
+        let rendered = format!("{:?}", a.backend_block("central_fga").unwrap());
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "api_key leaked into Debug output: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"), "{rendered}");
     }
 }

--- a/crates/core/src/assignment/service.rs
+++ b/crates/core/src/assignment/service.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use tokio::sync::RwLock;
 use tracing::{error, warn};
 
@@ -37,6 +37,7 @@ use openstack_keystone_core_types::role::{Role, RoleListParameters};
 use crate::assignment::{AssignmentApi, AssignmentProviderError, backend::AssignmentBackend};
 use crate::auth::ExecutionContext;
 use crate::domain_config::DomainConfigResolver;
+use crate::domain_config::backend::DomainConfigBackend;
 use crate::domain_config::resolver::effective_domain_config_sources;
 use crate::events::AuditDispatchError;
 use crate::keystone::ServiceState;
@@ -121,9 +122,18 @@ pub struct AssignmentService {
     /// Resolves a domain's effective stored configuration. `Some` only when
     /// `[assignment] domain_specific_drivers_enabled` and at least one
     /// domain-config source is active; `None` disables per-domain dispatch
-    /// entirely. Fixed at construction — changing the source set needs a
-    /// restart (ADR 0034 risk note on cross-reload source changes).
-    resolver: Option<Arc<DomainConfigResolver>>,
+    /// entirely. Rebuilt from the live configuration on every reload (ADR 0034
+    /// §9) from the backend handles in [`Self::dc_file_backend`] /
+    /// [`Self::dc_sql_backend`], so flipping the dispatch switch or the source
+    /// set takes effect without a restart.
+    resolver: ArcSwapOption<DomainConfigResolver>,
+    /// The `fs` domain-config backend, captured once at construction so a
+    /// reload can re-wire the resolver without a plugin manager. `None` when no
+    /// `fs` domain-config driver is registered.
+    dc_file_backend: Option<Arc<dyn DomainConfigBackend>>,
+    /// The `sql` domain-config backend, same rationale as
+    /// [`Self::dc_file_backend`].
+    dc_sql_backend: Option<Arc<dyn DomainConfigBackend>>,
     /// The live routing table (ADR 0034 §9).
     bundle: ArcSwap<AssignmentBundle>,
     /// Cache of `domain_id` → resolved `assignment/driver` name (empty string =
@@ -151,6 +161,16 @@ impl AssignmentService {
         let global = plugin_manager
             .get_assignment_backend(config.assignment.driver.clone())?
             .clone();
+
+        // Domain-config backend handles for later resolver rebuilds. Captured
+        // unconditionally (independent of the current switches, which a reload
+        // may flip on) and best-effort — a driver that is not registered is
+        // simply unavailable as a source.
+        let dc_file_backend = plugin_manager.get_domain_config_backend("fs").ok().cloned();
+        let dc_sql_backend = plugin_manager
+            .get_domain_config_backend("sql")
+            .ok()
+            .cloned();
 
         let (from_files, from_database) = effective_domain_config_sources(config);
         let resolver =
@@ -186,7 +206,9 @@ impl AssignmentService {
         };
 
         Ok(Self {
-            resolver,
+            resolver: ArcSwapOption::new(resolver),
+            dc_file_backend,
+            dc_sql_backend,
             bundle: ArcSwap::from_pointee(bundle),
             binding_cache: RwLock::new(HashMap::new()),
         })
@@ -207,7 +229,9 @@ impl AssignmentService {
             global: backend,
         };
         Self {
-            resolver: None,
+            resolver: ArcSwapOption::empty(),
+            dc_file_backend: None,
+            dc_sql_backend: None,
             bundle: ArcSwap::from_pointee(bundle),
             binding_cache: RwLock::new(HashMap::new()),
         }
@@ -244,10 +268,21 @@ impl AssignmentService {
             fanout,
         };
         Self {
-            resolver,
+            resolver: ArcSwapOption::new(resolver),
+            dc_file_backend: None,
+            dc_sql_backend: None,
             bundle: ArcSwap::from_pointee(bundle),
             binding_cache: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Attach a `sql` domain-config backend handle so [`Self::rebuild`] treats
+    /// this service as one that can re-wire its resolver on reload (the
+    /// production path). Test-only.
+    #[cfg(test)]
+    pub(crate) fn with_dc_sql_backend(mut self, backend: Arc<dyn DomainConfigBackend>) -> Self {
+        self.dc_sql_backend = Some(backend);
+        self
     }
 
     /// The backend that serves an assignment on `(kind, target_id)`.
@@ -267,7 +302,8 @@ impl AssignmentService {
         if !bundle.dispatch_enabled {
             return Ok(bundle.global.clone());
         }
-        let Some(resolver) = &self.resolver else {
+        let resolver = self.resolver.load_full();
+        let Some(resolver) = resolver.as_deref() else {
             return Ok(bundle.global.clone());
         };
 
@@ -354,15 +390,43 @@ impl AssignmentService {
             build_global_assignment_backend(&config, &global_driver_name).await?
         };
 
-        let dispatch_enabled =
-            self.resolver.is_some() && config.assignment.domain_specific_drivers_enabled;
+        // Re-wire the resolver from the live configuration (ADR 0034 §9): the
+        // dispatch switch and the two source switches can all change across a
+        // reload, and a DB-sourced binding written on another node only becomes
+        // visible once the resolver is consulted again. The backend handles
+        // themselves are stable, captured at construction.
+        //
+        // A service with no captured handles (the test constructors, and any
+        // deployment with neither domain-config driver registered) keeps the
+        // resolver it was built with, re-gated on the dispatch switch alone.
+        let resolver = if self.dc_file_backend.is_some() || self.dc_sql_backend.is_some() {
+            config
+                .assignment
+                .domain_specific_drivers_enabled
+                .then(|| {
+                    DomainConfigResolver::from_backends(
+                        &config,
+                        self.dc_file_backend.clone(),
+                        self.dc_sql_backend.clone(),
+                    )
+                })
+                .filter(DomainConfigResolver::has_source)
+                .map(Arc::new)
+        } else {
+            self.resolver
+                .load_full()
+                .filter(|_| config.assignment.domain_specific_drivers_enabled)
+        };
+        self.resolver.store(resolver.clone());
+
+        let dispatch_enabled = resolver.is_some();
 
         let domains = config.assignment.domains.clone();
         let backend_blocks = config.assignment.backends.clone();
 
         // The blocks a currently bound domain maps to and that actually exist.
         let mut active: HashSet<String> = HashSet::new();
-        if dispatch_enabled && let Some(resolver) = &self.resolver {
+        if let Some(resolver) = &resolver {
             let bound = resolver
                 .bound_domains(state)
                 .await

--- a/crates/core/src/assignment/service/tests/reload.rs
+++ b/crates/core/src/assignment/service/tests/reload.rs
@@ -192,6 +192,41 @@ async fn an_unresolvable_new_config_keeps_the_previous_bundle() {
     );
 }
 
+/// The dispatch switch flipped **on** by a config reload takes effect: the
+/// resolver is re-wired from the captured backend handle, not frozen at
+/// construction.
+#[tokio::test]
+async fn flipping_the_dispatch_switch_on_via_reload_takes_effect() {
+    // Built with the switch off — no resolver, dispatch disabled.
+    let state = get_mocked_state(Some(config(assignment_section(false, false))), None).await;
+    let mut sql_mock = MockDomainConfigBackend::new();
+    sql_mock
+        .expect_list_domains_with_option()
+        .returning(|_, _, _| Ok(Vec::new()));
+    let sql_backend: Arc<dyn DomainConfigBackend> = Arc::new(sql_mock);
+    let provider = AssignmentService::from_parts(
+        "openfga",
+        Arc::new(MockAssignmentBackend::default()),
+        HashMap::new(),
+        HashMap::new(),
+        HashMap::new(),
+        None,
+    )
+    .with_dc_sql_backend(sql_backend);
+    assert!(!provider.bundle.load_full().dispatch_enabled);
+
+    // Operator turns per-domain dispatch on; the config reloads.
+    *state.config_manager.config.write().await = config(assignment_section(true, false));
+    let changed = provider.reload(&state).await.unwrap();
+
+    assert!(changed, "the switch flip must be observable");
+    assert!(
+        provider.bundle.load_full().dispatch_enabled,
+        "dispatch is live after the reload without a restart"
+    );
+    assert!(provider.resolver.load_full().is_some());
+}
+
 #[tokio::test]
 async fn refresh_bindings_swallows_a_rebuild_error() {
     let named: Arc<dyn AssignmentBackend> = Arc::new(MockAssignmentBackend::default());

--- a/crates/core/src/domain_config/resolver.rs
+++ b/crates/core/src/domain_config/resolver.rs
@@ -151,6 +151,38 @@ impl DomainConfigResolver {
         Ok(Self { file, database })
     }
 
+    /// A resolver wired directly to already-resolved backend handles, taking
+    /// only the two source switches from the configuration.
+    ///
+    /// Unlike [`Self::new`] this needs no plugin manager, so a running service
+    /// can rebuild the resolver on a config reload (ADR 0034 §9) from handles
+    /// it captured at construction. A source that its switch turns on but whose
+    /// handle is `None` (the driver was never registered) is simply skipped.
+    ///
+    /// # Parameters
+    /// - `config`: The running service configuration; [`effective_domain_config_sources`]
+    ///   decides which sources are consulted.
+    /// - `file`: The `fs` domain-config backend handle, if registered.
+    /// - `database`: The `sql` domain-config backend handle, if registered.
+    pub fn from_backends(
+        config: &Config,
+        file: Option<Arc<dyn DomainConfigBackend>>,
+        database: Option<Arc<dyn DomainConfigBackend>>,
+    ) -> Self {
+        let (from_files, from_database) = effective_domain_config_sources(config);
+        Self {
+            file: from_files.then_some(file).flatten(),
+            database: from_database.then_some(database).flatten(),
+        }
+    }
+
+    /// Whether the resolver has at least one active source. A sourceless
+    /// resolver resolves every domain to the empty configuration, so a caller
+    /// gating per-domain dispatch can treat it as "off".
+    pub fn has_source(&self) -> bool {
+        self.file.is_some() || self.database.is_some()
+    }
+
     /// A resolver with no source: every domain resolves to the empty
     /// configuration. Used by the mocked provider builder.
     ///

--- a/crates/core/src/domain_config/service.rs
+++ b/crates/core/src/domain_config/service.rs
@@ -188,18 +188,14 @@ impl DomainConfigService {
     async fn validate_assignment_binding(
         &self,
         state: &ServiceState,
+        domain_id: &str,
         driver: Option<&str>,
     ) -> Result<(), DomainConfigProviderError> {
         let Some(driver) = driver else {
             return Ok(());
         };
-        let bindable = state
-            .config_manager
-            .config
-            .read()
-            .await
-            .assignment
-            .bindable_driver_names();
+        let config = state.config_manager.config.read().await;
+        let bindable = config.assignment.bindable_driver_names();
         if !bindable.contains(driver) {
             let mut names: Vec<_> = bindable.into_iter().collect();
             names.sort();
@@ -210,6 +206,30 @@ impl DomainConfigService {
                     "{driver:?} names no configured assignment backend; valid names: {names:?}"
                 )),
             });
+        }
+        // The name is bindable, but a per-domain instance only spins up when
+        // `[assignment.domains]` maps this domain to a matching backend block
+        // (ADR 0034 §4). A non-global name with no such mapping is stored
+        // happily and then falls straight back to the global driver at resolve
+        // time -- an inert binding. Reject nothing (the operator may add the
+        // mapping next), but say so loudly.
+        let global = config.assignment.driver.as_str();
+        if driver != "sql" && driver != global {
+            let mapped = config
+                .assignment
+                .domains
+                .get(domain_id)
+                .and_then(|block| config.assignment.backends.get(block))
+                .map(|block| block.driver_name());
+            if mapped != Some(driver) {
+                tracing::warn!(
+                    domain_id,
+                    driver,
+                    "domain bound to assignment driver {driver:?} with no matching \
+                     [assignment.domains] mapping; the binding is inert and resolves \
+                     to the global {global:?} driver until the mapping is added"
+                );
+            }
         }
         Ok(())
     }
@@ -250,7 +270,7 @@ impl DomainConfigApi for DomainConfigService {
         let assignment_driver = Self::assignment_driver(&config.0);
         // Validate before `reconcile_registration_before`: a rejected write
         // must not leave the SQL identity-driver registration claimed.
-        self.validate_assignment_binding(state, assignment_driver.as_deref())
+        self.validate_assignment_binding(state, domain_id, assignment_driver.as_deref())
             .await?;
         self.reconcile_registration_before(state, domain_id, driver.as_deref())
             .await?;
@@ -306,7 +326,7 @@ impl DomainConfigApi for DomainConfigService {
     ) -> Result<DomainConfig, DomainConfigProviderError> {
         let driver = Self::identity_driver(&config.0);
         let assignment_driver = Self::assignment_driver(&config.0);
-        self.validate_assignment_binding(state, assignment_driver.as_deref())
+        self.validate_assignment_binding(state, domain_id, assignment_driver.as_deref())
             .await?;
         self.reconcile_registration_before(state, domain_id, driver.as_deref())
             .await?;
@@ -334,7 +354,7 @@ impl DomainConfigApi for DomainConfigService {
         let assignment_driver = (group == DomainConfigGroupName::Assignment)
             .then(|| Self::assignment_driver(&config.0))
             .flatten();
-        self.validate_assignment_binding(state, assignment_driver.as_deref())
+        self.validate_assignment_binding(state, domain_id, assignment_driver.as_deref())
             .await?;
         self.reconcile_registration_before(state, domain_id, driver.as_deref())
             .await?;
@@ -362,7 +382,7 @@ impl DomainConfigApi for DomainConfigService {
             && option.option == "driver")
             .then(|| option.value.as_value().as_str().map(str::to_owned))
             .flatten();
-        self.validate_assignment_binding(state, assignment_driver.as_deref())
+        self.validate_assignment_binding(state, domain_id, assignment_driver.as_deref())
             .await?;
         self.reconcile_registration_before(state, domain_id, driver.as_deref())
             .await?;
@@ -703,6 +723,53 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn a_bindable_driver_with_no_domains_mapping_warns_that_the_binding_is_inert() {
+        let state = get_mocked_state(Some(config_with_openfga_backend()), None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_create_domain_config()
+            .returning(|_, _, _| Ok(config(json!({"assignment": {"driver": "openfga"}}))));
+
+        // The write is accepted (the name is bindable), but there is no
+        // `[assignment.domains]` entry for `d1`, so the stored binding will
+        // resolve straight back to the global driver.
+        service(backend, false)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({"assignment": {"driver": "openfga"}}))),
+            )
+            .await
+            .unwrap();
+        assert!(logs_contain("the binding is inert"));
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn a_bindable_driver_with_a_matching_domains_mapping_does_not_warn() {
+        let mut cfg = config_with_openfga_backend();
+        cfg.assignment
+            .domains
+            .insert("d1".to_string(), "central_fga".to_string());
+        let state = get_mocked_state(Some(cfg), None).await;
+        let mut backend = MockDomainConfigBackend::new();
+        backend
+            .expect_create_domain_config()
+            .returning(|_, _, _| Ok(config(json!({"assignment": {"driver": "openfga"}}))));
+
+        service(backend, false)
+            .create_domain_config(
+                &state,
+                "d1",
+                DomainConfigCreate(config(json!({"assignment": {"driver": "openfga"}}))),
+            )
+            .await
+            .unwrap();
+        assert!(!logs_contain("the binding is inert"));
     }
 
     #[tokio::test]

--- a/crates/keystone/src/api/v3/domain_config/group.rs
+++ b/crates/keystone/src/api/v3/domain_config/group.rs
@@ -412,6 +412,56 @@ mod tests {
             ValidatedSecurityContext::test_new(sc)
         }
 
+        /// A `system`-scoped caller (maps to `input.credentials.system ==
+        /// "all"` in policy input). ADR 0034 §6: only such a token — a genuine
+        /// cloud administrator — may write the `assignment` group.
+        fn system_scoped_vsc(roles: &[&str]) -> ValidatedSecurityContext {
+            let authz = AuthzInfoBuilder::default()
+                .scope(ScopeInfo::System("system".to_string()))
+                .roles(
+                    roles
+                        .iter()
+                        .enumerate()
+                        .map(|(i, name)| RoleRef {
+                            domain_id: None,
+                            id: format!("role-{i}"),
+                            name: Some((*name).to_string()),
+                        })
+                        .collect::<Vec<_>>(),
+                )
+                .build()
+                .unwrap();
+
+            let sc = SecurityContext::test_build()
+                .authentication_context(AuthenticationContext::Password)
+                .principal(PrincipalInfo {
+                    identity: IdentityInfo::User(
+                        UserIdentityInfoBuilder::default()
+                            .user_id("caller")
+                            .user(
+                                UserResponseBuilder::default()
+                                    .id("caller")
+                                    .domain_id("caller")
+                                    .enabled(true)
+                                    .name("caller")
+                                    .build()
+                                    .unwrap(),
+                            )
+                            .user_domain(Domain {
+                                id: "caller".to_string(),
+                                name: "caller".to_string(),
+                                enabled: true,
+                                ..Default::default()
+                            })
+                            .build()
+                            .unwrap(),
+                    ),
+                })
+                .authorization(authz)
+                .build();
+            ValidatedSecurityContext::test_new(sc)
+        }
+
         /// `PATCH /did/config/<group>` with `{"config": body}` under `vsc`,
         /// against the real policy. The provider mock echoes the write back,
         /// so a policy `allow` yields 200 and a deny yields 403.
@@ -506,11 +556,37 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn admin_role_may_write_the_assignment_group() {
+        async fn domain_scoped_admin_is_denied_the_assignment_group() {
+            // ADR 0034 §6: binding a domain to an assignment backend is a
+            // role-minting surface reserved for cloud admins. A domain-scoped
+            // `admin` — however privileged within its own domain — must not
+            // reach it.
             let status = patch_group(
                 domain_scoped_vsc("did", &["admin"]),
                 "assignment",
                 json!({"assignment": {"driver": "sql"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn system_scoped_admin_may_write_the_assignment_group() {
+            let status = patch_group(
+                system_scoped_vsc(&["admin"]),
+                "assignment",
+                json!({"assignment": {"driver": "sql"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn domain_scoped_admin_may_still_write_a_non_assignment_group() {
+            let status = patch_group(
+                domain_scoped_vsc("did", &["admin"]),
+                "ldap",
+                json!({"ldap": {"url": "ldap://in"}}),
             )
             .await;
             assert_eq!(status, StatusCode::OK);
@@ -529,9 +605,21 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn admin_role_may_write_the_assignment_group_on_the_option_path() {
+        async fn domain_scoped_admin_is_denied_the_assignment_group_on_the_option_path() {
             let status = patch_option(
                 domain_scoped_vsc("did", &["admin"]),
+                "assignment",
+                "driver",
+                json!({"assignment": {"driver": "sql"}}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn system_scoped_admin_may_write_the_assignment_group_on_the_option_path() {
+            let status = patch_option(
+                system_scoped_vsc(&["admin"]),
                 "assignment",
                 "driver",
                 json!({"assignment": {"driver": "sql"}}),
@@ -578,6 +666,63 @@ mod tests {
                 .unwrap();
 
             assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn domain_scoped_admin_is_denied_deleting_the_assignment_group() {
+            let mut mock = MockDomainConfigProvider::default();
+            mock.expect_delete_domain_config_group().never();
+
+            let (state, _opa_guard) =
+                get_state_with_real_policy(Provider::mocked_builder().mock_domain_config(mock))
+                    .await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            let response = api
+                .as_service()
+                .oneshot(
+                    Request::builder()
+                        .method("DELETE")
+                        .uri("/did/config/assignment")
+                        .extension(domain_scoped_vsc("did", &["admin"]))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn system_scoped_admin_may_delete_the_assignment_group() {
+            let mut mock = MockDomainConfigProvider::default();
+            mock.expect_delete_domain_config_group()
+                .returning(|_, _, _| Ok(()));
+
+            let (state, _opa_guard) =
+                get_state_with_real_policy(Provider::mocked_builder().mock_domain_config(mock))
+                    .await;
+            let mut api = openapi_router()
+                .layer(TraceLayer::new_for_http())
+                .with_state(state);
+
+            let response = api
+                .as_service()
+                .oneshot(
+                    Request::builder()
+                        .method("DELETE")
+                        .uri("/did/config/assignment")
+                        .extension(system_scoped_vsc(&["admin"]))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
         }
     }
 }

--- a/crates/keystone/src/api/v4/auth_plugin/identity_link/mod.rs
+++ b/crates/keystone/src/api/v4/auth_plugin/identity_link/mod.rs
@@ -19,7 +19,7 @@
 
 use openstack_keystone_config::{DynamicPluginConfig, PluginMode};
 use openstack_keystone_core::auth::ExecutionContext;
-use openstack_keystone_core_types::assignment::RoleAssignmentListParameters;
+use openstack_keystone_core_types::assignment::{AssignmentType, RoleAssignmentListParameters};
 
 use crate::api::error::KeystoneApiError;
 use crate::keystone::ServiceState;
@@ -86,7 +86,15 @@ async fn target_holds_system_role(
         .get_assignment_provider()
         .list_role_assignments(exec, &params)
         .await?;
-    Ok(!assignments.is_empty())
+    // The `system_id` filter already narrows the query, but this gate mints an
+    // RBAC tier: re-check the assignment type so a driver that honours the
+    // filter loosely cannot widen it.
+    Ok(assignments.iter().any(|a| {
+        matches!(
+            a.r#type,
+            AssignmentType::UserSystem | AssignmentType::GroupSystem
+        )
+    }))
 }
 
 #[cfg(test)]

--- a/crates/keystone/src/scim/group/delete.rs
+++ b/crates/keystone/src/scim/group/delete.rs
@@ -51,16 +51,13 @@ pub(super) async fn delete(
 
     // §6.B step 1: clear the group's role assignments — this is the
     // security-relevant action, since a "deleted-looking" group that still
-    // grants roles would be a silent escalation path.
-    // `effective(true)` on an actor-only listing: ADR 0034 §5 — the OpenFGA
-    // driver cannot answer a non-effective actor-only query (no target scope
-    // to `read` by) and returns 501, which would fail this whole listing once
-    // any domain runs on OpenFGA. Effective mode is answerable there, and for
-    // the SQL driver a `group_id`-only listing is unaffected by the flag (it
-    // only expands a `user_id`).
+    // grants roles would be a silent escalation path. A non-effective
+    // actor-only listing: we want the group's own stored grants, not the
+    // expanded effective set. Both the SQL and OpenFGA drivers answer this
+    // directly (the OpenFGA driver issues a type-scoped `read` per target
+    // type).
     let params = RoleAssignmentListParametersBuilder::default()
         .group_id(id.clone())
-        .effective(true)
         .build()?;
     let assignments = state
         .provider

--- a/policy/domain_config/create.rego
+++ b/policy/domain_config/create.rego
@@ -13,17 +13,29 @@ package identity.domain_config.create
 
 default allow := false
 
-allow if {
-	"admin" in input.credentials.roles
-}
-
+# The configured admin SVID (system-level operator) may write any group.
 allow if {
 	input.credentials.is_admin
 }
 
-# A domain manager may configure the domain their token is scoped to, except
-# the `assignment` group: binding a domain to an assignment backend is a
-# role-minting surface reserved for cloud admins (ADR 0034 §6).
+# A system-scoped `admin` — a cloud administrator — may write any group,
+# including `assignment` (ADR 0034 §6).
+allow if {
+	"admin" in input.credentials.roles
+	input.credentials.system == "all"
+}
+
+# An `admin` on any other scope may write any group EXCEPT `assignment`:
+# binding a domain to an assignment backend is a role-minting surface reserved
+# for cloud admins, and must not be satisfiable by a domain- or project-scoped
+# token (ADR 0034 §6).
+allow if {
+	"admin" in input.credentials.roles
+	not touches_assignment_group
+}
+
+# A domain manager may configure the domain their token is scoped to, with the
+# same `assignment` carve-out.
 allow if {
 	"manager" in input.credentials.roles
 	input.credentials.domain_id == input.target.domain_id

--- a/policy/domain_config/create_test.rego
+++ b/policy/domain_config/create_test.rego
@@ -18,7 +18,8 @@ test_domain_manager_allowed if {
 	}
 }
 
-# ADR 0034 §6: the `assignment` group is cloud-admin only.
+# ADR 0034 §6: the `assignment` group is cloud-admin only — not satisfiable by
+# a domain- or project-scoped token, whatever role it carries.
 test_domain_manager_denied_the_assignment_group if {
 	not create.allow with input as {
 		"credentials": {"roles": ["manager"], "domain_id": "d1"},
@@ -30,9 +31,32 @@ test_domain_manager_denied_the_assignment_group if {
 	}
 }
 
-test_admin_allowed_the_assignment_group if {
+# A non-system `admin` (domain- or project-scoped) is refused the `assignment`
+# group but keeps every other group.
+test_non_system_admin_denied_the_assignment_group if {
+	not create.allow with input as {
+		"credentials": {"roles": ["admin"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
+	not create.allow with input as {
+		"credentials": {"roles": ["admin"]},
+		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
+	}
 	create.allow with input as {
-		"credentials": {"roles": ["admin"], "is_admin": true},
+		"credentials": {"roles": ["admin"]},
+		"target": {"domain_id": "d1", "group": "identity"},
+	}
+}
+
+test_admin_allowed_the_assignment_group if {
+	# configured admin SVID
+	create.allow with input as {
+		"credentials": {"roles": [], "is_admin": true},
+		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
+	}
+	# system-scoped `admin`
+	create.allow with input as {
+		"credentials": {"roles": ["admin"], "system": "all"},
 		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
 	}
 }

--- a/policy/domain_config/delete.rego
+++ b/policy/domain_config/delete.rego
@@ -12,20 +12,30 @@ package identity.domain_config.delete
 
 default allow := false
 
-allow if {
-	"admin" in input.credentials.roles
-}
-
+# The configured admin SVID (system-level operator) may delete any group.
 allow if {
 	input.credentials.is_admin
 }
 
-# A domain manager may configure the domain their token is scoped to, except
-# the `assignment` group: binding a domain to an assignment backend is a
-# role-minting surface reserved for cloud admins (ADR 0034 §6). A whole-config
-# DELETE carries no group, so a manager can still drop their domain's whole
-# configuration — that only reverts the domain to the global driver, which
-# mints nothing.
+# A system-scoped `admin` — a cloud administrator — may delete any group,
+# including `assignment` (ADR 0034 §6).
+allow if {
+	"admin" in input.credentials.roles
+	input.credentials.system == "all"
+}
+
+# An `admin` on any other scope may delete any group EXCEPT `assignment`, which
+# is reserved for cloud admins and must not be satisfiable by a domain- or
+# project-scoped token (ADR 0034 §6). A whole-config DELETE carries no group,
+# so it is still reachable — that only reverts the domain to the global driver,
+# which mints nothing.
+allow if {
+	"admin" in input.credentials.roles
+	not touches_assignment_group
+}
+
+# A domain manager may drop the configuration of the domain their token is
+# scoped to, with the same `assignment` carve-out.
 allow if {
 	"manager" in input.credentials.roles
 	input.credentials.domain_id == input.target.domain_id

--- a/policy/domain_config/delete_test.rego
+++ b/policy/domain_config/delete_test.rego
@@ -18,7 +18,8 @@ test_domain_manager_allowed if {
 	}
 }
 
-# ADR 0034 §6: the `assignment` group is cloud-admin only.
+# ADR 0034 §6: the `assignment` group is cloud-admin only — not satisfiable by
+# a domain- or project-scoped token, whatever role it carries.
 test_domain_manager_denied_the_assignment_group if {
 	not delete.allow with input as {
 		"credentials": {"roles": ["manager"], "domain_id": "d1"},
@@ -30,9 +31,36 @@ test_domain_manager_denied_the_assignment_group if {
 	}
 }
 
-test_admin_allowed_the_assignment_group if {
+# A non-system `admin` is refused the `assignment` group but keeps every other
+# group and the whole-config delete (which only reverts to the global driver).
+test_non_system_admin_denied_the_assignment_group if {
+	not delete.allow with input as {
+		"credentials": {"roles": ["admin"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
+	not delete.allow with input as {
+		"credentials": {"roles": ["admin"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment", "option": "driver"},
+	}
 	delete.allow with input as {
-		"credentials": {"roles": ["admin"], "is_admin": true},
+		"credentials": {"roles": ["admin"]},
+		"target": {"domain_id": "d1", "group": "identity"},
+	}
+	delete.allow with input as {
+		"credentials": {"roles": ["admin"]},
+		"target": {"domain_id": "d1"},
+	}
+}
+
+test_admin_allowed_the_assignment_group if {
+	# configured admin SVID
+	delete.allow with input as {
+		"credentials": {"roles": [], "is_admin": true},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
+	# system-scoped `admin`
+	delete.allow with input as {
+		"credentials": {"roles": ["admin"], "system": "all"},
 		"target": {"domain_id": "d1", "group": "assignment"},
 	}
 }

--- a/policy/domain_config/update.rego
+++ b/policy/domain_config/update.rego
@@ -14,17 +14,29 @@ package identity.domain_config.update
 
 default allow := false
 
-allow if {
-	"admin" in input.credentials.roles
-}
-
+# The configured admin SVID (system-level operator) may write any group.
 allow if {
 	input.credentials.is_admin
 }
 
-# A domain manager may configure the domain their token is scoped to, except
-# the `assignment` group: binding a domain to an assignment backend is a
-# role-minting surface reserved for cloud admins (ADR 0034 §6).
+# A system-scoped `admin` — a cloud administrator — may write any group,
+# including `assignment` (ADR 0034 §6).
+allow if {
+	"admin" in input.credentials.roles
+	input.credentials.system == "all"
+}
+
+# An `admin` on any other scope may write any group EXCEPT `assignment`:
+# binding a domain to an assignment backend is a role-minting surface reserved
+# for cloud admins, and must not be satisfiable by a domain- or project-scoped
+# token (ADR 0034 §6).
+allow if {
+	"admin" in input.credentials.roles
+	not touches_assignment_group
+}
+
+# A domain manager may configure the domain their token is scoped to, with the
+# same `assignment` carve-out.
 allow if {
 	"manager" in input.credentials.roles
 	input.credentials.domain_id == input.target.domain_id

--- a/policy/domain_config/update_test.rego
+++ b/policy/domain_config/update_test.rego
@@ -18,7 +18,8 @@ test_domain_manager_allowed if {
 	}
 }
 
-# ADR 0034 §6: the `assignment` group is cloud-admin only.
+# ADR 0034 §6: the `assignment` group is cloud-admin only — not satisfiable by
+# a domain- or project-scoped token, whatever role it carries.
 test_domain_manager_denied_the_assignment_group if {
 	not update.allow with input as {
 		"credentials": {"roles": ["manager"], "domain_id": "d1"},
@@ -34,13 +35,36 @@ test_domain_manager_denied_the_assignment_group if {
 	}
 }
 
-test_admin_allowed_the_assignment_group if {
+# A non-system `admin` (domain- or project-scoped) is refused the `assignment`
+# group but keeps every other group.
+test_non_system_admin_denied_the_assignment_group if {
+	not update.allow with input as {
+		"credentials": {"roles": ["admin"], "domain_id": "d1"},
+		"target": {"domain_id": "d1", "group": "assignment"},
+	}
+	not update.allow with input as {
+		"credentials": {"roles": ["admin"]},
+		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
+	}
 	update.allow with input as {
-		"credentials": {"roles": ["admin"], "is_admin": true},
+		"credentials": {"roles": ["admin"]},
+		"target": {"domain_id": "d1", "group": "identity"},
+	}
+}
+
+test_admin_allowed_the_assignment_group if {
+	# configured admin SVID
+	update.allow with input as {
+		"credentials": {"roles": [], "is_admin": true},
+		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
+	}
+	# system-scoped `admin`
+	update.allow with input as {
+		"credentials": {"roles": ["admin"], "system": "all"},
 		"target": {"domain_id": "d1", "group": "assignment"},
 	}
 	update.allow with input as {
-		"credentials": {"roles": [], "is_admin": true},
+		"credentials": {"roles": ["admin"], "system": "all"},
 		"target": {"domain_id": "d1", "config": {"assignment": {"driver": "openfga"}}},
 	}
 }

--- a/tests/api/tests/api_v3/domain_config.rs
+++ b/tests/api/tests/api_v3/domain_config.rs
@@ -16,16 +16,23 @@
 //! role-minting surface reserved for cloud admins.
 //!
 //! A cloud (system) admin can write it on every shape; a non-system caller
-//! is refused it by the real OPA policy over real HTTP.
+//! is refused it by the real OPA policy over real HTTP. The non-system caller
+//! reachable here is a project-scoped domain `manager`; a project-scoped
+//! `admin` is refused by the same carve-out.
 //!
 //! Two ADR aspects are covered elsewhere, not here:
 //!
-//! - **The domain-`manager` carve-out** — a domain manager may write every
-//!   other group of their own domain but not `assignment` — needs a
-//!   domain-scoped non-admin token, which the v3 API cannot mint (there is
-//!   no domain role-grant route; only project and system). It is verified in
-//!   `policy/domain_config/{create,update}_test.rego` and the
-//!   `crates/keystone/src/api/v3/domain_config/group.rs` handler tests.
+//! - **The domain-scoped carve-out** — a domain-scoped token (whether it
+//!   carries `manager` or even `admin`) may write every other group of its
+//!   own domain but not `assignment` — needs a domain-scoped token, which the
+//!   v3 API cannot mint (there is no domain role-grant route; only project
+//!   and system). It is verified in
+//!   `policy/domain_config/{create,update,delete}_test.rego` and the
+//!   `crates/keystone/src/api/v3/domain_config/group.rs`
+//!   `real_policy_decision` handler tests (real `opa`), which drive both a
+//!   `domain_scoped_vsc(&["manager"])` and a `domain_scoped_vsc(&["admin"])`
+//!   to a `FORBIDDEN` on the `assignment` group and to `OK` on every other
+//!   group.
 //! - **Provisioning a named OpenFGA backend and routing a domain onto it** —
 //!   the live server runs a fixed sql-only `[assignment]` config. That path
 //!   is covered by `tests/integration/src/assignment_per_domain.rs`.


### PR DESCRIPTION
- **fix(policy): Restrict assignment domain-config group to cloud admins**
- **fix(assignment): Rebuild domain-config resolver on config reload**
- **fix(assignment-openfga): Apply a default request timeout**
- **fix(assignment-openfga): Read stored tuples for actor-only listings**
- **fix(auth): Gate the system-role check with a system_id filter**
- **fix(domain-config): Warn when a bound assignment driver is inert**
- **fix(config): Redact api_key from OpenFGAAssignmentDriver Debug**
- **docs(test): Note the assignment-group policy coverage split**
