### PR TITLE
feat(ci): Add full service set + spiffe-helper

### DIFF
--- a/.github/workflows/devstack.yml
+++ b/.github/workflows/devstack.yml
@@ -282,3 +282,254 @@ jobs:
       - name: Dump Apache error log
         if: failure()
         run: sudo cat /var/log/apache2/error.log || true
+
+  # Phase 1.5 of doc/plans/spire-integration.md: a full single-node stack
+  # with Nova/Cinder/Glance/Neutron, still using standard password/token
+  # keystone auth (no SPIFFE-based auth cutover - that needs the patched
+  # keystonemiddleware from Phase 4, not started yet). Kept as a separate,
+  # initially non-blocking job rather than folded into "devstack" above:
+  # this stack is materially heavier (image download, instance boot,
+  # extra services) and shouldn't slow every PR's feedback loop until
+  # proven stable. continue-on-error at the job level means a failure here
+  # is visible but doesn't fail the overall workflow.
+  devstack-full:
+    runs-on: ubuntu-24.04
+    needs:
+      - build
+    continue-on-error: true
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      OS_CLOUD: devstack-admin
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Materialize local branch ref for devstack's file:// plugin clone
+        run: |
+          ref="$(git symbolic-ref --short -q HEAD || true)"
+          if [[ -z "$ref" ]]; then
+            ref="${{ github.head_ref || github.ref_name }}"
+            git branch -f "$ref" HEAD
+          fi
+          echo "KEYSTONE_RS_GIT_REF=$ref" >> "$GITHUB_ENV"
+
+      - name: Download built binaries
+        uses: actions/download-artifact@abefc31eafcfbdf6c5336127c1346fdae79ff41c # v5.0.0
+        with:
+          name: keystone-devstack-bin
+          path: ${{ github.workspace }}/bin
+
+      - name: Fix binary permissions
+        run: chmod u+x ${{ github.workspace }}/bin/keystone ${{ github.workspace }}/bin/keystone-manage
+
+      - name: Remove pre-installed MySQL
+        run: |
+          sudo systemctl stop mysql.service || true
+          sudo apt-get purge -y --auto-remove 'mysql-*' 'mariadb-*' || true
+          sudo rm -rf /etc/mysql /var/lib/mysql
+
+      - name: Runner package workarounds for a full devstack (nova/cinder/glance/neutron)
+        # Same workarounds gophercloud/devstack-action uses to run a full
+        # (non-keystone-only) devstack on GitHub-hosted Ubuntu runners:
+        # - a documented runner-image /etc/hosts bug that otherwise breaks apt
+        # - the pre-installed esl-erlang package conflicts with the
+        #   rabbitmq-server package devstack's `enable_service rabbit` needs
+        # - stray postgresql/docker.io packages that collide with devstack's
+        #   own setup
+        # See https://github.com/gophercloud/devstack-action's action.yaml.
+        run: |
+          sudo sed -i 's/^-e \+//g' /etc/hosts
+          sudo apt-get update
+          sudo apt-get purge -y esl-erlang || true
+          sudo apt-get install -y erlang rabbitmq-server
+          sudo apt-get install -y runc || true
+          sudo apt-get purge -y python3-simplejson python3-pyasn1-modules postgresql* || true
+
+      - name: Clone devstack
+        run: git clone https://opendev.org/openstack/devstack /opt/stack/devstack
+
+      - name: Package SPIRE plugin as a standalone devstack plugin repo
+        run: |
+          sudo mkdir -p /opt/spire-plugin/devstack
+          sudo cp -rT tools/devstack-plugin-spire /opt/spire-plugin/devstack
+          sudo git -C /opt/spire-plugin init -q -b main
+          sudo git -C /opt/spire-plugin add -A
+          sudo git -C /opt/spire-plugin \
+            -c user.name=ci -c user.email=ci@localhost \
+            commit -qm "SPIRE devstack plugin"
+
+      - name: Write local.conf
+        run: |
+          cat <<EOF > /opt/stack/devstack/local.conf
+          [[local|localrc]]
+          ADMIN_PASSWORD=password
+          DATABASE_PASSWORD=password
+          RABBIT_PASSWORD=password
+          SERVICE_PASSWORD=password
+          SERVICE_TOKEN=service-token
+          GIT_BASE=https://github.com
+
+          disable_all_services
+          enable_service mysql
+          enable_service rabbit
+          enable_service key
+          enable_service key-rs
+          enable_service tempest
+          enable_service spire
+
+          # Nova (+ placement, a hard Nova dependency in modern devstack)
+          enable_service n-api n-cpu n-sch n-cond n-novnc n-crt n-api-meta
+          enable_service placement-api placement-client
+          # Cinder (c-vol defaults to an LVM-over-loopback backend when no
+          # CINDER_DRIVER is set - no real block device needed)
+          enable_service c-api c-sch c-vol
+          # Glance
+          enable_service g-api
+          # Neutron with OVN (devstack's default ML2 mechanism driver since
+          # 2023). The legacy agents (q-agt/q-dhcp/q-l3/q-meta) are mutually
+          # exclusive with OVN - devstack's ovn_sanity_check aborts the run
+          # if any of them is enabled. OVN's own services must be listed
+          # explicitly because disable_all_services drops stackrc's defaults.
+          enable_service q-svc q-ovn-agent
+          enable_service ovn-controller ovn-northd ovs-vswitchd ovsdb-server
+
+          enable_plugin spire file:///opt/spire-plugin main
+          enable_plugin key-rs file://${{ github.workspace }} ${{ env.KEYSTONE_RS_GIT_REF }}
+
+          SPIRE_TRUST_DOMAIN=cloud.trust.domain
+
+          KEYSTONE_RS_BIN_DIR=${{ github.workspace }}/bin
+
+          LOGFILE=\$HOME/devstack.log
+          LOG_COLOR=False
+          EOF
+          cat /opt/stack/devstack/local.conf
+
+      - name: Run stack.sh
+        working-directory: /opt/stack/devstack
+        run: FORCE=yes ./stack.sh
+
+      - name: Verify rust Keystone is serving directly
+        run: curl -sf http://127.0.0.1:8080/v3
+
+      - name: Issue a token via the openstack CLI
+        run: |
+          source /opt/stack/devstack/openrc admin admin
+          openstack token issue
+
+      - name: Verify OpenStack service health
+        run: |
+          source /opt/stack/devstack/openrc admin admin
+          openstack compute service list
+          openstack volume service list
+          openstack image list
+          openstack network agent list
+          # devstack no longer binds per-service ports (8774/8776/9292/9696):
+          # all APIs are proxied by a single Apache on port 80 via URL path
+          # prefixes. -f is omitted on purpose: unauthenticated requests get
+          # 3xx/401 back, which still proves the API is up and answering.
+          curl -s -o /dev/null http://127.0.0.1/compute/
+          curl -s -o /dev/null http://127.0.0.1/volume/v3/
+          curl -s -o /dev/null http://127.0.0.1/image/
+          curl -s -o /dev/null http://127.0.0.1/networking/
+
+      - name: Smoke test - boot and delete a cirros instance
+        run: |
+          source /opt/stack/devstack/openrc admin admin
+          image_id=$(openstack image list -f value -c ID | head -n1)
+          network_id=$(openstack network list -f value -c ID --long -c "Name" | awk '$0 !~ /public/ {print $1; exit}')
+          openstack server create --image "$image_id" \
+            --flavor cirros256 --network "$network_id" smoke-test --wait
+          openstack server delete smoke-test --wait
+
+      - name: Verify SPIRE server and agent are healthy
+        run: |
+          /usr/local/bin/spire-server healthcheck -socketPath /opt/stack/data/spire/server.sock
+          /usr/local/bin/spire-agent healthcheck -socketPath /opt/stack/data/spire/agent.sock
+
+      - name: Verify pre-registered SPIRE entries exist
+        run: |
+          /usr/local/bin/spire-server entry show -socketPath /opt/stack/data/spire/server.sock | tee /tmp/spire-entries.txt
+          grep -q "service/keystone" /tmp/spire-entries.txt
+          grep -q "service/nova-api" /tmp/spire-entries.txt
+          grep -q "service/neutron" /tmp/spire-entries.txt
+          grep -q "service/cinder" /tmp/spire-entries.txt
+          grep -q "service/glance" /tmp/spire-entries.txt
+          grep -q "service/nova-compute/host/" /tmp/spire-entries.txt
+
+      - name: Verify SPIRE CA bundle was exported
+        run: test -s /etc/keystone/spiffe/ca.crt
+
+      - name: Verify spiffe-helper processes are running
+        run: |
+          for svc in nova cinder glance neutron; do
+            sudo systemctl is-active "devstack@spiffe-helper-$svc"
+          done
+
+      - name: Verify spiffe-helper certs were issued and are valid
+        run: |
+          # SPIRE does not put the SPIFFE ID in the cert's Subject (it is
+          # C=US, O=SPIRE) - the identity lives in the URI SAN. So assert
+          # the exact per-service identity each helper is pinned to, and
+          # verify the SVID chains to the trust bundle the helper stored
+          # alongside it.
+          for pair in nova:nova-api cinder:cinder glance:glance neutron:neutron; do
+            svc=${pair%%:*}
+            dir=/opt/stack/data/spire/certs/$svc
+            openssl x509 -in $dir/tls.crt -noout -checkend 0
+            openssl verify -CAfile $dir/ca.crt $dir/tls.crt
+            openssl x509 -in $dir/tls.crt -noout -text | grep -q "URI:spiffe://cloud.trust.domain/service/${pair#*:}"
+          done
+
+      - name: Dump devstack log
+        if: failure()
+        run: cat "$HOME/devstack.log" || true
+
+      - name: Dump rust Keystone service log
+        if: failure()
+        run: sudo journalctl -u devstack@key-rs --no-pager || true
+
+      - name: Dump Nova API log
+        if: failure()
+        run: sudo journalctl -u devstack@n-api --no-pager || true
+
+      - name: Dump Nova Compute log
+        if: failure()
+        run: sudo journalctl -u devstack@n-cpu --no-pager || true
+
+      - name: Dump Cinder API log
+        if: failure()
+        run: sudo journalctl -u devstack@c-api --no-pager || true
+
+      - name: Dump Cinder Volume log
+        if: failure()
+        run: sudo journalctl -u devstack@c-vol --no-pager || true
+
+      - name: Dump Glance API log
+        if: failure()
+        run: sudo journalctl -u devstack@g-api --no-pager || true
+
+      - name: Dump Neutron server log
+        if: failure()
+        run: sudo journalctl -u devstack@q-svc --no-pager || true
+
+      - name: Dump SPIRE server log
+        if: failure()
+        run: sudo journalctl -u devstack@spire-server --no-pager || true
+
+      - name: Dump SPIRE agent log
+        if: failure()
+        run: sudo journalctl -u devstack@spire-agent --no-pager || true
+
+      - name: Dump spiffe-helper logs
+        if: failure()
+        run: |
+          for svc in nova cinder glance neutron; do
+            sudo journalctl -u "devstack@spiffe-helper-$svc" --no-pager || true
+          done

--- a/doc/plans/spire-integration.md
+++ b/doc/plans/spire-integration.md
@@ -243,6 +243,102 @@ spire-agent healthcheck -socketPath /tmp/spire-ci-test-harness/agent.sock
 
 ---
 
+### Phase 1.5: Full DevStack Service Set (Standard Auth) + spiffe-helper Cert Sidecars
+
+**Goal:** exercise SPIRE against a realistic multi-service OpenStack control
+plane before Phase 4/5's keystonemiddleware cutover exists — bring up
+Nova/Cinder/Glance/Neutron in the devstack CI job (previously keystone-only)
+using today's standard, unmodified keystone password/token auth, and add a
+`spiffe-helper` sidecar per service so each starts getting real X.509 SVIDs
+written to disk. The certs are issued but **not consumed** by any service in
+this phase — that consumption step belongs to Phase 4/5, once the patched
+keystonemiddleware exists to actually authenticate with them.
+
+**Prerequisites:** Phase 1 (SPIRE devstack plugin).
+
+**New/changed files:**
+
+| File                                                          | Purpose                                              |
+| --------------------------------------------------------------- | --------------------------------------------------- |
+| `tools/devstack-plugin-spire/etc/spiffe-helper.conf.tpl`        | spiffe-helper config template (done)                 |
+| `tools/devstack-plugin-spire/lib/spire`                         | `install_spiffe_helper`, `_spire_start_helper`, extended `_spire_register_static_entries` (cinder/glance), wiring into `start_spire`/`stop_spire`/`cleanup_spire` (done) |
+| `tools/devstack-plugin-spire/plugin.sh`                         | `enable_service spiffe-helper-{nova,cinder,glance,neutron}` run_process units (done) |
+| `.github/workflows/devstack.yml`                                | New `devstack-full` job: Nova/Cinder/Glance/Neutron enabled, `continue-on-error: true` (non-blocking until proven stable) (done) |
+
+**Details:**
+
+`spiffe-helper` (github.com/spiffe/spiffe-helper) connects to the SPIRE
+agent's Workload API and writes an SVID/key/CA bundle to disk per workload,
+refreshing them on rotation — the same tool and config shape already used in
+the k8s deployment (`tools/k8s/keystone/base/statefulset-rs.yaml`,
+`tools/k8s/keystone/base/conf/helper.conf`), reimplemented here for devstack
+via `run_process` (one instance per service) instead of a k8s sidecar
+container. Registration entries extend Phase 1's table with Cinder and
+Glance, using the same `unix:uid:$uid` selector pattern (and the same
+single-node-shared-user caveat Phase 1 already documents for nova-compute):
+
+| Service | SPIFFE ID |
+| ------- | --------- |
+| Cinder  | `spiffe://{trust_domain}/service/cinder` |
+| Glance  | `spiffe://{trust_domain}/service/glance` |
+
+In single-user devstack every entry's `unix:uid` selector matches every
+helper (they all run as `$STACK_USER`), so the agent hands each helper ALL
+registered SVIDs. spiffe-helper without a pin writes the "default" SVID (the
+first in the list — arbitrary, e.g. the nova-compute/host entry), so each
+entry is created with a `hint` equal to its SPIFFE ID and each helper's
+config sets the matching `hint`, pinning it to its own service's SVID.
+
+**Unlike SPIRE's own releases** (which publish a `_sha256sum.txt` per
+asset), spiffe-helper's release workflow uploads only the tarballs with no
+companion checksum file — `install_spiffe_helper` pins the sha256 of the
+downloaded tarball inline instead (computed from the published release
+asset at implementation time), rather than skipping verification.
+
+The new `devstack-full` CI job is deliberately separate from the existing
+keystone-only `devstack` job (a full nova/cinder/glance/neutron stack is
+materially heavier — image download, instance boot, extra services — and
+shouldn't slow every PR's feedback loop) and runs with `continue-on-error:
+true` until proven stable across several runs. Its approach to the
+classic "does nova-compute work without `/dev/kvm` on a GitHub-hosted
+runner" question follows a validated precedent
+(`gophercloud/devstack-action`, which runs stock devstack defaults
+including `n-cpu` on plain `ubuntu-24.04`/`22.04` runners across several
+OpenStack releases with no `NOVA_USE_QEMU`/`LIBVIRT_TYPE` override) rather
+than forcing software emulation proactively — devstack's own
+compute-driver detection is expected to handle the no-KVM case itself. That
+same project's workflow is also the source of the apt-level package
+workarounds the new job applies (RabbitMQ/erlang version conflict, a
+runner-image `/etc/hosts` bug, stray postgresql/docker.io packages).
+
+**Explicitly out of scope:** changing any service's actual keystone auth
+transport to SPIFFE/mTLS (Phase 4, not started); per-instance `compute-vm`
+ephemeral SPIFFE entries or mapping rulesets (Phase 6); any wiring of the
+emitted certs into a Nova/Cinder/Glance/Neutron config file.
+
+**Verification:**
+
+```bash
+# After stack.sh completes:
+openstack compute service list
+openstack volume service list
+openstack network agent list
+
+spire-server entry show -socketPath /opt/stack/data/spire/server.sock
+# Should show service/cinder and service/glance alongside Phase 1's entries
+
+for pair in nova:nova-api cinder:cinder glance:glance neutron:neutron; do
+  svc=${pair%%:*}
+  systemctl is-active "devstack@spiffe-helper-$svc"
+  # The SPIFFE ID is in the URI SAN, not the Subject (C=US, O=SPIRE):
+  openssl x509 -in /opt/stack/data/spire/certs/$svc/tls.crt -noout -checkend 0
+  openssl x509 -in /opt/stack/data/spire/certs/$svc/tls.crt -noout -text \
+    | grep -q "URI:spiffe://{trust_domain}/service/${pair#*:}"
+done
+```
+
+---
+
 ### Phase 2: Vendor Data JWT API (keystone-rs)
 
 **Goal:** keystone-rs exposes a new endpoint that signs a JWT per VM instance.

--- a/tools/devstack-plugin-spire/etc/spiffe-helper.conf.tpl
+++ b/tools/devstack-plugin-spire/etc/spiffe-helper.conf.tpl
@@ -1,0 +1,7 @@
+agent_address = "@SPIRE_AGENT_SOCKET@"
+cmd = ""
+cert_dir = "@SPIFFE_HELPER_CERT_DIR@"
+hint = "@SPIFFE_HELPER_HINT@"
+svid_file_name = "tls.crt"
+svid_key_file_name = "tls.key"
+svid_bundle_file_name = "ca.crt"

--- a/tools/devstack-plugin-spire/lib/spire
+++ b/tools/devstack-plugin-spire/lib/spire
@@ -35,6 +35,16 @@ SPIRE_AGENT_CONF=$SPIRE_DATA_DIR/agent.conf
 # Python services will read this to validate SPIFFE peers.
 SPIRE_CA_BUNDLE_DEST=${SPIRE_CA_BUNDLE_DEST:-$KEYSTONE_CONF_DIR/spiffe/ca.crt}
 
+# spiffe-helper (github.com/spiffe/spiffe-helper) writes an SVID/key/bundle
+# to disk per workload, refreshing them from the SPIRE agent's Workload API
+# on rotation. Phase 1.5: one helper instance per OpenStack service
+# (nova/cinder/glance/neutron), writing certs nothing consumes yet - this
+# is preparation for the Phase 4/5 keystonemiddleware cutover, not an auth
+# change. Mirrors tools/k8s/keystone/base/conf/helper.conf's config shape,
+# using run_process instead of a k8s sidecar container.
+SPIFFE_HELPER_VERSION=${SPIFFE_HELPER_VERSION:-0.11.0}
+SPIFFE_HELPER_CERTS_DIR=${SPIFFE_HELPER_CERTS_DIR:-$SPIRE_DATA_DIR/certs}
+
 function install_spire {
     local arch tarball url checksums_url tmp_dir
 
@@ -70,6 +80,47 @@ function install_spire {
     tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
     sudo install -m 0755 "$tmp_dir/spire-${SPIRE_VERSION}/bin/spire-server" /usr/local/bin/spire-server
     sudo install -m 0755 "$tmp_dir/spire-${SPIRE_VERSION}/bin/spire-agent" /usr/local/bin/spire-agent
+
+    rm -rf "$tmp_dir"
+}
+
+# Unlike SPIRE's own releases (which publish a
+# <asset>_sha256sum.txt per asset), spiffe-helper's release workflow
+# (github.com/spiffe/spiffe-helper .github/workflows/release_build.yaml)
+# uploads only the tarballs themselves, with no companion checksum file to
+# verify against. So the checksums below are pinned inline instead,
+# computed directly from the published release assets at the time this was
+# written - same "verify, don't skip" rationale as install_spire (this
+# binary writes actual SVID/key material to disk, at least as sensitive as
+# SPIRE itself). Bumping SPIFFE_HELPER_VERSION requires updating these.
+function install_spiffe_helper {
+    local arch tarball url checksum tmp_dir
+
+    case "$(uname -m)" in
+        x86_64)
+            arch=x86_64
+            checksum=7fba909574320d6a656e2e7d7f0657890fefad08a2abecd86c7bafe62d6d9134
+            ;;
+        aarch64)
+            arch=arm64
+            checksum=0386fd6113c4a4fcdd13cbf1663cdc29441d65f25c12a3662c6c9b01505bf329
+            ;;
+        *) die $LINENO "Unsupported architecture for spiffe-helper: $(uname -m)" ;;
+    esac
+
+    tmp_dir=$(mktemp -d)
+    tarball="spiffe-helper_v${SPIFFE_HELPER_VERSION}_Linux-${arch}.tar.gz"
+    url="https://github.com/spiffe/spiffe-helper/releases/download/v${SPIFFE_HELPER_VERSION}/${tarball}"
+
+    curl --proto '=https' --tlsv1.2 -sSfL "$url" -o "$tmp_dir/$tarball"
+
+    if ! (echo "$checksum  $tmp_dir/$tarball" | sha256sum -c - >/dev/null 2>&1); then
+        rm -rf "$tmp_dir"
+        die $LINENO "spiffe-helper release checksum verification failed for $tarball"
+    fi
+
+    tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
+    sudo install -m 0755 "$tmp_dir/spiffe-helper" /usr/local/bin/spiffe-helper
 
     rm -rf "$tmp_dir"
 }
@@ -131,15 +182,43 @@ function start_spire {
     _spire_register_static_entries
     _spire_register_compute_host "$(hostname)"
     _spire_export_ca_bundle
+
+    # No-ops unless the corresponding OpenStack service is enabled in
+    # local.conf (Phase 1.5's devstack-full CI job); in today's
+    # keystone-only job none of these are enabled, so this block does
+    # nothing there. Each guard is a full `if` (not `cmd && cmd`) so a
+    # disabled service leaves the last statement - and thus start_spire's
+    # return code - at 0; devstack runs with `set -e` and a non-zero
+    # return here would trip its ERR trap.
+    if is_service_enabled n-api; then
+        _spire_start_helper nova "$SPIFFE_HELPER_CERTS_DIR/nova" "spiffe://$SPIRE_TRUST_DOMAIN/service/nova-api"
+    fi
+    if is_service_enabled c-api; then
+        _spire_start_helper cinder "$SPIFFE_HELPER_CERTS_DIR/cinder" "spiffe://$SPIRE_TRUST_DOMAIN/service/cinder"
+    fi
+    if is_service_enabled g-api; then
+        _spire_start_helper glance "$SPIFFE_HELPER_CERTS_DIR/glance" "spiffe://$SPIRE_TRUST_DOMAIN/service/glance"
+    fi
+    if is_service_enabled q-svc; then
+        _spire_start_helper neutron "$SPIFFE_HELPER_CERTS_DIR/neutron" "spiffe://$SPIRE_TRUST_DOMAIN/service/neutron"
+    fi
 }
 
 # Create a SPIRE registration entry if one for this SPIFFE ID doesn't
 # already exist. devstack routinely re-runs stack.sh, and
 # `spire-server entry create` errors out on an exact duplicate, which
 # would otherwise break that workflow.
+#
+# The hint is the SPIFFE ID itself: spiffe-helper 0.11.0 selects which
+# SVID to write via `hint` (matched against the entry's hint), and without
+# a pin every helper in a single-user devstack - where all entries share
+# the same unix:uid selector - would fall back to the same arbitrary
+# "default" SVID (the first in the agent's list) instead of its own
+# service's identity.
 function _spire_entry_create_idempotent {
     local spiffe_id=$1
     local selector=$2
+    local hint=$3
 
     if spire-server entry show -socketPath "$SPIRE_SERVER_SOCKET" -spiffeID "$spiffe_id" 2>/dev/null | grep -q "$spiffe_id"; then
         return 0
@@ -149,16 +228,25 @@ function _spire_entry_create_idempotent {
         -socketPath "$SPIRE_SERVER_SOCKET" \
         -parentID "spiffe://$SPIRE_TRUST_DOMAIN/agent" \
         -spiffeID "$spiffe_id" \
-        -selector "$selector"
+        -selector "$selector" \
+        -hint "$hint"
 }
 
 function _spire_register_static_entries {
-    local uid
+    local uid cinder_uid glance_uid
     uid=$(id -u "$STACK_USER")
+    # devstack single-node CI may not create dedicated cinder/glance system
+    # users (all API services can end up running as $STACK_USER) - same
+    # caveat _spire_register_compute_host documents for nova below. Falling
+    # back to $STACK_USER's uid keeps this idempotent-safe either way.
+    cinder_uid=$(id -u cinder 2>/dev/null || echo "$uid")
+    glance_uid=$(id -u glance 2>/dev/null || echo "$uid")
 
-    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/keystone" "unix:uid:$uid"
-    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/nova-api" "unix:uid:$uid"
-    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/neutron" "unix:uid:$uid"
+    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/keystone" "unix:uid:$uid" "spiffe://$SPIRE_TRUST_DOMAIN/service/keystone"
+    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/nova-api" "unix:uid:$uid" "spiffe://$SPIRE_TRUST_DOMAIN/service/nova-api"
+    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/neutron" "unix:uid:$uid" "spiffe://$SPIRE_TRUST_DOMAIN/service/neutron"
+    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/cinder" "unix:uid:$cinder_uid" "spiffe://$SPIRE_TRUST_DOMAIN/service/cinder"
+    _spire_entry_create_idempotent "spiffe://$SPIRE_TRUST_DOMAIN/service/glance" "unix:uid:$glance_uid" "spiffe://$SPIRE_TRUST_DOMAIN/service/glance"
 }
 
 # Per-host nova-compute registration (ownership binding for Phase 2's
@@ -186,7 +274,8 @@ function _spire_register_compute_host {
 
     _spire_entry_create_idempotent \
         "spiffe://$SPIRE_TRUST_DOMAIN/service/nova-compute/host/$host" \
-        "unix:uid:$uid"
+        "unix:uid:$uid" \
+        "spiffe://$SPIRE_TRUST_DOMAIN/service/nova-compute/host/$host"
 }
 
 function _spire_export_ca_bundle {
@@ -196,7 +285,44 @@ function _spire_export_ca_bundle {
     sudo chmod 0644 "$SPIRE_CA_BUNDLE_DEST"
 }
 
+# Start one spiffe-helper instance for the given service, writing its SVID/
+# key/CA bundle to its own cert_dir under $SPIFFE_HELPER_CERTS_DIR. One
+# run_process unit per service (not a single shared helper) so a stuck
+# helper for one service doesn't block the others, and stop_spire/
+# cleanup_spire stay symmetric to extend.
+#
+# The spiffe_id argument pins the helper to that service's own SVID via
+# the config's `hint` (matched against the entry's hint, see
+# _spire_entry_create_idempotent). It must match the entry the service's
+# real processes will be attested against in Phase 4/5 - note nova's API
+# identity is service/nova-api, not service/nova.
+#
+# Nothing consumes these certs yet in Phase 1.5 - this only issues them,
+# in preparation for the Phase 4/5 keystonemiddleware cutover.
+function _spire_start_helper {
+    local service_name=$1
+    local cert_dir=$2
+    local spiffe_id=$3
+    local conf=$SPIRE_DATA_DIR/spiffe-helper-${service_name}.conf
+
+    sudo install -d -o "$STACK_USER" -m 0755 "$cert_dir"
+
+    sed \
+        -e "s|@SPIRE_AGENT_SOCKET@|$SPIRE_AGENT_SOCKET|g" \
+        -e "s|@SPIFFE_HELPER_CERT_DIR@|$cert_dir|g" \
+        -e "s|@SPIFFE_HELPER_HINT@|$spiffe_id|g" \
+        "$SPIRE_PLUGIN_ROOT/etc/spiffe-helper.conf.tpl" | \
+        sudo -u "$STACK_USER" tee "$conf" >/dev/null
+
+    run_process "spiffe-helper-${service_name}" \
+        "/usr/local/bin/spiffe-helper -config $conf"
+}
+
 function stop_spire {
+    local svc
+    for svc in nova cinder glance neutron; do
+        stop_process "spiffe-helper-${svc}"
+    done
     stop_process spire-agent
     stop_process spire-server
 }

--- a/tools/devstack-plugin-spire/plugin.sh
+++ b/tools/devstack-plugin-spire/plugin.sh
@@ -15,15 +15,20 @@ SPIRE_PLUGIN_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "$SPIRE_PLUGIN_DIR/lib/spire"
 
 if is_service_enabled spire; then
-    # spire-server and spire-agent are the internal run_process units the
-    # start/stop functions target, not user-facing toggles - devstack's
-    # run_process silently no-ops for any service name that isn't enabled,
-    # so they must be enabled here (mirroring key-rs's key-rs-opa). "spire"
-    # remains the single toggle operators use in local.conf.
+    # spire-server, spire-agent, and the per-service spiffe-helper-*
+    # instances are the internal run_process units the start/stop
+    # functions target, not user-facing toggles - devstack's run_process
+    # silently no-ops for any service name that isn't enabled, so they
+    # must be enabled here (mirroring key-rs's key-rs-opa). "spire" remains
+    # the single toggle operators use in local.conf; each spiffe-helper-*
+    # instance is itself only started (lib/spire's start_spire) when its
+    # corresponding OpenStack service (n-api/c-api/g-api/q-svc) is enabled.
     enable_service spire-server spire-agent
+    enable_service spiffe-helper-nova spiffe-helper-cinder spiffe-helper-glance spiffe-helper-neutron
 
     if [[ "$1" == "stack" && "$2" == "install" ]]; then
         install_spire
+        install_spiffe_helper
     elif [[ "$1" == "stack" && "$2" == "post-config" ]]; then
         configure_spire
     elif [[ "$1" == "stack" && "$2" == "extra" ]]; then


### PR DESCRIPTION
Add a new, non-blocking devstack-full CI job that brings up
Nova/Cinder/Glance/Neutron alongside keystone-rs using standard
password/token auth (no SPIFFE auth cutover yet - that needs the
Phase 4 keystonemiddleware). Extend the SPIRE devstack plugin with a
spiffe-helper sidecar per service so each starts getting real X.509
SVIDs written to disk, in preparation for that later phase.

Registers Cinder/Glance SPIRE entries alongside the existing
keystone/nova-api/neutron ones, and folds in the apt-level package
workarounds gophercloud/devstack-action uses to run a full devstack
on GitHub-hosted runners (RabbitMQ/erlang, /etc/hosts, stray
postgres/docker.io packages).

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
