### PR TITLE
feat(storage): Bump openraft to 0.10.0-alpha.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,18 +1039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byte-unit"
-version = "5.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a813de7f2bbedb7dce265b64f1cf5908ebe4d56281ece8d847e98113788b9b0"
-dependencies = [
- "rust_decimal",
- "schemars",
- "serde",
- "utf8-width",
-]
-
-[[package]]
 name = "bytecheck"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4707,14 +4695,13 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51538caa677a285eafe62ede8a366445383988c2a23344cfdb4e95174717ef38"
+checksum = "06fe14d529f8fc098fbb4b9655d5db9b7ee0594e6a9d4e220aa931618de17b1f"
 dependencies = [
  "anyerror",
  "backoff-series",
  "base2histogram",
- "byte-unit",
  "chrono",
  "clap",
  "derive_more",
@@ -4725,6 +4712,7 @@ dependencies = [
  "openraft-macros",
  "openraft-rt",
  "openraft-rt-tokio",
+ "parse-size",
  "peel-off",
  "rand 0.10.2",
  "serde",
@@ -4736,9 +4724,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.32"
+version = "0.10.0-alpha.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1943a9ac257416e81237ded75b8650688b34ae66743d7f82204c212ca29a5bd"
+checksum = "f5c57259539e016f70d05ea7e264573cc5ddabd651a127a13374e47b165b7664"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -4749,9 +4737,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.32"
+version = "0.10.0-alpha.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d4147d21ae5cf0ea56fec6041b4a5d9ad193e046516f6123035d75bce371f2"
+checksum = "02379ddf29c426905a6e91c5df522003ee2a9a9811b3b8be01e90ab1106ecef6"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -4762,9 +4750,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.32"
+version = "0.10.0-alpha.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb6d7da496b598d8a6b6ebc236840525487d0c45672ad9c5b9c92197b81e777"
+checksum = "cfeb8c656d8b0e01319aafc70f77b3b312cac56d07adf157d80b49677cc2fcec"
 dependencies = [
  "futures-util",
  "openraft-rt",
@@ -6372,6 +6360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
 name = "parse-zoneinfo"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7346,26 +7340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
 name = "regalloc2"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7904,18 +7878,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -9961,12 +9923,6 @@ checksum = "a77b65c7a7ab8283571978ef99afd537e1485bb48a3e5341de9bbedb9ca5c57d"
 dependencies = [
  "url",
 ]
-
-[[package]]
-name = "utf8-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159a7cadce548703edd50d24069bc294c5415ecab0a480e0cd1ca06d112dc94a"
 
 [[package]]
 name = "utf8-zero"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ mockall = { version = "0.15" }
 mockall_double = { version = "0.3" }
 nix = { version = "0.31", default-features = false }
 openidconnect = { version = "4.0" }
-openraft = { version = "=0.10.0-alpha.31" }
+openraft = { version = "=0.10.0-alpha.34" }
 openstack-keystone-api-key-driver-raft = { version = "0.1", path = "crates/api-key-driver-raft/" }
 openstack-keystone-api-types = { version = "0.1", features = ["openapi", "validate", "conv"], path = "crates/api-types" }
 openstack-keystone-audit = { version = "0.1.0", path = "crates/audit" }

--- a/crates/storage/src/grpc/cluster_admin_service.rs
+++ b/crates/storage/src/grpc/cluster_admin_service.rs
@@ -1330,12 +1330,16 @@ impl ClusterAdminService for ClusterAdminServiceImpl {
 
         // Trigger snapshot build via the snapshot builder trait.
         let mut builder = self.sm.clone();
-        let built = builder
+        let _built = builder
             .build_snapshot()
             .await
             .map_err(|e| Status::internal(format!("snapshot build failed: {e}")))?;
 
-        let snapshot_path = self.sm.snapshot_dir().join(&built.meta.snapshot_id);
+        let snapshot_path = self
+            .sm
+            .latest_snapshot_path()
+            .map_err(|e| Status::internal(format!("cannot locate snapshot file: {e}")))?
+            .ok_or_else(|| Status::internal("snapshot build did not produce a file"))?;
         let file = tokio::fs::File::open(&snapshot_path)
             .await
             .map_err(|e| Status::internal(format!("cannot open snapshot file: {e}")))?;

--- a/crates/storage/src/grpc/raft_service.rs
+++ b/crates/storage/src/grpc/raft_service.rs
@@ -166,7 +166,6 @@ impl RaftService for RaftServiceImpl {
                             Status::invalid_argument(format!("invalid membership: {:?}", e))
                         })?,
                 ),
-                snapshot_id: meta.snapshot_id,
             };
         }
 

--- a/crates/storage/src/network.rs
+++ b/crates/storage/src/network.rs
@@ -363,7 +363,11 @@ impl NetSnapshot<TypeConfig> for NetworkConnection {
                         .log_id()
                         .map(|log_id| log_id.into()),
                     last_membership: Some(meta.last_membership.membership().clone().into()),
-                    snapshot_id: meta.snapshot_id.to_string(),
+                    // openraft 0.10 dropped `snapshot_id` from `SnapshotMeta` (two snapshots at
+                    // the same `last_log_id` are the same state regardless of transfer id); the
+                    // receiver derives its own on-disk id from `last_log_id`, so this proto field
+                    // is unused but kept for wire-format compatibility.
+                    snapshot_id: String::new(),
                 },
             )),
         };

--- a/crates/storage/src/store/state_machine.rs
+++ b/crates/storage/src/store/state_machine.rs
@@ -534,6 +534,38 @@ impl FjallStateMachine {
         &self.snapshot_dir
     }
 
+    /// Return the path of the most recently written snapshot file, if any.
+    ///
+    /// Snapshot filenames sort lexicographically by `<leader_id>-<index>-<rand>`, so the
+    /// lexicographically greatest filename is the latest snapshot. openraft 0.10 dropped
+    /// `snapshot_id` from `SnapshotMeta`, so callers that need the on-disk path (rather than
+    /// going through `RaftStateMachine::get_current_snapshot`) must locate it this way.
+    pub(crate) fn latest_snapshot_path(&self) -> io::Result<Option<std::path::PathBuf>> {
+        let mut latest_snapshot_id: Option<String> = None;
+
+        for entry in fs::read_dir(&self.snapshot_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if !path.is_file() {
+                continue;
+            }
+
+            if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
+                let snapshot_id = filename.to_string();
+
+                if latest_snapshot_id
+                    .as_ref()
+                    .is_none_or(|current| snapshot_id > *current)
+                {
+                    latest_snapshot_id = Some(snapshot_id);
+                }
+            }
+        }
+
+        Ok(latest_snapshot_id.map(|id| self.snapshot_dir.join(id)))
+    }
+
     /// Validate and decrypt an operator backup blob (produced by the `Backup`
     /// gRPC RPC) and return an OpenRaft `Snapshot` ready for
     /// `Raft::install_full_snapshot`.
@@ -1242,7 +1274,6 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<FjallStateMachine> {
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,
             last_membership,
-            snapshot_id: snapshot_id.clone(),
         };
 
         tracing::trace!("snapshot metadata: {:?}", meta);
@@ -1337,11 +1368,6 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Vec<u8>, io::Error> {
-        Ok(Vec::new())
-    }
-
-    #[tracing::instrument(skip(self))]
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMetaOf<TypeConfig>,
@@ -1394,6 +1420,18 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
             .persist(PersistMode::SyncAll)
             .map_err(|e| io::Error::other(e.to_string()))?;
 
+        let snapshot_idx: u64 = rand::rng().random_range(0..1000);
+        let snapshot_id = if let Some(last) = meta.last_log_id.as_ref() {
+            format!(
+                "{}-{}-{}",
+                last.committed_leader_id(),
+                last.index(),
+                snapshot_idx
+            )
+        } else {
+            format!("--{}", snapshot_idx)
+        };
+
         let snapshot_file = SnapshotFile {
             meta: meta.clone(),
             data: snapshot_data_clone,
@@ -1423,7 +1461,7 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
         disk_bytes.extend_from_slice(&utc_epoch.to_be_bytes());
         disk_bytes.extend_from_slice(&encrypted);
 
-        let snapshot_path = self.snapshot_dir.join(&meta.snapshot_id);
+        let snapshot_path = self.snapshot_dir.join(&snapshot_id);
         fs::write(&snapshot_path, &disk_bytes)?;
 
         Ok(())
@@ -1433,33 +1471,9 @@ impl RaftStateMachine<TypeConfig> for Arc<FjallStateMachine> {
     async fn get_current_snapshot(
         &mut self,
     ) -> Result<Option<SnapshotOf<TypeConfig, Vec<u8>>>, io::Error> {
-        let mut latest_snapshot_id: Option<String> = None;
-
-        for entry in fs::read_dir(&self.snapshot_dir)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if !path.is_file() {
-                continue;
-            }
-
-            if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
-                let snapshot_id = filename.to_string();
-
-                if latest_snapshot_id
-                    .as_ref()
-                    .is_none_or(|current| snapshot_id > *current)
-                {
-                    latest_snapshot_id = Some(snapshot_id);
-                }
-            }
-        }
-
-        let Some(snapshot_id) = latest_snapshot_id else {
+        let Some(snapshot_path) = self.latest_snapshot_path()? else {
             return Ok(None);
         };
-
-        let snapshot_path = self.snapshot_dir.join(&snapshot_id);
 
         let disk_bytes = fs::read(&snapshot_path)?;
         let (snapshot_file, _, _) =


### PR DESCRIPTION
alpha.34 drops `snapshot_id` from `SnapshotMeta` (two snapshots at
the same last_log_id are the same state regardless of transfer id)
and removes `RaftStateMachine::begin_receiving_snapshot` now that
SnapshotData is used directly without a separate receive step.

- Derive on-disk snapshot filenames locally from last_log_id instead
  of reading them off SnapshotMeta
- Add FjallStateMachine::latest_snapshot_path() to locate the most
  recent snapshot file, reused by get_current_snapshot() and the
  gRPC backup handler
- Zero out the wire-level snapshot_id field on send; receiver no
  longer depends on it

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
